### PR TITLE
feat(market): wishlist demand x supply matrix (#84 phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantik Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added — `badi market wishlist` (#84 phase 2)
+
+New subcommand for the demand × supply matrix:
+
+```
+badi market wishlist "habit tracker"
+badi market wishlist "ai journaling" --json --days 60
+```
+
+Demand signal: Reddit anonymous JSON search (no API key, last 30 days
+by default). Supply signal: App Store search result count for the
+same query. The matrix maps four quadrants: `BLUE_OCEAN` (high demand
+× low supply), `COMPETITIVE`, `NICHE`, `SATURATED`.
+
+`--json` flag emits a structured report with the demand sample (top
+posts + subreddits) and supply sample (top apps with rating + count)
+for piping into other tools.
+
+Implements the second of three Phase-2 capabilities. SensorTower
+revenue (#84-1) stays blocked on paid API access; opportunity gaps
+cross-analysis (#84-3) follows up.
+
 ## [1.18.0] - 2026-05-02
 
 ### Added — agent frontmatter audit (#90)

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -4,6 +4,29 @@
 
 Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [Semantik Versiyonlama](https://semver.org/lang/tr/) standardini takip eder.
 
+## [Yayinlanmamis]
+
+### Eklendi — `badi market wishlist` (#84 phase 2)
+
+Demand × supply matrix icin yeni alt-komut:
+
+```
+badi market wishlist "habit tracker"
+badi market wishlist "ai journaling" --json --days 60
+```
+
+Talep sinyali: Reddit anonim JSON araması (API anahtari gerekmez,
+varsayilan son 30 gun). Arz sinyali: App Store araması sonuc sayisi.
+Matrix dort kadrana ayrilir: `BLUE_OCEAN` (yuksek talep × dusuk arz),
+`COMPETITIVE`, `NICHE`, `SATURATED`.
+
+`--json` bayragi yapilandirilmis rapor cikarir (top post + subreddit
+ornekleri + top app'ler rating ve sayisi ile) — diger araclara
+borulamak icin.
+
+Phase 2'nin ucunden ikincisi. SensorTower revenue (#84-1) paid API
+erisimine takili; opportunity gaps cross-analysis (#84-3) takip eder.
+
 ## [1.18.0] - 2026-05-02
 
 ### Eklendi — agent frontmatter audit (#90)

--- a/lib/commands/market.js
+++ b/lib/commands/market.js
@@ -12,12 +12,14 @@
 // Phase 2 (issue-tracked): SensorTower revenue, demand×supply wishlist
 // matrix, opportunity gaps cross-analysis, JSON output for piping.
 
-import { lookupAppStore } from "../aso-helpers.js";
+import { lookupAppStore, searchAppStore } from "../aso-helpers.js";
 import { chalk, showBanner } from "../cli.js";
 import {
 	aggregateReviewsMultiRegion,
 	calculateDifficulty,
+	computeWishlistMatrix,
 	discoverCompetitors,
+	fetchRedditDemand,
 	findCrossCompetitorComplaints,
 	summarizeReviews,
 } from "../market-helpers.js";
@@ -28,6 +30,8 @@ function parseFlags(args) {
 		countries: ["us"],
 		pages: 3,
 		limit: 10,
+		json: false,
+		days: 30,
 	};
 	for (let i = 0; i < args.length; i++) {
 		const a = args[i];
@@ -38,6 +42,10 @@ function parseFlags(args) {
 			flags.pages = Math.max(1, Number.parseInt(args[++i], 10) || 3);
 		} else if (a === "--limit") {
 			flags.limit = Math.max(1, Number.parseInt(args[++i], 10) || 10);
+		} else if (a === "--json") {
+			flags.json = true;
+		} else if (a === "--days") {
+			flags.days = Math.max(1, Number.parseInt(args[++i], 10) || 30);
 		}
 	}
 	return flags;
@@ -52,6 +60,7 @@ function showHelp() {
 	console.log(`  ${chalk.cyan("badi market discover <appId>")}        Sadece rakip kesfi`);
 	console.log(`  ${chalk.cyan("badi market reviews <appId>")}         Coklu bolge yorum aggregation`);
 	console.log(`  ${chalk.cyan("badi market difficulty <appId>")}      Sadece zorluk skoru`);
+	console.log(`  ${chalk.cyan("badi market wishlist <kategori>")}     Demand × supply matrix (Reddit + App Store)`);
 	console.log("");
 	console.log(chalk.bold("Secenekler:"));
 	console.log("  --country <c1,c2,..>    Bolgeler (varsayilan: us)");
@@ -62,6 +71,8 @@ function showHelp() {
 	console.log("  badi market 284882215");
 	console.log("  badi market 284882215 --country us,gb,de --pages 5");
 	console.log("  badi market discover 284882215 --limit 15");
+	console.log('  badi market wishlist "habit tracker"');
+	console.log('  badi market wishlist "ai journaling" --json');
 	console.log("");
 	console.log(
 		chalk.dim("App ID = numerik id (284882215) veya tam URL (https://apps.apple.com/us/app/id284882215)"),
@@ -77,6 +88,113 @@ function parseAppId(input) {
 	// App Store URL: ...id123456789...
 	const m = input.match(/id(\d+)/);
 	return m ? m[1] : null;
+}
+
+async function subWishlist(query, flags) {
+	if (!query) {
+		console.error(chalk.red("Kategori/anahtar kelime gerekli"));
+		console.log(chalk.dim('Ornek: badi market wishlist "habit tracker"'));
+		process.exit(1);
+	}
+
+	if (!flags.json) {
+		showBanner();
+		console.log(chalk.bold(`Wishlist Matrix: ${query}`));
+		console.log(chalk.dim(`Demand: Reddit (son ${flags.days} gun) | Supply: App Store`));
+		console.log("");
+		console.log(chalk.dim("[1/2] Reddit talep sinyali toplaniyor..."));
+	}
+
+	const demand = await fetchRedditDemand(query, { days: flags.days, limit: 100 });
+
+	if (!flags.json) {
+		console.log(chalk.dim(`[2/2] App Store rakip arz hacmi olculuyor...`));
+	}
+
+	let supply = 0;
+	let supplySample = [];
+	try {
+		const results = await searchAppStore(query, flags.countries[0], 25);
+		supply = results.length;
+		supplySample = results.slice(0, 5).map((r) => ({
+			id: r.id,
+			name: r.name,
+			rating: r.rating,
+			ratingCount: r.ratingCount,
+		}));
+	} catch (e) {
+		if (!flags.json) {
+			console.log(chalk.yellow(`  Arz olcumu basarisiz: ${e.message}`));
+		}
+	}
+
+	const matrix = computeWishlistMatrix({
+		demand: demand.mentions,
+		supply,
+	});
+
+	const report = {
+		query,
+		demand: {
+			mentions: demand.mentions,
+			subreddits: demand.subreddits,
+			sample: demand.sample,
+			error: demand.error,
+		},
+		supply: {
+			count: supply,
+			sample: supplySample,
+		},
+		matrix,
+		generatedAt: new Date().toISOString(),
+	};
+
+	if (flags.json) {
+		console.log(JSON.stringify(report, null, 2));
+		return;
+	}
+
+	console.log("");
+	const verdictColor =
+		matrix.quadrant === "BLUE_OCEAN"
+			? chalk.green
+			: matrix.quadrant === "COMPETITIVE"
+				? chalk.yellow
+				: matrix.quadrant === "NICHE"
+					? chalk.cyan
+					: chalk.red;
+
+	console.log(chalk.bold("Sonuc:"));
+	console.log(`  ${verdictColor(chalk.bold(matrix.quadrant))}`);
+	console.log("");
+	console.log(chalk.bold("Demand (Reddit):"));
+	console.log(`  ${demand.mentions} mention son ${flags.days} gunde`);
+	if (demand.error) {
+		console.log(chalk.yellow(`  Uyari: ${demand.error}`));
+	}
+	const topSubs = Object.entries(demand.subreddits)
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, 5);
+	if (topSubs.length > 0) {
+		console.log(chalk.bold("  Top subreddit'ler:"));
+		for (const [sub, c] of topSubs) {
+			console.log(`    r/${sub.padEnd(25)} ${c}`);
+		}
+	}
+	console.log("");
+	console.log(chalk.bold("Supply (App Store):"));
+	console.log(`  ${supply} app bulundu (ilk sayfa)`);
+	for (const s of supplySample) {
+		console.log(
+			`    ${(s.name || "").substring(0, 38).padEnd(40)} ${chalk.dim(`★${s.rating || "-"} (${s.ratingCount || 0})`)}`,
+		);
+	}
+	console.log("");
+	console.log(chalk.bold("Quadrant rehberi:"));
+	console.log(chalk.green("  BLUE_OCEAN")    + "    yuksek talep, dusuk arz  -> firsat");
+	console.log(chalk.yellow("  COMPETITIVE") + "  yuksek talep, yuksek arz -> farklilas");
+	console.log(chalk.cyan("  NICHE")        + "        dusuk talep, dusuk arz   -> ozel kitle");
+	console.log(chalk.red("  SATURATED")    + "    dusuk talep, yuksek arz  -> kacin");
 }
 
 async function subDiscover(appId, flags) {
@@ -276,6 +394,18 @@ export async function runMarket(args) {
 	if (!args[0] || args[0] === "--help" || args[0] === "-h") {
 		showHelp();
 		return;
+	}
+
+	// Wishlist subcommand: takes a free-text query, not appId
+	if (args[0] === "wishlist") {
+		const query = args[1];
+		const flags = parseFlags(args.slice(2));
+		try {
+			return await subWishlist(query, flags);
+		} catch (e) {
+			console.error(chalk.red(`Hata: ${e.message}`));
+			process.exit(1);
+		}
 	}
 
 	let sub = "full";

--- a/lib/market-helpers.js
+++ b/lib/market-helpers.js
@@ -214,4 +214,94 @@ export function findCrossCompetitorComplaints(competitorSummaries) {
 		.sort((a, b) => b.total - a.total);
 }
 
+/**
+ * Reddit'te bir kategori/anahtar kelime icin son N gunluk talep sinyali.
+ * Anonim JSON endpoint kullanir (ucretsiz, 60 req/min). API anahtari yok.
+ *
+ * @returns { mentions, subreddits, sample, fetchedAt }
+ */
+export async function fetchRedditDemand(query, opts = {}) {
+	const { days = 30, limit = 100 } = opts;
+	const sinceTs = Math.floor((Date.now() - days * 86400_000) / 1000);
+	const url = `https://www.reddit.com/search.json?q=${encodeURIComponent(query)}&sort=new&t=month&limit=${limit}`;
+
+	let data;
+	try {
+		const res = await fetch(url, {
+			headers: {
+				// Reddit reddediyor User-Agent yoksa
+				"User-Agent": "badi-market/1.0 (+https://github.com/fatihkan/badi)",
+			},
+		});
+		if (!res.ok) {
+			throw new Error(`Reddit ${res.status}`);
+		}
+		data = await res.json();
+	} catch (e) {
+		return {
+			mentions: 0,
+			subreddits: {},
+			sample: [],
+			error: e.message,
+			fetchedAt: new Date().toISOString(),
+		};
+	}
+
+	const posts = (data?.data?.children || [])
+		.map((c) => c?.data || {})
+		.filter((p) => p.created_utc >= sinceTs);
+
+	const subreddits = {};
+	const sample = [];
+	for (const p of posts) {
+		const sub = p.subreddit || "unknown";
+		subreddits[sub] = (subreddits[sub] || 0) + 1;
+		if (sample.length < 5) {
+			sample.push({
+				title: p.title,
+				subreddit: sub,
+				score: p.score,
+				comments: p.num_comments,
+				url: `https://reddit.com${p.permalink}`,
+			});
+		}
+	}
+
+	return {
+		mentions: posts.length,
+		subreddits,
+		sample,
+		fetchedAt: new Date().toISOString(),
+	};
+}
+
+/**
+ * Wishlist demand × supply matrix.
+ * Demand from Reddit mentions; supply from App Store competitor count.
+ *
+ * Quadrants:
+ *   high demand × low supply  → BLUE_OCEAN
+ *   high demand × high supply → COMPETITIVE
+ *   low demand  × low supply  → NICHE
+ *   low demand  × high supply → SATURATED
+ */
+export function computeWishlistMatrix({ demand, supply, thresholds = {} }) {
+	const { highDemand = 30, highSupply = 8 } = thresholds;
+	const isHighDemand = demand >= highDemand;
+	const isHighSupply = supply >= highSupply;
+
+	let quadrant;
+	if (isHighDemand && !isHighSupply) quadrant = "BLUE_OCEAN";
+	else if (isHighDemand && isHighSupply) quadrant = "COMPETITIVE";
+	else if (!isHighDemand && !isHighSupply) quadrant = "NICHE";
+	else quadrant = "SATURATED";
+
+	return {
+		demand,
+		supply,
+		quadrant,
+		thresholds: { highDemand, highSupply },
+	};
+}
+
 export { ISSUE_CODES };

--- a/tests/cli.market.test.js
+++ b/tests/cli.market.test.js
@@ -6,6 +6,7 @@ import { describe, it } from "node:test";
 import {
 	calculateDifficulty,
 	categorizeReviewIssue,
+	computeWishlistMatrix,
 	findCrossCompetitorComplaints,
 	ISSUE_CODES,
 	summarizeReviews,
@@ -208,5 +209,63 @@ describe("market: CLI smoke", () => {
 		});
 		// Help mentions URL parsing
 		assert.match(out, /apps\.apple\.com/);
+	});
+
+	it("--help wishlist subcommand'i listeler", () => {
+		const out = execFileSync("node", [BIN, "market", "--help"], {
+			encoding: "utf-8",
+			timeout: 10000,
+		});
+		assert.match(out, /wishlist/);
+		assert.match(out, /Demand × supply matrix/);
+	});
+});
+
+describe("market: computeWishlistMatrix", () => {
+	it("yuksek talep + dusuk arz -> BLUE_OCEAN", () => {
+		const m = computeWishlistMatrix({ demand: 50, supply: 3 });
+		assert.equal(m.quadrant, "BLUE_OCEAN");
+	});
+
+	it("yuksek talep + yuksek arz -> COMPETITIVE", () => {
+		const m = computeWishlistMatrix({ demand: 100, supply: 25 });
+		assert.equal(m.quadrant, "COMPETITIVE");
+	});
+
+	it("dusuk talep + dusuk arz -> NICHE", () => {
+		const m = computeWishlistMatrix({ demand: 5, supply: 2 });
+		assert.equal(m.quadrant, "NICHE");
+	});
+
+	it("dusuk talep + yuksek arz -> SATURATED", () => {
+		const m = computeWishlistMatrix({ demand: 10, supply: 50 });
+		assert.equal(m.quadrant, "SATURATED");
+	});
+
+	it("eslik (esit) demand threshold -> high tarafta", () => {
+		const m = computeWishlistMatrix({ demand: 30, supply: 3 });
+		assert.equal(m.quadrant, "BLUE_OCEAN");
+	});
+
+	it("eslik (esit) supply threshold -> high tarafta", () => {
+		const m = computeWishlistMatrix({ demand: 5, supply: 8 });
+		assert.equal(m.quadrant, "SATURATED");
+	});
+
+	it("custom thresholds uygulanir", () => {
+		const m = computeWishlistMatrix({
+			demand: 15,
+			supply: 4,
+			thresholds: { highDemand: 10, highSupply: 3 },
+		});
+		assert.equal(m.quadrant, "COMPETITIVE");
+	});
+
+	it("response shape doğru", () => {
+		const m = computeWishlistMatrix({ demand: 50, supply: 3 });
+		assert.equal(typeof m.demand, "number");
+		assert.equal(typeof m.supply, "number");
+		assert.ok(m.thresholds.highDemand);
+		assert.ok(m.thresholds.highSupply);
 	});
 });


### PR DESCRIPTION
## Summary
New `badi market wishlist <kategori>` subcommand — second of three Phase-2 capabilities for #84.

```
badi market wishlist "habit tracker"
badi market wishlist "ai journaling" --json --days 60
```

### Signals
- **Demand**: Reddit anonymous JSON search (no API key, configurable window, default 30 days). Returns mention count + top subreddits + sample posts.
- **Supply**: App Store search result count + top apps with rating + ratingCount.

### Matrix quadrants
| Demand × Supply | Quadrant | Action |
|-----------------|----------|--------|
| High × Low | `BLUE_OCEAN` | opportunity |
| High × High | `COMPETITIVE` | differentiate |
| Low × Low | `NICHE` | targeted audience |
| Low × High | `SATURATED` | avoid |

Default thresholds: 30 mentions = high demand, 8 apps = high supply. Tunable via `thresholds` arg in the helper for testability; CLI uses defaults.

### `--json` mode
Emits a structured report (demand sample + supply sample + matrix + metadata) for piping.

## Scope decisions
- **Product Hunt skipped** — requires OAuth. Reddit is enough for v1; PH can be additive later.
- **#84-1 SensorTower revenue** — still blocked on paid API. Issue stays open with that note.
- **#84-3 opportunity gaps cross-analysis** — follows up; this matrix feeds into it.

## Test plan
- [x] `npm test` — 547/547 green (538 → +9 wishlist tests)
- [x] 8 unit tests for `computeWishlistMatrix` (all 4 quadrants + threshold edges + custom thresholds + shape)
- [x] 1 CLI smoke for `--help` listing the subcommand
- [x] `node bin/badi.js market --help` shows wishlist line

## Network behavior
- Reddit JSON endpoint, anonymous, custom User-Agent — no auth, no API key
- Returns `{ error: ... }` gracefully if Reddit fails (CLI prints warning, doesn't exit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)