### PR TITLE
feat(v1.14): badi publish --skill-bundle flag (issue #56 step 3)

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -1,6 +1,11 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { chalk, showBanner } from "../cli.js";
+import {
+	bundleSkills,
+	generateRouterSkill,
+} from "../harnesses/skills-bundler.js";
 import { hasCommand, shCapture as sh } from "../helpers.js";
 
 // ─── Yardimcilar ───
@@ -42,11 +47,108 @@ function parseFlags(args) {
 		else if (a === "--skip-github") flags.skipGithub = true;
 		else if (a === "--skip-changelog") flags.skipChangelog = true;
 		else if (a === "--message" || a === "-m") flags.message = args[++i];
+		else if (a === "--skill-bundle") flags.skillBundle = true;
+		else if (a === "--target") flags.target = args[++i];
+		else if (a === "--source") flags.source = args[++i];
+		else if (a === "--strict") flags.strict = true;
 	}
 	if (!["patch", "minor", "major"].includes(flags.version)) {
 		throw new Error(`--version gecersiz: ${flags.version} (patch|minor|major)`);
 	}
 	return flags;
+}
+
+// ─── Skill-bundle akisi (issue #56) ───
+
+export async function runSkillBundle(flags) {
+	const source = flags.source || join(process.cwd(), ".claude", "skills");
+	const target = flags.target || join(process.cwd(), "badi-skills");
+	const dryRun = flags.dryRun || false;
+	const strict = flags.strict || false;
+
+	showBanner();
+	console.log(
+		chalk.bold(
+			`Badi Skill Bundle ${dryRun ? chalk.yellow("[DRY RUN]") : ""}${strict ? chalk.cyan(" [STRICT]") : ""}`,
+		),
+	);
+	console.log("");
+	console.log(`  Source: ${chalk.cyan(source)}`);
+	console.log(`  Target: ${chalk.cyan(target)}`);
+	console.log("");
+
+	if (!existsSync(source)) {
+		throw new Error(`Source dir does not exist: ${source}`);
+	}
+
+	const result = await bundleSkills({ source, target, dryRun, strict });
+
+	console.log(chalk.bold("Sonuc:"));
+	console.log(
+		`  ${chalk.green(`+ ${result.bundled.length} skill bundle edildi`)}`,
+	);
+	if (result.skipped.length > 0) {
+		console.log(
+			`  ${chalk.yellow(`! ${result.skipped.length} skill atlandi`)}`,
+		);
+	}
+
+	let totalEnriched = 0;
+	let totalWarnings = 0;
+	for (const b of result.bundled) {
+		totalEnriched += b.enriched.length;
+		totalWarnings += b.warnings.length;
+	}
+	if (totalEnriched > 0) {
+		console.log(
+			chalk.dim(
+				`  ${totalEnriched} alan otomatik dolduruldu (license, compatibility, allowed-tools, metadata.*)`,
+			),
+		);
+	}
+	if (totalWarnings > 0) {
+		console.log(
+			chalk.dim(`  ${totalWarnings} schema uyarisi (description<50ch, vb.)`),
+		);
+	}
+
+	if (result.skipped.length > 0) {
+		console.log("");
+		console.log(chalk.bold("Atlanan skill'ler:"));
+		for (const s of result.skipped) {
+			console.log(`  ${chalk.yellow("-")} ${s.name}: ${s.reason}`);
+			if (s.errors) {
+				for (const e of s.errors) {
+					console.log(chalk.dim(`      ${e}`));
+				}
+			}
+		}
+	}
+
+	// Generate router skill
+	if (!dryRun && result.bundled.length > 0) {
+		const routerContent = generateRouterSkill(result.bundled);
+		const routerDir = join(target, "skills", "badi");
+		const { mkdirSync } = await import("node:fs");
+		mkdirSync(routerDir, { recursive: true });
+		writeFileSync(join(routerDir, "SKILL.md"), routerContent);
+		console.log("");
+		console.log(chalk.green(`+ Router skill yazildi: ${join(routerDir, "SKILL.md")}`));
+	}
+
+	console.log("");
+	console.log(chalk.bold("Sonraki adimlar:"));
+	if (dryRun) {
+		console.log("  --dry-run modu — disk degisikligi yok");
+		console.log("  Gercek bundle icin: badi publish --skill-bundle");
+	} else {
+		console.log(`  1. ${chalk.cyan(`cd ${target}`)} — bundle ciktisini incele`);
+		console.log("  2. badi-skills repo'sundaysan: git diff, commit, tag, push");
+		console.log(
+			"  3. npm publish (ayri paket olarak yayinlanacaksa) veya GitHub release",
+		);
+	}
+	return result;
 }
 
 // ─── Ana orkestrator ───
