### PR TITLE
chore(release): v1.15.0 — badi market

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantik Versioning](https://semver.org/).
 
+## [1.15.0] - 2026-04-26
+
+### Added — `badi market`
+
+App Store pazar arastirmasi komutu. Inspired by
+[vibecodingex.com/skills/app-market-research](https://vibecodingex.com/skills/app-market-research).
+MVP scope: rakip kesfi + coklu bolge yorum aggregation + 11-kod sikayet
+kategorize + zorluk skoru (BLUE_OCEAN / COMPETITIVE / HARD / SATURATED).
+
+Subcommands:
+- `badi market <appId>` — full report (5-stage pipeline)
+- `badi market discover <appId>` — competitor discovery (genre filter)
+- `badi market reviews <appId>` — multi-region multi-page reviews +
+  rating distribution + complaint categories
+- `badi market difficulty <appId>` — 0-100 score + categorical verdict
+
+Flags: `--country <c1,c2,...>`, `--pages <N>`, `--limit <N>`. No API keys
+required (iTunes Lookup, iTunes Search, Apple RSS endpoints).
+
+New `lib/market-helpers.js`: `discoverCompetitors`,
+`aggregateReviewsMultiRegion`, `categorizeReviewIssue` (11 codes,
+TR+EN stem patterns), `summarizeReviews`, `calculateDifficulty`,
+`findCrossCompetitorComplaints`. Reuses existing `aso-helpers.js` for
+the iTunes API surface.
+
+### Phase 2 (separate issues, not in 1.15.0)
+
+- SensorTower revenue scrape (real $/downloads)
+- Wishlist demand×supply matrix (`✓✓✓ eksik` / `✓✓ buggy` / `✓ var ama
+  kötü` / `✓✓✓ var` notation)
+- Opportunity gap report (complaint ∩ wishlist intersection + verbatim
+  quotes)
+- `--format json` for piping
+- Region-aware difficulty (US vs TR vs JP)
+
+### Tests
+
+359 → 379 (+20). 7 helper unit-test suites + 4 CLI smoke tests.
+
 ## [1.14.1] - 2026-04-26
 
 CI / engines bump. No runtime-code changes.

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -4,6 +4,41 @@
 
 Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [Semantik Versiyonlama](https://semver.org/lang/tr/) standardini takip eder.
 
+## [1.15.0] - 2026-04-26
+
+### Eklenen — `badi market`
+
+App Store pazar arastirmasi komutu. [vibecodingex.com/skills/app-market-research](https://vibecodingex.com/skills/app-market-research)
+skill'inden esinlenildi. MVP kapsam: rakip kesfi + coklu bolge yorum
+aggregation + 11-kod sikayet kategorize + zorluk skoru (BLUE_OCEAN /
+COMPETITIVE / HARD / SATURATED).
+
+Alt komutlar:
+- `badi market <appId>` — tam rapor (5-asama pipeline)
+- `badi market discover <appId>` — rakip kesfi (genre filtreli)
+- `badi market reviews <appId>` — coklu bolge yorum + rating dagilimi +
+  sikayet kategorileri
+- `badi market difficulty <appId>` — 0-100 skor + kategorik verdict
+
+Bayraklar: `--country <c1,c2,...>`, `--pages <N>`, `--limit <N>`. API
+anahtari gerekmez (iTunes Lookup, iTunes Search, Apple RSS).
+
+Yeni `lib/market-helpers.js`: 6 helper. Mevcut `aso-helpers.js`'i
+yeniden kullaniyor (iTunes API yuzeyi icin).
+
+### Faz 2 (ayri issue'lar, 1.15.0 disinda)
+
+- SensorTower revenue scrape (gercek $/indirme)
+- Wishlist demand×supply matrix (`✓✓✓ eksik` / `✓✓ buggy` / `✓ var ama
+  kötü` / `✓✓✓ var` notasyon)
+- Opportunity gap raporu (sikayet ∩ wishlist + verbatim alintilar)
+- `--format json` (otomasyon)
+- Bolge-bilincli zorluk (US vs TR vs JP)
+
+### Testler
+
+359 → 379 (+20).
+
 ## [1.14.1] - 2026-04-26
 
 CI / engines bump. Runtime kod degisimi yok.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Claude is the canonical source. Cursor and Gemini adapters compile from the same
 | **21 expert agents + 77 commands** | Full toolkit from security scanner to performance profiler |
 | **12 automation hooks + 25 skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants |
 | **Multi-harness support (v1.12+)** | Claude Code, Cursor, Gemini CLI — same `.claude/` source, different targets |
-| **359 passing tests** | 41 watcher/scheduler + 49 schema/bundler/publish + 44 harness adapter + 222 CLI/integration |
+| **379 passing tests** | 20 market + 41 watcher/scheduler + 49 schema/bundler/publish + 44 harness adapter + 222 CLI/integration |
 | **TR/EN content engine** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
 | **Modular architecture** | 22 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
@@ -443,6 +443,7 @@ npm run format     # Biome formatting
 
 | Version | Summary |
 |---------|---------|
+| **v1.15.0** | `badi market` — App Store market research (inspired by [vibecodingex.com/skills/app-market-research](https://vibecodingex.com/skills/app-market-research)). MVP: competitor discovery + multi-region reviews + 11-code complaint categorization + difficulty score (BLUE_OCEAN / COMPETITIVE / HARD / SATURATED). Subcommands: `discover`, `reviews`, `difficulty`, full report. No API keys. 379 tests (+20). Phase 2 (issues): SensorTower revenue, wishlist demand×supply matrix, opportunity gaps. |
 | **v1.14.1** | Drop Node 18 from CI matrix. Tests use `import.meta.dirname` (Node 20.11+); Node 18 row was failing silently. `engines.node` bumped to `>=20.11.0`. No runtime-code changes; production CLI already works on Node 20+. |
 | **v1.14.0** | Skill ecosystem MVP — agentskills.io-compatible skill bundle pipeline. New `lib/skills/schema.js` validator + `lib/harnesses/skills-bundler.js` compiler + `badi publish --skill-bundle` orchestrator. 23 `.claude/skills/*/SKILL.md` enriched with full frontmatter. New `badi-discipline` behavioral skill (Karpathy-pattern 8 principles) ready to ship in the separate `badi-skills` repo. Bootstrap kit under `_bootstrap/badi-skills/` for one-time repo setup. 307 → 359 tests (+52). Closes #56 and #57. |
 | **v1.13.2** | 7-finding code-review hotfix: UTC-bias in `icerik durum/kapat` "today" counts (now uses local `startOfToday`); `runTemplate` switch hardened with `default: throw`; "unknown subcommand" error lists all 21 valid commands; `icerik.js` shim removed (direct import in `bin/badi.js`); doc/comment polish. 307 tests still green. |

--- a/README.tr.md
+++ b/README.tr.md
@@ -38,7 +38,7 @@ Claude kaynak (canonical). Cursor ve Gemini adapter'lari ayni `.claude/` dizinin
 | **21 Uzman Ajan ve 77 Komut** | Guvenlik tarayicidan performans profiler'a kadar genis arac seti |
 | **12 Otomatik Hook ve 25 Skill Kategorisi** | Branch koruma, yedekleme, OWASP Top 10 taramasi, 9 Frontend Taste varyanti |
 | **Multi-harness destegi (v1.12+)** | Claude Code, Cursor, Gemini CLI — ayni `.claude/` kaynagi, farkli hedefler |
-| **359 Onaylanmis Test** | 41 watcher/scheduler + 49 schema/bundler/publish + 44 harness adapter + 222 CLI/entegrasyon |
+| **379 Onaylanmis Test** | 20 market + 41 watcher/scheduler + 49 schema/bundler/publish + 44 harness adapter + 222 CLI/entegrasyon |
 | **TR/EN Icerik Motoru** | Sablon mirasi ile post, thread, bulten, podcast, case-study uretimi |
 | **WordPress + SEO + ASO + Mobile Modulleri** | WP-CLI/REST, 20+ SEO kontrolu, App Store + Play Store, crash/deeplink/OTA iskelesi |
 | **Modular Mimari** | 22 komut modulu, `lib/harnesses/` adapter katmani, ~6MB `.claude/` agaci |
@@ -410,6 +410,7 @@ npm run format     # Biome ile formatlama
 
 | Surum | Icerik |
 |-------|--------|
+| **v1.15.0** | `badi market` — App Store pazar arastirmasi komutu ([vibecodingex.com/skills/app-market-research](https://vibecodingex.com/skills/app-market-research) skill'inden esinlenildi). MVP: rakip kesfi + coklu bolge yorum + 11-kod sikayet kategorize + zorluk skoru (BLUE_OCEAN / COMPETITIVE / HARD / SATURATED). Alt komutlar: `discover`, `reviews`, `difficulty`, tam rapor. API anahtari gerekmez. 379 test (+20). Faz 2 (issue'lar): SensorTower revenue, wishlist demand×supply matrix, opportunity gaps. |
 | **v1.14.1** | CI matrisinden Node 18 cikarildi. Test dosyalari `import.meta.dirname` (Node 20.11+) kullaniyor; Node 18 satiri sessizce kiriliyordu. `engines.node` `>=20.11.0`'e bumped. Runtime kod degisimi yok; production CLI zaten Node 20+ ile calisiyor. |
 | **v1.14.0** | Skill ekosistemi MVP — agentskills.io-uyumlu skill bundle pipeline. Yeni `lib/skills/schema.js` validator + `lib/harnesses/skills-bundler.js` compiler + `badi publish --skill-bundle` orkestrator. 23 `.claude/skills/*/SKILL.md` tam frontmatter ile zenginlesti. Yeni `badi-discipline` davranissal skill (Karpathy-pattern 8 ilke) ayri `badi-skills` repo'sunda ship'e hazir. Bootstrap kit `_bootstrap/badi-skills/` altinda. 307 → 359 test (+52). #56 ve #57 close. |
 | **v1.13.2** | 7-bulgu code-review hotfix: `icerik durum/kapat` "bugun" sayim'inda UTC-bias duzeltildi (yerel `startOfToday`); `runTemplate` switch'i `default: throw` ile saglamlastirildi; "bilinmeyen subcommand" hatasi 21 gecerli komutu listeliyor; `icerik.js` shim'i kaldirildi (direkt import); doc/yorum cilasi. 307 test yesil. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fatihkan/badi",
-	"version": "1.14.1",
+	"version": "1.15.0",
 	"description": "Claude Code kullanicilari icin profesyonel is akisi yonetim sistemi",
 	"type": "module",
 	"main": "bin/badi.js",


### PR DESCRIPTION
Release commit. v1.14.1 → v1.15.0 minor bump. Tests 359 → 379.