### PR TITLE
docs(v1.18): README + CLAUDE.md component count + Version History

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Badi - Is Akisi Yonetim Sistemi
 
-> Claude Code icin yapilandirilmis operasyon yonetimi. 21 ajan, 77 komut, 12 hook, 23 opt-in skill kategorisi.
+> Claude Code icin yapilandirilmis operasyon yonetimi. 22 ajan, 77 komut, 12 hook, 24 opt-in skill kategorisi.
 
 ## Bellek Kurallari
 
@@ -9,7 +9,7 @@
 | Oturum | `.claude/memory.md` | 100 satir, astiginda `/clear` |
 | Bilgi Tabani | `.claude/knowledge-base.md` | 200 satir, Auditor onayiyla |
 | Gorev Panosu | `.claude/workspace/TaskBoard.md` | Sinir yok |
-| Skills Vault | `.claude/skills-vault/` | 23 kategori, yuklenmez (opt-in) |
+| Skills Vault | `.claude/skills-vault/` | 24 kategori, yuklenmez (opt-in) |
 | Aktif Skills | `.claude/skills/` | Kullanici secimi (`badi skills`) |
 
 - `knowledge-base.md` icinde TBD/TODO/FIXME **YASAK**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **21 AI subagents**, **77 slash commands**, **12 automation hooks**, and **23 skill categories** (OWASP Top 10 scans, code review, content production, mobile/web SEO). Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
+**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **22 AI subagents**, **77 slash commands**, **12 automation hooks**, and **24 opt-in skill categories** (OWASP Top 10 scans, code review, content production, mobile/web SEO). Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
 
 ## Demo
 
@@ -32,7 +32,7 @@
 /plugin install badi@badi-marketplace
 ```
 
-**As an npm CLI (full feature set: 21 agents · 77 commands · 12 hooks · 23 skill categories)**:
+**As an npm CLI (full feature set: 22 agents · 77 commands · 12 hooks · 24 opt-in skill categories)**:
 
 ```bash
 npx @fatihkan/badi init                    # interactive harness picker
@@ -46,7 +46,7 @@ npx @fatihkan/badi init --harness all      # write files for every supported har
 
 | Harness | Rules | Commands | MCP | Subagents | Hooks | Skills |
 |---------|:-----:|:--------:|:---:|:---------:|:-----:|:------:|
-| Claude Code | `CLAUDE.md` | 77 | `.mcp.json` | 21 | 12 | 23 |
+| Claude Code | `CLAUDE.md` | 77 | `.mcp.json` | 22 | 12 | 24 |
 | Cursor | `.cursor/rules/badi-main.mdc` | 77 | `.cursor/mcp.json` | — | — | — |
 | Gemini CLI | `GEMINI.md` (merged) | inline | `.gemini/settings.json` | — | — | — |
 
@@ -56,8 +56,8 @@ Claude is the canonical source. Cursor and Gemini adapters compile from the same
 
 | Feature | Details |
 |---------|---------|
-| **21 expert agents + 77 commands** | Full toolkit from security scanner to performance profiler |
-| **12 automation hooks + 23 skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants |
+| **22 expert agents + 77 commands** | Full toolkit from security scanner to performance profiler — read-only agents enforce `disallowedTools` for defense-in-depth |
+| **12 automation hooks + 24 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants — skills load zero tokens by default since v1.17 |
 | **Multi-harness support (v1.12+)** | Claude Code, Cursor, Gemini CLI — same `.claude/` source, different targets |
 | **398 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, tasarim |
 | **TR/EN content engine** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
@@ -77,7 +77,7 @@ npx @fatihkan/badi init
 badi doctor
 
 # Daily workflow