@@ -74,6 +176,14 @@ export async function runPublish(args) {
 		console.log("  --skip-changelog     CHANGELOG kontrolunu atla");
 		console.log("  -m, --message <str>  Commit mesajinda extra not");
 		console.log("");
+		console.log(chalk.bold("Skill Bundle (issue #56, v1.14+):"));
+		console.log(
+			`  ${chalk.cyan("badi publish --skill-bundle")} [--target ./badi-skills] [--strict] [--dry-run]`,
+		);
+		console.log("    .claude/skills/ -> <target>/skills/ bundle eder.");
+		console.log("    Eksik frontmatter alanlarini otomatik doldurur.");
+		console.log("    Router skill (skills/badi/SKILL.md) uretir.");
+		console.log("");
 		console.log(chalk.bold("Adimlar (sirasiyla):"));
 		console.log("  1. Git temiz mi? (temizlik yoksa durur)");
 		console.log("  2. Branch main mi? (degilse uyari)");
@@ -89,6 +199,8 @@ export async function runPublish(args) {
 		console.log("  badi publish --dry-run");
 		console.log("  badi publish --version minor");
 		console.log("  badi publish --version patch --skip-github");
+		console.log("  badi publish --skill-bundle --dry-run");
+		console.log("  badi publish --skill-bundle --target ../badi-skills");
 		console.log("  badi publish check");
 		return;
 	}
@@ -98,6 +210,10 @@ export async function runPublish(args) {
 	}
 
 	const flags = parseFlags(args);
+
+	if (flags.skillBundle) {
+		return runSkillBundle(flags);
+	}
 
 	showBanner();
 	console.log(

--- a/lib/harnesses/skills-bundler.js
+++ b/lib/harnesses/skills-bundler.js
@@ -1,0 +1,291 @@
+// Skills bundler — `.claude/skills/<name>/` -> `<target>/skills/<name>/`
+//
+// Issue #56 step 2: ana repo'daki skill dosyalarini ayri `badi-skills` repo'su
+// (veya verilen target dizini) icin compile eder. Eksik frontmatter alanlarini
+// otomatik doldurur, references/ alt dizinini kopyalar, ve router skill
+// uretir.
+//
+// Auto-enrichment kurallari:
+// - license: "MIT"
+// - compatibility: standart agentskills.io uyumluluk metni
+// - allowed-tools: "Read Write Edit Bash Grep" (gunluk minimum)
+// - metadata.author: "fatihkan"
+// - metadata.homepage: badi-skills repo URL'i
+// - metadata.badi-version: ">=1.14.0"
+// - metadata.category: dizin adindan tahmin (KNOWN_CATEGORIES'te varsa)
+//
+// Bundler frontmatter'i UZERINE YAZMAZ — eksik alanlari doldurur. Mevcut
+// kullanici-degerli alan korunur.
+
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
+	KNOWN_CATEGORIES,
+	parseRichFrontmatter,
+	validateSkill,
+} from "../skills/schema.js";
+
+const DEFAULT_AUTHOR = "fatihkan";
+const DEFAULT_BADI_VERSION = ">=1.14.0";
+const DEFAULT_LICENSE = "MIT";
+const DEFAULT_ALLOWED_TOOLS = "Read Write Edit Bash Grep";
+const DEFAULT_COMPATIBILITY =
+	"Works with Claude Code, Cursor, or any agentskills.io-compatible agent.";
+const HOMEPAGE_BASE = "https://github.com/fatihkan/badi-skills/tree/main/skills";
+
+/**
+ * Skill dizinini al, eksik frontmatter alanlarini doldur, dogrula.
+ * @returns {{ok, meta, body, enriched: string[], errors, warnings}}
+ */
+export function enrichSkill(content, name, opts = {}) {
+	const enriched = [];
+	const parsed = parseRichFrontmatter(content);
+	const meta = parsed.meta ? structuredClone(parsed.meta) : {};
+	const body = parsed.body;
+
+	// Top-level fields
+	if (!meta.name) {
+		meta.name = name;
+		enriched.push("name");
+	}
+	if (!meta.description) {
+		// Try to derive from body's first non-heading paragraph
+		const firstPara = body
+			.split("\n")
+			.filter((l) => l && !l.startsWith("#") && !l.startsWith(">"))
+			.slice(0, 3)
+			.join(" ")
+			.replace(/\s+/g, " ")
+			.trim();
+		meta.description = firstPara
+			? `${firstPara.substring(0, 300)} (auto-generated; refine for better trigger activation)`
+			: `${name} skill — needs description.`;
+		enriched.push("description");
+	}
+	if (!meta.license) {
+		meta.license = DEFAULT_LICENSE;
+		enriched.push("license");
+	}
+	if (!meta.compatibility) {
+		meta.compatibility = DEFAULT_COMPATIBILITY;
+		enriched.push("compatibility");
+	}
+	if (!meta["allowed-tools"]) {
+		meta["allowed-tools"] = DEFAULT_ALLOWED_TOOLS;
+		enriched.push("allowed-tools");
+	}
+
+	// Metadata block
+	if (!meta.metadata || typeof meta.metadata !== "object") {
+		meta.metadata = {};
+	}
+	if (!meta.metadata.author) {
+		meta.metadata.author = DEFAULT_AUTHOR;
+		enriched.push("metadata.author");
+	}
+	if (!meta.metadata.homepage) {
+		meta.metadata.homepage = `${HOMEPAGE_BASE}/${name}`;
+		enriched.push("metadata.homepage");
+	}
+	if (!meta.metadata["badi-version"]) {
+		meta.metadata["badi-version"] = DEFAULT_BADI_VERSION;
+		enriched.push("metadata.badi-version");
+	}
+	if (!meta.metadata.category) {
+		// Heuristic: name itself OR substring match against KNOWN_CATEGORIES
+		meta.metadata.category = guessCategory(name) || "uncategorized";
+		enriched.push("metadata.category");
+	}
+
+	const validation = validateSkill(meta, {
+		strict: opts.strict,
+		expectedName: name,
+	});
+
+	return {
+		ok: validation.ok,
+		meta,
+		body,
+		enriched,
+		errors: validation.errors,
+		warnings: validation.warnings,
+	};
+}
+
+function guessCategory(name) {
+	const lower = name.toLowerCase();
+	if (KNOWN_CATEGORIES.includes(lower)) return lower;
+	for (const cat of KNOWN_CATEGORIES) {
+		if (lower.includes(cat) || cat.includes(lower.split("-")[0])) return cat;
+	}
+	return null;
+}
+
+/**
+ * Meta + body'den SKILL.md icerigi uretir. Frontmatter'i deterministik
+ * sirayla yazar (diff'leri stable yapmak icin).
+ */
+export function serializeSkill(meta, body) {
+	const lines = ["---"];
+	for (const k of ["name", "description", "license", "compatibility", "allowed-tools"]) {
+		if (meta[k] !== undefined && meta[k] !== null) {
+			lines.push(`${k}: ${formatScalar(meta[k])}`);
+		}
+	}
+	if (meta.metadata && typeof meta.metadata === "object") {
+		lines.push("metadata:");
+		const order = ["author", "homepage", "badi-version", "category"];
+		const seen = new Set();
+		for (const k of order) {
+			if (meta.metadata[k] !== undefined && meta.metadata[k] !== null) {
+				lines.push(`  ${k}: ${formatScalar(meta.metadata[k])}`);
+				seen.add(k);
+			}
+		}
+		for (const k of Object.keys(meta.metadata)) {
+			if (seen.has(k)) continue;
+			const v = meta.metadata[k];
+			if (Array.isArray(v)) {
+				lines.push(`  ${k}:`);
+				for (const item of v) lines.push(`    - ${formatScalar(item)}`);
+			} else {
+				lines.push(`  ${k}: ${formatScalar(v)}`);
+			}
+		}
+	}
+	lines.push("---");
+	return `${lines.join("\n")}\n${body}`;
+}
+
+function formatScalar(v) {
+	if (typeof v === "string") {
+		// Quote if it has special chars or starts with special
+		if (/[:#&*!|>'"%@`]/.test(v[0]) || /[\n]/.test(v)) {
+			return `"${v.replace(/"/g, '\\"')}"`;
+		}
+		return v;
+	}
+	return String(v);
+}
+
+/**
+ * Source dizinindeki tum skill'leri tara, target'a yaz.
+ * @returns {{bundled, skipped, totalSkills}}
+ */
+export async function bundleSkills(opts) {
+	const { source, target, dryRun = false, strict = false } = opts;
+	if (!existsSync(source)) {
+		throw new Error(`Source dir does not exist: ${source}`);
+	}
+
+	const bundled = [];
+	const skipped = [];
+
+	const entries = readdirSync(source, { withFileTypes: true });
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		const skillName = entry.name;
+		const skillDir = join(source, skillName);
+		const skillFile = join(skillDir, "SKILL.md");
+		if (!existsSync(skillFile)) {
+			skipped.push({ name: skillName, reason: "no SKILL.md" });
+			continue;
+		}
+
+		const content = readFileSync(skillFile, "utf-8");
+		const result = enrichSkill(content, skillName, { strict });
+
+		if (!result.ok) {
+			skipped.push({
+				name: skillName,
+				reason: "validation failed after enrichment",
+				errors: result.errors,
+			});
+			continue;
+		}
+
+		const targetSkillDir = join(target, "skills", skillName);
+		const targetFile = join(targetSkillDir, "SKILL.md");
+		const out = serializeSkill(result.meta, result.body);
+
+		if (!dryRun) {
+			mkdirSync(targetSkillDir, { recursive: true });
+			writeFileSync(targetFile, out);
+
+			// Copy references/ if present
+			const refsSrc = join(skillDir, "references");
+			if (existsSync(refsSrc) && statSync(refsSrc).isDirectory()) {
+				const refsDst = join(targetSkillDir, "references");
+				cpSync(refsSrc, refsDst, { recursive: true });
+			}
+		}
+
+		bundled.push({
+			name: skillName,
+			sourceFile: skillFile,
+			targetFile,
+			enriched: result.enriched,
+			warnings: result.warnings,
+			category: result.meta?.metadata?.category || "uncategorized",
+		});
+	}
+
+	return { bundled, skipped, totalSkills: bundled.length + skipped.length };
+}
+
+/**
+ * Bundle edilmis skill'lerden router skill (skills/badi/SKILL.md) uretir.
+ * Router, kategorilere gore gruplanmis skill listesidir.
+ */
+export function generateRouterSkill(bundled) {
+	const byCategory = new Map();
+	for (const b of bundled) {
+		// Read meta from re-parsed targetFile content if needed; for now
+		// caller passes meta. Simplest: parse minimal info from targetFile.
+		const cat = b.category || "uncategorized";
+		if (!byCategory.has(cat)) byCategory.set(cat, []);
+		byCategory.get(cat).push(b);
+	}
+
+	const lines = [
+		"---",
+		"name: badi",
+		'description: "Entry point and router for the Badi skill collection. Lists every bundled Badi skill grouped by category. Triggers when an agent needs to discover Badi capabilities or pick the right skill for a task."',
+		"license: MIT",
+		"compatibility: Works with Claude Code, Cursor, or any agentskills.io-compatible agent.",
+		"allowed-tools: Read",
+		"metadata:",
+		"  author: fatihkan",
+		`  homepage: ${HOMEPAGE_BASE}/badi`,
+		'  badi-version: ">=1.14.0"',
+		"  category: behavioral",
+		"---",
+		"",
+		"# Badi Skills",
+		"",
+		"Auto-generated router. Each entry links to a bundled skill.",
+		"",
+	];
+
+	const sortedCats = [...byCategory.keys()].sort();
+	for (const cat of sortedCats) {
+		lines.push(`## ${cat}`);
+		lines.push("");
+		const skills = byCategory.get(cat).sort((a, b) => a.name.localeCompare(b.name));
+		for (const s of skills) {
+			lines.push(`- [${s.name}](../${s.name}/) — see \`SKILL.md\``);
+		}
+		lines.push("");
+	}
+
+	return lines.join("\n");
+}
+

--- a/lib/skills/schema.js
+++ b/lib/skills/schema.js
@@ -65,6 +65,7 @@ export const KNOWN_CATEGORIES = [
 	"seo",
 	"social-media",
 	"development",
+	"uncategorized",
 ];
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{1,63}$/;

--- a/tests/cli.publish.test.js
+++ b/tests/cli.publish.test.js
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 
@@ -42,5 +44,70 @@ describe("badi publish", () => {
 		const out = run("publish", "--help");
 		assert.ok(out.includes("--dry-run"));
 		assert.ok(out.includes("--version minor"));
+	});
+
+	it("--skill-bundle flag yardim metninde gorunur", () => {
+		const out = run("publish", "--help");
+		assert.ok(out.includes("--skill-bundle"));
+		assert.ok(out.includes("badi-skills"));
+		assert.ok(out.includes("Router skill"));
+	});
+});
+
+describe("badi publish --skill-bundle", () => {
+	function setupTmpProject() {
+		const dir = mkdtempSync(join(tmpdir(), "badi-publish-skill-"));
+		const skillsDir = join(dir, ".claude", "skills", "frontend-taste");
+		mkdirSync(skillsDir, { recursive: true });
+		writeFileSync(
+			join(skillsDir, "SKILL.md"),
+			`---
+name: frontend-taste
+description: Premium frontend design skills triggering on UI tasarla, design a UI, premium landing.
+license: MIT
+compatibility: Works.
+allowed-tools: Read Write
+metadata:
+  author: fatihkan
+  homepage: https://example.com
+  badi-version: ">=1.14.0"
+  category: design
+---
+
+# body
+`,
+		);
+		return dir;
+	}
+
+	it("--skill-bundle --dry-run dosya yazmaz", () => {
+		const cwd = setupTmpProject();
+		const out = execFileSync(
+			"node",
+			[BIN, "publish", "--skill-bundle", "--dry-run"],
+			{ encoding: "utf-8", cwd, timeout: 10000 },
+		);
+		assert.match(out, /DRY RUN/);
+		assert.match(out, /1 skill bundle edildi/);
+	});
+
+	it("--skill-bundle gercek modda target dizini yazar", () => {
+		const cwd = setupTmpProject();
+		const target = join(cwd, "out");
+		const out = execFileSync(
+			"node",
+			[BIN, "publish", "--skill-bundle", "--target", target],
+			{ encoding: "utf-8", cwd, timeout: 10000 },
+		);
+		assert.match(out, /1 skill bundle edildi/);
+		assert.match(out, /Router skill yazildi/);
+		assert.ok(
+			existsSync(join(target, "skills", "frontend-taste", "SKILL.md")),
+			"target SKILL.md should exist",
+		);
+		assert.ok(
+			existsSync(join(target, "skills", "badi", "SKILL.md")),
+			"router SKILL.md should exist",
+		);
 	});
 });

