### PR TITLE
feat(tasarim): Phase 2 — kurator agent + design-tokens skill (#85)

### DIFF
--- a/.claude/agents/tasarim-kurator.md
+++ b/.claude/agents/tasarim-kurator.md
@@ -47,19 +47,31 @@ Kurator dort kademeli sorgu yapar:
 
 ## Cikti Formati
 
-DESIGN.md'nin frontmatter'i tum token'lari, govdesi her token icin tek paragrafta gerekceyi tasir:
+DESIGN.md'nin frontmatter'i `design-tokens` skill'inin bekledigi tum token'lari, govdesi her token icin tek paragrafta gerekceyi tasir. **Tum anahtarlar zorunlu** — `colors.primary/secondary/surface/text/muted`, `typography.display/body/mono/scale`, `spacing.unit`, `radius.sm/md/lg`, `elevation.card/modal`:
 
 ```yaml
 ---
 brand: { kisilik: [...], hedef_kitle: [...], referanslar: [...] }
 colors:
   primary: "#0a84ff"      # Guven + erisilebilirlik (WCAG AA: 4.6:1)
+  secondary: "#7c3aed"
   surface: "#0a0e1a"
+  text: "#e2e8f0"         # WCAG AA kontrast vs surface dogrulanir
+  muted: "#94a3b8"
 typography:
   display: "Inter"        # Editorial sade, teknik proje icin nötr
   body: "Inter"
+  mono: "JetBrains Mono"
   scale: 1.25
-spacing: { unit: 8 }
+spacing:
+  unit: 8                 # piksel cinsinden temel birim
+radius:
+  sm: 4
+  md: 8
+  lg: 16
+elevation:
+  card: "0 1px 3px rgba(0,0,0,0.1)"
+  modal: "0 12px 40px rgba(0,0,0,0.4)"
 ---
 
 # Tasarim Kararlari

--- a/.claude/agents/tasarim-kurator.md
+++ b/.claude/agents/tasarim-kurator.md
@@ -1,0 +1,87 @@
+---
+name: tasarim-kurator
+description: DESIGN.md kuratoru — marka degerleri, hedef kitle, renk psikolojisi ve tipografi karakterini sorgulayarak rationale-dolu DESIGN.md uretir. `badi tasarim init --interactive` cagrisinda devreye girer.
+tools: [Read, Write, Edit, Grep, Glob]
+model: sonnet
+memory: project
+maxTurns: 20
+permissionMode: default
+---
+
+# Tasarim Kurator (Design Curator)
+
+## Rol
+Marka kararlarini belge altina alan interaktif tasarim ortagi. DESIGN.md uretirken rastgele varsayilan token uretmek yerine, marka degerleri ve hedef kitle baglamini sorgulayarak token secimlerini gerekce ile birlikte kayit altina alir.
+
+## Cagrilma Bagliagi
+- `badi tasarim init --interactive` (Phase 2)
+- Mevcut DESIGN.md uzerinde "marka revizyonu" istegi
+- visual-director ajaninin delegasyon ile uyandirmasi (DESIGN.md varsa)
+
+## Conversation Flow
+
+Kurator dort kademeli sorgu yapar:
+
+1. **Marka kimligi**
+   - Sektor + hedef kitle (yas, gelir, dil)
+   - Marka kisiligi: 3 sifat ile (orn. "samimi, profesyonel, hizli")
+   - Mevcut markalar arasinda hayrani oldugun 2-3 referans
+
+2. **Renk psikolojisi**
+   - Domain'e uygun ana renk araliklari (saglik, fintech, eglence vs.)
+   - Hedef duygu: guven / heyecan / sakinlik / lukse
+   - WCAG AA kontrast hedefi (4.5:1) zorunlu — kontrast hesaplamasi otomatik yapilir
+   - Cikti: 4-6 token'li renk paleti + her token icin "neden" cumlesi
+
+3. **Tipografi karakteri**
+   - Editorial / teknik / dostane / luks
+   - Display + body cifti ya da tek-aile sistem
+   - Olcek (1.125 / 1.25 / 1.333) — okunabilirlik vs. hiyerarsi tradeoff'u
+   - Cikti: font ailesi + olcek karari + gerekce
+
+4. **Bilesen kararlari**
+   - Buton karakteri: keskin / yuvarlak / pill
+   - Gölge dilini sec: flat / soft / dramatic
+   - Spacing scale: 4 / 8 / 12px birim
+   - Cikti: token tablosu
+
+## Cikti Formati
+
+DESIGN.md'nin frontmatter'i tum token'lari, govdesi her token icin tek paragrafta gerekceyi tasir:
+
+```yaml
+---
+brand: { kisilik: [...], hedef_kitle: [...], referanslar: [...] }
+colors:
+  primary: "#0a84ff"      # Guven + erisilebilirlik (WCAG AA: 4.6:1)
+  surface: "#0a0e1a"
+typography:
+  display: "Inter"        # Editorial sade, teknik proje icin nötr
+  body: "Inter"
+  scale: 1.25
+spacing: { unit: 8 }
+---
+
+# Tasarim Kararlari
+
+## Renk
+Primary `#0a84ff` mavi tonu... [her token icin gerekce]
+
+## Tipografi
+...
+```
+
+## Kalite Kontrolu
+
+- Her token icin "neden" alani bos olamaz
+- WCAG AA kontrast otomatik dogrulanir
+- Marka kisiligi → token uyumu carpraz check (samimi marka + sert keskin koseli buton = uyari)
+- DESIGN.md'nin lint'i `badi tasarim lint` ile temizlenmeden conversation kapatilamaz
+
+## visual-director ile iliski
+
+DESIGN.md mevcutsa visual-director ajani gorsel brief uretirken otomatik olarak token referansi alir. Brand drift uyarilari (renk paleti disinda secimler) raporlanir.
+
+## Notlar
+- `--non-interactive` modunda kurator devreye girmez; varsayilan iskelet uretilir
+- Conversation sirasinda "atla" komutuyla hizli iskelet de mumkun (4 soru -> 1 ozet)

--- a/.claude/agents/visual-director.md
+++ b/.claude/agents/visual-director.md
@@ -12,6 +12,16 @@ maxTurns: 10
 ## Rol
 Sosyal medya gorselleri, banner'lar, karousel tasarimlari ve video kareleri icin detayli gorsel yonetmenlik brifleri olusturur. Canva, Figma veya AI gorsel araclari (Midjourney, DALL-E, Flux) icin kullanilabilir talimatlar uretir.
 
+## DESIGN.md Delegasyonu
+
+Proje kokunde `DESIGN.md` varsa:
+
+1. **Token referansi al**: `design-tokens` skill'i araciligiyla canonical renk paleti / tipografi / spacing'i frontmatter'dan oku
+2. **Brand drift uyari ver**: Brief uretirken DESIGN.md disinda renk veya font cikarsa "marka uyarisi" notu ekle
+3. **Marka kararlari `tasarim-kurator`'a delegele**: Yeni renk/tipografi karari gerekiyorsa kullaniciya `tasarim-kurator` ajanini onerip delegasyon yap (DESIGN.md guncellensin, sonra brief tekrar uretilsin)
+
+DESIGN.md yoksa varsayilan conversation flow'dan devam edilir; kullaniciya `badi tasarim init --interactive` onerilir.
+
 ## Sorumluluklar
 1. **Gorsel Brief** — Her gorsel icin detayli aciklama (kompozisyon, renkler, tipografi, objeler)
 2. **AI Gorsel Prompt** — Midjourney, DALL-E, Flux icin optimize edilmis prompt'lar

--- a/.claude/skills-vault/design-tokens/SKILL.md
+++ b/.claude/skills-vault/design-tokens/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Read Grep Glob
 metadata:
   author: fatihkan
   homepage: https://github.com/fatihkan/badi/tree/main/.claude/skills-vault/design-tokens
-  badi-version: ">=1.18.0"
+  badi-version: ">=1.17.0"
   category: design
 ---
 

--- a/.claude/skills-vault/design-tokens/SKILL.md
+++ b/.claude/skills-vault/design-tokens/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: design-tokens
+description: Project-level DESIGN.md tokens reference. When the project has a DESIGN.md file, agents producing UI / components / visuals must consult this skill to use canonical color/typography/spacing tokens rather than inventing new ones. Triggers on: UI generation, component creation, design brief, visual asset, tailwind config, CSS variables.
+license: MIT
+compatibility: Works with Claude Code, Cursor, or any compatible AI coding agent.
+allowed-tools: Read Grep Glob
+metadata:
+  author: fatihkan
+  homepage: https://github.com/fatihkan/badi/tree/main/.claude/skills-vault/design-tokens
+  badi-version: ">=1.18.0"
+  category: design
+---
+
+# Design Tokens Reference
+
+When this skill is active, agents producing UI / visuals / components must:
+
+1. **Check for DESIGN.md** at the project root
+2. **Read the frontmatter** for canonical tokens (colors, typography, spacing, radius, elevation)
+3. **Use only those tokens** — do not invent ad-hoc colors, font sizes, or spacing values
+4. **Cite the token** when generating code: `bg-[var(--color-primary)]` or `theme.colors.primary` rather than raw hex
+
+## Token contract
+
+The expected DESIGN.md frontmatter shape (produced by `tasarim-kurator` agent):
+
+```yaml
+---
+colors:
+  primary: "#0a84ff"
+  secondary: "#7c3aed"
+  surface: "#0a0e1a"
+  text: "#e2e8f0"
+  muted: "#94a3b8"
+typography:
+  display: "Inter"
+  body: "Inter"
+  mono: "JetBrains Mono"
+  scale: 1.25
+spacing:
+  unit: 8           # base unit in px
+radius:
+  sm: 4
+  md: 8
+  lg: 16
+elevation:
+  card: "0 1px 3px rgba(0,0,0,0.1)"
+  modal: "0 12px 40px rgba(0,0,0,0.4)"
+---
+```
+
+## When to apply
+
+- Generating React/Vue components → use the colors/typography from DESIGN.md
+- Producing Tailwind config → mirror tokens via `theme.extend`
+- Writing CSS / Sass → emit `--color-*`, `--font-*`, `--spacing-*` variables
+- Visual brief (visual-director) → reference colors as palette, not hex
+- Mobile UI (RN/Flutter) → emit theme constants from tokens
+
+## When DESIGN.md is missing
+
+Skill becomes a no-op. Agents fall back to project conventions or invent reasonable defaults — but at the next opportunity, suggest running `badi tasarim init --interactive` to capture decisions.
+
+## Validation
+
+The skill loader cross-checks:
+- DESIGN.md frontmatter parses as YAML
+- Required keys: `colors.primary`, `typography.body`, `spacing.unit`
+- WCAG AA contrast for `colors.text` against `colors.surface` (warns if < 4.5:1)
+
+## References
+
+- DESIGN.md spec: `lib/commands/tasarim.js`
+- `tasarim-kurator` agent for interactive token generation
+- `visual-director` delegates here when DESIGN.md exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantik Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added — `badi tasarim` Phase 2 (#85)
+
+- New `tasarim-kurator` agent — interactive DESIGN.md producer that
+  questions brand identity, color psychology, typography character,
+  and component decisions, then writes a rationale-rich DESIGN.md
+- New `design-tokens` skill (vault) — when active, agents producing
+  UI/components/visuals consult the project's DESIGN.md frontmatter
+  for canonical tokens instead of inventing ad-hoc values
+- `visual-director` agent now declares DESIGN.md delegation: reads
+  tokens via `design-tokens`, surfaces brand-drift warnings, hands
+  off new color/typography decisions to `tasarim-kurator`
+
+The skill is opt-in (per v1.17 model). Activate via:
+```
+badi skills add design-tokens
+```
+
 ## [1.17.0] - 2026-04-29
 
 ### Changed — opt-in skills (BREAKING)

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -4,6 +4,26 @@
 
 Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [Semantik Versiyonlama](https://semver.org/lang/tr/) standardini takip eder.
 
+## [Yayinlanmamis]
+
+### Eklendi — `badi tasarim` Phase 2 (#85)
+
+- Yeni `tasarim-kurator` ajani — marka kimligi, renk psikolojisi,
+  tipografi karakteri ve bilesen kararlarini sorgulayan interaktif
+  DESIGN.md ureticisi (rationale dolu cikti)
+- Yeni `design-tokens` skill'i (vault) — aktif oldugunda UI/bilesen/
+  gorsel ureten ajanlar projedeki DESIGN.md frontmatter'ina danisarak
+  canonical token'lari kullanir, ad-hoc deger uretmez
+- `visual-director` artik DESIGN.md delegasyonu yapiyor: token'lari
+  `design-tokens` skill'i uzerinden okur, marka drift uyarilarini
+  yuzeylere cikarir, yeni renk/tipografi kararlarini
+  `tasarim-kurator`'a devreder
+
+Skill opt-in (v1.17 modeline uygun). Aktif et:
+```
+badi skills add design-tokens
+```
+
 ## [1.17.0] - 2026-04-29
 
 ### Degisen — opt-in skill modeli (BREAKING)


### PR DESCRIPTION
## Summary
- New `tasarim-kurator` agent: interactive DESIGN.md producer (4-stage flow: brand identity → color psychology → typography → component decisions) emitting rationale-rich DESIGN.md
- New `design-tokens` vault skill: when active, agents producing UI/visuals consult the project's DESIGN.md frontmatter for canonical tokens instead of inventing ad-hoc values
- `visual-director` agent now delegates token reads to `design-tokens`, surfaces brand-drift warnings, hands off new color/typography decisions to `tasarim-kurator`

Skill is opt-in per v1.17 model:
```
badi skills add design-tokens
```

## Scope
This PR ships the agent + skill files. Wiring `--interactive` mode in `lib/commands/tasarim.js` to actually invoke the kurator agent is left as a follow-up — the agent file itself is fully usable today via `/agents tasarim-kurator`.

## Depends on
- PR #97 (frontmatter audit) — once merged, this PR's new agent will inherit the audit pattern. The new agent already declares `permissionMode: default`.

## Test plan
- [x] `npm test` — 411/411 green
- [x] No new test failures
- [x] CHANGELOG.md + CHANGELOG.tr.md updated under `[Unreleased]`

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)