### PR TITLE
chore(seo): English-first metadata + Claude 4.7 / Sonnet 4.6 keywords

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Badi - Is Akisi Yonetim Sistemi
 
-> Claude Code icin yapilandirilmis operasyon yonetimi. 21 ajan, 50 komut, 12 hook, 21 beceri kategorisi.
+> Claude Code icin yapilandirilmis operasyon yonetimi. 21 ajan, 77 komut, 12 hook, 23 beceri kategorisi.
 
 ## Bellek Kurallari
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
   <img src="https://img.shields.io/npm/dt/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm total downloads" />
   <img src="https://img.shields.io/npm/l/@fatihkan/badi?color=00d4ff&style=flat-square" alt="license" />
   <img src="https://github.com/fatihkan/badi/actions/workflows/test.yml/badge.svg" alt="tests" />
-  <img src="https://img.shields.io/badge/node-%3E%3D18-00d4ff?style=flat-square" alt="node" />
+  <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-An open-source workflow management system for Claude Code users. Automates repetitive commands, runs security scans, and optimizes token consumption by **~96%**, boosting developer productivity. **v1.4+** added a digital-agency workflow: WordPress management + SEO audits. **v1.9** ships English-first documentation and a built-in App Store screenshot skill. **v1.12+** adds multi-harness support — the same Badi workflow can now compile into Cursor or Gemini CLI assets.
+**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **21 AI subagents**, **77 slash commands**, **12 automation hooks**, and **23 skill categories** (OWASP Top 10 scans, code review, content production, mobile/web SEO). Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
 
 ## One-Command Install
 
@@ -36,9 +36,9 @@ Claude is the canonical source. Cursor and Gemini adapters compile from the same
 | Feature | Details |
 |---------|---------|
 | **21 expert agents + 77 commands** | Full toolkit from security scanner to performance profiler |
-| **12 automation hooks + 25 skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants |
+| **12 automation hooks + 23 skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants |
 | **Multi-harness support (v1.12+)** | Claude Code, Cursor, Gemini CLI — same `.claude/` source, different targets |
-| **395 passing tests** | 16 tasarim + 20 market + 41 watcher/scheduler + 49 schema/bundler/publish + 44 harness adapter + 222 CLI/integration |
+| **398 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, tasarim |
 | **TR/EN content engine** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
 | **Modular architecture** | 22 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |

--- a/README.tr.md
+++ b/README.tr.md
@@ -8,10 +8,10 @@
   <img src="https://img.shields.io/npm/dt/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm total downloads" />
   <img src="https://img.shields.io/npm/l/@fatihkan/badi?color=00d4ff&style=flat-square" alt="license" />
   <img src="https://github.com/fatihkan/badi/actions/workflows/test.yml/badge.svg" alt="tests" />
-  <img src="https://img.shields.io/badge/node-%3E%3D18-00d4ff?style=flat-square" alt="node" />
+  <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-Claude Code kullanicilari icin gelistirilmis acik kaynakli bir is akisi yonetim sistemi. Tekrarlayan komutlari **otomatize ederek**, guvenlik taramalari yaparak ve token kullanimini **%96 oraninda optimize ederek** gelistirici uretkenligini artirir. **v1.4** ile dijital ajans calisma akisi: WordPress yonetimi + SEO denetim. **v1.12+** ile multi-harness destegi — ayni Badi is akisi artik Cursor veya Gemini CLI icin de derlenebiliyor.
+**Anthropic Claude Code, Cursor ve Gemini CLI icin is akisi yonetim CLI'i** — **Claude Opus 4.7** ve **Sonnet 4.6** uyumlu. **21 AI subagent**, **77 slash komut**, **12 otomatik hook** ve **23 skill kategorisi** (OWASP Top 10 tarama, code review, icerik uretimi, mobile/web SEO) icerir. Tekrarlayan is akislarinda token tuketimini **~%96** azaltir. **v1.12+** ile multi-harness destegi — ayni `.claude/` agaci Cursor ve Gemini CLI hedeflerine derlenir. **v1.16+** CodeQL sertlesmesi (TLS strict-first, DOM bazli HTML parse, URL hostname dogrulamasi).
 
 ## Tek Komutla Kurulum
 
@@ -36,9 +36,9 @@ Claude kaynak (canonical). Cursor ve Gemini adapter'lari ayni `.claude/` dizinin
 | Ozellik | Detay |
 |---------|-------|
 | **21 Uzman Ajan ve 77 Komut** | Guvenlik tarayicidan performans profiler'a kadar genis arac seti |
