### PR TITLE
feat(market): opportunity gaps cross-analysis (#84 phase 2 final)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Added — `badi market gaps` (#84 phase 2)
+
+New `gaps` subcommand cross-references the existing market signals into
+ranked opportunity findings:
+
+```
+badi market gaps 284882215
+badi market gaps 284882215 --query "facebook alternative" --json
+```
+
+For every cross-competitor complaint code the helper computes a
+`gapScore = coverage% * volume * (1 - difficulty/100)`, optionally
+boosted by Reddit demand when `--query` is supplied. Each finding
+carries a coverage percentage (how many competitors carry the
+complaint), volume (negative review count), severity (`HIGH` /
+`MEDIUM` / `LOW`), and a one-line human-readable rationale.
+
+Output sorted by `gapScore` descending — top entries are the strongest
+signals for "this market segment has a broadly under-served need".
+`--json` mode emits the structured report (target + difficulty +
+demand + ranked findings).
+
+This closes the third Phase-2 capability for #84. SensorTower revenue
+(#84-1) stays blocked on paid API access; `gaps` does not depend on it.
+
 ### Added — `badi market wishlist` (#84 phase 2)
 
 New subcommand for the demand × supply matrix:

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,30 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Yayinlanmamis]
 
+### Eklendi — `badi market gaps` (#84 phase 2)
+
+Mevcut market sinyallerini cross-pozisyonlayan yeni `gaps` alt-komutu:
+
+```
+badi market gaps 284882215
+badi market gaps 284882215 --query "facebook alternative" --json
+```
+
+Her cross-rakip sikayet kodu icin
+`gapScore = coverage% * volume * (1 - difficulty/100)` hesaplanir;
+`--query` verildiginde Reddit demand ile carpilarak skor zenginlesir.
+Her bulgu coverage yuzdesi (kac rakip etkilenmis), volume (negatif
+yorum sayisi), severity (`HIGH`/`MEDIUM`/`LOW`) ve tek satirlik
+rationale icerir.
+
+Cikti gapScore azalan sirada — en ust girisler "bu pazar dilimi
+yaygin olarak yetersiz hizmet alan bir ihtiyaç tasiyor" sinyalinin
+en gucludu. `--json` modu yapilandirilmis raporu yazar (hedef +
+difficulty + demand + siralanmis bulgular).
+
+#84 Phase 2'nin ucuncu yetenegi de boylece kapaniyor. SensorTower
+revenue (#84-1) hala paid API'ye bagli; `gaps` ona bagimli degil.
+
 ### Eklendi — `badi market wishlist` (#84 phase 2)
 
 Demand × supply matrix icin yeni alt-komut:

--- a/lib/commands/market.js
+++ b/lib/commands/market.js
@@ -21,6 +21,7 @@ import {
 	discoverCompetitors,
 	fetchRedditDemand,
 	findCrossCompetitorComplaints,
+	findOpportunityGaps,
 	summarizeReviews,
 } from "../market-helpers.js";
 
@@ -32,6 +33,7 @@ function parseFlags(args) {
 		limit: 10,
 		json: false,
 		days: 30,
+		query: null,
 	};
 	for (let i = 0; i < args.length; i++) {
 		const a = args[i];
@@ -46,6 +48,8 @@ function parseFlags(args) {
 			flags.json = true;
 		} else if (a === "--days") {
 			flags.days = Math.max(1, Number.parseInt(args[++i], 10) || 30);
+		} else if (a === "--query") {
+			flags.query = args[++i] || null;
 		}
 	}
 	return flags;
@@ -61,6 +65,7 @@ function showHelp() {
 	console.log(`  ${chalk.cyan("badi market reviews <appId>")}         Coklu bolge yorum aggregation`);
 	console.log(`  ${chalk.cyan("badi market difficulty <appId>")}      Sadece zorluk skoru`);
 	console.log(`  ${chalk.cyan("badi market wishlist <kategori>")}     Demand × supply matrix (Reddit + App Store)`);
+	console.log(`  ${chalk.cyan("badi market gaps <appId>")}            Opportunity gaps (difficulty × complaints × demand)`);
 	console.log("");
 	console.log(chalk.bold("Secenekler:"));
 	console.log("  --country <c1,c2,..>    Bolgeler (varsayilan: us)");
@@ -73,6 +78,8 @@ function showHelp() {
 	console.log("  badi market discover 284882215 --limit 15");
 	console.log('  badi market wishlist "habit tracker"');
 	console.log('  badi market wishlist "ai journaling" --json');
+	console.log("  badi market gaps 284882215");
+	console.log("  badi market gaps 284882215 --json --query \"facebook alternative\"");
 	console.log("");
 	console.log(
 		chalk.dim("App ID = numerik id (284882215) veya tam URL (https://apps.apple.com/us/app/id284882215)"),
@@ -195,6 +202,116 @@ async function subWishlist(query, flags) {
 	console.log(chalk.yellow("  COMPETITIVE") + "  yuksek talep, yuksek arz -> farklilas");
 	console.log(chalk.cyan("  NICHE")        + "        dusuk talep, dusuk arz   -> ozel kitle");
 	console.log(chalk.red("  SATURATED")    + "    dusuk talep, yuksek arz  -> kacin");
+}
+
+async function subGaps(appId, flags) {
+	if (!flags.json) {
+		showBanner();
+		console.log(chalk.bold(`Opportunity Gaps: app ${appId}`));
+		console.log(chalk.dim("Difficulty + cross-rakip sikayetler + (opsiyonel) Reddit demand"));
+		console.log("");
+		console.log(chalk.dim("[1/5] Hedef profili..."));
+	}
+	const target = await lookupAppStore(appId, flags.countries[0]);
+
+	if (!flags.json) console.log(chalk.dim(`[2/5] Rakip kesfi (${flags.limit} app)...`));
+	const competitors = await discoverCompetitors(target, {
+		country: flags.countries[0],
+		limit: flags.limit,
+	});
+
+	if (!flags.json) console.log(chalk.dim(`[3/5] Rakip yorumlari toplaniyor...`));
+	const competitorSummaries = [];
+	for (const c of competitors) {
+		try {
+			const cReviews = await aggregateReviewsMultiRegion(c.id, {
+				countries: flags.countries,
+				pages: Math.max(1, Math.floor(flags.pages / 2)),
+			});
+			competitorSummaries.push({
+				name: c.name,
+				id: c.id,
+				summary: summarizeReviews(cReviews),
+			});
+		} catch {
+			// non-fatal
+		}
+	}
+
+	const difficulty = calculateDifficulty(target, competitors);
+	const crossComplaints = findCrossCompetitorComplaints(competitorSummaries);
+
+	let demandSignal;
+	let demandMeta = null;
+	if (flags.query) {
+		if (!flags.json) console.log(chalk.dim(`[4/5] Reddit demand: "${flags.query}"`));
+		try {
+			const demand = await fetchRedditDemand(flags.query, { days: flags.days });
+			demandSignal = demand.mentions;
+			demandMeta = demand;
+		} catch {
+			// non-fatal
+		}
+	} else if (!flags.json) {
+		console.log(chalk.dim("[4/5] Reddit demand atlandi (--query verilmedi)"));
+	}
+
+	if (!flags.json) console.log(chalk.dim("[5/5] Gap skoru hesaplaniyor..."));
+	const gaps = findOpportunityGaps({
+		crossComplaints,
+		competitorCount: competitorSummaries.length,
+		difficulty,
+		demandSignal,
+	});
+
+	const report = {
+		target: {
+			id: target.id,
+			name: target.name,
+			genre: target.primaryGenre,
+		},
+		difficulty,
+		competitorCount: competitorSummaries.length,
+		demand: demandMeta && {
+			query: flags.query,
+			mentions: demandMeta.mentions,
+			subreddits: demandMeta.subreddits,
+		},
+		gaps,
+		generatedAt: new Date().toISOString(),
+	};
+
+	if (flags.json) {
+		console.log(JSON.stringify(report, null, 2));
+		return;
+	}
+
+	console.log("");
+	console.log(chalk.bold(`Hedef: ${target.name}`));
+	console.log(chalk.dim(`Tur: ${target.primaryGenre} | Zorluk: ${difficulty.score}/100 (${difficulty.verdict})`));
+	console.log(chalk.dim(`Rakip: ${competitorSummaries.length} | Sikayet kategorisi: ${crossComplaints.length}`));
+	if (demandMeta) {
+		console.log(chalk.dim(`Demand: "${flags.query}" → ${demandMeta.mentions} mention/${flags.days} gun`));
+	}
+	console.log("");
+
+	if (gaps.length === 0) {
+		console.log(chalk.dim("(yetersiz veri — daha fazla rakip yorumu gerekli)"));
+		return;
+	}
+
+	console.log(chalk.bold("Top Opportunity Gaps:"));
+	console.log(chalk.dim(`  ${"Kod".padEnd(18)} ${"Sev".padEnd(8)} ${"Score".padEnd(8)} Aciklama`));
+	for (const g of gaps.slice(0, 8)) {
+		const sevColor =
+			g.severity === "HIGH" ? chalk.red : g.severity === "MEDIUM" ? chalk.yellow : chalk.dim;
+		console.log(
+			`  ${chalk.bold(g.code.padEnd(18))} ${sevColor(g.severity.padEnd(8))} ${String(g.gapScore).padStart(6)}  ${chalk.dim(g.rationale)}`,
+		);
+	}
+	console.log("");
+	console.log(chalk.dim("Yuksek skor + HIGH severity = pazara giris icin guclu sinyal"));
+	console.log(chalk.dim("--query <kategori> ile Reddit demand ekleyerek skoru zenginlestir"));
 }
 
 async function subDiscover(appId, flags) {
@@ -410,7 +527,7 @@ export async function runMarket(args) {
 
 	let sub = "full";
 	let appIdInput = args[0];
-	if (["discover", "reviews", "difficulty", "full"].includes(args[0])) {
+	if (["discover", "reviews", "difficulty", "gaps", "full"].includes(args[0])) {
 		sub = args[0];
 		appIdInput = args[1];
 	}
@@ -429,6 +546,7 @@ export async function runMarket(args) {
 		if (sub === "discover") return await subDiscover(appId, flags);
 		if (sub === "reviews") return await subReviews(appId, flags);
 		if (sub === "difficulty") return await subDifficulty(appId, flags);
+		if (sub === "gaps") return await subGaps(appId, flags);
 		return await subFull(appId, flags);
 	} catch (e) {
 		console.error(chalk.red(`Hata: ${e.message}`));

--- a/lib/market-helpers.js
+++ b/lib/market-helpers.js
@@ -215,6 +215,74 @@ export function findCrossCompetitorComplaints(competitorSummaries) {
 }
 
 /**
+ * Cross-rakip sikayet kesim verisi + difficulty + (opsiyonel) wishlist demand
+ * sinyallerini carpazliyarak opportunity findings uretir.
+ *
+ * Her finding bir sikayet kategorisi etrafinda dururlmus:
+ *   - kac rakip uygulamasi bu sikayetten muzdarip (coverage)
+ *   - toplam negatif yorum sayisi (volume)
+ *   - bu kategoride pazar bosluğu skorunun (gap score) birlesik tahmini
+ *
+ * gap score = coverage% (yuzde / 100) * volume * (1 - difficulty/100)
+ *   - high coverage: bircok rakipte var -> sikayet sektorel
+ *   - high volume: ucuz olarak surdurulebilen sikayet
+ *   - low difficulty: pazara girmek mumkun
+ *
+ * @param {Object} input
+ * @param {Array} input.crossComplaints — findCrossCompetitorComplaints cikartisi
+ * @param {Number} input.competitorCount — toplam rakip sayisi (coverage% icin)
+ * @param {Object} input.difficulty — calculateDifficulty sonucu
+ * @param {Number} [input.demandSignal] — opsiyonel Reddit mentions
+ * @returns Array<{ code, coverage, volume, gapScore, severity, rationale }>
+ */
+export function findOpportunityGaps(input) {
+	const {
+		crossComplaints = [],
+		competitorCount = 0,
+		difficulty = { score: 50 },
+		demandSignal,
+	} = input;
+
+	if (competitorCount === 0 || crossComplaints.length === 0) {
+		return [];
+	}
+
+	const findings = crossComplaints.map((c) => {
+		const affected = Object.keys(c.perApp || {}).length;
+		const coverage = competitorCount > 0 ? affected / competitorCount : 0;
+		const volume = c.total || 0;
+		const difficultyFactor = 1 - difficulty.score / 100;
+		const gapScore = Math.round(coverage * 100 * volume * difficultyFactor);
+
+		// Demand boost: if reddit demand exists, multiply gap score
+		const boostedScore = demandSignal
+			? Math.round(gapScore * (1 + Math.min(2, demandSignal / 50)))
+			: gapScore;
+
+		let severity;
+		if (coverage >= 0.6 && volume >= 8) severity = "HIGH";
+		else if (coverage >= 0.4 || volume >= 5) severity = "MEDIUM";
+		else severity = "LOW";
+
+		const coveragePct = Math.round(coverage * 100);
+		const rationale = `${affected}/${competitorCount} rakip (${coveragePct}%) bu sorundan etkileniyor; ${volume} negatif yorum; pazar zorlugu ${difficulty.score}/100`;
+
+		return {
+			code: c.code,
+			coverage: coveragePct,
+			affected,
+			volume,
+			gapScore: boostedScore,
+			severity,
+			rationale,
+			perApp: c.perApp,
+		};
+	});
+
+	return findings.sort((a, b) => b.gapScore - a.gapScore);
+}
+
+/**
  * Reddit'te bir kategori/anahtar kelime icin son N gunluk talep sinyali.
  * Anonim JSON endpoint kullanir (ucretsiz, 60 req/min). API anahtari yok.
  *

--- a/tests/cli.market.test.js
+++ b/tests/cli.market.test.js
@@ -8,6 +8,7 @@ import {
 	categorizeReviewIssue,
 	computeWishlistMatrix,
 	findCrossCompetitorComplaints,
+	findOpportunityGaps,
 	ISSUE_CODES,
 	summarizeReviews,
 } from "../lib/market-helpers.js";
@@ -267,5 +268,105 @@ describe("market: computeWishlistMatrix", () => {
 		assert.equal(typeof m.supply, "number");
 		assert.ok(m.thresholds.highDemand);
 		assert.ok(m.thresholds.highSupply);
+	});
+});
+
+describe("market: findOpportunityGaps", () => {
+	const sampleCross = [
+		{ code: "crash", total: 12, perApp: { A: 5, B: 4, C: 3 } },
+		{ code: "ads", total: 5, perApp: { A: 3, B: 2 } },
+		{ code: "ui", total: 2, perApp: { C: 2 } },
+	];
+
+	it("bos input bos array doner", () => {
+		assert.deepEqual(findOpportunityGaps({ crossComplaints: [], competitorCount: 0 }), []);
+		assert.deepEqual(
+			findOpportunityGaps({ crossComplaints: sampleCross, competitorCount: 0 }),
+			[],
+		);
+	});
+
+	it("gap score = coverage% * volume * (1 - difficulty/100)", () => {
+		const gaps = findOpportunityGaps({
+			crossComplaints: sampleCross,
+			competitorCount: 5,
+			difficulty: { score: 50 },
+		});
+		const crash = gaps.find((g) => g.code === "crash");
+		// coverage = 3/5 = 0.6 -> 60%
+		// gapScore = 60 * 12 * 0.5 = 360
+		assert.equal(crash.gapScore, 360);
+		assert.equal(crash.coverage, 60);
+	});
+
+	it("HIGH severity = high coverage + high volume", () => {
+		const gaps = findOpportunityGaps({
+			crossComplaints: [{ code: "crash", total: 10, perApp: { A: 4, B: 3, C: 3 } }],
+			competitorCount: 5,
+			difficulty: { score: 30 },
+		});
+		assert.equal(gaps[0].severity, "HIGH");
+	});
+
+	it("LOW severity = low coverage + low volume", () => {
+		const gaps = findOpportunityGaps({
+			crossComplaints: [{ code: "ui", total: 2, perApp: { A: 2 } }],
+			competitorCount: 5,
+			difficulty: { score: 30 },
+		});
+		assert.equal(gaps[0].severity, "LOW");
+	});
+
+	it("dusuk difficulty -> yuksek gapScore (1 - difficulty etkisi)", () => {
+		const cross = [{ code: "crash", total: 10, perApp: { A: 5, B: 5 } }];
+		const easy = findOpportunityGaps({
+			crossComplaints: cross,
+			competitorCount: 5,
+			difficulty: { score: 10 },
+		});
+		const hard = findOpportunityGaps({
+			crossComplaints: cross,
+			competitorCount: 5,
+			difficulty: { score: 90 },
+		});
+		assert.ok(easy[0].gapScore > hard[0].gapScore);
+	});
+
+	it("Reddit demand boost gapScore'u artirir", () => {
+		const cross = [{ code: "crash", total: 10, perApp: { A: 5, B: 5 } }];
+		const noBoost = findOpportunityGaps({
+			crossComplaints: cross,
+			competitorCount: 5,
+			difficulty: { score: 50 },
+		});
+		const withBoost = findOpportunityGaps({
+			crossComplaints: cross,
+			competitorCount: 5,
+			difficulty: { score: 50 },
+			demandSignal: 100,
+		});
+		assert.ok(withBoost[0].gapScore > noBoost[0].gapScore);
+	});
+
+	it("sonuc gapScore'a gore azalan sirali", () => {
+		const gaps = findOpportunityGaps({
+			crossComplaints: sampleCross,
+			competitorCount: 5,
+			difficulty: { score: 50 },
+		});
+		for (let i = 1; i < gaps.length; i++) {
+			assert.ok(gaps[i - 1].gapScore >= gaps[i].gapScore);
+		}
+	});
+
+	it("rationale insan-okunabilir cumle", () => {
+		const gaps = findOpportunityGaps({
+			crossComplaints: sampleCross,
+			competitorCount: 5,
+			difficulty: { score: 40 },
+		});
+		assert.match(gaps[0].rationale, /rakip/);
+		assert.match(gaps[0].rationale, /negatif yorum/);
+		assert.match(gaps[0].rationale, /pazar zorlugu/);
 	});
 });


### PR DESCRIPTION
## Summary
Closes the third and final Phase-2 capability for #84.

```
badi market gaps 284882215
badi market gaps 284882215 --query "facebook alternative" --json
```

### Algorithm
For every cross-competitor complaint code:

```
gapScore = coverage% * volume * (1 - difficulty/100)
        × (1 + min(2, demandSignal/50))   if --query supplied
```

Each finding carries:
- `coverage` (% of competitors affected)
- `volume` (negative review count)
- `severity` (`HIGH` / `MEDIUM` / `LOW`)
- `rationale` (one-line human-readable summary)

### Output
- Default: terminal table sorted by `gapScore` descending, top 8 findings
- `--json`: structured report `{ target, difficulty, demand, gaps[], generatedAt }`

### Phase 2 status (issue #84)
| Sub-capability | Status |
|----------------|--------|
| #84-1 SensorTower revenue | Still blocked on paid API |
| #84-2 wishlist matrix | Shipped (#104) |
| #84-3 opportunity gaps | **This PR** |

## Test plan
- [x] `npm test` — 555/555 green (547 → +8 gap tests)
- [x] 8 unit tests for `findOpportunityGaps`: input edges, score formula, severity buckets, difficulty inverse, demand boost, sort order, rationale shape
- [x] `node bin/badi.js market --help` shows the `gaps` line
- [x] CHANGELOG `[Unreleased]` entries in both EN + TR

🤖 Generated with [Claude Code](https://claude.com/claude-code)