### PR TITLE
chore(release): v1.14.0 — skill ecosystem MVP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,68 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantik Versioning](https://semver.org/).
 
+## [1.14.0] - 2026-04-26
+
+**Skill ecosystem MVP.** Closes issue #56 (skill-bundle infrastructure)
+and #57 (badi-discipline behavioral skill).
+
+### Added — Skill bundle pipeline
+
+- `lib/skills/schema.js` — agentskills.io frontmatter validator
+  (required/optional fields, allowed-tools allowlist, semver-shaped
+  badi-version, known categories). Two modes: warn (default) and
+  strict (CI). Includes `parseRichFrontmatter` for nested metadata
+  blocks.
+- `lib/harnesses/skills-bundler.js` — compiles `.claude/skills/<name>/`
+  into `<target>/skills/<name>/` with auto-enriched frontmatter,
+  copies `references/` subdirs, and generates a router skill grouping
+  bundled skills by category.
+- `badi publish --skill-bundle [--target <dir>] [--source <dir>]
+  [--strict] [--dry-run]` — wires the bundler into the publish
+  orchestrator. The actual git/npm push for the badi-skills repo is
+  out of scope; the orchestrator stops after writing the bundle and
+  prints next-step git commands.
+- `scripts/enrich-skills.js` — in-place enrichment for the source
+  `.claude/skills/<name>/SKILL.md` files. Idempotent. Reads
+  `scripts/skill-descriptions.json` for curated trigger-rich
+  descriptions.
+- All 23 top-level `.claude/skills/<name>/SKILL.md` files now carry
+  the full agentskills.io frontmatter (name, description, license,
+  compatibility, allowed-tools, metadata.{author, homepage,
+  badi-version, category}).
+
+### Added — `badi-skills` bootstrap kit
+
+- `_bootstrap/badi-skills/` — bare repo skeleton for the separate
+  `badi-skills` GitHub repo. LICENSE (MIT), README install
+  instructions for skills CLI / Claude Code marketplace / Cursor
+  Remote Rule / OpenAI Codex, CLAUDE.md and AGENTS.md routing,
+  `.claude-plugin/plugin.json` and `.cursor-plugin/manifest.json`
+  manifests, `.github/workflows/validate.yml` CI that pulls the
+  schema from this repo and validates every SKILL.md in strict mode.
+- `_bootstrap/README.md` walks through one-time repo creation:
+  `gh repo create` → push bootstrap → `badi publish --skill-bundle`
+  → copy bundle → tag `v1.0.0`.
+
+### Added — `badi-discipline` behavioral skill
+
+- `_bootstrap/badi-skills/skills/badi-discipline/SKILL.md` — 8
+  principles: Think Before Coding, Simplicity First, Surgical
+  Changes, Goal-Driven Execution (the four are framed after Andrej
+  Karpathy's coding observations / forrestchang/andrej-karpathy-skills,
+  82.6k★), plus Yak-Shave Detection, TaskBoard Discipline,
+  Knowledge-Base Source Requirement, and Destructive Action Gate
+  (extracted from Badi's own subagents and hooks).
+- 4 progressive-disclosure references: task-discipline,
+  destructive-actions, yak-shave-patterns, knowledge-base-sources.
+- Carries an explicit tradeoff note: "These are prompt-level
+  guidelines, not enforcement. Bias toward caution over speed; for
+  trivial tasks, use judgment."
+
+### Tests
+
+- 307 → 359 (+52). Schema 32, bundler 17, publish 3.
+
 ## [1.13.2] - 2026-04-25
 
 Code-review follow-up to v1.13.1. Seven findings from the post-merge review

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -4,6 +4,50 @@
 
 Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [Semantik Versiyonlama](https://semver.org/lang/tr/) standardini takip eder.
 
+## [1.14.0] - 2026-04-26
+
+**Skill ekosistemi MVP.** Issue #56 (skill-bundle altyapisi) ve #57
+(badi-discipline davranissal skill) kapaniyor.
+
+### Eklenen — Skill bundle pipeline
+
+- `lib/skills/schema.js` — agentskills.io frontmatter validator'i.
+  Iki mod: warn (varsayilan) ve strict (CI).
+- `lib/harnesses/skills-bundler.js` — `.claude/skills/<name>/` →
+  `<target>/skills/<name>/` compile eder. Eksik frontmatter
+  alanlarini otomatik doldurur, `references/` alt dizinini kopyalar,
+  router skill uretir (kategoriye gore gruplanmis liste).
+- `badi publish --skill-bundle [--target] [--source] [--strict]
+  [--dry-run]` — bundler'i publish orkestratorune bagliyor.
+- `scripts/enrich-skills.js` + `scripts/skill-descriptions.json` —
+  source `.claude/skills/<name>/SKILL.md` dosyalarini in-place
+  zenginlestiriyor. Idempotent.
+- 23 `.claude/skills/<name>/SKILL.md` dosyasi tam agentskills.io
+  frontmatter'ina sahip.
+
+### Eklenen — `badi-skills` bootstrap kit
+
+- `_bootstrap/badi-skills/` — ayri `badi-skills` GitHub repo'su icin
+  bare skeleton. LICENSE, README (skills CLI / Claude Code marketplace
+  / Cursor Remote Rule / OpenAI Codex install rehberi), CLAUDE.md +
+  AGENTS.md, `.claude-plugin/plugin.json`, `.cursor-plugin/manifest.json`,
+  `.github/workflows/validate.yml` (CI ana repo'dan schema'yi cekiyor
+  ve strict modda dogruluyor).
+
+### Eklenen — `badi-discipline` davranissal skill
+
+- 8 ilke (Karpathy 4 + Badi 4): Think Before Coding, Simplicity
+  First, Surgical Changes, Goal-Driven Execution, Yak-Shave Detection,
+  TaskBoard Discipline, Knowledge-Base Source Requirement, Destructive
+  Action Gate.
+- 4 progressive-disclosure references.
+- SKILL.md preamble Karpathy'nin tradeoff notunu acikca tasiyor:
+  "These are prompt-level guidelines, not enforcement."
+
+### Testler
+
+- 307 → 359 (+52).
+
 ## [1.13.2] - 2026-04-25
 
 v1.13.1 sonrasi kod incelemesinden cikan 7 bulguyu tek hotfix'te kapatir.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Claude is the canonical source. Cursor and Gemini adapters compile from the same
 | **21 expert agents + 77 commands** | Full toolkit from security scanner to performance profiler |
 | **12 automation hooks + 25 skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants |
 | **Multi-harness support (v1.12+)** | Claude Code, Cursor, Gemini CLI — same `.claude/` source, different targets |
-| **307 passing tests** | 41 watcher/scheduler + agent CLI + 44 harness adapter + 222 CLI/integration |
+| **359 passing tests** | 41 watcher/scheduler + 49 schema/bundler/publish + 44 harness adapter + 222 CLI/integration |
 | **TR/EN content engine** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
 | **Modular architecture** | 22 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
@@ -432,6 +432,7 @@ npm run format     # Biome formatting
 
 | Version | Summary |
 |---------|---------|
+| **v1.14.0** | Skill ecosystem MVP — agentskills.io-compatible skill bundle pipeline. New `lib/skills/schema.js` validator + `lib/harnesses/skills-bundler.js` compiler + `badi publish --skill-bundle` orchestrator. 23 `.claude/skills/*/SKILL.md` enriched with full frontmatter. New `badi-discipline` behavioral skill (Karpathy-pattern 8 principles) ready to ship in the separate `badi-skills` repo. Bootstrap kit under `_bootstrap/badi-skills/` for one-time repo setup. 307 → 359 tests (+52). Closes #56 and #57. |
 | **v1.13.2** | 7-finding code-review hotfix: UTC-bias in `icerik durum/kapat` "today" counts (now uses local `startOfToday`); `runTemplate` switch hardened with `default: throw`; "unknown subcommand" error lists all 21 valid commands; `icerik.js` shim removed (direct import in `bin/badi.js`); doc/comment polish. 307 tests still green. |
 | **v1.13.1** | Hotfix on v1.13.0 review: `agent install` confirmation actually waits for y/N (was logging the prompt then proceeding) + `--yes`/`-y` flag for scripted use. Clean errors for missing watchers in `install` and `tail`. Includes the icerik split refactor (issue #41) — `lib/commands/icerik.js` (1667 lines) split into per-subcommand modules under `lib/commands/icerik/`. 304 → 307 tests. |
 | **v1.13.0** | Background agents — define `.claude/watchers/*.md` with git/shell/file/log/http checks, install to launchd/systemd/cron, alerts surface in next `/start` briefing. 8 new `badi agent` subcommands + 2 templates + 38 new tests (total 304). |

--- a/README.tr.md
+++ b/README.tr.md
@@ -38,7 +38,7 @@ Claude kaynak (canonical). Cursor ve Gemini adapter'lari ayni `.claude/` dizinin
 | **21 Uzman Ajan ve 77 Komut** | Guvenlik tarayicidan performans profiler'a kadar genis arac seti |
 | **12 Otomatik Hook ve 25 Skill Kategorisi** | Branch koruma, yedekleme, OWASP Top 10 taramasi, 9 Frontend Taste varyanti |
 | **Multi-harness destegi (v1.12+)** | Claude Code, Cursor, Gemini CLI — ayni `.claude/` kaynagi, farkli hedefler |
-| **307 Onaylanmis Test** | 41 watcher/scheduler + agent CLI + 44 harness adapter + 222 CLI/entegrasyon |
+| **359 Onaylanmis Test** | 41 watcher/scheduler + 49 schema/bundler/publish + 44 harness adapter + 222 CLI/entegrasyon |
 | **TR/EN Icerik Motoru** | Sablon mirasi ile post, thread, bulten, podcast, case-study uretimi |
 | **WordPress + SEO + ASO + Mobile Modulleri** | WP-CLI/REST, 20+ SEO kontrolu, App Store + Play Store, crash/deeplink/OTA iskelesi |
 | **Modular Mimari** | 22 komut modulu, `lib/harnesses/` adapter katmani, ~6MB `.claude/` agaci |
@@ -410,6 +410,7 @@ npm run format     # Biome ile formatlama
 
 | Surum | Icerik |
 |-------|--------|
+| **v1.14.0** | Skill ekosistemi MVP — agentskills.io-uyumlu skill bundle pipeline. Yeni `lib/skills/schema.js` validator + `lib/harnesses/skills-bundler.js` compiler + `badi publish --skill-bundle` orkestrator. 23 `.claude/skills/*/SKILL.md` tam frontmatter ile zenginlesti. Yeni `badi-discipline` davranissal skill (Karpathy-pattern 8 ilke) ayri `badi-skills` repo'sunda ship'e hazir. Bootstrap kit `_bootstrap/badi-skills/` altinda. 307 → 359 test (+52). #56 ve #57 close. |
 | **v1.13.2** | 7-bulgu code-review hotfix: `icerik durum/kapat` "bugun" sayim'inda UTC-bias duzeltildi (yerel `startOfToday`); `runTemplate` switch'i `default: throw` ile saglamlastirildi; "bilinmeyen subcommand" hatasi 21 gecerli komutu listeliyor; `icerik.js` shim'i kaldirildi (direkt import); doc/yorum cilasi. 307 test yesil. |
 | **v1.13.1** | v1.13.0 review hotfix: `agent install` onay prompt'u artik gercekten y/N bekliyor (eskiden mesaji yazip yine de install ediyordu) + `--yes`/`-y` bayragi script kullanim icin. Bilinmeyen watcher icin temiz hata mesajlari. icerik split refactor'u (issue #41) — `lib/commands/icerik.js` (1667 satir) `lib/commands/icerik/` altinda alt-komut modullerine bolundu. 304 → 307 test. |
 | **v1.13.0** | Arka plan agent'lari — `.claude/watchers/*.md` YAML frontmatter ile git/shell/file/log/http kontrolleri tanimla, launchd/systemd/cron'a kayit et, bir sonraki `/start` brifing'inde uyarilar otomatik gorunur. 8 yeni `badi agent` alt komutu + 2 template + 38 yeni test (toplam 304). |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fatihkan/badi",
-	"version": "1.13.2",
+	"version": "1.14.0",
 	"description": "Claude Code kullanicilari icin profesyonel is akisi yonetim sistemi",
 	"type": "module",
 	"main": "bin/badi.js",


### PR DESCRIPTION
Release commit. Closes #56 ve #57. Tests 307 → 359 (+52). README + CHANGELOG (EN/TR) v1.14.0 entry'siyle guncel.