### PR TITLE
fix(v1.14.1): drop Node 18 from CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantik Versioning](https://semver.org/).
 
+## [1.14.1] - 2026-04-26
+
+CI / engines bump. No runtime-code changes.
+
+### Changed
+- **CI matrix dropped Node 18.** `tests/cli.*.test.js` (14 files) and
+  `scripts/enrich-skills.js` use `import.meta.dirname`, which requires
+  Node 20.11+. The Node 18 row in CI had been failing silently for
+  these files; bumping the matrix surfaces the rest of the suite cleanly.
+- **`engines.node` bumped to `>=20.11.0`** (was `>=18.0.0`). Aligns
+  package metadata with the actual runtime requirement of the test suite.
+- README install instructions updated to require Node 20.11+.
+
+### Notes
+- Production CLI surface (`bin/badi.js` and `lib/`) already used the
+  cross-version-safe `fileURLToPath(import.meta.url)` pattern; users
+  on Node 20+ are unaffected. Node 18 users were never able to run the
+  test suite, but the CLI itself worked.
+
 ## [1.14.0] - 2026-04-26
 
 **Skill ecosystem MVP.** Closes issue #56 (skill-bundle infrastructure)

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -4,6 +4,26 @@
 
 Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [Semantik Versiyonlama](https://semver.org/lang/tr/) standardini takip eder.
 
+## [1.14.1] - 2026-04-26
+
+CI / engines bump. Runtime kod degisimi yok.
+
+### Degisti
+- **CI matrisinden Node 18 cikarildi.** `tests/cli.*.test.js` (14
+  dosya) ve `scripts/enrich-skills.js` `import.meta.dirname`
+  kullaniyor — Node 20.11+ ozelligi. Node 18 satiri bu dosyalar icin
+  sessizce kiriliyordu; matris bumped'i kalan suite'i temizliyor.
+- **`engines.node` `>=20.11.0`'e bumped** (eskiden `>=18.0.0`).
+  Paket metadatasi gercek runtime gereksinimine hizali.
+- README kurulum talimatlari Node 20.11+ gerektirecek sekilde
+  guncellendi.
+
+### Notlar
+- Production CLI yuzeyi (`bin/badi.js`, `lib/`) zaten cross-version
+  guvenli `fileURLToPath(import.meta.url)` paternini kullaniyor;
+  Node 20+ kullanicisi etkilenmiyor. Node 18 kullanicilari test
+  suite'ini hicbir zaman calistiramazdi ama CLI calisiyordu.
+
 ## [1.14.0] - 2026-04-26
 
 **Skill ekosistemi MVP.** Issue #56 (skill-bundle altyapisi) ve #57

--- a/README.md
+++ b/README.md
@@ -393,9 +393,9 @@ chmod +x .claude/hooks/*.sh
 ```
 
 ### Node version error
-Badi requires Node 18+:
+Badi requires Node 20.11+:
 ```bash
-node --version   # Must be v18.0.0+
+node --version   # Must be v20.11.0+
 ```
 
 ### Temporarily disable all hooks
@@ -432,6 +432,7 @@ npm run format     # Biome formatting
 
 | Version | Summary |
 |---------|---------|
+| **v1.14.1** | Drop Node 18 from CI matrix. Tests use `import.meta.dirname` (Node 20.11+); Node 18 row was failing silently. `engines.node` bumped to `>=20.11.0`. No runtime-code changes; production CLI already works on Node 20+. |
 | **v1.14.0** | Skill ecosystem MVP — agentskills.io-compatible skill bundle pipeline. New `lib/skills/schema.js` validator + `lib/harnesses/skills-bundler.js` compiler + `badi publish --skill-bundle` orchestrator. 23 `.claude/skills/*/SKILL.md` enriched with full frontmatter. New `badi-discipline` behavioral skill (Karpathy-pattern 8 principles) ready to ship in the separate `badi-skills` repo. Bootstrap kit under `_bootstrap/badi-skills/` for one-time repo setup. 307 → 359 tests (+52). Closes #56 and #57. |
 | **v1.13.2** | 7-finding code-review hotfix: UTC-bias in `icerik durum/kapat` "today" counts (now uses local `startOfToday`); `runTemplate` switch hardened with `default: throw`; "unknown subcommand" error lists all 21 valid commands; `icerik.js` shim removed (direct import in `bin/badi.js`); doc/comment polish. 307 tests still green. |
 | **v1.13.1** | Hotfix on v1.13.0 review: `agent install` confirmation actually waits for y/N (was logging the prompt then proceeding) + `--yes`/`-y` flag for scripted use. Clean errors for missing watchers in `install` and `tail`. Includes the icerik split refactor (issue #41) — `lib/commands/icerik.js` (1667 lines) split into per-subcommand modules under `lib/commands/icerik/`. 304 → 307 tests. |

--- a/README.tr.md
+++ b/README.tr.md
@@ -387,9 +387,9 @@ chmod +x .claude/hooks/*.sh
 ```
 
 ### Node surumu hatasi
-Badi >= Node 18 gerektirir:
+Badi >= Node 20.11 gerektirir:
 ```bash
-node --version   # v18.0.0+ olmali
+node --version   # v20.11.0+ olmali
 ```
 
 ### Tum hook'lari devre disi birakma (gecici)
@@ -410,6 +410,7 @@ npm run format     # Biome ile formatlama
 
 | Surum | Icerik |
 |-------|--------|
+| **v1.14.1** | CI matrisinden Node 18 cikarildi. Test dosyalari `import.meta.dirname` (Node 20.11+) kullaniyor; Node 18 satiri sessizce kiriliyordu. `engines.node` `>=20.11.0`'e bumped. Runtime kod degisimi yok; production CLI zaten Node 20+ ile calisiyor. |
 | **v1.14.0** | Skill ekosistemi MVP — agentskills.io-uyumlu skill bundle pipeline. Yeni `lib/skills/schema.js` validator + `lib/harnesses/skills-bundler.js` compiler + `badi publish --skill-bundle` orkestrator. 23 `.claude/skills/*/SKILL.md` tam frontmatter ile zenginlesti. Yeni `badi-discipline` davranissal skill (Karpathy-pattern 8 ilke) ayri `badi-skills` repo'sunda ship'e hazir. Bootstrap kit `_bootstrap/badi-skills/` altinda. 307 → 359 test (+52). #56 ve #57 close. |
 | **v1.13.2** | 7-bulgu code-review hotfix: `icerik durum/kapat` "bugun" sayim'inda UTC-bias duzeltildi (yerel `startOfToday`); `runTemplate` switch'i `default: throw` ile saglamlastirildi; "bilinmeyen subcommand" hatasi 21 gecerli komutu listeliyor; `icerik.js` shim'i kaldirildi (direkt import); doc/yorum cilasi. 307 test yesil. |
 | **v1.13.1** | v1.13.0 review hotfix: `agent install` onay prompt'u artik gercekten y/N bekliyor (eskiden mesaji yazip yine de install ediyordu) + `--yes`/`-y` bayragi script kullanim icin. Bilinmeyen watcher icin temiz hata mesajlari. icerik split refactor'u (issue #41) — `lib/commands/icerik.js` (1667 satir) `lib/commands/icerik/` altinda alt-komut modullerine bolundu. 304 → 307 test. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fatihkan/badi",
-	"version": "1.14.0",
+	"version": "1.14.1",
 	"description": "Claude Code kullanicilari icin profesyonel is akisi yonetim sistemi",
 	"type": "module",
 	"main": "bin/badi.js",
@@ -33,7 +33,7 @@
 	"author": "Fatih Kan",
 	"license": "MIT",
 	"engines": {
-		"node": ">=18.0.0"
+		"node": ">=20.11.0"
 	},
 	"files": [
 		"bin/",


### PR DESCRIPTION
Y1 finding from /review of v1.14.0. Drops Node 18 from CI matrix; bumps engines.node to >=20.11.0.

## Why

14 `tests/cli.*.test.js` files plus `scripts/enrich-skills.js` use `import.meta.dirname` — Node 20.11+ only. The Node 18 row in CI had been failing silently for these tests. Pre-existing.

Production CLI (`bin/badi.js`, `lib/`) already uses the cross-version-safe `fileURLToPath(import.meta.url)` pattern, so end users on Node 20+ are unaffected.

## Why patch (1.14.0 → 1.14.1) and not major

- No runtime-code change.
- No CLI behavior change.
- Node 18 users could never run the test suite (existing latent bug); only the engines field was misleading.
- Node 18 EOL Apr 2025 (past).

## Changes

- `.github/workflows/test.yml`: matrix `18.x` row removed.
- `package.json`: `engines.node` `>=18.0.0` → `>=20.11.0`, version 1.14.0 → 1.14.1.
- `README.md` + `README.tr.md`: install instructions Node 20.11+.
- `CHANGELOG.md` + `CHANGELOG.tr.md`: v1.14.1 entry.

After merge: 6 dependabot PRs (#34-#39) should rebase cleanly and unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)