### PR TITLE
chore(docs): strip remaining external author references

### DIFF
--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -129,12 +129,11 @@ CI / engines bump. Runtime kod degisimi yok.
 
 ### Eklenen — `badi-discipline` davranissal skill
 
-- 8 ilke (Karpathy 4 + Badi 4): Think Before Coding, Simplicity
-  First, Surgical Changes, Goal-Driven Execution, Yak-Shave Detection,
-  TaskBoard Discipline, Knowledge-Base Source Requirement, Destructive
-  Action Gate.
+- 8 ilke: Think Before Coding, Simplicity First, Surgical Changes,
+  Goal-Driven Execution, Yak-Shave Detection, TaskBoard Discipline,
+  Knowledge-Base Source Requirement, Destructive Action Gate.
 - 4 progressive-disclosure references.
-- SKILL.md preamble Karpathy'nin tradeoff notunu acikca tasiyor:
+- SKILL.md preamble tradeoff notunu acikca tasiyor:
   "These are prompt-level guidelines, not enforcement."
 
 ### Testler

--- a/docs/v1.14-plan.md
+++ b/docs/v1.14-plan.md
@@ -13,7 +13,7 @@ every PR.
 | Issue | Title | Effort | Depends on | Recommended for |
 |------:|-------|--------|------------|-----------------|
 | [#56](https://github.com/fatihkan/badi/issues/56) | skill-bundle publishing + portable bundle format | 2-3 days | — | **v1.14.0** |
-| [#57](https://github.com/fatihkan/badi/issues/57) | `badi-discipline` — Karpathy-style behavioral skill | 1 day | #56 (hard) | **v1.14.0** |
+| [#57](https://github.com/fatihkan/badi/issues/57) | `badi-discipline` — behavioral guideline skill | 1 day | #56 (hard) | **v1.14.0** |
 | [#58](https://github.com/fatihkan/badi/issues/58) | `badi tasarim` — design.md integration | ~4 days | — | **v1.14.1** |
 
 ## Why this split
@@ -72,7 +72,7 @@ purely about review surface and ship discipline.
 |----------|----------|
 | `badi-skills` versioning vs `@fatihkan/badi` | **Independent.** Badi 1.14.0 → badi-skills 1.0.0. The two evolve at different cadences; coupling them locks both teams to the slower one. |
 | `badi-skills` license | **MIT** (matches main repo; allows agents to remix). |
-| `badi-discipline` slug | **`badi-discipline`** (matches issue title; "discipline" carries the rigor connotation, differentiates from Karpathy's "guidelines"). |
+| `badi-discipline` slug | **`badi-discipline`** (matches issue title; "discipline" carries the rigor connotation and differentiates from generic "guidelines" framing). |
 | Schema source of truth | **`@fatihkan/badi`'s `lib/skills/schema.js`** is canonical. `badi-skills` CI imports it as a dev-dep at validation time. |
 | Plugin system overlap | **Distinct concepts.** `badi plugin install` = CLI extensions. `badi-skills` = agent behavior skills. Documented side-by-side in README, not unified. |
 | Multi-language SKILL.md (TR variants) | **Out of v1.14.0.** Phase 2. Ecosystem support unverified; ship English-first. |
@@ -130,7 +130,7 @@ purely about review surface and ship discipline.
 | `badi-skills` repo creation is one-shot — name, license, structure all become public commitments. | Spend half a day on the bare repo layout (template + CI + READMEs) before the first real skill lands. Easy to walk back if nothing has been published. |
 | Frontmatter enrichment for 25 skills is mostly automation but the description fields need triggers tuned for agent activation. Mechanical enrichment will produce weak triggers. | Budget half a day of manual review per ~5 skills. Use the existing `frontend-taste` SKILL.md as the description template. |
 | `@google/design.md` is v0.1.1 — alpha. Breaking changes between minor releases are likely. | Pin exact version. Add `tests/cli.tasarim.test.js` smoke test that calls the pinned version's `lint` against a fixture and asserts on output shape. Bump deliberately. |
-| Behavioral skills (#57) make claims they cannot enforce — "simplicity first" is a guideline, not a check. README must say so or users feel cheated. | Lift Karpathy's tradeoff note into the SKILL.md preamble verbatim: "These are prompt-level guidelines, not enforcement." |
+| Behavioral skills (#57) make claims they cannot enforce — "simplicity first" is a guideline, not a check. README must say so or users feel cheated. | State the tradeoff verbatim in the SKILL.md preamble: "These are prompt-level guidelines, not enforcement." |
 | Two repos (`@fatihkan/badi` + `badi-skills`) means two release flows. CI drift between them is easy. | Add a cross-check job in `badi-skills` CI that pulls `@fatihkan/badi`'s `lib/skills/schema.js` and validates every SKILL.md against it. |
 
 ## Concrete next steps


### PR DESCRIPTION
## Sorun

Bugun (Gorev 2 — PR review hijyeni) 26.04.2026 mergelenen 24 PR'in body'leri ve repo dosyalari yasak harici proje atifi acisindan tarandi.

3 PR body'si zaten \`gh pr edit\` ile temizlendi (#61, #62, #63). **Repo dosyalarinda** ise iki dosya hala atif iceriyordu:

- \`docs/v1.14-plan.md\` (3 yer): "Karpathy-style behavioral skill", "Karpathy's guidelines", "Karpathy's tradeoff note"
- \`CHANGELOG.tr.md\` (2 yer): "Karpathy 4 + Badi 4", "Karpathy'nin tradeoff notu"

## Kural Hatirlatmasi

Memory: "harici proje atifi yok — README/CHANGELOG/source-comments/PR/issue/release notes'ta random 3rd-party repo veya marketplace adi olmayacak. Istisna: kurumsal markalar (Google, Meta gibi)."

## Cozum

Atifsiz, notr ifadeler. Listelenen ilkeler / icerik degismedi:

- "Karpathy-style behavioral skill" → "behavioral guideline skill"
- "differentiates from Karpathy's 'guidelines'" → "differentiates from generic 'guidelines' framing"
- "Lift Karpathy's tradeoff note" → "State the tradeoff verbatim"
- "8 ilke (Karpathy 4 + Badi 4)" → "8 ilke" (atfsiz)
- "SKILL.md preamble Karpathy'nin tradeoff notu" → "SKILL.md preamble tradeoff notu"

## Dogrulama

- \`npm test\`: **395/395 yesil** ✅
- \`grep -rn -iE "karpathy|agentskills|skills\\.sh|vibecoding"\` repo genelinde **temiz** (sadece daily-notes ve incident-log'da kuralin kendisi geciyor)

## Kalan is (bu PR'in disinda)

- v1.13.2 release notu \`agentskills.io\` + \`skills.sh\` referansi iceriyor — \`gh release edit\` ile ayrica temizlenecek