### PR TITLE
fix(skills): decouple parseFrontmatter from cli.js for CI validator

### DIFF
--- a/lib/frontmatter.js
+++ b/lib/frontmatter.js
@@ -1,0 +1,28 @@
+// Minimal markdown frontmatter parser.
+//
+// Bagimsiz tutuldu (chalk/cli yok) — boylece harici tooling (orn.
+// badi-skills CI validate workflow) sadece bu dosyayi cekerek skill
+// schema'sini dogrulayabilir.
+
+export function parseFrontmatter(content) {
+	const lines = content.split("\n");
+	if (lines[0] !== "---") return { meta: {}, body: content };
+	const endIdx = lines.indexOf("---", 1);
+	if (endIdx === -1) return { meta: {}, body: content };
+	const meta = {};
+	for (let i = 1; i < endIdx; i++) {
+		const colonIdx = lines[i].indexOf(": ");
+		if (colonIdx > 0) {
+			meta[lines[i].substring(0, colonIdx).trim()] = lines[i]
+				.substring(colonIdx + 2)
+				.trim();
+		}
+	}
+	return {
+		meta,
+		body: lines
+			.slice(endIdx + 1)
+			.join("\n")
+			.trim(),
+	};
+}

--- a/lib/icerik-helpers.js
+++ b/lib/icerik-helpers.js
@@ -8,6 +8,9 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { chalk } from "./cli.js";
+import { parseFrontmatter } from "./frontmatter.js";
+
+export { parseFrontmatter };
 
 export function loadPreferences() {
 	const prefFile = join(homedir(), ".config", "badi", "preferences.json");
@@ -80,29 +83,6 @@ export function calculateSimilarity(a, b) {
 	const union = new Set([...wordsA, ...wordsB]).size;
 	const jaccard = union > 0 ? intersection / union : 0;
 	return levSim * 0.4 + jaccard * 0.6;
-}
-
-export function parseFrontmatter(content) {
-	const lines = content.split("\n");
-	if (lines[0] !== "---") return { meta: {}, body: content };
-	const endIdx = lines.indexOf("---", 1);
-	if (endIdx === -1) return { meta: {}, body: content };
-	const meta = {};
-	for (let i = 1; i < endIdx; i++) {
-		const colonIdx = lines[i].indexOf(": ");
-		if (colonIdx > 0) {
-			meta[lines[i].substring(0, colonIdx).trim()] = lines[i]
-				.substring(colonIdx + 2)
-				.trim();
-		}
-	}
-	return {
-		meta,
-		body: lines
-			.slice(endIdx + 1)
-			.join("\n")
-			.trim(),
-	};
 }
 
 export function slugify(text) {

--- a/lib/skills/schema.js
+++ b/lib/skills/schema.js
@@ -11,7 +11,7 @@
 // cikti dili Turkce ama schema mesajlari (validate ciktisi) standart
 // sekilde okumak icin English.
 
-import { parseFrontmatter } from "../icerik-helpers.js";
+import { parseFrontmatter } from "../frontmatter.js";
 
 export const KNOWN_TOOLS = [
 	"Read",


### PR DESCRIPTION
## Sorun

\`badi-skills\` repo'sunun \`validate\` workflow'u 2 kez ust uste failure dondurdu (run #24942650548 ve #24942658011):

\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../cli.js'
imported from .../icerik-helpers.js
\`\`\`

### Kok Neden

Workflow ana repo'dan iki dosya cekiyor: \`lib/skills/schema.js\` + \`lib/icerik-helpers.js\`. Ama \`icerik-helpers.js\`'in tepe basinda \`import { chalk } from "./cli.js"\` var → Node \`cli.js\`'i de yuklemeye calisiyor → CI'da yok → modul yuklenemiyor → \`validateSkillFile\` calismadan exit 1.

\`cli.js\`'i ek olarak cekmek **kotu cozum** olurdu:
- \`package.json\` da gerekli (cli.js okuyor)
- \`chalk\`/\`figlet\` npm paketleri yuklenmeli
- \`PKG_ROOT/.claude\` referansi zincirli kirilmaya acik

## Cozum

\`parseFrontmatter\`'i sifir-bagimlilikli yeni bir module (\`lib/frontmatter.js\`) tasidim. \`schema.js\` direkt buradan import ediyor. \`icerik-helpers.js\` re-export ile geri uyumlulugu koruyor.

## Etki

| Dosya | Degisiklik |
|-------|-----------|
| \`lib/frontmatter.js\` | **Yeni** — parseFrontmatter (sifir bagimlilik) |
| \`lib/skills/schema.js\` | Import yolu degisti |
| \`lib/icerik-helpers.js\` | parseFrontmatter cikarildi, re-export eklendi |

## Dogrulama

- Tum testler yesil: 395/395 ✅
- Lokal CI simulasyonu (curl + sed + validate.mjs) gecti: \`exit=0\` ✅

## Test Plani

- [x] \`npm test\` 395/395 yesil
- [x] Lokal CI simulasyonu (workflow ile ayni curl + sed mantigi) basarili
- [ ] Merge sonrasi badi-skills repo'sunda \`validate\` workflow'u re-run yesil dondurmeli