### PR TITLE
feat(agents): explicit permissionMode + disallowedTools (#90)

### DIFF
--- a/.claude/agents/api-designer.md
+++ b/.claude/agents/api-designer.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project
 maxTurns: 10
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # API Tasarimcisi (API Designer)

--- a/.claude/agents/archaeologist.md
+++ b/.claude/agents/archaeologist.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: none
 maxTurns: 10
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # Arkeolog (Archaeologist)

--- a/.claude/agents/architecture-advisor.md
+++ b/.claude/agents/architecture-advisor.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project
 maxTurns: 15
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # Mimari Danisman (Architecture Advisor)

--- a/.claude/agents/auditor.md
+++ b/.claude/agents/auditor.md
@@ -5,6 +5,7 @@ tools: [Read, Grep, Glob, Write, Edit, Bash]
 model: sonnet
 memory: project
 maxTurns: 15
+permissionMode: default
 ---
 
 # Denetci (Auditor)

--- a/.claude/agents/coach.md
+++ b/.claude/agents/coach.md
@@ -5,6 +5,7 @@ tools: [Read, Grep, Glob, Write, Edit]
 model: sonnet
 memory: project
 maxTurns: 10
+permissionMode: default
 ---
 
 # Koc (Coach)

--- a/.claude/agents/code-generator.md
+++ b/.claude/agents/code-generator.md
@@ -5,6 +5,7 @@ tools: [Read, Write, Grep, Glob, Bash]
 model: sonnet
 memory: project
 maxTurns: 12
+permissionMode: default
 ---
 
 # Kod Ureticisi (Code Generator)

--- a/.claude/agents/content-creator.md
+++ b/.claude/agents/content-creator.md
@@ -5,6 +5,7 @@ tools: [Read, Write, Edit, Grep, Glob, Bash]
 model: sonnet
 memory: project
 maxTurns: 15
+permissionMode: default
 ---
 
 # Icerik Ureticisi (Content Creator)

--- a/.claude/agents/debt-collector.md
+++ b/.claude/agents/debt-collector.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project
 maxTurns: 12
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # Borc Tahsildar (Debt Collector)

--- a/.claude/agents/error-whisperer.md
+++ b/.claude/agents/error-whisperer.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: none
 maxTurns: 10
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # Hata Fisildayicisi (Error Whisperer)

--- a/.claude/agents/migration-pilot.md
+++ b/.claude/agents/migration-pilot.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project
 maxTurns: 15
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # Goc Pilotu (Migration Pilot)

--- a/.claude/agents/onboarding-sherpa.md
+++ b/.claude/agents/onboarding-sherpa.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project
 maxTurns: 12
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # Alistirma Serpasi (Onboarding Sherpa)

--- a/.claude/agents/performance-profiler.md
+++ b/.claude/agents/performance-profiler.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project
 maxTurns: 10
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # Performans Profili Uzmani (Performance Profiler)

--- a/.claude/agents/pr-ghostwriter.md
+++ b/.claude/agents/pr-ghostwriter.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: none
 maxTurns: 8
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # PR Hayalet Yazari (PR Ghostwriter)

--- a/.claude/agents/project-architect.md
+++ b/.claude/agents/project-architect.md
@@ -5,6 +5,7 @@ tools: [Read, Write, Edit, Grep, Glob, Bash]
 model: sonnet
 memory: project
 maxTurns: 25
+permissionMode: default
 ---
 
 # Proje Mimar (Project Architect)

--- a/.claude/agents/refactoring-advisor.md
+++ b/.claude/agents/refactoring-advisor.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project
 maxTurns: 12
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # Yeniden Duzenleme Danismani (Refactoring Advisor)

--- a/.claude/agents/rubber-duck.md
+++ b/.claude/agents/rubber-duck.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob]
 model: sonnet
 memory: none
 maxTurns: 10
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # Lastik Ordek (Rubber Duck)

--- a/.claude/agents/security-scanner.md
+++ b/.claude/agents/security-scanner.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project
 maxTurns: 12
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # Guvenlik Tarayicisi (Security Scanner)

