### PR TITLE
docs: v1.14 plan — sequence #56, #57, #58 across two minor releases

### DIFF
--- a/docs/v1.14-plan.md
+++ b/docs/v1.14-plan.md
@@ -1,0 +1,169 @@
+# v1.14 Plan
+
+> Status: **draft** · Authored 2026-04-25 · Owner: @fatihkan
+
+This document sequences the three v1.14-tagged GitHub issues into a coherent
+release plan. It does not duplicate scope detail — each issue remains the
+authoritative spec. The job here is to fix order, ownership, and cross-issue
+decisions so implementation can start without re-deciding the same things in
+every PR.
+
+## At a glance
+
+| Issue | Title | Effort | Depends on | Recommended for |
+|------:|-------|--------|------------|-----------------|
+| [#56](https://github.com/fatihkan/badi/issues/56) | skill-bundle publishing + agentskills.io compliance | 2-3 days | — | **v1.14.0** |
+| [#57](https://github.com/fatihkan/badi/issues/57) | `badi-discipline` — Karpathy-style behavioral skill | 1 day | #56 (hard) | **v1.14.0** |
+| [#58](https://github.com/fatihkan/badi/issues/58) | `badi tasarim` — design.md integration | ~4 days | — | **v1.14.1** |
+
+## Why this split
+
+The three issues fall into two storylines:
+
+**Skill ecosystem (v1.14.0).** #56 builds the infrastructure — a separate
+`badi-skills` repository, frontmatter schema, bundler, and router skill — that
+makes Badi's 25 skill categories installable on Cursor / Codex / Windsurf /
+the wider agentskills.io world. #57 is the flagship payload: it packages
+Badi's behavioral discipline (the `yak-shave-detector` / `unsticker` /
+`auditor` / `CLAUDE.md` philosophy) into a single portable skill that proves
+the bundle works and gives the new repo a strong opening exhibit. Shipping
+these together tells one story: "Badi now publishes skills, and here is the
+one we are most opinionated about."
+
+**Visual identity feature (v1.14.1).** #58 is a self-contained product
+addition — `badi tasarim init / lint / export / show`, a `tasarim-kurator`
+agent, and a `design-tokens` skill that injects `DESIGN.md` tokens into
+content briefs. It is independent of the skill bundle (touches
+`lib/commands/tasarim.js` and a new agent/skill, not the bundler) and is
+roughly the same size as #56 + #57 combined. Bundling all three into one
+release would double the surface area of v1.14.0 review and stretch ship
+time. Shipping it as v1.14.1 keeps each release reviewable.
+
+The alternative — running #56/#57 and #58 as parallel work streams into a
+single v1.14.0 — is viable if there is appetite for a bigger release cut.
+The dependency graph permits it; the recommendation against it is
+purely about review surface and ship discipline.
+
+## v1.14.0 — skill ecosystem
+
+### Sequence
+
+1. Create `badi-skills` GitHub repo (empty, MIT, basic CI). One-time setup;
+   should happen first because `badi publish --skill-bundle` needs a target.
+2. Land `feature/v1.14.0-skill-bundle` on this repo:
+   - `lib/skills/schema.js` — frontmatter validator (the SoT for what
+     enrichment must produce).
+   - `lib/harnesses/skills-bundler.js` — compiles `.claude/skills/<name>/`
+     into `badi-skills/skills/<name>/` with enriched frontmatter.
+   - `lib/commands/publish.js` — `--skill-bundle` flag.
+   - Frontmatter enrichment for the 25 existing skills (automation does ~80%;
+     manual review for the rest).
+   - Router skill at `skills/badi/SKILL.md`.
+   - Manifests: `.claude-plugin/plugin.json`, `.cursor-plugin/`, `AGENTS.md`,
+     `CLAUDE.md`.
+3. Land `feature/v1.14.0-badi-discipline` (off the same branch, merged in
+   sequence): drops `skills/badi-discipline/SKILL.md` + 4 reference files
+   into `badi-skills/skills/`. Schema validator from step 2 must pass.
+4. Cut v1.14.0 of `@fatihkan/badi`. Cut v1.0.0 of `badi-skills` separately.
+
+### Cross-issue decisions (resolved)
+
+| Question | Decision |
+|----------|----------|
+| `badi-skills` versioning vs `@fatihkan/badi` | **Independent.** Badi 1.14.0 → badi-skills 1.0.0. The two evolve at different cadences; coupling them locks both teams to the slower one. |
+| `badi-skills` license | **MIT** (matches main repo; allows agents to remix). |
+| `badi-discipline` slug | **`badi-discipline`** (matches issue title; "discipline" carries the rigor connotation, differentiates from Karpathy's "guidelines"). |
+| Schema source of truth | **`@fatihkan/badi`'s `lib/skills/schema.js`** is canonical. `badi-skills` CI imports it as a dev-dep at validation time. |
+| Plugin system overlap | **Distinct concepts.** `badi plugin install` = CLI extensions. `badi-skills` = agent behavior skills. Documented side-by-side in README, not unified. |
+| Multi-language SKILL.md (TR variants) | **Out of v1.14.0.** Phase 2. agentskills.io ecosystem support is unverified; ship English-first. |
+
+### Open questions (still to answer)
+
+- **Schema strictness.** Does `allowed-tools` validate against tools actually
+  used in the SKILL.md body, or is it free-form? Strict drift detection is
+  cleaner but blocks legitimate experimentation. Recommend: **warn, don't
+  block**, with a `--strict` mode for CI.
+- **Router skill maintenance.** Does `lib/harnesses/skills-bundler.js`
+  regenerate `skills/badi/SKILL.md` on every publish, or is it hand-edited?
+  Recommend: **regenerated** — the source of truth is the file system; the
+  router becomes a derived artifact. Hand-edits would drift.
+- **Submission to skills.sh.** Manual form? PR? The issue lists this as a
+  Phase 2 item — confirm before v1.14.0 ships so the README install
+  instructions are accurate.
+
+## v1.14.1 — design.md integration (#58)
+
+### Sequence
+
+1. **Faz 1: CLI wrapper** (~1 day). `lib/commands/tasarim.js` with `init` /
+   `lint` / `export` / `show` subcommands. Each shells out to
+   `npx @google/design.md@0.1.1` (pinned — package is alpha v0.1.1).
+2. **Faz 2: `tasarim-kurator` agent** (~2 days). Reads the project
+   `DESIGN.md`, answers token queries, delegates from `visual-director`.
+3. **Faz 3: `design-tokens` skill** (~1 day). Injects DESIGN.md tokens into
+   content briefs from `icerik gorsel|karousel|video|takvim`.
+
+### Cross-issue decisions (resolved)
+
+| Question | Decision |
+|----------|----------|
+| Pin `@google/design.md` version | **`@0.1.1`** (alpha — API may break). Add regression test against the pinned version. |
+| Add as dependency or shell out via `npx` | **Shell out via `npx`.** Matches Badi's "minimum runtime dependencies" stance and avoids pulling TypeScript into a Node-only runtime. |
+| Default DESIGN.md location | **`.claude/workspace/DESIGN.md`** (consistent with how `marka-sesi.md` lives in workspace). |
+| Behavior when no DESIGN.md | **Skill skips silently** (failsafe — content commands keep working). The `tasarim show` and `lint` commands print a helpful "run `tasarim init`" message. |
+
+### Open questions (still to answer)
+
+- **Internet-required commands.** `lint` and `export` shell out to `npx`,
+  which fetches the package on first run and uses cache after. Decide what
+  the offline UX is: hard fail with "internet required" message vs. attempt
+  cached run. Recommend: **try cached run first; fall back to clear error**.
+- **Agent delegation pattern.** Should `visual-director` always call
+  `tasarim-kurator`, or only when prompts mention colors/typography/spacing?
+  Always-call is simpler; conditional is leaner. Recommend: **always-call,
+  but `tasarim-kurator` returns "no DESIGN.md found, skipping" quickly when
+  the file is absent**.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `badi-skills` repo creation is one-shot — name, license, structure all become public commitments. | Spend half a day on the bare repo layout (template + CI + READMEs) before the first real skill lands. Easy to walk back if nothing has been published. |
+| Frontmatter enrichment for 25 skills is mostly automation but the description fields need triggers tuned for agent activation. Mechanical enrichment will produce weak triggers. | Budget half a day of manual review per ~5 skills. Use the existing `frontend-taste` SKILL.md as the description template. |
+| `@google/design.md` is v0.1.1 — alpha. Breaking changes between minor releases are likely. | Pin exact version. Add `tests/cli.tasarim.test.js` smoke test that calls the pinned version's `lint` against a fixture and asserts on output shape. Bump deliberately. |
+| Behavioral skills (#57) make claims they cannot enforce — "simplicity first" is a guideline, not a check. README must say so or users feel cheated. | Lift Karpathy's tradeoff note into the SKILL.md preamble verbatim: "These are prompt-level guidelines, not enforcement." |
+| Two repos (`@fatihkan/badi` + `badi-skills`) means two release flows. CI drift between them is easy. | Add a cross-check job in `badi-skills` CI that pulls `@fatihkan/badi`'s `lib/skills/schema.js` and validates every SKILL.md against it. |
+
+## Concrete next steps
+
+1. **Resolve the open questions above** before writing code. Each one is
+   small but each closes off rework.
+2. **Create the `badi-skills` repo** with: `LICENSE` (MIT), basic CI
+   (`node --test`), placeholder README, `.claude-plugin/plugin.json`,
+   `AGENTS.md` and `CLAUDE.md` stubs. No skills yet.
+3. **Cut `feature/v1.14.0-skill-bundle`** off `main` of `@fatihkan/badi`.
+   Land in this order:
+   1. `lib/skills/schema.js` + tests.
+   2. `lib/harnesses/skills-bundler.js` + tests against fixture skills.
+   3. `lib/commands/publish.js` `--skill-bundle` flag + tests.
+   4. Frontmatter enrichment of the 25 in-repo skills (separate sub-PRs if
+      review surface gets uncomfortable — group by category).
+4. **Cut `feature/v1.14.0-badi-discipline`** off the merged skill-bundle
+   work. Land `skills/badi-discipline/` in `badi-skills`. Verify schema +
+   `npx skills add fatihkan/badi-skills --skill badi-discipline`.
+5. **Ship v1.14.0** of both repos.
+6. After that lands, **start `feature/v1.14.1-tasarim`** for #58.
+
+## Out of scope for v1.14
+
+These came up in issue discussions but are explicitly deferred:
+
+- **Self-tuning watchers** (`badi agent tune <name>`) — combines #56's bundle
+  pattern with #55's watcher system. v1.15 candidate.
+- **Self-auditing discipline watcher** — pairs `badi-discipline` with the
+  watcher system to scorecard PRs against the 8 principles. v1.15 candidate.
+- **`badi-discipline-tr`** — Turkish variant. Phase 2 of #57.
+- **Skill inheritance** (`badi agent create discipline-custom --extends
+  badi-discipline`) — mirrors `badi icerik sablon`. Phase 2 of #57.
+- **`badi stats` install telemetry** — opt-in metric for skill-bundle
+  installs. Phase 2 of #56.


### PR DESCRIPTION
## Summary

Adds `docs/v1.14-plan.md` capturing the cross-issue decisions and dependency analysis for the three open v1.14-tagged issues (#56, #57, #58). Goal: each implementation PR starts with these things already resolved instead of re-deciding them.

## Onerilen siralama

| Release | Icerik | Why |
|---|---|---|
| **v1.14.0** | #56 (skill-bundle infra) + #57 (badi-discipline) | #57'nin badi-skills repo'suna bagli — birlikte kaydirma uretir: "Badi artik skill yayinliyor, iste en iddiali olani." |
| **v1.14.1** | #58 (badi tasarim) | Tek basina ~4 gun, bagimsiz kod yollari. Birlikte yayinlamak v1.14.0 review yuzeyini ikiye katlardi. |

## Cozulen cross-issue sorulari (PR'larda tekrar tartisilmasin diye)

- **badi-skills versioning** → bagimsiz (Badi 1.14.0 → badi-skills 1.0.0)
- **badi-skills license** → MIT
- **Schema SoT** → ana repo'daki `lib/skills/schema.js` kanonik; `badi-skills` CI dev-dep olarak kullanir
- **Plugin vs skill-bundle** → ayri kavramlar (CLI uzantisi vs ajan davranisi)
- **TR varyantlari** → v1.14.0 disinda
- **`@google/design.md` pin** → `@0.1.1` (alpha, breaking degisiklik beklenir)
- **DESIGN.md varsayilan yer** → `.claude/workspace/DESIGN.md`

## Hala acik kalan sorular

- Schema strictness (`allowed-tools` drift detection: warn vs block) — onerim warn + `--strict` mode CI icin
- Router skill regenerated mi hand-edited mi — onerim regenerated
- Harici skill registry submission akisi — v1.14.0 oncesi netlestir
- `tasarim` offline UX (cache try-fallback)
- `visual-director` her zaman mi `tasarim-kurator`'a delegate eder yoksa kosullu mu

## Concrete next steps

1. Acik sorulari kapat (yarim gun)
2. `badi-skills` repo'sunu yarat (LICENSE + CI + manifestler)
3. `feature/v1.14.0-skill-bundle` branch — schema → bundler → publish flag → 25 skill enrichment
4. `feature/v1.14.0-badi-discipline` branch — discipline skill + references
5. v1.14.0 ship
6. `feature/v1.14.1-tasarim` branch

## Test plan
- [x] Markdown link yapisi gozden gecirildi (issue/PR linkleri dogru)
- [x] Cross-issue tutarlilik: #56 ve #57 issue body'leri ile kararlar uyumlu
- [x] v1.15+ asamasi olarak listelenenler issue body'lerindeki "Faz 3" notlariyla esleseyor
