### PR TITLE
fix(v1.13.1): agent install confirmation + clean errors + CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantik Versioning](https://semver.org/).
 
+## [1.13.1] - 2026-04-25
+
+### Fixed — `badi agent`
+- **`agent install` confirmation was fake.** When a watcher contained a `shell`
+  check, install printed "shall I register this with the scheduler?" and then
+  installed anyway, without reading any input. The prompt now actually waits
+  for `y/N`. Added `--yes` / `-y` to opt out for non-interactive use.
+- **`agent install <unknown>` and `agent tail <unknown>` threw raw stack
+  traces** from `WatcherError`. Both now print a clean `Watcher yok: <path>`
+  message and exit `1`.
+
+### Refactored
+- `lib/commands/icerik.js` was a single 1,667-line if-chain over 13
+  subcommands. Split into per-subcommand modules under `lib/commands/icerik/`
+  (issue #41). `icerik.js` is now a one-line re-export so import paths stay
+  stable. No behavior change.
+
+### Tests
+- 304 → 307 (+3): `--yes` flag visible in help, clean errors for missing
+  watchers in `install` and `tail`.
+
 ## [1.13.0] - 2026-04-24
 
 ### Added — Background Agents (issue #55)

--- a/lib/commands/agent.js
+++ b/lib/commands/agent.js
@@ -193,34 +193,44 @@ async function subRun(args, cwd) {
 
 // ─── install / uninstall ───
 
-function subInstall(args, cwd) {
+async function subInstall(args, cwd) {
 	const name = args[0];
 	let preferred = null;
 	let dryRun = false;
+	let yesFlag = false;
 	for (let i = 1; i < args.length; i++) {
 		if (args[i] === "--scheduler") preferred = args[++i];
 		else if (args[i] === "--dry-run") dryRun = true;
+		else if (args[i] === "--yes" || args[i] === "-y") yesFlag = true;
 	}
 	if (!name) {
 		console.error(
 			chalk.red(
-				"Kullanim: badi agent install <isim> [--scheduler id] [--dry-run]",
+				"Kullanim: badi agent install <isim> [--scheduler id] [--dry-run] [--yes]",
 			),
 		);
 		process.exit(1);
 	}
 	const file = watcherPath(cwd, name);
+	if (!existsSync(file)) {
+		console.error(chalk.red(`Watcher yok: ${file}`));
+		process.exit(1);
+	}
 	const w = loadWatcher(file);
 	const intervalSeconds = parseEvery(w.every) || 900;
 
-	// Onay iste: shell watcher varsa acikca uyar
+	// Onay iste: shell watcher varsa
 	const hasShell = w.watches.some((c) => c.type === "shell");
-	if (hasShell && process.stdin.isTTY && !dryRun) {
-		console.log(
+	if (hasShell && !dryRun && !yesFlag && process.stdin.isTTY) {
+		const answer = await ask(
 			chalk.yellow(
-				`Dikkat: '${name}' rastgele shell komutu calistiracak. Zamanlayiciya kayit edilsin mi?`,
+				`Dikkat: '${name}' rastgele shell komutu calistiracak. Zamanlayiciya kayit edilsin mi? [y/N]: `,
 			),
 		);
+		if (!/^y(es)?$/i.test(answer)) {
+			console.log(chalk.dim("Iptal edildi."));
+			return;
+		}
 	}
 
 	const scheduler = pickScheduler(preferred);
@@ -290,7 +300,12 @@ function subTail(args, cwd) {
 		console.error(chalk.red("Kullanim: badi agent tail <isim> [-n N]"));
 		process.exit(1);
 	}
-	const w = loadWatcher(watcherPath(cwd, name));
+	const file = watcherPath(cwd, name);
+	if (!existsSync(file)) {
+		console.error(chalk.red(`Watcher yok: ${file}`));
+		process.exit(1);
+	}
+	const w = loadWatcher(file);
 	const p = resolve(cwd, w.reportTo);
 	if (!existsSync(p)) {
 		console.log(chalk.dim(`Rapor yok: ${p}`));
@@ -378,7 +393,7 @@ function showAgentHelp() {
 	console.log("  create <isim> [--template project-health|deploy-watchdog]");
 	console.log("  list");
 	console.log("  run <isim>                       # manual calistir (test)");
-	console.log("  install <isim> [--scheduler id] [--dry-run]");
+	console.log("  install <isim> [--scheduler id] [--dry-run] [--yes]");
 	console.log("  uninstall <isim>");
 	console.log("  tail <isim> [-n N]");
 	console.log("  status [--since 24h|7d] [--format text|json]");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fatihkan/badi",
-	"version": "1.13.0",
+	"version": "1.13.1",
 	"description": "Claude Code kullanicilari icin profesyonel is akisi yonetim sistemi",
 	"type": "module",
 	"main": "bin/badi.js",

--- a/tests/watcher.test.js
+++ b/tests/watcher.test.js
@@ -471,6 +471,34 @@ describe("badi agent CLI", () => {
 		assert.match(out, /DRY-RUN/);
 	});
 
+	it("agent install bilinmeyen watcher icin temiz hata", () => {
+		assert.throws(() => {
+			execFileSync(
+				"node",
+				[CLI, "agent", "install", "yok-boyle", "--dry-run"],
+				{ cwd: dir, stdio: "pipe", encoding: "utf-8" },
+			);
+		}, /Watcher yok/);
+	});
+
+	it("agent tail bilinmeyen watcher icin temiz hata", () => {
+		assert.throws(() => {
+			execFileSync("node", [CLI, "agent", "tail", "yok-boyle"], {
+				cwd: dir,
+				stdio: "pipe",
+				encoding: "utf-8",
+			});
+		}, /Watcher yok/);
+	});
+
+	it("agent --help install satirinda --yes bayragini gosterir", () => {
+		const out = execFileSync("node", [CLI, "agent", "--help"], {
+			cwd: dir,
+			encoding: "utf-8",
+		});
+		assert.match(out, /install .*--yes/);
+	});
+
 	it("agent status bos projede hata vermez", () => {
 		const r = execFileSync("node", [CLI, "agent", "status"], {
 			cwd: mkTmp(),


### PR DESCRIPTION
## Summary

v1.13.0 incelemesinde `lib/commands/agent.js`'de iki gercek bug bulundu:

1. **Sahte onay prompt'u** — `badi agent install <shell-watcher>` "kayit edilsin mi?" yaziyordu ama hicbir input beklemiyordu. Sonra her halukarda install ediyordu. Artik gercekten `y/N` bekliyor. Scripted kullanim icin `--yes` / `-y` eklendi.
2. **Kirik hata mesajlari** — `agent install <yok>` ve `agent tail <yok>` ham `WatcherError` stack trace firlatiyordu. Artik temiz `Watcher yok: <path>` veriyor ve `1` ile cikiyor.

Ayrica `package.json` 1.13.0 → 1.13.1 bumped + `CHANGELOG.md`'ye v1.13.1 entry'si eklendi. **Bu entry icerik split'i (PR #59) de iceriyor** — siralama: PR #59 merge → bu PR merge → kullanici `npm publish` → v1.13.1 her ikisini de kapsamis olur.

## Sirali merge plani

1. PR #59 (refactor/issue-41-icerik-split) merge
2. Bu PR rebase + merge
3. Kullanici: `git tag v1.13.1 && git push --tags && npm publish && gh release create v1.13.1`

## Degisiklikler

| Dosya | Diff |
|-------|------|
| `lib/commands/agent.js` | `subInstall` async + gercek `await ask`, `--yes` flag, missing-watcher checks |
| `tests/watcher.test.js` | 3 yeni test (`--yes` help, install/tail missing watcher) |
| `CHANGELOG.md` | v1.13.1 entry (agent fix + icerik split) |
| `package.json` | 1.13.0 → 1.13.1 |

## Test plan

- [x] `npm test` — 304 → 307 (+3 yeni), hepsi yesil
- [x] `npm run lint` — agent.js / watcher.test.js'de yeni hata yok
- [x] CLI smoke: `node bin/badi.js agent --help` artik `--yes` bayragini gosteriyor
- [x] CLI smoke: `node bin/badi.js agent install yok-boyle --dry-run` temiz hata
- [x] CLI smoke: `node bin/badi.js agent tail yok-boyle` temiz hata

🤖 Generated with [Claude Code](https://claude.com/claude-code)