### PR TITLE
fix(v1.13.2): 7 review findings from v1.13.1 hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantik Versioning](https://semver.org/).
 
+## [1.13.2] - 2026-04-25
+
+Code-review follow-up to v1.13.1. Seven findings from the post-merge review
+addressed in a single hotfix.
+
+### Fixed
+- **Yerel-saat "bugun" hesabi.** `badi icerik durum` ve `badi icerik kapat`
+  bugun sayisini `mtime.toISOString()` (UTC) ile yerel `getDateString()`
+  arasinda kiyasliyordu. UTC siniri yerel sinirla farkliysa (ornek: UTC+3
+  saat 01:00) "bugun" yanlis sayilirdi. Artik yerel `startOfToday` ile
+  karsilastirma yapiliyor.
+- **`runTemplate` switch** olası tip drift'ine karsi `default: throw` ile
+  korundu. `TEMPLATE_TYPES` listesi switch ile esitsiz olursa erken patliyor
+  (uretilen dosya bos icerikle yazilmiyor).
+- **`badi icerik` bilinmeyen subcommand mesaji** sadece template-tiplerini
+  degil, oturum komutlarini (`list`, `basla`, `durum`, ...) da gosteriyor.
+
+### Refactored
+- `lib/commands/icerik.js` shim'i kaldirildi; `bin/badi.js` artik
+  `lib/commands/icerik/index.js`'i dogrudan import ediyor (gereksiz
+  indirection silindi).
+- `lib/commands/agent.js` `subInstall` yorumu shell-watcher onayinin
+  *neden* gerekli oldugunu anlatiyor.
+
+### Tests
+- 307/307 yesil — davranis korundu.
+
 ## [1.13.1] - 2026-04-25
 
 ### Fixed — `badi agent`
@@ -18,12 +45,13 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 ### Refactored
 - `lib/commands/icerik.js` was a single 1,667-line if-chain over 13
   subcommands. Split into per-subcommand modules under `lib/commands/icerik/`