--- a/.claude/agents/test-strategist.md
+++ b/.claude/agents/test-strategist.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project
 maxTurns: 10
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # Test Stratejisti (Test Strategist)

--- a/.claude/agents/unsticker.md
+++ b/.claude/agents/unsticker.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: none
 maxTurns: 10
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # Tikaniklik Cozucu (Unsticker)

--- a/.claude/agents/visual-director.md
+++ b/.claude/agents/visual-director.md
@@ -5,6 +5,7 @@ tools: [Read, Write, Edit, Grep, Glob]
 model: sonnet
 memory: project
 maxTurns: 10
+permissionMode: default
 ---
 
 # Gorsel Yonetmen (Visual Director)

--- a/.claude/agents/yak-shave-detector.md
+++ b/.claude/agents/yak-shave-detector.md
@@ -5,6 +5,8 @@ tools: [Read, Grep, Glob]
 model: haiku
 memory: none
 maxTurns: 4
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
 ---
 
 # Yak Tiras Dedektoru (Yak-Shave Detector)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantik Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added — agent frontmatter audit (#90)
+
+Each of the 21 agents now carries an explicit `permissionMode: default`.
+The 15 read-only / advisor agents (archaeologist, api-designer,
+architecture-advisor, debt-collector, error-whisperer, migration-pilot,
+onboarding-sherpa, performance-profiler, pr-ghostwriter,
+refactoring-advisor, rubber-duck, security-scanner, test-strategist,
+unsticker, yak-shave-detector) now declare
+`disallowedTools: [Write, Edit, NotebookEdit]` for defense-in-depth
+under Claude Code 2.1.119+ headless/`--print` execution where these
+fields are honored.
+
+A new `tests/agent-frontmatter.test.js` validates the policy on every
+run (122 assertions covering all 21 agents).
+
 ## [1.17.0] - 2026-04-29
 
 ### Changed — opt-in skills (BREAKING)

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -4,6 +4,22 @@
 
 Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [Semantik Versiyonlama](https://semver.org/lang/tr/) standardini takip eder.
 
+## [Yayinlanmamis]
+
+### Eklendi — agent frontmatter audit (#90)
+
+21 ajanin tumune acik `permissionMode: default` eklendi. 15 read-only/
+danisman ajan (archaeologist, api-designer, architecture-advisor,
+debt-collector, error-whisperer, migration-pilot, onboarding-sherpa,
+performance-profiler, pr-ghostwriter, refactoring-advisor, rubber-duck,
+security-scanner, test-strategist, unsticker, yak-shave-detector)
+artik `disallowedTools: [Write, Edit, NotebookEdit]` tasiyor — Claude
+Code 2.1.119+ headless/`--print` calistirmalarinda bu alanlar uygulandigi
+icin defense-in-depth saglaniyor.
+
+`tests/agent-frontmatter.test.js` her calismada politikayi dogruluyor
+(21 ajan icin 122 assertion).
+
 ## [1.17.0] - 2026-04-29
 
 ### Degisen — opt-in skill modeli (BREAKING)

--- a/tests/agent-frontmatter.test.js
+++ b/tests/agent-frontmatter.test.js
@@ -1,0 +1,134 @@
+// Agent frontmatter audit testleri (#90).
+// Her .claude/agents/*.md icin: tools whitelist, permissionMode acik,
+// read-only ajanlarda disallowedTools ile Write/Edit/NotebookEdit yasak.
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const AGENTS_DIR = resolve(__dirname, "..", ".claude", "agents");
+
+const READ_ONLY_AGENTS = new Set([
+	"archaeologist",
+	"api-designer",
+	"architecture-advisor",
+	"debt-collector",
+	"error-whisperer",
+	"migration-pilot",
+	"onboarding-sherpa",
+	"performance-profiler",
+	"pr-ghostwriter",
+	"refactoring-advisor",
+	"rubber-duck",
+	"security-scanner",
+	"test-strategist",
+	"unsticker",
+	"yak-shave-detector",
+]);
+
+const PRODUCER_AGENTS = new Set([
+	"auditor",
+	"coach",
+	"code-generator",
+	"content-creator",
+	"project-architect",
+	"visual-director",
+]);
+
+const VALID_PERMISSION_MODES = new Set([
+	"default",
+	"acceptEdits",
+	"plan",
+	"bypassPermissions",
+]);
+
+function parseFrontmatter(content) {
+	const match = content.match(/^---\n([\s\S]*?)\n---/);
+	if (!match) return null;
+	const obj = {};
+	for (const line of match[1].split("\n")) {
+		const m = line.match(/^([a-zA-Z][a-zA-Z0-9_]*):\s*(.*)$/);
+		if (m) obj[m[1]] = m[2].trim();
+	}
+	return obj;
+}
+
+function listAgents() {
+	return readdirSync(AGENTS_DIR)
+		.filter((f) => f.endsWith(".md"))
+		.map((f) => f.replace(/\.md$/, ""));
+}
+
+describe("agent frontmatter audit (#90)", () => {
+	const agents = listAgents();
+
+	it("21 ajan mevcut", () => {
+		assert.equal(agents.length, 21);
+	});
+
+	it("her ajan READ_ONLY veya PRODUCER kategorisinde", () => {
+		for (const a of agents) {
+			assert.ok(
+				READ_ONLY_AGENTS.has(a) || PRODUCER_AGENTS.has(a),
+				`${a}: kategorisize`,
+			);
+		}
+	});
+
+	for (const agent of agents) {
+		describe(agent, () => {
+			const fm = parseFrontmatter(
+				readFileSync(join(AGENTS_DIR, `${agent}.md`), "utf-8"),
+			);
+
+			it("frontmatter parse edilebilir", () => {
+				assert.ok(fm, "frontmatter yok");
+			});
+
+			it("name alani dosya adiyla eslesiyor", () => {
+				assert.equal(fm.name, agent);
+			});
+
+			it("tools alani var", () => {
+				assert.ok(fm.tools, "tools: tanimsiz");
+				assert.match(fm.tools, /^\[.*\]$/, "tools array formatinda olmali");
+			});
+
+			it("permissionMode acikca tanimli", () => {
+				assert.ok(fm.permissionMode, "permissionMode: tanimsiz");
+				assert.ok(
+					VALID_PERMISSION_MODES.has(fm.permissionMode),
+					`gecersiz permissionMode: ${fm.permissionMode}`,
+				);
+			});
+
+			if (READ_ONLY_AGENTS.has(agent)) {
+				it("read-only: tools'ta Write/Edit yok", () => {
+					assert.doesNotMatch(fm.tools, /\bWrite\b/);
+					assert.doesNotMatch(fm.tools, /\bEdit\b/);
+				});
+
+				it("read-only: disallowedTools Write/Edit/NotebookEdit icerir", () => {
+					assert.ok(fm.disallowedTools, "disallowedTools tanimsiz");
+					assert.match(fm.disallowedTools, /Write/);
+					assert.match(fm.disallowedTools, /Edit/);
+					assert.match(fm.disallowedTools, /NotebookEdit/);
+				});
+			}
+
+			if (PRODUCER_AGENTS.has(agent)) {
+				it("producer: tools'ta Write veya Edit var", () => {
+					const hasWrite = /\bWrite\b/.test(fm.tools);
+					const hasEdit = /\bEdit\b/.test(fm.tools);
+					assert.ok(
+						hasWrite || hasEdit,
+						"producer en az Write veya Edit icermeli",
+					);
+				});
+			}
+		});
+	}
+});


### PR DESCRIPTION
## Summary
- All 21 agents declare explicit `permissionMode: default`
- 15 read-only / advisor agents add `disallowedTools: [Write, Edit, NotebookEdit]` for defense-in-depth under Claude Code 2.1.119+ headless execution
- New `tests/agent-frontmatter.test.js` enforces the policy (122 assertions)

Producer agents (auditor, coach, code-generator, content-creator, project-architect, visual-director) keep Write/Edit since they emit files.

## Test plan
- [x] `npm test` — 533/533 green (was 411 pre-audit, +122 from new audit suite)
- [x] `node --test tests/agent-frontmatter.test.js` — isolated suite green
- [x] CHANGELOG.md + CHANGELOG.tr.md updated under `[Unreleased]`

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)