### PR TITLE
chore: gitignore generated skill bundle output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ Desktop.ini
 dist/
 build/
 *.tgz
+
+# Generated skill bundle output (lives in separate badi-skills repo)
+_bootstrap/badi-skills/skills/*
+!_bootstrap/badi-skills/skills/badi-discipline/
+_bootstrap/badi-skills/.git/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@fatihkan/badi",
-	"version": "1.14.1",
+	"version": "1.15.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@fatihkan/badi",
-			"version": "1.14.1",
+			"version": "1.15.3",
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^5.3.0",


### PR DESCRIPTION
Bundle output ayri repo'ya ait — main repo'da takip edilmiyor. badi-discipline tracked kaldi.