-badi list --agents     # List 21 agents
+badi list --agents     # List 22 agents
 badi stats             # Usage analytics
 badi schedule list     # Reminders
 ```
@@ -352,7 +352,7 @@ lib/                   17 ESM modules
   templates/           TR/EN template generators
   icerik-helpers.js    Search, similarity, frontmatter
 .claude/
-  agents/              21 expert agents
+  agents/              22 expert agents
   commands/            50 workflow commands
   hooks/               12 automation hooks
   skills/              22 categories + 48 security skills
@@ -464,6 +464,7 @@ npm run format     # Biome formatting
 
 | Version | Summary |
 |---------|---------|
+| **v1.18.0** | **Agent frontmatter audit + `badi tasarim` Phase 2.** All 22 agents now declare explicit `permissionMode: default`; the 15 read-only / advisor agents add `disallowedTools: [Write, Edit, NotebookEdit]` for defense-in-depth under Claude Code 2.1.119+ headless / `--print` execution. New `tasarim-kurator` agent: interactive DESIGN.md producer with 4-stage flow (brand identity → color psychology → typography → component decisions). New opt-in `design-tokens` skill: when active, agents producing UI/components/visuals consult the project's DESIGN.md frontmatter for canonical tokens. `visual-director` now delegates token reads to `design-tokens` and hands off new color/typography decisions to `tasarim-kurator`. Plus VitePress docs scaffold (GitHub Pages workflow), reproducible vhs demo tape, social preview SVG. 411 → 538 tests. |
 | **v1.17.0** | **Opt-in skills (BREAKING).** Skills no longer auto-load. All 23 categories live in `.claude/skills-vault/`; `.claude/skills/` starts empty. New `badi skills` command (status table + interactive picker, `add`/`remove`/`list`/`available`/`clear`/`reset`) lets users opt into exactly what they want. Plugin path also drops the `skills` field — no auto-load tax for plugin consumers either. Saves ~10–15k tokens per turn. Existing installs are protected: `.claude/skills/` is treated as user-customizable on update, so anything already there stays. Token analyzer reports vault size as "Vault (yuklenmez)" so the savings are visible. |
 | **v1.16.5** | **Plugin-level safety hooks.** The Claude Code plugin path now ships two universal Bash safety hooks inline in `plugin.json`: `guard-bash.sh` (blocks `rm -rf /`, force-push to main, `chmod 777`, `curl \| bash`, secret exfiltration, etc.) and `branch-guard.sh` (refuses direct commits to main/master/production and force-push to release/*). Hooks reference scripts via `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/` so they resolve from the plugin cache. Project-state hooks (memory handoff, logs, backups) stay npm-only — they need a writable `.claude/` tree the plugin cache can't provide. |
 | **v1.16.4** | **Claude Code plugin distribution.** Badi now installs via `/plugin marketplace add fatihkan/badi` + `/plugin install badi@badi-marketplace` — alongside the existing npm path. New `.claude-plugin/plugin.json` + `marketplace.json` declare 21 agents, 77 commands, and 23 skill categories via custom paths to the canonical `.claude/` tree (no duplication). Both manifests pass `claude plugin validate`; end-to-end smoke-tested. Hooks and the multi-harness compiler stay npm-only — they need a project-local writable `.claude/` tree the plugin cache can't provide. |

--- a/README.tr.md
+++ b/README.tr.md
@@ -11,7 +11,7 @@
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-**Anthropic Claude Code, Cursor ve Gemini CLI icin is akisi yonetim CLI'i** — **Claude Opus 4.7** ve **Sonnet 4.6** uyumlu. **21 AI subagent**, **77 slash komut**, **12 otomatik hook** ve **23 skill kategorisi** (OWASP Top 10 tarama, code review, icerik uretimi, mobile/web SEO) icerir. Tekrarlayan is akislarinda token tuketimini **~%96** azaltir. **v1.12+** ile multi-harness destegi — ayni `.claude/` agaci Cursor ve Gemini CLI hedeflerine derlenir. **v1.16+** CodeQL sertlesmesi (TLS strict-first, DOM bazli HTML parse, URL hostname dogrulamasi).
+**Anthropic Claude Code, Cursor ve Gemini CLI icin is akisi yonetim CLI'i** — **Claude Opus 4.7** ve **Sonnet 4.6** uyumlu. **22 AI subagent**, **77 slash komut**, **12 otomatik hook** ve **24 opt-in skill kategorisi** (OWASP Top 10 tarama, code review, icerik uretimi, mobile/web SEO) icerir. Tekrarlayan is akislarinda token tuketimini **~%96** azaltir. **v1.12+** ile multi-harness destegi — ayni `.claude/` agaci Cursor ve Gemini CLI hedeflerine derlenir. **v1.16+** CodeQL sertlesmesi (TLS strict-first, DOM bazli HTML parse, URL hostname dogrulamasi).
 
 ## Demo
 
@@ -32,7 +32,7 @@
 /plugin install badi@badi-marketplace
 ```
 
