### PR TITLE
fix(skills): inline parseFrontmatter for CI self-containment

### DIFF
--- a/lib/skills/schema.js
+++ b/lib/skills/schema.js
@@ -10,8 +10,34 @@
 // Hata mesajlari English — uluslararasi kullaniciya hitap eder. Badi CLI
 // cikti dili Turkce ama schema mesajlari (validate ciktisi) standart
 // sekilde okumak icin English.
+//
+// parseFrontmatter inline tutuldu — bu dosya badi-skills CI tarafindan tek
+// basina curl ile cekiliyor. Disardan import = kirik bagimlilik zinciri.
+// Canonical kopya: lib/frontmatter.js. Iki yer arasinda davranis ayni
+// olmali (test: tests/skill-schema.test.js parseRichFrontmatter).
 
-import { parseFrontmatter } from "../frontmatter.js";
+function parseFrontmatter(content) {
+	const lines = content.split("\n");
+	if (lines[0] !== "---") return { meta: {}, body: content };
+	const endIdx = lines.indexOf("---", 1);
+	if (endIdx === -1) return { meta: {}, body: content };
+	const meta = {};
+	for (let i = 1; i < endIdx; i++) {
+		const colonIdx = lines[i].indexOf(": ");
+		if (colonIdx > 0) {
+			meta[lines[i].substring(0, colonIdx).trim()] = lines[i]
+				.substring(colonIdx + 2)
+				.trim();
+		}
+	}
+	return {
+		meta,
+		body: lines
+			.slice(endIdx + 1)
+			.join("\n")
+			.trim(),
+	};
+}
 
 export const KNOWN_TOOLS = [
 	"Read",


### PR DESCRIPTION
## Sorun

PR #80 sonrasi badi-skills validate workflow'u hala kirik:

\`\`\`
Cannot find module '.../frontmatter.js' imported from .../.ci/schema.js
\`\`\`

PR #80 \`parseFrontmatter\`'i \`lib/frontmatter.js\`'e cikardi (cli.js zincirini kirmak icin) — ama \`schema.js\` hala bir kardes dosyaya bagimli. badi-skills CI yalnizca \`schema.js\`'i curl ediyor, dolayisiyla **disardan herhangi bir import** kirik bagimlilik zinciri demek.

## Cozum

\`parseFrontmatter\`'i \`schema.js\`'in **icine** inline et. schema.js artik **sifir relatif import** iceriyor — CI tek dosya olarak curl edebilir, hicbir ek isleme gerekmez. Mevcut \`badi-skills/validate.yml\` workflow'u hic degismeden calisir (kullanilmayan \`icerik-helpers.js\` curl ve sed satiri no-op olur).

## Trade-off

\`parseFrontmatter\` artik iki yerde:
- \`lib/frontmatter.js\` — ana kod icin canonical
- \`lib/skills/schema.js\` — CI self-contained kopya

Kabul edilebilir cunku:
- Fonksiyon **22 satir** ve stabil pure logic
- Schema.js zaten **kasten** curl-dostu olacak sekilde tasarlanmis
- Schema test'leri (\`tests/skill-schema.test.js\`) regresyon koruyor

## Dogrulama

- \`npm test\`: **395/395 yesil** ✅
- Lokal CI simulasyonu (workflow ile birebir flow: curl + sed + validate.mjs): \`exit=0\` ✅
- Workflow degismedi: badi-skills'e dokunmadan CI kirmizidan yesile cikacak

## Test Plani

- [x] \`npm test\` 395/395
- [x] Lokal CI simulasyonu basarili
- [ ] Merge sonrasi badi-skills'de validate workflow re-run yesil dondurmeli (bu sefer beklenen)

## Iliskili

- Refines #80 (#80'i tamamlayan ikinci adim)