-| **12 Otomatik Hook ve 25 Skill Kategorisi** | Branch koruma, yedekleme, OWASP Top 10 taramasi, 9 Frontend Taste varyanti |
+| **12 Otomatik Hook ve 23 Skill Kategorisi** | Branch koruma, yedekleme, OWASP Top 10 taramasi, 9 Frontend Taste varyanti |
 | **Multi-harness destegi (v1.12+)** | Claude Code, Cursor, Gemini CLI — ayni `.claude/` kaynagi, farkli hedefler |
-| **395 Onaylanmis Test** | 16 tasarim + 20 market + 41 watcher/scheduler + 49 schema/bundler/publish + 44 harness adapter + 222 CLI/entegrasyon |
+| **398 Onaylanmis Test** | CLI entegrasyon, harness adapter, schema/bundler/publish, watcher/scheduler, market, tasarim |
 | **TR/EN Icerik Motoru** | Sablon mirasi ile post, thread, bulten, podcast, case-study uretimi |
 | **WordPress + SEO + ASO + Mobile Modulleri** | WP-CLI/REST, 20+ SEO kontrolu, App Store + Play Store, crash/deeplink/OTA iskelesi |
 | **Modular Mimari** | 22 komut modulu, `lib/harnesses/` adapter katmani, ~6MB `.claude/` agaci |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fatihkan/badi",
   "version": "1.16.2",
-  "description": "Claude Code kullanicilari icin profesyonel is akisi yonetim sistemi",
+  "description": "Workflow management CLI for Claude Code, Cursor, and Gemini CLI — 21 AI agents, 77 commands, OWASP security scans. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
   "type": "module",
   "main": "bin/badi.js",
   "bin": {
@@ -20,15 +20,26 @@
     "prepare": "echo 'Hazir'"
   },
   "keywords": [
+    "claude",
     "claude-code",
+    "claude-opus",
+    "claude-sonnet",
+    "anthropic",
+    "ai-agents",
+    "subagents",
+    "ai-workflow",
     "workflow",
-    "productivity",
     "agents",
     "skills",
     "hooks",
-    "turkish",
-    "business-operating-system",
-    "ai-workflow"
+    "cli",
+    "developer-tools",
+    "productivity",
+    "security-scanner",
+    "owasp",
+    "code-review",
+    "cursor",
+    "gemini-cli"
   ],
   "author": "Fatih Kan",
   "license": "MIT",


### PR DESCRIPTION
## Summary

SEO metadata push to broaden the international (English-speaking) audience and improve discoverability for **Anthropic Claude Opus 4.7 / Sonnet 4.6** related searches on npm, GitHub, Google, and AI search engines.

## Changes

- **package.json**
  - `description`: Turkish → English, includes Anthropic + Claude Opus 4.7 + Sonnet 4.6 + multi-harness
  - `keywords`: dropped narrow terms (`turkish`, `business-operating-system`); added `anthropic`, `claude`, `claude-opus`, `claude-sonnet`, `ai-agents`, `subagents`, `cli`, `developer-tools`, `security-scanner`, `owasp`, `code-review`, `cursor`, `gemini-cli` (20 total)

- **README.md / README.tr.md**
  - Hero paragraph rewrite — now leads with "Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI — built for Claude Opus 4.7 and Sonnet 4.6"
  - Badge: `node >=18` → `node >=20.11` (matches `engines.node`)
  - Test count: 395 → 398 (matches actual)
  - Skill category count: 25 → 23 (matches actual)

- **CLAUDE.md**
  - Hero: `50 komut` → `77`, `21 beceri kategorisi` → `23` (matched real component counts)

## GitHub Surface (already applied via gh CLI)

- **Repo description**: English, includes Anthropic + Claude Opus 4.7 / Sonnet 4.6 + counts
- **Topics**: removed `typescript`, `nodejs`, `npm-package`, `workflow-automation`, `open-source`, `security-scanning` (low-value, broad). Added `anthropic`, `claude`, `claude-opus`, `claude-sonnet`, `ai-agents`, `subagents`, `llm-tools`, `claude-cli`, `code-review`, `cursor`, `gemini-cli` (20-topic GitHub limit reached)

## Verification

- 398/398 tests pass
- Component counts cross-checked: `find .claude/agents/*.md → 21`, `commands/*.md → 77`, `hooks/*.sh → 12`, `skills/ subdirs → 23`

## Test plan

- [x] Tests pass locally (398/398)
- [ ] CI green
- [ ] npm publish picks up new description/keywords on next release
- [ ] GitHub topic browse surfaces Badi for `claude-opus`, `subagents`, `ai-agents`

## Out of scope (future)

- CLI i18n (full English CLI output) — v1.10 roadmap
- README marketing copy / use-cases section expansion
- Issue #90 — agent frontmatter audit (separate work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)