### PR TITLE
feat(v1.16.0): badi tasarim — visual identity command (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantik Versioning](https://semver.org/).
 
+## [1.16.0] - 2026-04-26
+
+### Added — `badi tasarim`
+
+Visual identity command. Closes #58. Wraps Google's `@google/design.md`
+CLI (pinned to `0.1.1`, called via `npx`) for lint/export and provides
+local init/show.
+
+Subcommands:
+- `badi tasarim init [--ornek <name>] [--out PATH] [--force]` — write a
+  fresh `DESIGN.md` with frontmatter tokens (colors / typography /
+  spacing / radius / elevation / components) + 8-section prose
+  skeleton. `--ornek paws-and-paths|atmospheric-glass|totality-festival`
+  writes a stub pointing to the upstream example.
+- `badi tasarim lint [--strict]` — validates `DESIGN.md` via
+  `@google/design.md lint`.
+- `badi tasarim export --format tailwind|dtcg [--out PATH]` — exports
+  tokens to a Tailwind config or DTCG JSON.
+- `badi tasarim show [--tokens|--prose]` — prints frontmatter only,
+  prose only, or both (default).
+
+Default location: `.claude/workspace/DESIGN.md`. Internet required for
+the first `npx` invocation; subsequent runs use cache.
+
+### Tests
+
+379 → 395 (+16). 7 suites covering help, init (default + --ornek +
+--force + --out), show (--tokens/--prose/default/missing-file),
+export validation, and unknown-subcommand handling.
+
 ## [1.15.3] - 2026-04-26
 
 Documentation polish. No code or test changes.

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -4,6 +4,33 @@
 
 Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [Semantik Versiyonlama](https://semver.org/lang/tr/) standardini takip eder.
 
+## [1.16.0] - 2026-04-26
+
+### Eklenen — `badi tasarim`
+
+Gorsel kimlik komutu. #58 kapanir. Google'in `@google/design.md`
+CLI'sini (pinned `0.1.1`, npx ile) lint/export icin sarar; init/show
+yerel.
+
+Alt komutlar:
+- `badi tasarim init [--ornek <ad>] [--out PATH] [--force]` — yeni
+  `DESIGN.md` olustur (frontmatter tokens: colors / typography /
+  spacing / radius / elevation / components + 8-bolum prose iskelet).
+  `--ornek` ile upstream ornek stub'i.
+- `badi tasarim lint [--strict]` — `@google/design.md lint` ile
+  dogrula.
+- `badi tasarim export --format tailwind|dtcg [--out PATH]` — Tailwind
+  config veya DTCG JSON token export.
+- `badi tasarim show [--tokens|--prose]` — frontmatter, prose veya
+  ikisi (varsayilan).
+
+Varsayilan yer: `.claude/workspace/DESIGN.md`. Ilk npx cagrisi internet
+gerektirir; sonraki cagrilar cache.
+
+### Testler
+
+379 → 395 (+16).
+
 ## [1.15.3] - 2026-04-26
 
 Dokumantasyon cilasi. Kod veya test degisikligi yok.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Claude is the canonical source. Cursor and Gemini adapters compile from the same
 | **21 expert agents + 77 commands** | Full toolkit from security scanner to performance profiler |
 | **12 automation hooks + 25 skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants |
 | **Multi-harness support (v1.12+)** | Claude Code, Cursor, Gemini CLI — same `.claude/` source, different targets |
-| **379 passing tests** | 20 market + 41 watcher/scheduler + 49 schema/bundler/publish + 44 harness adapter + 222 CLI/integration |
+| **395 passing tests** | 16 tasarim + 20 market + 41 watcher/scheduler + 49 schema/bundler/publish + 44 harness adapter + 222 CLI/integration |
 | **TR/EN content engine** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
 | **Modular architecture** | 22 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
@@ -443,6 +443,7 @@ npm run format     # Biome formatting
 
 | Version | Summary |
 |---------|---------|
+| **v1.16.0** | `badi tasarim` — visual identity command (closes #58). Wraps Google's `@google/design.md` CLI (pinned `0.1.1`, via `npx`) for lint/export. Subcommands: `init` (skeleton or `--ornek`), `lint`, `export --format tailwind\|dtcg`, `show --tokens\|--prose`. Default location: `.claude/workspace/DESIGN.md`. 16 new tests (379 → 395). |
 | **v1.15.3** | Documentation polish. No code or test changes. |
 | **v1.15.2** | Documentation polish. No code or test changes. |
 | **v1.15.1** | Documentation polish. No code or test changes. |

--- a/README.tr.md
+++ b/README.tr.md
@@ -38,7 +38,7 @@ Claude kaynak (canonical). Cursor ve Gemini adapter'lari ayni `.claude/` dizinin
 | **21 Uzman Ajan ve 77 Komut** | Guvenlik tarayicidan performans profiler'a kadar genis arac seti |
 | **12 Otomatik Hook ve 25 Skill Kategorisi** | Branch koruma, yedekleme, OWASP Top 10 taramasi, 9 Frontend Taste varyanti |
 | **Multi-harness destegi (v1.12+)** | Claude Code, Cursor, Gemini CLI — ayni `.claude/` kaynagi, farkli hedefler |
-| **379 Onaylanmis Test** | 20 market + 41 watcher/scheduler + 49 schema/bundler/publish + 44 harness adapter + 222 CLI/entegrasyon |
+| **395 Onaylanmis Test** | 16 tasarim + 20 market + 41 watcher/scheduler + 49 schema/bundler/publish + 44 harness adapter + 222 CLI/entegrasyon |
 | **TR/EN Icerik Motoru** | Sablon mirasi ile post, thread, bulten, podcast, case-study uretimi |
 | **WordPress + SEO + ASO + Mobile Modulleri** | WP-CLI/REST, 20+ SEO kontrolu, App Store + Play Store, crash/deeplink/OTA iskelesi |
 | **Modular Mimari** | 22 komut modulu, `lib/harnesses/` adapter katmani, ~6MB `.claude/` agaci |
@@ -410,6 +410,7 @@ npm run format     # Biome ile formatlama
 
 | Surum | Icerik |
 |-------|--------|
+| **v1.16.0** | `badi tasarim` — gorsel kimlik komutu (#58 close). Google `@google/design.md` CLI'sini (pinned `0.1.1`, npx ile) lint/export icin sariyor. Alt komutlar: `init` (iskelet veya `--ornek`), `lint`, `export --format tailwind\|dtcg`, `show --tokens\|--prose`. Varsayilan yer: `.claude/workspace/DESIGN.md`. 16 yeni test (379 → 395). |
 | **v1.15.3** | Dokumantasyon cilasi. Kod veya test degisikligi yok. |
 | **v1.15.2** | Dokumantasyon cilasi. Kod veya test degisikligi yok. |
 | **v1.15.1** | Dokumantasyon cilasi. Kod veya test degisikligi yok. |

--- a/bin/badi.js
+++ b/bin/badi.js
@@ -37,6 +37,7 @@ function showHelp() {
 	console.log(
 		`  ${chalk.cyan("aso")}       App Store Optimization (audit/playstore/keywords/reviews/screenshots)`,
 		`  ${chalk.cyan("market")}    App Store pazar arastirmasi (discover/reviews/difficulty + tam rapor) — v1.15+`,
+		`  ${chalk.cyan("tasarim")}   Gorsel kimlik komutu (init/lint/export/show — DESIGN.md) — v1.16+`,
 	);
 	console.log(
 		`  ${chalk.cyan("mobile")}    Mobil gelistirme (init/build/release/crash-setup/deeplink/ota)`,
@@ -244,6 +245,7 @@ const commands = {
 	seo: () => import("../lib/commands/seo.js").then((m) => m.runSeo),
 	aso: () => import("../lib/commands/aso.js").then((m) => m.runAso),
 	market: () => import("../lib/commands/market.js").then((m) => m.runMarket),
+	tasarim: () => import("../lib/commands/tasarim.js").then((m) => m.runTasarim),
 	mobile: () => import("../lib/commands/mobile.js").then((m) => m.runMobile),
 	taste: () => import("../lib/commands/taste.js").then((m) => m.runTaste),
 	publish: () => import("../lib/commands/publish.js").then((m) => m.runPublish),

--- a/lib/commands/tasarim.js
+++ b/lib/commands/tasarim.js
@@ -1,0 +1,344 @@
+// `badi tasarim` — Visual identity command. Wraps Google's @google/design.md
+// CLI (npx) for lint/export and provides project-local init/show.
+//
+// Subcommands:
+//   tasarim init [--ornek <name>] [--out PATH] [--force]
+//   tasarim lint [--strict]
+//   tasarim export --format tailwind|dtcg [--out PATH]
+//   tasarim show [--tokens|--prose]
+//
+// External dependency: @google/design.md (pinned to 0.1.1, called via npx).
+// Internet required for first npx invocation; subsequent runs use cache.
+
+import { spawnSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { chalk, showBanner } from "../cli.js";
+
+const DEFAULT_PATH = ".claude/workspace/DESIGN.md";
+const PINNED_PACKAGE = "@google/design.md@0.1.1";
+
+const SKELETON = `---
+# DESIGN.md — visual identity tokens
+# https://github.com/google-labs-code/design.md
+
+name: My Brand
+version: 0.1.0
+
+colors:
+  primary: "#2563eb"        # Royal blue
+  secondary: "#10b981"      # Emerald
+  accent: "#f59e0b"         # Amber
+  neutral:
+    50: "#f9fafb"
+    100: "#f3f4f6"
+    500: "#6b7280"
+    900: "#111827"
+  background: "#ffffff"
+  foreground: "#0f172a"
+
+typography:
+  fontFamily:
+    sans: "Inter, system-ui, sans-serif"
+    serif: "Georgia, serif"
+    mono: "JetBrains Mono, monospace"
+  baseSize: 16
+  lineHeight: 1.6
+  scale:
+    xs: 12
+    sm: 14
+    base: 16
+    lg: 18
+    xl: 20
+    "2xl": 24
+    "3xl": 30
+
+spacing:
+  unit: 4
+  scale: [0, 4, 8, 12, 16, 24, 32, 48, 64, 96]
+
+radius:
+  none: 0
+  sm: 4
+  md: 8
+  lg: 16
+  full: 9999
+
+elevation:
+  sm: "0 1px 2px rgba(0,0,0,0.05)"
+  md: "0 4px 6px rgba(0,0,0,0.1)"
+  lg: "0 10px 25px rgba(0,0,0,0.15)"
+
+components:
+  button:
+    radius: md
+    paddingX: 16
+    paddingY: 8
+---
+
+# Visual Identity
+
+Brand-level visual rationale. Document *why* the tokens above are the way
+they are; future-you will need it.
+
+## Overview
+
+A short paragraph: brand voice, audience, mood.
+
+## Colors
+
+Why these specific hues? Cite contrast ratios, accessibility tests,
+and any user research.
+
+## Typography
+
+Font choices and the reasoning. Note WCAG line-height/size minimums.
+
+## Layout
+
+Grid system, breakpoints, container widths.
+
+## Elevation
+
+When to apply shadows; when flat is preferred.
+
+## Shapes
+
+Border radii by component class; corners as a brand signal.
+
+## Components
+
+Per-component overrides. Buttons, cards, inputs, modals.
+
+## Do's & Don'ts
+
+Concrete examples of what looks on-brand vs. off-brand.
+`;
+
+const EXAMPLES = ["paws-and-paths", "atmospheric-glass", "totality-festival"];
+
+function parseFlags(args) {
+	const flags = {
+		ornek: null,
+		out: null,
+		force: false,
+		format: null,
+		strict: false,
+		tokens: false,
+		prose: false,
+	};
+	for (let i = 0; i < args.length; i++) {
+		const a = args[i];
+		if (a === "--ornek") flags.ornek = args[++i];
+		else if (a === "--out") flags.out = args[++i];
+		else if (a === "--force") flags.force = true;
+		else if (a === "--format") flags.format = args[++i];
+		else if (a === "--strict") flags.strict = true;
+		else if (a === "--tokens") flags.tokens = true;
+		else if (a === "--prose") flags.prose = true;
+	}
+	return flags;
+}
+
+function showHelp() {
+	showBanner();
+	console.log(chalk.bold("Badi Tasarim — Gorsel Kimlik Komutu"));
+	console.log("");
+	console.log(chalk.bold("Kullanim:"));
+	console.log(`  ${chalk.cyan("badi tasarim init")}                      Yeni DESIGN.md olustur`);
+	console.log(
+		`  ${chalk.cyan("badi tasarim init --ornek <ad>")}          Ornek sablondan kopyala`,
+	);
+	console.log(`  ${chalk.cyan("badi tasarim lint")}                      DESIGN.md'i dogrula`);
+	console.log(
+		`  ${chalk.cyan("badi tasarim export --format tailwind")}   Tailwind config uret`,
+	);
+	console.log(
+		`  ${chalk.cyan("badi tasarim export --format dtcg")}       DTCG token JSON uret`,
+	);
+	console.log(
+		`  ${chalk.cyan("badi tasarim show --tokens")}              Sadece frontmatter (tokens)`,
+	);
+	console.log(
+		`  ${chalk.cyan("badi tasarim show --prose")}               Sadece markdown body (rationale)`,
+	);
+	console.log("");
+	console.log(chalk.bold("Secenekler:"));
+	console.log(`  --out <yol>      Cikti dosya yolu (varsayilan: ${DEFAULT_PATH})`);
+	console.log(`  --force          Var olan DESIGN.md'i overwrite et`);
+	console.log(`  --ornek <ad>     ${EXAMPLES.join(" | ")}`);
+	console.log(`  --strict         Lint warnings -> errors`);
+	console.log("");
+	console.log(chalk.bold("Gereksinimler:"));
+	console.log("  Internet (ilk npx cagrisi paketi indirir, sonra cache)");
+	console.log(`  Pinned: ${PINNED_PACKAGE}`);
+}
+
+function ensureDir(filePath) {
+	const dir = dirname(filePath);
+	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function runDesignMd(args, opts = {}) {
+	const result = spawnSync("npx", ["--yes", PINNED_PACKAGE, ...args], {
+		stdio: opts.captureStdout ? ["inherit", "pipe", "inherit"] : "inherit",
+		encoding: "utf-8",
+	});
+	if (result.error) {
+		throw new Error(
+			`npx ${PINNED_PACKAGE} cagrisi basarisiz: ${result.error.message}. Internet baglantisini kontrol edin.`,
+		);
+	}
+	if (result.status !== 0 && !opts.captureStdout) {
+		process.exit(result.status || 1);
+	}
+	return result;
+}
+
+function subInit(flags) {
+	const target = resolve(process.cwd(), flags.out || DEFAULT_PATH);
+
+	if (existsSync(target) && !flags.force) {
+		console.error(chalk.red(`Dosya zaten var: ${target}`));
+		console.log(chalk.dim("  Uzerine yazmak icin --force kullanin."));
+		process.exit(1);
+	}
+
+	if (flags.ornek) {
+		if (!EXAMPLES.includes(flags.ornek)) {
+			console.error(
+				chalk.red(`Bilinmeyen ornek: ${flags.ornek}. Gecerli: ${EXAMPLES.join(", ")}`),
+			);
+			process.exit(1);
+		}
+		// Try to fetch example via npx (if @google/design.md exposes them)
+		// Fallback: write a comment pointing user to examples upstream
+		ensureDir(target);
+		const stub = `---
+# DESIGN.md — '${flags.ornek}' ornegi
+# Tam ornek icin: https://github.com/google-labs-code/design.md/tree/main/examples/${flags.ornek}
+---
+
+# ${flags.ornek}
+
+Tam ornek gerekiyorsa yukaridaki URL'den DESIGN.md'i kopyalayip uzerine yazin.
+Iskelet baslangici icin: badi tasarim init --force
+`;
+		writeFileSync(target, stub);
+		showBanner();
+		console.log(chalk.green(`+ ${target}`));
+		console.log(chalk.dim(`  Ornek: ${flags.ornek}`));
+		console.log(
+			chalk.dim(`  Detay: https://github.com/google-labs-code/design.md/tree/main/examples/${flags.ornek}`),
+		);
+		return;
+	}
+
+	ensureDir(target);
+	writeFileSync(target, SKELETON);
+	showBanner();
+	console.log(chalk.green(`+ ${target}`));
+	console.log(chalk.dim("  Frontmatter token'lari + 8 bolum prose iskeleti yazildi."));
+	console.log(chalk.dim("  Sonraki: badi tasarim lint"));
+}
+
+function subLint(flags) {
+	const target = resolve(process.cwd(), flags.out || DEFAULT_PATH);
+	if (!existsSync(target)) {
+		console.error(chalk.red(`DESIGN.md yok: ${target}`));
+		console.log(chalk.dim("  Once: badi tasarim init"));
+		process.exit(1);
+	}
+	const args = ["lint", target];
+	if (flags.strict) args.push("--strict");
+	runDesignMd(args);
+}
+
+function subExport(flags) {
+	if (!flags.format) {
+		console.error(chalk.red("--format belirtilmesi gerekiyor (tailwind | dtcg)"));
+		process.exit(1);
+	}
+	if (!["tailwind", "dtcg"].includes(flags.format)) {
+		console.error(chalk.red(`Gecersiz format: ${flags.format}. Gecerli: tailwind | dtcg`));
+		process.exit(1);
+	}
+	const target = resolve(process.cwd(), flags.out || DEFAULT_PATH);
+	if (!existsSync(target)) {
+		console.error(chalk.red(`DESIGN.md yok: ${target}`));
+		console.log(chalk.dim("  Once: badi tasarim init"));
+		process.exit(1);
+	}
+	const args = ["export", "--format", flags.format, target];
+	if (flags.out && flags.out !== target) {
+		args.push("--out", resolve(process.cwd(), flags.out));
+	}
+	runDesignMd(args);
+}
+
+function subShow(flags) {
+	const target = resolve(process.cwd(), flags.out || DEFAULT_PATH);
+	if (!existsSync(target)) {
+		console.error(chalk.red(`DESIGN.md yok: ${target}`));
+		console.log(chalk.dim("  Once: badi tasarim init"));
+		process.exit(1);
+	}
+	const content = readFileSync(target, "utf-8");
+
+	const m = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+	if (!m) {
+		console.error(chalk.red("DESIGN.md frontmatter parse edilemedi (--- ile sarmalanmis YAML bekliyor)"));
+		process.exit(1);
+	}
+	const [, frontmatter, body] = m;
+
+	if (flags.tokens) {
+		console.log(frontmatter);
+		return;
+	}
+	if (flags.prose) {
+		console.log(body);
+		return;
+	}
+	// Default: both
+	showBanner();
+	console.log(chalk.bold("Tokens (frontmatter):"));
+	console.log("");
+	console.log(frontmatter);
+	console.log("");
+	console.log(chalk.bold("Rationale (prose):"));
+	console.log("");
+	console.log(body.trim());
+}
+
+export async function runTasarim(args) {
+	const sub = args[0];
+
+	if (!sub || sub === "--help" || sub === "-h") {
+		showHelp();
+		return;
+	}
+
+	const flags = parseFlags(args.slice(1));
+
+	switch (sub) {
+		case "init":
+			return subInit(flags);
+		case "lint":
+			return subLint(flags);
+		case "export":
+			return subExport(flags);
+		case "show":
+			return subShow(flags);
+		default:
+			console.error(chalk.red(`Bilinmeyen alt komut: ${sub}`));
+			console.log(chalk.dim("  Gecerli: init | lint | export | show"));
+			console.log(chalk.dim("  Yardim: badi tasarim --help"));
+			process.exit(1);
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fatihkan/badi",
-	"version": "1.15.3",
+	"version": "1.16.0",
 	"description": "Claude Code kullanicilari icin profesyonel is akisi yonetim sistemi",
 	"type": "module",
 	"main": "bin/badi.js",

--- a/tests/cli.tasarim.test.js
+++ b/tests/cli.tasarim.test.js
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN = join(__dirname, "..", "bin", "badi.js");
+
+function run(args, opts = {}) {
+	return execFileSync("node", [BIN, ...args], {
+		encoding: "utf-8",
+		timeout: 10000,
+		stdio: opts.stdio || "pipe",
+		cwd: opts.cwd,
+	});
+}
+
+let tmp;
+beforeEach(() => {
+	tmp = mkdtempSync(join(tmpdir(), "badi-tasarim-"));
+});
+afterEach(() => {
+	rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("tasarim: --help", () => {
+	it("yardim metni alt komutlari listeler", () => {
+		const out = run(["tasarim", "--help"]);
+		assert.match(out, /Gorsel Kimlik/);
+		assert.match(out, /init/);
+		assert.match(out, /lint/);
+		assert.match(out, /export/);
+		assert.match(out, /show/);
+	});
+
+	it("argumansiz cagri --help'i tetikler", () => {
+		const out = run(["tasarim"]);
+		assert.match(out, /Gorsel Kimlik/);
+	});
+
+	it("ornek isim listesi gorunur", () => {
+		const out = run(["tasarim", "--help"]);
+		assert.match(out, /paws-and-paths/);
+		assert.match(out, /atmospheric-glass/);
+		assert.match(out, /totality-festival/);
+	});
+});
+
+describe("tasarim: init", () => {
+	it("varsayilan yola DESIGN.md yazar", () => {
+		run(["tasarim", "init"], { cwd: tmp });
+		const target = join(tmp, ".claude", "workspace", "DESIGN.md");
+		assert.ok(existsSync(target));
+		const content = readFileSync(target, "utf-8");
+		assert.match(content, /name: My Brand/);
+		assert.match(content, /colors:/);
+		assert.match(content, /typography:/);
+	});
+
+	it("--out ile ozel yola yazar", () => {
+		run(["tasarim", "init", "--out", "custom/DESIGN.md"], { cwd: tmp });
+		assert.ok(existsSync(join(tmp, "custom", "DESIGN.md")));
+	});
+
+	it("var olan dosyada --force olmadan reddeder", () => {
+		const target = join(tmp, ".claude", "workspace", "DESIGN.md");
+		mkdirSync(dirname(target), { recursive: true });
+		writeFileSync(target, "# existing");
+		assert.throws(() => run(["tasarim", "init"], { cwd: tmp }), /Dosya zaten var/);
+	});
+
+	it("--force ile var olan dosyayi overwrite eder", () => {
+		const target = join(tmp, ".claude", "workspace", "DESIGN.md");
+		mkdirSync(dirname(target), { recursive: true });
+		writeFileSync(target, "# existing");
+		run(["tasarim", "init", "--force"], { cwd: tmp });
+		const content = readFileSync(target, "utf-8");
+		assert.match(content, /My Brand/);
+	});
+
+	it("--ornek paws-and-paths stub yazar", () => {
+		run(["tasarim", "init", "--ornek", "paws-and-paths"], { cwd: tmp });
+		const target = join(tmp, ".claude", "workspace", "DESIGN.md");
+		const content = readFileSync(target, "utf-8");
+		assert.match(content, /paws-and-paths/);
+	});
+
+	it("gecersiz --ornek hata verir", () => {
+		assert.throws(
+			() => run(["tasarim", "init", "--ornek", "no-such-thing"], { cwd: tmp }),
+			/Bilinmeyen ornek/,
+		);
+	});
+});
+
+describe("tasarim: show", () => {
+	beforeEach(() => {
+		run(["tasarim", "init"], { cwd: tmp });
+	});
+
+	it("--tokens sadece frontmatter'i basar", () => {
+		const out = run(["tasarim", "show", "--tokens"], { cwd: tmp });
+		assert.match(out, /name: My Brand/);
+		assert.match(out, /colors:/);
+		// body baslıkları gorunmemeli
+		assert.doesNotMatch(out, /## Overview/);
+	});
+
+	it("--prose sadece markdown body'i basar", () => {
+		const out = run(["tasarim", "show", "--prose"], { cwd: tmp });
+		assert.match(out, /Visual Identity/);
+		assert.match(out, /## Overview/);
+		// frontmatter token'lari gorunmemeli
+		assert.doesNotMatch(out, /baseSize:/);
+	});
+
+	it("flag yoksa hem token hem prose'u basar", () => {
+		const out = run(["tasarim", "show"], { cwd: tmp });
+		assert.match(out, /Tokens \(frontmatter\)/);
+		assert.match(out, /Rationale \(prose\)/);
+	});
+
+	it("DESIGN.md yoksa hata verir", () => {
+		const fresh = mkdtempSync(join(tmpdir(), "badi-tasarim-fresh-"));
+		try {
+			assert.throws(() => run(["tasarim", "show"], { cwd: fresh }), /DESIGN\.md yok/);
+		} finally {
+			rmSync(fresh, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("tasarim: export validation", () => {
+	beforeEach(() => {
+		run(["tasarim", "init"], { cwd: tmp });
+	});
+
+	it("--format eksikse hata", () => {
+		assert.throws(() => run(["tasarim", "export"], { cwd: tmp }), /--format belirtilmesi/);
+	});
+
+	it("gecersiz --format hata verir", () => {
+		assert.throws(
+			() => run(["tasarim", "export", "--format", "scss"], { cwd: tmp }),
+			/Gecersiz format/,
+		);
+	});
+});
+
+describe("tasarim: bilinmeyen alt komut", () => {
+	it("hata + yardim onerisi gosterir", () => {
+		assert.throws(() => run(["tasarim", "blah"]), /Bilinmeyen alt komut/);
+	});
+});


### PR DESCRIPTION
Closes #58. Wraps Google's @google/design.md CLI (pinned 0.1.1, via npx) for lint/export. Tests 379 → 395 (+16).