### PR TITLE
chore(release): v1.18.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,13 @@
 .claude/logs/
 .claude/agent-memory/
 .claude/backups/
+.claude/daily-notes/
 .claude/hooks/__counter
 .claude/hooks/quality-gate-active
 .claude/.compaction-occurred
 .claude/plugins/*/node_modules/
+.claude/skills/INDEX.md
+.claude/skills/SOLOPRENEUR-REHBER.md
 .test-tmp/
 .test-tmp-*/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantik Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.18.0] - 2026-05-02
 
 ### Added — agent frontmatter audit (#90)
 

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -4,7 +4,7 @@
 
 Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [Semantik Versiyonlama](https://semver.org/lang/tr/) standardini takip eder.
 
-## [Yayinlanmamis]
+## [1.18.0] - 2026-05-02
 
 ### Eklendi — agent frontmatter audit (#90)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fatihkan/badi",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fatihkan/badi",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fatihkan/badi",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Workflow management CLI for Claude Code, Cursor, and Gemini CLI — 21 AI agents, 77 commands, OWASP security scans. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
   "type": "module",
   "main": "bin/badi.js",

--- a/tests/agent-frontmatter.test.js
+++ b/tests/agent-frontmatter.test.js
@@ -35,6 +35,7 @@ const PRODUCER_AGENTS = new Set([
 	"code-generator",
 	"content-creator",
 	"project-architect",
+	"tasarim-kurator",
 	"visual-director",
 ]);
 
@@ -65,8 +66,8 @@ function listAgents() {
 describe("agent frontmatter audit (#90)", () => {
 	const agents = listAgents();
 
-	it("21 ajan mevcut", () => {
-		assert.equal(agents.length, 21);
+	it("22 ajan mevcut", () => {
+		assert.equal(agents.length, 22);
 	});
 
 	it("her ajan READ_ONLY veya PRODUCER kategorisinde", () => {


### PR DESCRIPTION
## Summary
v1.18.0 npm + GitHub release. Tag `v1.18.0` and GitHub release are already published from this branch.

### Included
- `#90` — Agent frontmatter audit (PR #97)
- `#85` — `badi tasarim` Phase 2: tasarim-kurator + design-tokens skill (PR #100)
- `#26` — VitePress docs scaffold + GitHub Pages workflow (PR #99)
- `#30`, `#25` — Reproducible vhs demo tape + OG image SVG (PR #98)

### This PR
- gitignore tweaks (daily-notes, leftover skill markdowns)
- CHANGELOG `[Unreleased]` -> `[1.18.0] - 2026-05-02`
- Test suite update (tasarim-kurator added to frontmatter audit, 22 agents)
- `chore(release): v1.18.0` commit + version bump in `package.json`/`package-lock.json`

## Test plan
- [x] `npm test` — 538/538 green
- [x] `npm publish` — landed on registry as 1.18.0
- [x] GitHub release v1.18.0 published

🤖 Generated with [Claude Code](https://claude.com/claude-code)