### PR TITLE
feat(v1.14): lib/skills/schema.js — frontmatter validator (issue #56 step 1)

### DIFF
--- a/lib/skills/schema.js
+++ b/lib/skills/schema.js
@@ -1,0 +1,317 @@
+// Skill frontmatter schema — agentskills.io standardi (issue #56) + Badi
+// gereksinimleri.
+//
+// Mevcut .claude/skills/<name>/SKILL.md dosyalarini bu modul dogrular ve
+// badi-skills repo'suna bundle edilirken eksik alanlar uyari uretir.
+//
+// Calisma kipleri:
+// - default ("warn"): eksik alanlar warning, ana akis devam
+// - "strict": her warning error'a yukselir, validate yesil donmez
+//
+// Hata mesajlari English — agentskills.io ekosisteminde uluslarararasi
+// kullaniciya hitap eder. Badi CLI cikti dili Turkce ama schema mesajlari
+// (validate ciktisi) standart sekilde okumak icin English.
+
+import { parseFrontmatter } from "../icerik-helpers.js";
+
+export const KNOWN_TOOLS = [
+	"Read",
+	"Write",
+	"Edit",
+	"Bash",
+	"Grep",
+	"Glob",
+	"Agent",
+	"WebFetch",
+	"WebSearch",
+];
+
+export const REQUIRED_TOP_FIELDS = [
+	"name",
+	"description",
+	"license",
+	"compatibility",
+	"allowed-tools",
+];
+
+export const REQUIRED_METADATA_FIELDS = [
+	"author",
+	"homepage",
+	"badi-version",
+	"category",
+];
+
+export const KNOWN_CATEGORIES = [
+	"design",
+	"security",
+	"content",
+	"devops",
+	"testing",
+	"data-analytics",
+	"ai-automation",
+	"behavioral",
+	"finance",
+	"sales",
+	"marketing",
+	"customer-success",
+	"product",
+	"productivity",
+	"consulting",
+	"startup",
+	"ecommerce",
+	"email",
+	"frontend",
+	"mobile",
+	"seo",
+	"social-media",
+	"development",
+];
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{1,63}$/;
+const URL_RE = /^https?:\/\/[^\s]+$/;
+const BADI_VERSION_RE = /^[><=^~]*\s*\d+\.\d+\.\d+/;
+const MIN_DESCRIPTION_LEN = 50;
+
+function isObject(v) {
+	return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+/**
+ * Parse SKILL.md icerigini frontmatter + body olarak ayir. parseFrontmatter
+ * (icerik-helpers'taki) frontmatter'i basit bir flat-object olarak donduyor.
+ * Schema icin nested metadata bekledigimiz icin frontmatter'i ham YAML
+ * stringi olarak da almak istiyoruz.
+ */
+export function parseSkillFile(content) {
+	const fm = parseFrontmatter(content);
+	if (!fm.meta || Object.keys(fm.meta).length === 0) {
+		return { meta: null, body: content, raw: "" };
+	}
+	// parseFrontmatter raw'i da dondursun istiyorduk; helper sadece flat
+	// dondurmuyor — meta + body alani var, raw'i ayrica cikaralim.
+	const m = content.match(/^---\n([\s\S]*?)\n---\n?/);
+	const raw = m ? m[1] : "";
+	return { meta: fm.meta, body: fm.body, raw };
+}
+
+/**
+ * Daha zengin bir frontmatter parser — nested metadata icin. icerik-helpers'in
+ * parseFrontmatter'i flat key-value cikariyor (security-check'in `metadata:`
+ * blok yapisini parse edemiyor). Bu fonksiyon block-style YAML'in subset'ini
+ * tanir: 1 seviye nested object + scalar/string/list values.
+ */
+export function parseRichFrontmatter(content) {
+	const m = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+	if (!m) return { meta: null, body: content };
+	const yaml = m[1];
+	const body = m[2] || "";
+
+	const result = {};
+	const lines = yaml.split("\n");
+	let i = 0;
+	while (i < lines.length) {
+		const line = lines[i];
+		if (!line.trim() || line.trim().startsWith("#")) {
+			i++;
+			continue;
+		}
+
+		const topMatch = line.match(/^([a-zA-Z][\w-]*):\s*(.*)$/);
+		if (!topMatch) {
+			i++;
+			continue;
+		}
+		const key = topMatch[1];
+		const inline = topMatch[2];
+
+		// Block-scalar marker (e.g. "description: >")
+		if (inline === ">" || inline === "|") {
+			let acc = "";
+			i++;
+			while (i < lines.length && /^\s+/.test(lines[i])) {
+				acc += `${lines[i].trim()} `;
+				i++;
+			}
+			result[key] = acc.trim();
+			continue;
+		}
+
+		// Inline value
+		if (inline) {
+			result[key] = parseScalar(inline);
+			i++;
+			continue;
+		}
+
+		// Nested block — collect indented lines
+		const child = {};
+		i++;
+		while (i < lines.length) {
+			const childLine = lines[i];
+			if (!childLine.startsWith("  ") && childLine.trim() !== "") break;
+			if (!childLine.trim()) {
+				i++;
+				continue;
+			}
+			const cm = childLine.match(/^\s+([a-zA-Z][\w-]*):\s*(.*)$/);
+			if (cm) {
+				const k = cm[1];
+				const v = cm[2];
+				if (v.startsWith("- ") || v === "") {
+					// Inline list start or list-only — collect items
+					const items = [];
+					if (v.startsWith("- ")) items.push(parseScalar(v.slice(2)));
+					i++;
+					while (i < lines.length) {
+						const itm = lines[i].match(/^\s+-\s+(.*)$/);
+						if (!itm) break;
+						items.push(parseScalar(itm[1]));
+						i++;
+					}
+					child[k] = items;
+					continue;
+				}
+				child[k] = parseScalar(v);
+				i++;
+				continue;
+			}
+			i++;
+		}
+		result[key] = child;
+	}
+
+	return { meta: result, body };
+}
+
+function parseScalar(v) {
+	const s = v.trim();
+	if (s === "true") return true;
+	if (s === "false") return false;
+	if (s === "null" || s === "") return null;
+	if (/^-?\d+$/.test(s)) return Number.parseInt(s, 10);
+	if (/^-?\d+\.\d+$/.test(s)) return Number.parseFloat(s);
+	if (
+		(s.startsWith('"') && s.endsWith('"')) ||
+		(s.startsWith("'") && s.endsWith("'"))
+	) {
+		return s.slice(1, -1);
+	}
+	return s;
+}
+
+/**
+ * Bir SKILL.md frontmatter'ini schema'ya gore dogrula.
+ *
+ * @param {object} meta — parseRichFrontmatter sonucu
+ * @param {object} opts — { strict: bool, expectedName?: string }
+ * @returns {{ok: boolean, errors: string[], warnings: string[]}}
+ */
+export function validateSkill(meta, opts = {}) {
+	const errors = [];
+	const warnings = [];
+
+	if (!isObject(meta)) {
+		errors.push("Frontmatter parse edilemedi (--- ile sarmalanmis YAML bekliyor).");
+		return finalize(errors, warnings, opts);
+	}
+
+	for (const f of REQUIRED_TOP_FIELDS) {
+		if (meta[f] === undefined || meta[f] === null || meta[f] === "") {
+			errors.push(`Required field missing: ${f}`);
+		}
+	}
+
+	if (typeof meta.name === "string" && !SLUG_RE.test(meta.name)) {
+		errors.push(
+			`name must match ${SLUG_RE} (lowercase alphanumeric + dash, 2-64 chars). Got: ${meta.name}`,
+		);
+	}
+
+	if (
+		opts.expectedName &&
+		typeof meta.name === "string" &&
+		meta.name !== opts.expectedName
+	) {
+		warnings.push(
+			`name "${meta.name}" does not match directory "${opts.expectedName}".`,
+		);
+	}
+
+	if (typeof meta.description === "string") {
+		if (meta.description.length < MIN_DESCRIPTION_LEN) {
+			warnings.push(
+				`description is ${meta.description.length} chars; >=${MIN_DESCRIPTION_LEN} recommended for trigger activation.`,
+			);
+		}
+	}
+
+	if (typeof meta["allowed-tools"] === "string") {
+		const tools = meta["allowed-tools"].split(/\s+/).filter(Boolean);
+		const unknown = tools.filter((t) => !KNOWN_TOOLS.includes(t));
+		if (unknown.length > 0) {
+			warnings.push(
+				`allowed-tools contains unknown tool(s): ${unknown.join(", ")}. Known: ${KNOWN_TOOLS.join(", ")}`,
+			);
+		}
+		if (tools.length === 0) {
+			errors.push("allowed-tools is empty (must list at least one tool).");
+		}
+	}
+
+	if (!isObject(meta.metadata)) {
+		errors.push("metadata block required (object with author/homepage/badi-version/category).");
+	} else {
+		for (const f of REQUIRED_METADATA_FIELDS) {
+			if (
+				meta.metadata[f] === undefined ||
+				meta.metadata[f] === null ||
+				meta.metadata[f] === ""
+			) {
+				errors.push(`Required field missing: metadata.${f}`);
+			}
+		}
+		if (
+			typeof meta.metadata.homepage === "string" &&
+			!URL_RE.test(meta.metadata.homepage)
+		) {
+			errors.push(
+				`metadata.homepage must be an http(s) URL. Got: ${meta.metadata.homepage}`,
+			);
+		}
+		if (
+			typeof meta.metadata["badi-version"] === "string" &&
+			!BADI_VERSION_RE.test(meta.metadata["badi-version"])
+		) {
+			warnings.push(
+				`metadata.badi-version "${meta.metadata["badi-version"]}" does not look like a semver constraint (e.g. ">=1.14.0").`,
+			);
+		}
+		if (
+			typeof meta.metadata.category === "string" &&
+			!KNOWN_CATEGORIES.includes(meta.metadata.category)
+		) {
+			warnings.push(
+				`metadata.category "${meta.metadata.category}" is not in the known list. Known: ${KNOWN_CATEGORIES.join(", ")}`,
+			);
+		}
+	}
+
+	return finalize(errors, warnings, opts);
+}
+
+function finalize(errors, warnings, opts) {
+	if (opts.strict) {
+		// Strict mode: warnings -> errors
+		const all = [...errors, ...warnings];
+		return { ok: all.length === 0, errors: all, warnings: [] };
+	}
+	return { ok: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Dosya icerigini parse + validate sarici.
+ */
+export function validateSkillFile(content, opts = {}) {
+	const { meta } = parseRichFrontmatter(content);
+	return validateSkill(meta, opts);
+}

--- a/tests/skill-schema.test.js
+++ b/tests/skill-schema.test.js
@@ -1,0 +1,273 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	KNOWN_CATEGORIES,
+	KNOWN_TOOLS,
+	parseRichFrontmatter,
+	validateSkill,
+	validateSkillFile,
+} from "../lib/skills/schema.js";
+
+const validMeta = () => ({
+	name: "frontend-taste",
+	description:
+		"Premium frontend design skills. Triggers on UI tasarla, design a UI, premium landing page, anti-slop, dashboard redesign, calibrated palette.",
+	license: "MIT",
+	compatibility: "Node.js 18+, Claude Code or skills CLI compatible agent.",
+	"allowed-tools": "Read Write Edit Bash Grep",
+	metadata: {
+		author: "fatihkan",
+		homepage: "https://github.com/fatihkan/badi-skills/tree/main/skills/frontend-taste",
+		"badi-version": ">=1.14.0",
+		category: "design",
+	},
+});
+
+describe("schema: parseRichFrontmatter", () => {
+	it("flat scalars", () => {
+		const c = "---\nname: foo\nlicense: MIT\n---\n\n# Body";
+		const { meta, body } = parseRichFrontmatter(c);
+		assert.equal(meta.name, "foo");
+		assert.equal(meta.license, "MIT");
+		assert.match(body, /Body/);
+	});
+
+	it("nested metadata block", () => {
+		const c = `---
+name: foo
+metadata:
+  author: fatihkan
+  category: design
+---
+
+body`;
+		const { meta } = parseRichFrontmatter(c);
+		assert.equal(meta.metadata.author, "fatihkan");
+		assert.equal(meta.metadata.category, "design");
+	});
+
+	it("block-scalar (>) joins folded text", () => {
+		const c = `---
+name: foo
+description: >
+  Multi-line
+  description text
+license: MIT
+---
+`;
+		const { meta } = parseRichFrontmatter(c);
+		assert.match(meta.description, /Multi-line description text/);
+		assert.equal(meta.license, "MIT");
+	});
+
+	it("returns null meta when no frontmatter", () => {
+		const c = "# No frontmatter\n\nbody";
+		const { meta } = parseRichFrontmatter(c);
+		assert.equal(meta, null);
+	});
+});
+
+describe("schema: validateSkill — happy path", () => {
+	it("complete valid frontmatter passes", () => {
+		const r = validateSkill(validMeta());
+		assert.equal(r.ok, true);
+		assert.equal(r.errors.length, 0);
+		assert.equal(r.warnings.length, 0);
+	});
+});
+
+describe("schema: validateSkill — required fields", () => {
+	for (const field of ["name", "description", "license", "compatibility", "allowed-tools"]) {
+		it(`missing ${field} fails`, () => {
+			const m = validMeta();
+			delete m[field];
+			const r = validateSkill(m);
+			assert.equal(r.ok, false);
+			assert.match(r.errors.join("\n"), new RegExp(`Required field missing: ${field}`));
+		});
+	}
+
+	for (const field of ["author", "homepage", "badi-version", "category"]) {
+		it(`missing metadata.${field} fails`, () => {
+			const m = validMeta();
+			delete m.metadata[field];
+			const r = validateSkill(m);
+			assert.equal(r.ok, false);
+			assert.match(r.errors.join("\n"), new RegExp(`Required field missing: metadata.${field}`));
+		});
+	}
+
+	it("missing metadata block fails", () => {
+		const m = validMeta();
+		m.metadata = undefined;
+		const r = validateSkill(m);
+		assert.equal(r.ok, false);
+		assert.match(r.errors.join("\n"), /metadata block required/);
+	});
+});
+
+describe("schema: validateSkill — name slug", () => {
+	it("rejects uppercase", () => {
+		const m = validMeta();
+		m.name = "FrontendTaste";
+		const r = validateSkill(m);
+		assert.equal(r.ok, false);
+		assert.match(r.errors.join("\n"), /name must match/);
+	});
+
+	it("rejects underscore", () => {
+		const m = validMeta();
+		m.name = "front_end";
+		const r = validateSkill(m);
+		assert.equal(r.ok, false);
+	});
+
+	it("rejects single-char name", () => {
+		const m = validMeta();
+		m.name = "a";
+		const r = validateSkill(m);
+		assert.equal(r.ok, false);
+	});
+
+	it("warns when name mismatches expectedName", () => {
+		const m = validMeta();
+		const r = validateSkill(m, { expectedName: "different-dir" });
+		assert.equal(r.ok, true); // warning, not error
+		assert.match(r.warnings.join("\n"), /does not match directory/);
+	});
+});
+
+describe("schema: validateSkill — description length", () => {
+	it("warns when description < 50 chars", () => {
+		const m = validMeta();
+		m.description = "Short.";
+		const r = validateSkill(m);
+		assert.equal(r.ok, true);
+		assert.match(r.warnings.join("\n"), /trigger activation/);
+	});
+
+	it("ok at exactly 50 chars", () => {
+		const m = validMeta();
+		m.description = "x".repeat(50);
+		const r = validateSkill(m);
+		assert.equal(r.ok, true);
+		assert.equal(r.warnings.length, 0);
+	});
+});
+
+describe("schema: validateSkill — allowed-tools", () => {
+	it("warns on unknown tool", () => {
+		const m = validMeta();
+		m["allowed-tools"] = "Read Write Banana";
+		const r = validateSkill(m);
+		assert.equal(r.ok, true);
+		assert.match(r.warnings.join("\n"), /Banana/);
+	});
+
+	it("errors on empty allowed-tools list", () => {
+		const m = validMeta();
+		m["allowed-tools"] = "   ";
+		const r = validateSkill(m);
+		assert.equal(r.ok, false);
+	});
+
+	it("accepts all known tools", () => {
+		const m = validMeta();
+		m["allowed-tools"] = KNOWN_TOOLS.join(" ");
+		const r = validateSkill(m);
+		assert.equal(r.ok, true);
+		assert.equal(r.warnings.length, 0);
+	});
+});
+
+describe("schema: validateSkill — metadata fields", () => {
+	it("rejects non-URL homepage", () => {
+		const m = validMeta();
+		m.metadata.homepage = "not-a-url";
+		const r = validateSkill(m);
+		assert.equal(r.ok, false);
+		assert.match(r.errors.join("\n"), /http\(s\) URL/);
+	});
+
+	it("warns on non-semver badi-version", () => {
+		const m = validMeta();
+		m.metadata["badi-version"] = "latest";
+		const r = validateSkill(m);
+		assert.equal(r.ok, true);
+		assert.match(r.warnings.join("\n"), /semver constraint/);
+	});
+
+	it("accepts >=, ^, ~ semver prefixes", () => {
+		for (const v of [">=1.14.0", "^1.14.0", "~1.14.0", "1.14.0"]) {
+			const m = validMeta();
+			m.metadata["badi-version"] = v;
+			const r = validateSkill(m);
+			assert.equal(r.ok, true, `should accept ${v}`);
+		}
+	});
+
+	it("warns on unknown category", () => {
+		const m = validMeta();
+		m.metadata.category = "made-up";
+		const r = validateSkill(m);
+		assert.equal(r.ok, true);
+		assert.match(r.warnings.join("\n"), /not in the known list/);
+	});
+
+	it("accepts all known categories", () => {
+		for (const c of KNOWN_CATEGORIES) {
+			const m = validMeta();
+			m.metadata.category = c;
+			const r = validateSkill(m);
+			assert.equal(r.ok, true, `should accept category ${c}`);
+		}
+	});
+});
+
+describe("schema: strict mode", () => {
+	it("promotes warnings to errors", () => {
+		const m = validMeta();
+		m.description = "Short.";
+		m.metadata.category = "made-up";
+
+		const lenient = validateSkill(m);
+		assert.equal(lenient.ok, true);
+		assert.equal(lenient.warnings.length, 2);
+
+		const strict = validateSkill(m, { strict: true });
+		assert.equal(strict.ok, false);
+		assert.equal(strict.warnings.length, 0);
+		assert.ok(strict.errors.length >= 2);
+	});
+});
+
+describe("schema: validateSkillFile end-to-end", () => {
+	it("parses + validates valid SKILL.md", () => {
+		const content = `---
+name: frontend-taste
+description: Premium frontend design skills. Triggers on UI tasarla, design a UI, premium landing page, dashboard redesign.
+license: MIT
+compatibility: Node.js 18+, Claude Code compatible.
+allowed-tools: Read Write Edit Bash Grep
+metadata:
+  author: fatihkan
+  homepage: https://github.com/fatihkan/badi-skills/tree/main/skills/frontend-taste
+  badi-version: ">=1.14.0"
+  category: design
+---
+
+# Frontend Taste
+
+Body content.
+`;
+		const r = validateSkillFile(content);
+		assert.equal(r.ok, true);
+	});
+
+	it("flags missing frontmatter", () => {
+		const content = "# No frontmatter\n\nbody only";
+		const r = validateSkillFile(content);
+		assert.equal(r.ok, false);
+		assert.match(r.errors.join("\n"), /parse edilemedi/);
+	});
+});


### PR DESCRIPTION
## Summary

v1.14.0 skill-bundle work'unun ilk parcasi. Schema, bir SKILL.md'nin badi-skills repo'suna bundle edilebilmesi ve disardaki uyumlu ajanlarda kurulabilmesi icin gereken alanlarin **kanonik kaynagi**.

## Schema (issue #56'dan)

**Top-level required:** `name`, `description`, `license`, `compatibility`, `allowed-tools`

**Metadata required:** `author`, `homepage`, `badi-version`, `category`

**Validation modleri:**
- **default ("warn")**: Eksik alanlar error, soft sorunlar (description<50ch, unknown allowed-tool, non-semver badi-version, unknown category) warning.
- **strict**: Warnings → errors. CI icin.

## API

```js
import { validateSkill, validateSkillFile, parseRichFrontmatter } from './lib/skills/schema.js';

// Direct meta validation
validateSkill(meta, { strict: false, expectedName: 'frontend-taste' });
// → { ok, errors, warnings }

// File content
validateSkillFile(content, { strict: true });
```

## Yeni: parseRichFrontmatter

icerik-helpers'in `parseFrontmatter`'i flat key-value cikariyor (security-check'in `metadata:` bloklarini parse edemiyor). Schema icin yeni bir parser yazildi: 1 seviye nested object + scalar/string/list values. Block-scalar (`>`, `|`) destegi var.

## Tests

32 yeni test, 9 suite:
- parseRichFrontmatter (4) — flat scalars, nested metadata, block-scalar, no-frontmatter
- happy path (1)
- required fields (10) — top + metadata
- slug pattern (4)
- description length (2)
- allowed-tools (3) — known, unknown, empty
- metadata fields (5) — homepage URL, badi-version semver, category
- strict mode (1)
- validateSkillFile e2e (2)

Total suite: **307 → 339 (+32)**. Mevcut CLI surface'ine davranis degisikligi yok.

## Sonraki adimlar (bu PR disinda)

| PR | Konu | Durum |
|---|---|---|
| **A** | Bu PR — schema | open |
| B | `lib/harnesses/skills-bundler.js` (.claude/skills → badi-skills/) | sonraki |
| C | `badi publish --skill-bundle` flag | sonraki |
| D | 25 skill frontmatter enrichment | sonraki |
| E | `badi-skills` bootstrap kit | sonraki |
| F | `badi-discipline` skill icerigi (#57) | sonraki |
| G | v1.14.0 ship | sonraki |

[Plan dokumani](https://github.com/fatihkan/badi/blob/main/docs/v1.14-plan.md) · [Issue #56](https://github.com/fatihkan/badi/issues/56)