-  (issue #41). `icerik.js` is now a one-line re-export so import paths stay
-  stable. No behavior change.
+  (issue #41). `icerik.js` was a one-line re-export shim — kept for
+  backwards compatibility with imports, removed in 1.13.2.
 
 ### Tests
 - 304 → 307 (+3): `--yes` flag visible in help, clean errors for missing
-  watchers in `install` and `tail`.
+  watchers in `install` and `tail`. The +3 came entirely from the `agent.js`
+  polish; the icerik refactor itself was test-equivalent.
 
 ## [1.13.0] - 2026-04-24
 

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -4,6 +4,55 @@
 
 Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [Semantik Versiyonlama](https://semver.org/lang/tr/) standardini takip eder.
 
+## [1.13.2] - 2026-04-25
+
+v1.13.1 sonrasi kod incelemesinden cikan 7 bulguyu tek hotfix'te kapatir.
+
+### Duzeltildi
+- **Yerel-saat "bugun" hesabi.** `badi icerik durum` ve `badi icerik kapat`
+  bugun sayisini `mtime.toISOString()` (UTC) ile yerel `getDateString()`
+  arasinda kiyasliyordu. UTC siniri yerel sinirla farkliysa (ornek: UTC+3
+  saat 01:00) "bugun" yanlis sayilirdi. Artik yerel `startOfToday`
+  karsilastirmasi.
+- **`runTemplate` switch** olası tip drift'ine karsi `default: throw` ile
+  korundu. `TEMPLATE_TYPES` listesi switch ile esitsiz olursa erken
+  patliyor (uretilen dosya bos icerikle yazilmiyor).
+- **`badi icerik` bilinmeyen subcommand mesaji** sadece template-tiplerini
+  degil, oturum komutlarini (`list`, `basla`, `durum`, ...) da gosteriyor.
+  Toplam 21 gecerli komut listeleniyor.
+
+### Yeniden Duzenlendi
+- `lib/commands/icerik.js` shim'i kaldirildi; `bin/badi.js` artik
+  `lib/commands/icerik/index.js`'i dogrudan import ediyor (gereksiz
+  indirection silindi).
+- `lib/commands/agent.js` `subInstall` yorumu shell-watcher onayinin
+  *neden* gerekli oldugunu anlatiyor.
+
+### Testler
+- 307/307 yesil — davranis korundu.
+
+## [1.13.1] - 2026-04-25
+
+### Duzeltildi — `badi agent`
+- **`agent install` onay prompt'u sahteydi.** Watcher'da `shell` kontrolu
+  varsa, install "kayit edilsin mi?" yaziyor ama hicbir input beklemiyordu.
+  Sonra her halukarda install ediyordu. Artik gercekten `y/N` bekliyor.
+  Scripted kullanim icin `--yes` / `-y` bayragi.
+- **`agent install <yok>` ve `agent tail <yok>` ham `WatcherError` stack
+  trace firlatiyordu.** Ikisi de artik temiz `Watcher yok: <yol>` veriyor
+  ve `1` ile cikiyor.
+
+### Yeniden Duzenlendi
+- `lib/commands/icerik.js` 1667 satirlik tek if-chain idi (13 alt komut).
+  `lib/commands/icerik/` altinda alt-komut basina modullere bolundu
+  (issue #41). `icerik.js` 1-satirlik re-export shim oldu — geriye
+  uyumluluk icin tutuldu, v1.13.2'de tamamen kaldirildi.
+
+### Testler
+- 304 → 307 (+3): yardim ciktisinda `--yes`, install/tail icin eksik
+  watcher temiz hata. +3 sayisi tamamen `agent.js` cilasindan; icerik
+  refactor'u test-degisikligi getirmedi.
+
 ## [1.13.0] - 2026-04-24
 
 ### Eklenen — Arka Plan Agent'lar (issue #55)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Claude is the canonical source. Cursor and Gemini adapters compile from the same
 | **21 expert agents + 77 commands** | Full toolkit from security scanner to performance profiler |
 | **12 automation hooks + 25 skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants |
 | **Multi-harness support (v1.12+)** | Claude Code, Cursor, Gemini CLI — same `.claude/` source, different targets |
-| **304 passing tests** | 38 watcher/scheduler + 44 harness adapter + 222 CLI/integration |
+| **307 passing tests** | 41 watcher/scheduler + agent CLI + 44 harness adapter + 222 CLI/integration |
 | **TR/EN content engine** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
 | **Modular architecture** | 22 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
@@ -432,6 +432,8 @@ npm run format     # Biome formatting
 
 | Version | Summary |
 |---------|---------|
+| **v1.13.2** | 7-finding code-review hotfix: UTC-bias in `icerik durum/kapat` "today" counts (now uses local `startOfToday`); `runTemplate` switch hardened with `default: throw`; "unknown subcommand" error lists all 21 valid commands; `icerik.js` shim removed (direct import in `bin/badi.js`); doc/comment polish. 307 tests still green. |
+| **v1.13.1** | Hotfix on v1.13.0 review: `agent install` confirmation actually waits for y/N (was logging the prompt then proceeding) + `--yes`/`-y` flag for scripted use. Clean errors for missing watchers in `install` and `tail`. Includes the icerik split refactor (issue #41) — `lib/commands/icerik.js` (1667 lines) split into per-subcommand modules under `lib/commands/icerik/`. 304 → 307 tests. |
 | **v1.13.0** | Background agents — define `.claude/watchers/*.md` with git/shell/file/log/http checks, install to launchd/systemd/cron, alerts surface in next `/start` briefing. 8 new `badi agent` subcommands + 2 templates + 38 new tests (total 304). |
 | **v1.12.1** | Hotfix — 10 review findings fixed (`BADI_PREFS_HOME` env isolation, non-TTY safe init, Cursor content preface, case-insensitive `--harness`, validation, brittle test cleanup). 266 tests. |
 | **v1.12.0** | Multi-harness support — `badi init` now targets Claude Code, Cursor, or Gemini CLI. Interactive picker + `--harness` flag. New `lib/harnesses/` adapter layer. Update + doctor auto-detect installed harnesses. 44 new tests (total 251). |

--- a/README.tr.md
+++ b/README.tr.md
@@ -38,7 +38,7 @@ Claude kaynak (canonical). Cursor ve Gemini adapter'lari ayni `.claude/` dizinin
 | **21 Uzman Ajan ve 77 Komut** | Guvenlik tarayicidan performans profiler'a kadar genis arac seti |
 | **12 Otomatik Hook ve 25 Skill Kategorisi** | Branch koruma, yedekleme, OWASP Top 10 taramasi, 9 Frontend Taste varyanti |
 | **Multi-harness destegi (v1.12+)** | Claude Code, Cursor, Gemini CLI — ayni `.claude/` kaynagi, farkli hedefler |
-| **304 Onaylanmis Test** | 38 watcher/scheduler + 44 harness adapter + 222 CLI/entegrasyon |
+| **307 Onaylanmis Test** | 41 watcher/scheduler + agent CLI + 44 harness adapter + 222 CLI/entegrasyon |
 | **TR/EN Icerik Motoru** | Sablon mirasi ile post, thread, bulten, podcast, case-study uretimi |
 | **WordPress + SEO + ASO + Mobile Modulleri** | WP-CLI/REST, 20+ SEO kontrolu, App Store + Play Store, crash/deeplink/OTA iskelesi |
 | **Modular Mimari** | 22 komut modulu, `lib/harnesses/` adapter katmani, ~6MB `.claude/` agaci |
@@ -410,6 +410,8 @@ npm run format     # Biome ile formatlama
 
 | Surum | Icerik |
 |-------|--------|
+| **v1.13.2** | 7-bulgu code-review hotfix: `icerik durum/kapat` "bugun" sayim'inda UTC-bias duzeltildi (yerel `startOfToday`); `runTemplate` switch'i `default: throw` ile saglamlastirildi; "bilinmeyen subcommand" hatasi 21 gecerli komutu listeliyor; `icerik.js` shim'i kaldirildi (direkt import); doc/yorum cilasi. 307 test yesil. |
+| **v1.13.1** | v1.13.0 review hotfix: `agent install` onay prompt'u artik gercekten y/N bekliyor (eskiden mesaji yazip yine de install ediyordu) + `--yes`/`-y` bayragi script kullanim icin. Bilinmeyen watcher icin temiz hata mesajlari. icerik split refactor'u (issue #41) — `lib/commands/icerik.js` (1667 satir) `lib/commands/icerik/` altinda alt-komut modullerine bolundu. 304 → 307 test. |
 | **v1.13.0** | Arka plan agent'lari — `.claude/watchers/*.md` YAML frontmatter ile git/shell/file/log/http kontrolleri tanimla, launchd/systemd/cron'a kayit et, bir sonraki `/start` brifing'inde uyarilar otomatik gorunur. 8 yeni `badi agent` alt komutu + 2 template + 38 yeni test (toplam 304). |
 | **v1.12.1** | Hotfix — 10 review bulgusu kapandi (`BADI_PREFS_HOME` env izolasyonu, non-TTY guvenli init, Cursor icerik preface, case-insensitive `--harness`, validation, kirilgan test temizligi). 266 test. |
 | **v1.12.0** | Multi-harness destegi — `badi init` artik Claude Code, Cursor veya Gemini CLI hedefliyor. Interaktif menu + `--harness` bayragi. Yeni `lib/harnesses/` adapter katmani. Update + doctor kurulu harness'lari otomatik tespit ediyor. 44 yeni test (toplam 251). |

--- a/bin/badi.js
+++ b/bin/badi.js
@@ -232,7 +232,8 @@ const commands = {
 	doctor: () => import("../lib/commands/doctor.js").then((m) => m.runDoctor),
 	list: () => import("../lib/commands/list.js").then((m) => m.runList),
 	plugin: () => import("../lib/commands/plugin.js").then((m) => m.runPlugin),
-	icerik: () => import("../lib/commands/icerik.js").then((m) => m.runIcerik),
+	icerik: () =>
+		import("../lib/commands/icerik/index.js").then((m) => m.runIcerik),
 	stats: () => import("../lib/commands/stats.js").then((m) => m.runStats),
 	completion: () =>
 		import("../lib/commands/completion.js").then((m) => m.runCompletion),

--- a/docs/v1.14-plan.md
+++ b/docs/v1.14-plan.md
@@ -23,7 +23,8 @@ The three issues fall into two storylines:
 **Skill ecosystem (v1.14.0).** #56 builds the infrastructure — a separate
 `badi-skills` repository, frontmatter schema, bundler, and router skill — that
 makes Badi's 25 skill categories installable on Cursor / Codex / Windsurf /
-the wider agentskills.io world. #57 is the flagship payload: it packages
+the wider agentskills.io world (the standard backing the [skills.sh](https://skills.sh)
+registry). #57 is the flagship payload: it packages
 Badi's behavioral discipline (the `yak-shave-detector` / `unsticker` /
 `auditor` / `CLAUDE.md` philosophy) into a single portable skill that proves
 the bundle works and gives the new repo a strong opening exhibit. Shipping

--- a/lib/commands/agent.js
+++ b/lib/commands/agent.js
@@ -219,7 +219,8 @@ async function subInstall(args, cwd) {
 	const w = loadWatcher(file);
 	const intervalSeconds = parseEvery(w.every) || 900;
 
-	// Onay iste: shell watcher varsa
+	// shell watcher = arbitrary command in user's crontab/launchd/systemd —
+	// require explicit consent (TTY: y/N prompt; scripts: --yes)
 	const hasShell = w.watches.some((c) => c.type === "shell");
 	if (hasShell && !dryRun && !yesFlag && process.stdin.isTTY) {
 		const answer = await ask(

--- a/lib/commands/icerik.js
+++ b/lib/commands/icerik.js
@@ -1,1 +1,0 @@
-export { runIcerik } from "./icerik/index.js";

--- a/lib/commands/icerik/durum.js
+++ b/lib/commands/icerik/durum.js
@@ -23,10 +23,14 @@ export function runDurum() {
 
 	const subdirs = ["icerikler", "senaryolar", "gorseller", "takvim"];
 	const now = new Date();
-	const today = getDateString();
 	const startOfWeek = new Date(now);
 	startOfWeek.setDate(now.getDate() - now.getDay());
 	const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+	const startOfToday = new Date(
+		now.getFullYear(),
+		now.getMonth(),
+		now.getDate(),
+	);
 
 	const envanter = { total: 0, bugun: 0, buHafta: 0, buAy: 0, eski: 0 };
 	const tamamlanmislik = { tamamlanan: 0, kismi: 0, taslak: 0 };
@@ -43,7 +47,7 @@ export function runDurum() {
 			envanter.total++;
 
 			const mtime = stat.mtime;
-			if (mtime.toISOString().startsWith(today)) envanter.bugun++;
+			if (mtime >= startOfToday) envanter.bugun++;
 			if (mtime >= startOfWeek) envanter.buHafta++;
 			if (mtime >= startOfMonth) envanter.buAy++;
 

--- a/lib/commands/icerik/index.js
+++ b/lib/commands/icerik/index.js
@@ -13,6 +13,20 @@ import { runReleaseNotes } from "./release-notes.js";
 import { runSablon } from "./sablon.js";
 import { runTemplate, TEMPLATE_TYPES } from "./template.js";
 
+const SESSION_SUBCOMMANDS = [
+	"list",
+	"basla",
+	"durum",
+	"fikir",
+	"plan",
+	"kapat",
+	"ac",
+	"perf",
+	"ara",
+	"sablon",
+	"release-notes",
+];
+
 export async function runIcerik(args) {
 	const subcommand = args[0];
 
@@ -38,7 +52,9 @@ export async function runIcerik(args) {
 	}
 
 	console.error(chalk.red(`Bilinmeyen icerik turu: ${subcommand}`));
-	console.log(`Gecerli turler: ${TEMPLATE_TYPES.join(", ")}, ara, sablon`);
+	console.log(
+		`Gecerli komutlar: ${[...SESSION_SUBCOMMANDS, ...TEMPLATE_TYPES].join(", ")}`,
+	);
 	console.log("Yardim: badi icerik --help");
 	process.exit(1);
 }

--- a/lib/commands/icerik/kapat.js
+++ b/lib/commands/icerik/kapat.js
@@ -15,7 +15,12 @@ export function runKapat() {
 	console.log(chalk.dim(getDateString()));
 	console.log("");
 
-	const today = getDateString();
+	const now = new Date();
+	const startOfToday = new Date(
+		now.getFullYear(),
+		now.getMonth(),
+		now.getDate(),
+	);
 	const subdirs = [
 		{ dir: "icerikler", label: "Post/Karousel", icon: "P" },
 		{ dir: "senaryolar", label: "Video", icon: "V" },
@@ -31,8 +36,7 @@ export function runKapat() {
 		for (const f of files) {
 			const fullPath = join(dirPath, f);
 			const stat = statSync(fullPath);
-			const mtimeDate = stat.mtime.toISOString().split("T")[0];
-			if (mtimeDate === today) {
+			if (stat.mtime >= startOfToday) {
 				const content = readFileSync(fullPath, "utf-8");
 				const placeholders = content.match(/\[[^\]\n]{2,50}\]/g) || [];
 				const durum =

--- a/lib/commands/icerik/template.js
+++ b/lib/commands/icerik/template.js
@@ -153,6 +153,11 @@ export async function runTemplate(args) {
 				fileName = `${dateStr}-casestudy-${konuSlug}${langSuffix}.md`;
 				content = tmplSet.caseStudy(konu);
 				break;
+			default:
+				throw new Error(
+					`runTemplate: Unhandled template type: ${subcommand}. ` +
+						`TEMPLATE_TYPES diverj etti — switch ile esitle.`,
+				);
 		}
 
 		if (sablonFlag) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fatihkan/badi",
-	"version": "1.13.1",
+	"version": "1.13.2",
 	"description": "Claude Code kullanicilari icin profesyonel is akisi yonetim sistemi",
 	"type": "module",
 	"main": "bin/badi.js",


### PR DESCRIPTION
## Summary

Post-merge code review of v1.13.1 (PR #59 + #60) ortaya 7 bulgu cikardi (3 Orta, 4 Dusuk). Hepsi tek hotfix'te kapatildi. Davranis korundu, tests 307/307.

## Bulgular ve cozumleri

### Orta

| # | Bulgu | Cozum |
|---|-------|-------|
| M1 | `lib/commands/icerik.js` 1 satirlik shim — gereksiz indirection | shim silindi, `bin/badi.js` direkt `./icerik/index.js` import ediyor |
| M2 | `runTemplate` switch'te default branch yok — `TEMPLATE_TYPES` drift olursa undefined content yazardi | `default: throw` eklendi, drift'i derlenme oncesi yakalar |
| M3 | "Bilinmeyen icerik turu" mesajinda `ara, sablon` hard-coded suffix; `list/basla/durum/...` mesajinda yoktu | `SESSION_SUBCOMMANDS` sabitiyle birlestirildi, tum 21 komut listeleniyor |

### Dusuk

| # | Bulgu | Cozum |
|---|-------|-------|
| L1 | `durum.js` + `kapat.js` "bugun" sayim'i UTC-bias'li (`mtime.toISOString().startsWith(today)` yerel saatle uyumsuz) | Yerel `startOfToday` Date'i ile karsilastiriliyor — pre-existing bug refactor sirasinda tasimisti |
| L2 | `agent.js subInstall` yorumu yeni davranisi yansitmiyordu | Yorum yeniden yazildi: "shell watcher = arbitrary command, explicit consent required" |
| L3 | CHANGELOG "+3 test" attribution belirsizdi | "+3 came entirely from agent.js polish; icerik refactor test-equivalent" notu eklendi |
| L4 | Plan doc disardaki kayit servislerine atif vardi | Notr ifadeyle dengelendi (registry referansi) |

## Degisecek dosyalar

| Dosya | Diff |
|-------|------|
| `bin/badi.js` | shim yerine direkt `icerik/index.js` import |
| `lib/commands/icerik.js` | **silindi** (1 satirlik shim) |
| `lib/commands/icerik/index.js` | SESSION_SUBCOMMANDS sabit + birlesik hata mesaji |
| `lib/commands/icerik/template.js` | switch `default: throw` |
| `lib/commands/icerik/durum.js` | yerel `startOfToday` |
| `lib/commands/icerik/kapat.js` | yerel `startOfToday` |
| `lib/commands/agent.js` | yorum netlesti |
| `CHANGELOG.md` | v1.13.2 + v1.13.1 attribution duzeltmesi |
| `docs/v1.14-plan.md` | registry referansi |
| `package.json` | 1.13.1 → 1.13.2 |

## Test plan

- [x] `npm test` — 307/307 yesil (davranis degismedi)
- [x] `npm run lint` — touched dosyalarda yeni hata yok
- [x] CLI smoke: `node bin/badi.js icerik bilinmeyen` artik 21 komutu listeliyor
- [x] CLI smoke: `node bin/badi.js icerik post "smoke"` calisiyor (icerik.js shim'i olmadan)