-**npm CLI olarak (tam ozellik seti: 21 ajan · 77 komut · 12 hook · 23 skill kategorisi)**:
+**npm CLI olarak (tam ozellik seti: 22 ajan · 77 komut · 12 hook · 24 opt-in skill kategorisi)**:
 
 ```bash
 npx @fatihkan/badi init                    # interaktif harness secim menusu
@@ -46,7 +46,7 @@ npx @fatihkan/badi init --harness all      # tum desteklenen harness'lar
 
 | Harness | Kurallar | Komutlar | MCP | Subagents | Hooks | Skills |
 |---------|:--------:|:--------:|:---:|:---------:|:-----:|:------:|
-| Claude Code | `CLAUDE.md` | 77 | `.mcp.json` | 21 | 12 | 23 |
+| Claude Code | `CLAUDE.md` | 77 | `.mcp.json` | 22 | 12 | 24 |
 | Cursor | `.cursor/rules/badi-main.mdc` | 77 | `.cursor/mcp.json` | — | — | — |
 | Gemini CLI | `GEMINI.md` (birlesik) | inline | `.gemini/settings.json` | — | — | — |
 
@@ -56,7 +56,7 @@ Claude kaynak (canonical). Cursor ve Gemini adapter'lari ayni `.claude/` dizinin
 
 | Ozellik | Detay |
 |---------|-------|
-| **21 Uzman Ajan ve 77 Komut** | Guvenlik tarayicidan performans profiler'a kadar genis arac seti |
+| **22 Uzman Ajan ve 77 Komut** | Guvenlik tarayicidan performans profiler'a kadar genis arac seti — read-only ajanlar `disallowedTools` ile defense-in-depth saglıyor |
 | **12 Otomatik Hook ve 23 Skill Kategorisi** | Branch koruma, yedekleme, OWASP Top 10 taramasi, 9 Frontend Taste varyanti |
 | **Multi-harness destegi (v1.12+)** | Claude Code, Cursor, Gemini CLI — ayni `.claude/` kaynagi, farkli hedefler |
 | **398 Onaylanmis Test** | CLI entegrasyon, harness adapter, schema/bundler/publish, watcher/scheduler, market, tasarim |
@@ -75,7 +75,7 @@ npx @fatihkan/badi init
 badi doctor
 
 # Gunluk is akisi
-badi list --agents     # 21 ajan gor
+badi list --agents     # 22 ajan gor
 badi stats             # Kullanim analitikleri
 badi schedule list     # Hatirlaticilar
 ```
@@ -337,7 +337,7 @@ lib/                   17 ESM modul
   templates/           TR/EN sablon uretecleri
   icerik-helpers.js    Arama, benzerlik, frontmatter
 .claude/
-  agents/              21 uzman ajan
+  agents/              22 uzman ajan
   commands/            50 is akisi komutu
   hooks/               12 otomasyon hook'u
   skills/              22 kategori + 48 guvenlik skill
@@ -431,6 +431,7 @@ npm run format     # Biome ile formatlama
 
 | Surum | Icerik |
 |-------|--------|