--- a/tests/skills-bundler.test.js
+++ b/tests/skills-bundler.test.js
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+	bundleSkills,
+	enrichSkill,
+	generateRouterSkill,
+	serializeSkill,
+} from "../lib/harnesses/skills-bundler.js";
+import { parseRichFrontmatter } from "../lib/skills/schema.js";
+
+let tmpRoot;
+let source;
+let target;
+
+beforeEach(() => {
+	tmpRoot = mkdtempSync(join(tmpdir(), "skills-bundler-"));
+	source = join(tmpRoot, "src", "skills");
+	target = join(tmpRoot, "out");
+	mkdirSync(source, { recursive: true });
+});
+
+afterEach(() => {
+	rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function writeSkill(name, content) {
+	const dir = join(source, name);
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, "SKILL.md"), content);
+	return dir;
+}
+
+const COMPLETE_SKILL = `---
+name: complete-thing
+description: A complete skill with full frontmatter for testing pass-through behavior in the bundler.
+license: MIT
+compatibility: Works with any agent.
+allowed-tools: Read Write
+metadata:
+  author: alice
+  homepage: https://example.com/skills/complete-thing
+  badi-version: ">=1.14.0"
+  category: testing
+---
+
+# Complete Thing
+
+Body content.
+`;
+
+describe("bundler: enrichSkill", () => {
+	it("preserves complete frontmatter (no enrichment)", () => {
+		const r = enrichSkill(COMPLETE_SKILL, "complete-thing");
+		assert.equal(r.ok, true);
+		assert.deepEqual(r.enriched, []);
+		assert.equal(r.meta.metadata.author, "alice");
+	});
+
+	it("enriches all missing fields", () => {
+		const empty = `---\nname: empty-skill\n---\n\nbody`;
+		const r = enrichSkill(empty, "empty-skill");
+		assert.equal(r.ok, true);
+		assert.ok(r.enriched.includes("license"));
+		assert.ok(r.enriched.includes("compatibility"));
+		assert.ok(r.enriched.includes("allowed-tools"));
+		assert.ok(r.enriched.includes("metadata.author"));
+		assert.ok(r.enriched.includes("metadata.homepage"));
+		assert.ok(r.enriched.includes("metadata.badi-version"));
+		assert.equal(r.meta.license, "MIT");
+		assert.equal(r.meta.metadata.author, "fatihkan");
+		assert.match(r.meta.metadata.homepage, /badi-skills.*empty-skill/);
+	});
+
+	it("enriches name when missing from frontmatter", () => {
+		const noname = `---\nlicense: MIT\n---\n\nbody`;
+		const r = enrichSkill(noname, "some-name");
+		assert.equal(r.meta.name, "some-name");
+		assert.ok(r.enriched.includes("name"));
+	});
+
+	it("derives description from body when missing", () => {
+		const c = `---\nname: x\n---\n\n# Heading\n\nThis is the first paragraph that should land in description.\n`;
+		const r = enrichSkill(c, "x");
+		assert.match(r.meta.description, /first paragraph/);
+		assert.match(r.meta.description, /auto-generated/);
+		assert.ok(r.enriched.includes("description"));
+	});
+
+	it("guesses category from name when matching KNOWN_CATEGORIES", () => {
+		const c = `---\nname: x\n---\n\nbody`;
+		for (const [name, expected] of [
+			["security", "security"],
+			["design", "design"],
+			["frontend-taste", "frontend"], // matches via substring
+		]) {
+			const r = enrichSkill(c, name);
+			assert.equal(r.meta.metadata.category, expected, `${name} → ${expected}`);
+		}
+	});
+
+	it("falls back to 'uncategorized' when no match", () => {
+		const c = `---\nname: x\n---\n\nbody`;
+		const r = enrichSkill(c, "totally-unique-thing");
+		assert.equal(r.meta.metadata.category, "uncategorized");
+	});
+
+	it("preserves user-set values, only fills gaps", () => {
+		const c = `---
+name: mixed
+description: User-supplied description, long enough for trigger activation pretty please.
+license: Apache-2.0
+metadata:
+  author: someone-else
+---
+
+body`;
+		const r = enrichSkill(c, "mixed");
+		assert.equal(r.meta.license, "Apache-2.0");
+		assert.equal(r.meta.metadata.author, "someone-else");
+		// But these were filled
+		assert.ok(r.enriched.includes("compatibility"));
+		assert.ok(r.enriched.includes("allowed-tools"));
+		assert.ok(r.enriched.includes("metadata.homepage"));
+	});
+});
+
+describe("bundler: serializeSkill (round-trip)", () => {
+	it("parse -> serialize -> parse produces equivalent meta", () => {
+		const { meta } = parseRichFrontmatter(COMPLETE_SKILL);
+		const out = serializeSkill(meta, "\n# Body\n");
+		const reparsed = parseRichFrontmatter(out).meta;
+		assert.equal(reparsed.name, meta.name);
+		assert.equal(reparsed.license, meta.license);
+		assert.equal(reparsed.metadata.author, meta.metadata.author);
+		assert.equal(reparsed.metadata.category, meta.metadata.category);
+	});
+
+	it("emits required fields in deterministic order", () => {
+		const { meta } = parseRichFrontmatter(COMPLETE_SKILL);
+		const out = serializeSkill(meta, "");
+		const lines = out.split("\n");
+		const idx = (k) => lines.findIndex((l) => l.startsWith(`${k}:`));
+		assert.ok(idx("name") < idx("description"));
+		assert.ok(idx("description") < idx("license"));
+		assert.ok(idx("license") < idx("compatibility"));
+		assert.ok(idx("compatibility") < idx("allowed-tools"));
+	});
+});
+
+describe("bundler: bundleSkills", () => {
+	it("scans source, writes target, no behavior on dry-run", async () => {
+		writeSkill("skill-one", COMPLETE_SKILL);
+		const dryResult = await bundleSkills({ source, target, dryRun: true });
+		assert.equal(dryResult.bundled.length, 1);
+		assert.equal(existsSync(target), false, "dry run should not create target");
+
+		const realResult = await bundleSkills({ source, target });
+		assert.equal(realResult.bundled.length, 1);
+		assert.ok(existsSync(join(target, "skills", "skill-one", "SKILL.md")));
+	});
+
+	it("skips directories without SKILL.md", async () => {
+		mkdirSync(join(source, "no-skill-md"), { recursive: true });
+		writeFileSync(join(source, "no-skill-md", "README.md"), "# stub");
+		const r = await bundleSkills({ source, target });
+		assert.equal(r.bundled.length, 0);
+		assert.equal(r.skipped.length, 1);
+		assert.equal(r.skipped[0].reason, "no SKILL.md");
+	});
+
+	it("copies references/ subdirectory", async () => {
+		const dir = writeSkill("skill-with-refs", COMPLETE_SKILL);
+		mkdirSync(join(dir, "references"), { recursive: true });
+		writeFileSync(join(dir, "references", "doc.md"), "# extra");
+		await bundleSkills({ source, target });
+		const refDst = join(target, "skills", "skill-with-refs", "references", "doc.md");
+		assert.ok(existsSync(refDst), "references/doc.md should be copied");
+		assert.equal(readFileSync(refDst, "utf-8"), "# extra");
+	});
+
+	it("enriches skill missing frontmatter and bundles successfully", async () => {
+		writeSkill(
+			"design-bare",
+			"# Design Skills\n\nThis is the design skills category. It covers UI, UX, and visual identity workflows comprehensively.\n",
+		);
+		const r = await bundleSkills({ source, target });
+		assert.equal(r.bundled.length, 1);
+		const out = readFileSync(
+			join(target, "skills", "design-bare", "SKILL.md"),
+			"utf-8",
+		);
+		assert.match(out, /name: design-bare/);
+		assert.match(out, /license: MIT/);
+		assert.match(out, /author: fatihkan/);
+	});
+
+	it("strict mode rejects soft warnings", async () => {
+		writeSkill("short-desc", `---\nname: short-desc\ndescription: tiny\n---\n\nbody`);
+		const r = await bundleSkills({ source, target, strict: true });
+		// Strict promotes the <50 char description warning to an error,
+		// so this skill is skipped.
+		assert.equal(r.bundled.length, 0);
+		assert.equal(r.skipped.length, 1);
+	});
+
+	it("totalSkills reflects bundled + skipped", async () => {
+		writeSkill("ok-one", COMPLETE_SKILL);
+		mkdirSync(join(source, "no-skill-md"), { recursive: true });
+		const r = await bundleSkills({ source, target });
+		assert.equal(r.totalSkills, 2);
+	});
+});
+
+describe("bundler: generateRouterSkill", () => {
+	it("groups by category and outputs frontmatter + sections", () => {
+		const bundled = [
+			{ name: "alpha", category: "design" },
+			{ name: "beta", category: "security" },
+			{ name: "gamma", category: "design" },
+		];
+		const out = generateRouterSkill(bundled);
+		assert.match(out, /name: badi/);
+		assert.match(out, /## design/);
+		assert.match(out, /## security/);
+		// sorted alphabetically within category
+		const designIdx = out.indexOf("## design");
+		const securityIdx = out.indexOf("## security");
+		const alphaIdx = out.indexOf("alpha");
+		const gammaIdx = out.indexOf("gamma");
+		assert.ok(designIdx < alphaIdx && alphaIdx < gammaIdx);
+		assert.ok(gammaIdx < securityIdx);
+	});
+
+	it("handles uncategorized entries", () => {
+		const out = generateRouterSkill([{ name: "orphan" }]);
+		assert.match(out, /## uncategorized/);
+		assert.match(out, /\[orphan\]/);
+	});
+});


### PR DESCRIPTION
## Summary

PR #64'teki bundler'i mevcut \`badi publish\` orkestratorune yeni bir mod olarak bagliyor. \`--skill-bundle\` flag'i set edildiginde \`runPublish\` normal npm-release flow'u yerine \`runSkillBundle\`'a dispatch ediyor.

**Stacked on PR #64** (bundler). PR #64 merge edildikten sonra rebase edilip mainde mergelenebilir.

## Yeni flagler

| Flag | Default | Aciklama |
|------|---------|----------|
| \`--skill-bundle\` | — | Bundle modu acar |
| \`--target <path>\` | \`./badi-skills\` | Cikti dizini |
| \`--source <path>\` | \`./.claude/skills\` | Kaynak dizini |
| \`--strict\` | false | Schema warnings → errors |
| \`--dry-run\` | false | Disk yazma; sadece raporla |

## Bundle akisi

1. \`.claude/skills/\` taranir, her skill PR #63 schema ile dogrulanip PR #64 bundler ile zenginlestirilir
2. \`<target>/skills/<name>/SKILL.md\` yazilir
3. \`references/\` alt dizini varsa kopyalanir
4. Router skill (\`skills/badi/SKILL.md\`) uretilir
5. Ozet: bundled count, skipped count, enriched-field count, warnings

## Out-of-scope

\`badi-skills\` repo'sunun git tag / push / npm publish'i bu PR'da YOK — repo'nun olusmasi gerekiyor (PR E bootstrap kit). Orkestrator simdilik bundle'i yazip "next steps" basiyor (git diff/commit/tag/push).

## Tests

356 → 359 (+3):
- \`--skill-bundle\` flag'i help'te gorunuyor mu?
- \`--skill-bundle --dry-run\` disk degisikligi yapmiyor mu?
- \`--skill-bundle --target X\` dosyalari yaziyor + router uretiyor mu?

🤖 Generated with [Claude Code](https://claude.com/claude-code)