+| **v1.18.0** | **Agent frontmatter audit + `badi tasarim` Phase 2.** 22 ajanin tumu artik acik `permissionMode: default` deklare ediyor; 15 read-only/danisman ajan ek olarak `disallowedTools: [Write, Edit, NotebookEdit]` tasiyor — Claude Code 2.1.119+ headless/`--print` calistirmalarinda defense-in-depth. Yeni `tasarim-kurator` ajani: marka kimligi, renk psikolojisi, tipografi karakteri ve bilesen kararlarini sorgulayan 4 asamali interaktif DESIGN.md ureticisi. Yeni opt-in `design-tokens` skill'i: aktif oldugunda UI/bilesen/gorsel ureten ajanlar projedeki DESIGN.md frontmatter'ina danisarak canonical token'lari kullanir. `visual-director` artik token okumalarini `design-tokens`'a delege ediyor ve yeni renk/tipografi kararlarini `tasarim-kurator`'a devrediyor. Ayrica VitePress dokuman iskeleti (GitHub Pages workflow), reproducible vhs demo tape, social preview SVG. 411 → 538 test. |
 | **v1.17.0** | **Opt-in skill modeli (BREAKING).** Skill'ler artik otomatik yuklenmiyor. 23 kategorinin tumu `.claude/skills-vault/` dizininde; `.claude/skills/` bos baslar. Yeni `badi skills` komutu (durum tablosu + interaktif picker, `add`/`remove`/`list`/`available`/`clear`/`reset`) ile kullanici tam olarak istedigi skill'i secer. Plugin yolu da `skills` alanini kaldirdi — plugin kullanicilari icin de auto-load vergisi yok. Her tur ~10-15k token tasarrufu. Mevcut kurulumlar korunur: `.claude/skills/` update sirasinda kullanici verisi olarak isaretlenir. Token analizi vault boyutunu "Vault (yuklenmez)" olarak ayrica raporlar. |
 | **v1.16.5** | **Plugin seviyesi guvenlik hook'lari.** Claude Code plugin yolu artik `plugin.json` icinde inline olarak iki evrensel Bash guvenlik hook'u tasiyor: `guard-bash.sh` (`rm -rf /`, main'e force-push, `chmod 777`, `curl \| bash`, secret exfiltration vb. bloke eder) ve `branch-guard.sh` (main/master/production'a dogrudan commit ve release/*'a force-push'u reddeder). Hook'lar script'leri `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/` uzerinden cagirir, plugin cache'inden cozulur. Proje-state hook'lari (memory handoff, log'lar, yedekler) npm-only kaliyor — yazilabilir `.claude/` agacina ihtiyaclari var, plugin cache sunamaz. |
 | **v1.16.4** | **Claude Code plugin dagitimi.** Badi artik `/plugin marketplace add fatihkan/badi` + `/plugin install badi@badi-marketplace` ile kuruluyor — mevcut npm yoluna ek olarak. Yeni `.claude-plugin/plugin.json` + `marketplace.json` 21 ajan, 77 komut, 23 skill kategorisini kanonik `.claude/` agacina custom path'lerle bildiriyor (kopya yok). Iki manifest da `claude plugin validate`'den yesil gectti; end-to-end smoke-test edildi. Hook'lar ve multi-harness compiler npm-only kaliyor — plugin cache writable `.claude/` agacini saglayamiyor. |


### PR DESCRIPTION
## Summary
Post-release doc cleanup for v1.18.0:

- **Component counts**: 21 → 22 agents (`tasarim-kurator` added), 23 → 24 opt-in skill categories (`design-tokens` added)
- **README hero stats** updated in EN + TR
- **Harness support table** updated (Claude Code agents/skills column)
- **"What You Get"** table refreshed
- **Version History**: new v1.18.0 row in both READMEs
- **CLAUDE.md** project hero stats updated

## Test plan
- [x] Counts match filesystem: `.claude/agents/` (22) + `.claude/skills-vault/` (24)
- [x] No broken markdown
- [x] CHANGELOG already moved [Unreleased] → [1.18.0] in release PR (#101)

🤖 Generated with [Claude Code](https://claude.com/claude-code)