### PR TITLE
feat(skills): auto-router — prompt → matched skills

### DIFF
--- a/.claude/hooks/skill-router.sh
+++ b/.claude/hooks/skill-router.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Badi - UserPromptSubmit Auto-Router
+#
+# Kullanicinin yazdigi prompt'u okur, vault'taki SKILL.md aciklamalarina karsi
+# keyword match yapar, eslesen skill'lerin SKILL.md govdesini context olarak
+# Claude'a verir. Filesystem'e yazma yok — per-turn injection.
+#
+# Aktif etmek icin: badi skills auto on
+# Kapatmak icin:    badi skills auto off
+
+INPUT=$(cat)
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null || echo "")
+
+if [ -z "$PROMPT" ]; then
+  exit 0
+fi
+
+# Cok kisa prompt'lari atla (ornek: tek kelimelik komutlar)
+WORDS=$(echo "$PROMPT" | wc -w | tr -d ' ')
+if [ "$WORDS" -lt 3 ]; then
+  exit 0
+fi
+
+# badi binary'sini bul (npm-link, npm-global, npx fallback)
+if command -v badi >/dev/null 2>&1; then
+  BADI="badi"
+elif [ -f "node_modules/.bin/badi" ]; then
+  BADI="node_modules/.bin/badi"
+else
+  exit 0
+fi
+
+# Vault yoksa cikma
+if [ ! -d ".claude/skills-vault" ]; then
+  exit 0
+fi
+
+# Match'lenen skill'lerin govdesini al (top 3, esik 2)
+INJECTION=$($BADI skills route --inject --top 3 "$PROMPT" 2>/dev/null || echo "")
+
+if [ -z "$INJECTION" ]; then
+  exit 0
+fi
+
+# UserPromptSubmit hook output: additionalContext olarak inject
+jq -n --arg ctx "$INJECTION" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: $ctx
+  }
+}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Added — auto skill router (`badi skills route` + `auto on/off`)
+
+Prompt-based otomatik skill activation. Vault'taki SKILL.md
+aciklamalarindan keyword indeksi kurulur, kullanici prompt'una karsi
+puanlama yapilir. UserPromptSubmit hook'u ile entegre olunca prompt
+tipine gore eslesen skill'lerin govdesi context'e inject edilir
+(per-turn, filesystem'e yazma yok).
+
+```
+badi skills route "SEO icin schema markup ekle"   # eslesenleri puanla
+badi skills route --inject "..."                   # SKILL.md govdesi yazar
+badi skills auto on                                # hook'u aktif et
+badi skills auto off                               # kapat
+badi skills auto status                            # durum
+```
+
+**Skor formulu**: trigger token (`triggers on:` listesi) eslesmesi 3x,
+description token eslesmesi 1x agirlikli. Esik default `minScore=2`,
+top default 3 skill. Stopword filtresi (TR + EN) yanlis match'leri
+azaltir.
+
+**Auto-router opt-in**: `badi skills auto on` settings.json'a
+UserPromptSubmit hook ekler. Hook prompt'u okur, vault'tan eslesen
+skill'lerin SKILL.md govdesini Claude'a additionalContext olarak
+verir. Token vergisi sadece eslesme oldugunda — prompt 3 kelimeden
+kisaysa veya match yoksa hook sessizce gecer.
+
+**Yeni dosyalar**: `lib/skills-router.js` (matcher),
+`.claude/hooks/skill-router.sh` (hook), `tests/cli.skills-router.test.js`
+(22 test). doctor `skill-router.sh` hook'unu da denetliyor.
+
 ### Added — `badi market gaps` (#84 phase 2)
 
 New `gaps` subcommand cross-references the existing market signals into

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,35 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Yayinlanmamis]
 
+### Eklendi — otomatik skill router (`badi skills route` + `auto on/off`)
+
+Prompt'a gore otomatik skill aktivasyonu. Vault'taki SKILL.md
+aciklamalarindan keyword indeksi kurulur, kullanici prompt'una karsi
+puanlama yapilir. UserPromptSubmit hook'u ile entegre olunca prompt
+tipine gore eslesen skill'lerin govdesi her turun context'ine inject
+edilir (filesystem yazma yok).
+
+```
+badi skills route "SEO icin schema markup ekle"   # eslesenleri puanla
+badi skills route --inject "..."                   # SKILL.md govdesi yazar
+badi skills auto on                                # hook'u aktif et
+badi skills auto off                               # kapat
+badi skills auto status                            # durum
+```
+
+**Skor formulu**: trigger token (`triggers on:` listesi) eslesmesi 3x,
+description token eslesmesi 1x. Default `minScore=2`, top 3 skill.
+TR + EN stopword filtresi yanlis match'i azaltir.
+
+**Opt-in**: `badi skills auto on` settings.json'a UserPromptSubmit
+hook ekler. Hook prompt'u okur, eslesen skill'lerin SKILL.md
+govdesini additionalContext olarak verir. Token vergisi sadece
+eslesme aninda — kisa prompt veya match yoksa hook sessizce gecer.
+
+**Yeni dosyalar**: `lib/skills-router.js`,
+`.claude/hooks/skill-router.sh`, `tests/cli.skills-router.test.js`
+(22 test). doctor yeni hook'u denetliyor.
+
 ### Eklendi — `badi market gaps` (#84 phase 2)
 
 Mevcut market sinyallerini cross-pozisyonlayan yeni `gaps` alt-komutu:

--- a/lib/commands/skills.js
+++ b/lib/commands/skills.js
@@ -12,11 +12,17 @@ import {
 	readFileSync,
 	rmSync,
 	statSync,
+	writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { chalk } from "../cli.js";
 import { listDirs } from "../helpers.js";
+import {
+	buildContextInjection,
+	buildSkillIndex,
+	routePrompt,
+} from "../skills-router.js";
 
 function paths(target) {
 	const claudeDir = join(target, ".claude");
@@ -150,9 +156,17 @@ function showHelp() {
 	console.log("  badi skills clear               Tum aktif skill'leri sifirla");
 	console.log("  badi skills reset               clear ile ayni");
 	console.log("");
+	console.log(chalk.bold("Auto-router (v1.20+):"));
+	console.log('  badi skills route "<prompt>"    Prompt → eslesen skill\'leri puanla');
+	console.log("  badi skills route --inject      Match'lenenleri SKILL.md govdesi olarak yaz (hook icin)");
+	console.log("  badi skills auto on             UserPromptSubmit hook'unu aktif et");
+	console.log("  badi skills auto off            Hook'u kaldir");
+	console.log("  badi skills auto status         Hook durumunu goster");
+	console.log("");
 	console.log(chalk.dim("Ornek:"));
 	console.log(chalk.dim("  badi skills add seo marketing security"));
-	console.log(chalk.dim("  badi skills clear && badi skills add development"));
+	console.log(chalk.dim('  badi skills route "Instagram post yaz"'));
+	console.log(chalk.dim("  badi skills auto on   # her prompt'tan once otomatik route"));
 }
 
 export async function runSkills(args) {
@@ -316,6 +330,143 @@ export async function runSkills(args) {
 			console.log(
 				`${chalk.yellow(removed)} kaldirildi, ${chalk.dim(missing)} atlandi.`,
 			);
+			break;
+		}
+
+		case "route": {
+			const promptArgs = args.slice(1);
+			let inject = false;
+			let json = false;
+			let topN = 3;
+			const promptParts = [];
+			for (let i = 0; i < promptArgs.length; i++) {
+				const a = promptArgs[i];
+				if (a === "--inject") inject = true;
+				else if (a === "--json") json = true;
+				else if (a === "--top") topN = Math.max(1, Number.parseInt(promptArgs[++i], 10) || 3);
+				else promptParts.push(a);
+			}
+			let prompt = promptParts.join(" ").trim();
+			if (!prompt) {
+				// Read stdin if no arg
+				try {
+					const { readFileSync: r } = await import("node:fs");
+					prompt = r(0, "utf-8").trim();
+				} catch {
+					/* ignore */
+				}
+			}
+			if (!prompt) {
+				console.error(chalk.red("Hata: prompt gerekli (arg veya stdin)."));
+				console.log(chalk.dim('Ornek: badi skills route "SEO icin meta tag yaz"'));
+				process.exit(1);
+			}
+
+			const index = buildSkillIndex(vault);
+			const matched = routePrompt(prompt, index, { top: topN });
+
+			if (inject) {
+				const blob = buildContextInjection(matched, index);
+				if (json) {
+					console.log(
+						JSON.stringify({ matched, contextLength: blob.length }, null, 2),
+					);
+				} else {
+					process.stdout.write(blob);
+				}
+				return;
+			}
+			if (json) {
+				console.log(JSON.stringify({ prompt, matched }, null, 2));
+				return;
+			}
+			console.log(chalk.bold(`Prompt: "${prompt.slice(0, 80)}${prompt.length > 80 ? "…" : ""}"`));
+			console.log("");
+			if (matched.length === 0) {
+				console.log(chalk.dim("(eslesen skill yok — 'badi skills available' ile listeyi gor)"));
+				return;
+			}
+			console.log(chalk.bold(`Eslesen skill'ler (${matched.length}):`));
+			for (const m of matched) {
+				const trigText = m.matched.triggers.length
+					? chalk.cyan(`triggers: ${m.matched.triggers.join(", ")}`)
+					: "";
+				const descText = m.matched.description.length
+					? chalk.dim(`desc: ${m.matched.description.join(", ")}`)
+					: "";
+				console.log(
+					`  ${chalk.bold(m.name.padEnd(20))} ${chalk.green(`skor ${m.score}`.padEnd(10))} ${trigText} ${descText}`,
+				);
+			}
+			break;
+		}
+
+		case "auto": {
+			const onOff = args[1];
+			const settingsPath = join(target, ".claude", "settings.json");
+			let settings = {};
+			if (existsSync(settingsPath)) {
+				try {
+					settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+				} catch {
+					console.error(chalk.red("settings.json gecersiz JSON"));
+					process.exit(1);
+				}
+			}
+			settings.hooks = settings.hooks || {};
+			settings.hooks.UserPromptSubmit = settings.hooks.UserPromptSubmit || [];
+
+			const HOOK_ENTRY = {
+				matcher: "*",
+				hooks: [
+					{
+						type: "command",
+						command: "bash .claude/hooks/skill-router.sh",
+					},
+				],
+			};
+
+			const hasEntry = settings.hooks.UserPromptSubmit.some((entry) =>
+				JSON.stringify(entry).includes("skill-router.sh"),
+			);
+
+			if (onOff === "on") {
+				if (hasEntry) {
+					console.log(chalk.dim("Auto-router zaten aktif."));
+					return;
+				}
+				settings.hooks.UserPromptSubmit.push(HOOK_ENTRY);
+				writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
+				console.log(chalk.green("✓ Auto-router aktif"));
+				console.log(
+					chalk.dim("Her prompt'tan once vault taranir, eslesen skill'ler context'e inject edilir."),
+				);
+				console.log(chalk.dim("Kapatmak icin: badi skills auto off"));
+			} else if (onOff === "off") {
+				if (!hasEntry) {
+					console.log(chalk.dim("Auto-router zaten kapali."));
+					return;
+				}
+				settings.hooks.UserPromptSubmit = settings.hooks.UserPromptSubmit.filter(
+					(entry) => !JSON.stringify(entry).includes("skill-router.sh"),
+				);
+				if (settings.hooks.UserPromptSubmit.length === 0) {
+					delete settings.hooks.UserPromptSubmit;
+				}
+				writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
+				console.log(chalk.yellow("✓ Auto-router kapatildi"));
+			} else if (!onOff || onOff === "status") {
+				console.log(
+					chalk.bold(
+						`Auto-router: ${hasEntry ? chalk.green("AKTIF") : chalk.dim("kapali")}`,
+					),
+				);
+				console.log(chalk.dim("Acmak icin:  badi skills auto on"));
+				console.log(chalk.dim("Kapatmak:    badi skills auto off"));
+			} else {
+				console.error(chalk.red(`Bilinmeyen: ${onOff}. Kullan: on / off / status`));
+				process.exit(1);
+			}
 			break;
 		}
 

--- a/lib/harnesses/claude.js
+++ b/lib/harnesses/claude.js
@@ -140,6 +140,7 @@ export default {
 			"dependency-audit.sh",
 			"branch-guard.sh",
 			"track-usage.sh",
+			"skill-router.sh",
 		];
 		for (const h of hooks) {
 			run(`Hook: ${h}`, () => {

--- a/lib/skills-router.js
+++ b/lib/skills-router.js
@@ -1,0 +1,171 @@
+// Skills auto-router — keyword tabanli prompt → skill eslestirici.
+//
+// Vault'taki SKILL.md aciklamalarindan keyword indeksi kurar,
+// kullanici prompt'una karsi puanlama yapar. UserPromptSubmit hook'u
+// ile entegre olunca prompt tipine gore otomatik skill aktivasyonu
+// saglar (filesystem'e yazmaz, per-turn context inject eder).
+//
+// Algoritma:
+//  1. Tokenize prompt (lowercase, non-word split, stopword filter)
+//  2. Her skill icin description'dan + "triggers on:" listesinden
+//     keyword cumesi cikar
+//  3. Skill skoru = ortak token sayisi (description: 1x, triggers: 3x)
+//  4. Esik: skor >= 1 olanlar matched, skor azalan sirada
+//  5. Top K dondur
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const STOPWORDS = new Set([
+	"the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+	"have", "has", "had", "do", "does", "did", "will", "would", "should",
+	"could", "may", "might", "must", "can", "to", "of", "in", "on", "at",
+	"by", "for", "with", "about", "into", "through", "during", "and", "or",
+	"but", "if", "as", "this", "that", "these", "those", "it", "its", "i",
+	"you", "we", "they", "he", "she", "what", "which", "who", "how", "why",
+	"where", "when", "ben", "sen", "biz", "bir", "icin", "ile", "ve", "veya",
+	"ama", "su", "bu", "ne", "nasil", "nicin", "olan", "olmak",
+	"yap", "yapmak", "et", "etmek", "var", "yok", "iste", "lutfen",
+	"please", "help", "need", "want", "make", "create", "build",
+]);
+
+function tokenize(text) {
+	return String(text || "")
+		.toLowerCase()
+		.split(/[^a-z0-9-]+/i)
+		.filter((t) => t.length >= 3 && !STOPWORDS.has(t));
+}
+
+function parseFrontmatter(content) {
+	const m = content.match(/^---\s*\n([\s\S]*?)\n---/);
+	if (!m) return null;
+	const fm = {};
+	for (const line of m[1].split("\n")) {
+		const kv = line.match(/^([a-zA-Z][a-zA-Z0-9_-]*):\s*(.*)$/);
+		if (kv) fm[kv[1]] = kv[2].trim().replace(/^["']|["']$/g, "");
+	}
+	return fm;
+}
+
+/**
+ * Bir skill icin keyword indeksi kurar.
+ * description'dan + "Triggers on: ..." listesinden token cumesi.
+ *
+ * @returns { name, descriptionTokens, triggerTokens, body }
+ */
+export function indexSkill(skillDir) {
+	const skillFile = join(skillDir, "SKILL.md");
+	if (!existsSync(skillFile)) return null;
+	let content;
+	try {
+		content = readFileSync(skillFile, "utf-8");
+	} catch {
+		return null;
+	}
+	const fm = parseFrontmatter(content);
+	if (!fm || !fm.name) return null;
+
+	const description = fm.description || "";
+	const descriptionTokens = new Set(tokenize(description));
+
+	// "Triggers on: X, Y, Z" deseni description icinde gomulu olabilir
+	const triggerMatch = description.match(/triggers?\s+on:\s*([^.]+)/i);
+	const triggerTokens = new Set(
+		triggerMatch ? tokenize(triggerMatch[1]) : [],
+	);
+
+	return {
+		name: fm.name,
+		description,
+		descriptionTokens,
+		triggerTokens,
+		body: content,
+	};
+}
+
+/**
+ * Vault'taki tum skill'leri indeksle.
+ */
+export function buildSkillIndex(vaultDir) {
+	if (!existsSync(vaultDir)) return [];
+	const entries = [];
+	for (const name of readdirSync(vaultDir)) {
+		const dir = join(vaultDir, name);
+		try {
+			if (!statSync(dir).isDirectory()) continue;
+		} catch {
+			continue;
+		}
+		const idx = indexSkill(dir);
+		if (idx) entries.push(idx);
+	}
+	return entries;
+}
+
+/**
+ * Bir prompt'a karsi en uygun skill'leri puanla.
+ *
+ * @param {string} prompt
+ * @param {Array} index — buildSkillIndex cikartisi
+ * @param {Object} opts
+ * @param {number} [opts.minScore=2]      Esik puan
+ * @param {number} [opts.top=3]           En fazla kac skill dondur
+ * @param {number} [opts.descWeight=1]    description token agirligi
+ * @param {number} [opts.triggerWeight=3] trigger token agirligi
+ * @returns Array<{ name, score, matched: { description, triggers } }>
+ */
+export function routePrompt(prompt, index, opts = {}) {
+	const {
+		minScore = 2,
+		top = 3,
+		descWeight = 1,
+		triggerWeight = 3,
+	} = opts;
+
+	const promptTokens = new Set(tokenize(prompt));
+	if (promptTokens.size === 0) return [];
+
+	const scored = [];
+	for (const skill of index) {
+		const matchedDesc = [];
+		const matchedTrig = [];
+		for (const t of promptTokens) {
+			if (skill.triggerTokens.has(t)) matchedTrig.push(t);
+			else if (skill.descriptionTokens.has(t)) matchedDesc.push(t);
+		}
+		const score =
+			matchedDesc.length * descWeight + matchedTrig.length * triggerWeight;
+		if (score >= minScore) {
+			scored.push({
+				name: skill.name,
+				score,
+				matched: { description: matchedDesc, triggers: matchedTrig },
+			});
+		}
+	}
+
+	scored.sort((a, b) => b.score - a.score);
+	return scored.slice(0, top);
+}
+
+/**
+ * Match'lenen skill'lerin SKILL.md govdesini birlestirip context blob'u uretir.
+ * Hook'tan UserPromptSubmit additionalContext olarak Claude'a verilir.
+ *
+ * @param {Array} matched — routePrompt cikartisi
+ * @param {Array} index   — buildSkillIndex cikartisi
+ * @returns string — markdown blob
+ */
+export function buildContextInjection(matched, index) {
+	if (matched.length === 0) return "";
+	const byName = new Map(index.map((s) => [s.name, s]));
+	const sections = [];
+	for (const m of matched) {
+		const skill = byName.get(m.name);
+		if (!skill) continue;
+		sections.push(`## Skill: ${skill.name} (auto-routed)\n\n${skill.body}`);
+	}
+	if (sections.length === 0) return "";
+	const header = `# Auto-Activated Skills (${matched.length})\n\nBadi router prompt'unuza gore su skill'leri otomatik aktiflestirdi:\n${matched.map((m) => `- **${m.name}** (skor: ${m.score})`).join("\n")}\n\n---\n`;
+	return header + sections.join("\n\n---\n\n");
+}

--- a/tests/cli.skills-router.test.js
+++ b/tests/cli.skills-router.test.js
@@ -1,0 +1,283 @@
+// Skills auto-router testleri.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+	buildContextInjection,
+	buildSkillIndex,
+	indexSkill,
+	routePrompt,
+} from "../lib/skills-router.js";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const CLI = resolve(__dirname, "..", "bin", "badi.js");
+
+function setupVault() {
+	const dir = mkdtempSync(join(tmpdir(), "badi-router-test-"));
+	const vault = join(dir, ".claude", "skills-vault");
+	mkdirSync(vault, { recursive: true });
+	mkdirSync(join(dir, ".claude", "skills"), { recursive: true });
+
+	const skills = {
+		seo: "Technical SEO and content SEO. Triggers on: SEO, schema, keyword research, meta tags.",
+		marketing: "Email marketing, social media, growth. Triggers on: campaign, marketing, growth.",
+		design: "UI design and prototyping. Triggers on: UI, prototype, wireframe, figma.",
+	};
+	for (const [name, desc] of Object.entries(skills)) {
+		mkdirSync(join(vault, name), { recursive: true });
+		writeFileSync(
+			join(vault, name, "SKILL.md"),
+			`---\nname: ${name}\ndescription: ${desc}\n---\n\nBody for ${name}.\n`,
+		);
+	}
+	return { dir, vault };
+}
+
+describe("skills-router: routePrompt", () => {
+	let fixture;
+
+	beforeEach(() => {
+		fixture = setupVault();
+	});
+
+	afterEach(() => {
+		rmSync(fixture.dir, { recursive: true, force: true });
+	});
+
+	it("trigger eslesmesi description'dan daha guclu skor", () => {
+		const idx = buildSkillIndex(fixture.vault);
+		const matched = routePrompt("schema markup ekle", idx);
+		assert.ok(matched.length > 0);
+		assert.equal(matched[0].name, "seo");
+		// "schema" trigger'da var → skor >= 3
+		assert.ok(matched[0].score >= 3);
+	});
+
+	it("eslesen skill yoksa bos array", () => {
+		const idx = buildSkillIndex(fixture.vault);
+		const matched = routePrompt("xyz unrelated", idx);
+		assert.equal(matched.length, 0);
+	});
+
+	it("birden fazla skill eslesirse skor azalan sirali", () => {
+		const idx = buildSkillIndex(fixture.vault);
+		const matched = routePrompt("SEO icin meta tag ekle, marketing icin", idx);
+		assert.ok(matched.length >= 1);
+		for (let i = 1; i < matched.length; i++) {
+			assert.ok(matched[i - 1].score >= matched[i].score);
+		}
+	});
+
+	it("top sinirli", () => {
+		const idx = buildSkillIndex(fixture.vault);
+		const matched = routePrompt("SEO marketing UI ", idx, { top: 2 });
+		assert.ok(matched.length <= 2);
+	});
+
+	it("minScore esik altindakileri eler", () => {
+		const idx = buildSkillIndex(fixture.vault);
+		const matched = routePrompt("SEO", idx, { minScore: 100 });
+		assert.equal(matched.length, 0);
+	});
+
+	it("bos prompt -> bos sonuc", () => {
+		const idx = buildSkillIndex(fixture.vault);
+		assert.deepEqual(routePrompt("", idx), []);
+		assert.deepEqual(routePrompt("   ", idx), []);
+	});
+
+	it("stopword'ler skorlanmaz", () => {
+		const idx = buildSkillIndex(fixture.vault);
+		// "the and is" tum stopword
+		const matched = routePrompt("the and is do you", idx);
+		assert.equal(matched.length, 0);
+	});
+
+	it("matched.triggers eslesen trigger token'larini iceriyor", () => {
+		const idx = buildSkillIndex(fixture.vault);
+		const matched = routePrompt("schema markup", idx);
+		assert.ok(matched[0].matched.triggers.includes("schema"));
+	});
+});
+
+describe("skills-router: indexSkill", () => {
+	let fixture;
+	beforeEach(() => {
+		fixture = setupVault();
+	});
+	afterEach(() => {
+		rmSync(fixture.dir, { recursive: true, force: true });
+	});
+
+	it("frontmatter parse + token cikarimi", () => {
+		const idx = indexSkill(join(fixture.vault, "seo"));
+		assert.equal(idx.name, "seo");
+		assert.ok(idx.descriptionTokens.size > 0);
+		assert.ok(idx.triggerTokens.has("schema"));
+		assert.ok(idx.triggerTokens.has("seo"));
+	});
+
+	it("eksik SKILL.md null doner", () => {
+		mkdirSync(join(fixture.vault, "empty-skill"), { recursive: true });
+		const idx = indexSkill(join(fixture.vault, "empty-skill"));
+		assert.equal(idx, null);
+	});
+
+	it("frontmatter olmayan SKILL.md null doner", () => {
+		mkdirSync(join(fixture.vault, "no-fm"), { recursive: true });
+		writeFileSync(join(fixture.vault, "no-fm", "SKILL.md"), "Just body.");
+		const idx = indexSkill(join(fixture.vault, "no-fm"));
+		assert.equal(idx, null);
+	});
+});
+
+describe("skills-router: buildContextInjection", () => {
+	let fixture;
+	beforeEach(() => {
+		fixture = setupVault();
+	});
+	afterEach(() => {
+		rmSync(fixture.dir, { recursive: true, force: true });
+	});
+
+	it("matched yoksa bos string", () => {
+		assert.equal(buildContextInjection([], []), "");
+	});
+
+	it("match'leri SKILL.md govdesi olarak yazar", () => {
+		const idx = buildSkillIndex(fixture.vault);
+		const matched = routePrompt("schema markup keyword", idx);
+		const blob = buildContextInjection(matched, idx);
+		assert.match(blob, /Auto-Activated Skills/);
+		assert.match(blob, /Skill: seo/);
+		assert.match(blob, /Body for seo/);
+	});
+
+	it("birden fazla skill ayrac ile ayrilir", () => {
+		const idx = buildSkillIndex(fixture.vault);
+		const matched = routePrompt("SEO marketing UI prototype", idx);
+		const blob = buildContextInjection(matched, idx);
+		const sectionCount = (blob.match(/## Skill:/g) || []).length;
+		assert.equal(sectionCount, matched.length);
+	});
+});
+
+describe("skills-router: CLI integration", () => {
+	let fixture;
+	beforeEach(() => {
+		fixture = setupVault();
+	});
+	afterEach(() => {
+		rmSync(fixture.dir, { recursive: true, force: true });
+	});
+
+	it("badi skills route eslesen skill'leri yazar", () => {
+		const out = execFileSync(
+			"node",
+			[CLI, "skills", "route", "schema markup keyword"],
+			{ cwd: fixture.dir, encoding: "utf-8", timeout: 10000 },
+		);
+		assert.match(out, /seo/);
+	});
+
+	it("badi skills route --json yapilandirilmis cikti", () => {
+		const out = execFileSync(
+			"node",
+			[CLI, "skills", "route", "--json", "schema markup"],
+			{ cwd: fixture.dir, encoding: "utf-8", timeout: 10000 },
+		);
+		const parsed = JSON.parse(out);
+		assert.ok(parsed.matched);
+		assert.ok(parsed.matched.some((m) => m.name === "seo"));
+	});
+
+	it("badi skills route --inject SKILL.md govdesi yazar", () => {
+		const out = execFileSync(
+			"node",
+			[CLI, "skills", "route", "--inject", "schema markup"],
+			{ cwd: fixture.dir, encoding: "utf-8", timeout: 10000 },
+		);
+		assert.match(out, /Auto-Activated Skills/);
+		assert.match(out, /Body for seo/);
+	});
+
+	it("badi skills route prompt yoksa hata", () => {
+		assert.throws(() => {
+			execFileSync("node", [CLI, "skills", "route"], {
+				cwd: fixture.dir,
+				encoding: "utf-8",
+				timeout: 10000,
+				stdio: "pipe",
+				input: "", // empty stdin
+			});
+		});
+	});
+
+	it("badi skills auto status default kapali", () => {
+		const out = execFileSync("node", [CLI, "skills", "auto", "status"], {
+			cwd: fixture.dir,
+			encoding: "utf-8",
+			timeout: 10000,
+		});
+		assert.match(out, /kapali/);
+	});
+
+	it("badi skills auto on settings.json'a hook ekler", () => {
+		execFileSync("node", [CLI, "skills", "auto", "on"], {
+			cwd: fixture.dir,
+			encoding: "utf-8",
+			timeout: 10000,
+		});
+		const settingsPath = join(fixture.dir, ".claude", "settings.json");
+		assert.ok(existsSync(settingsPath));
+		const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		assert.ok(settings.hooks.UserPromptSubmit);
+		assert.ok(
+			settings.hooks.UserPromptSubmit.some((entry) =>
+				JSON.stringify(entry).includes("skill-router.sh"),
+			),
+		);
+	});
+
+	it("badi skills auto off hook'u kaldirir", () => {
+		execFileSync("node", [CLI, "skills", "auto", "on"], {
+			cwd: fixture.dir,
+			encoding: "utf-8",
+			timeout: 10000,
+		});
+		execFileSync("node", [CLI, "skills", "auto", "off"], {
+			cwd: fixture.dir,
+			encoding: "utf-8",
+			timeout: 10000,
+		});
+		const settingsPath = join(fixture.dir, ".claude", "settings.json");
+		const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		const has =
+			settings.hooks?.UserPromptSubmit?.some((entry) =>
+				JSON.stringify(entry).includes("skill-router.sh"),
+			) ?? false;
+		assert.equal(has, false);
+	});
+
+	it("--help auto-router bolumu listeler", () => {
+		const out = execFileSync("node", [CLI, "skills", "--help"], {
+			encoding: "utf-8",
+			timeout: 10000,
+		});
+		assert.match(out, /Auto-router/);
+		assert.match(out, /badi skills route/);
+		assert.match(out, /badi skills auto/);
+	});
+});


### PR DESCRIPTION
## Summary
Yeni feature: kullanicinin yazdigi prompt'a gore vault'tan eslesen skill'leri otomatik aktiflestiren router.

```
badi skills route "SEO icin schema markup ekle"
badi skills route --inject "..." | jq
badi skills auto on    # UserPromptSubmit hook'u aktif et
```

## How it works
1. **Indexer** (`lib/skills-router.js`): vault'taki her SKILL.md'nin frontmatter `description`'unu okur, `triggers on:` listesini ayikar, token kumeleri olusturur (TR + EN stopword filtresi)
2. **Matcher**: prompt token'larina karsi puan: trigger eslesmesi 3x, description eslesmesi 1x. Default top 3, minScore 2
3. **CLI**: `badi skills route` ranked sonuclar; `--json` yapilandirilmis cikti; `--inject` SKILL.md govdesini birlestirip yazar
4. **Hook** (`.claude/hooks/skill-router.sh`): UserPromptSubmit, prompt'u okur, `badi skills route --inject` cagirir, `hookSpecificOutput.additionalContext` olarak Claude'a verir
5. **Toggle** (`badi skills auto on/off`): hook'u settings.json'a ekler/cikarir

## Why this matters
v1.17 opt-in modeli token vergisini sıfıra çekti ama kullaniciya manuel `badi skills add` yuku bindirdi. Auto-router bu yuku ortadan kaldiriyor — prompt yazılan ana ihtiyaca gore eslesen skill'lerin govdesi sadece o turda inject ediliyor. Ne sürekli yuk, ne manuel sec.

## Per-turn semantics
- Hook filesystem'e yazmaz (`.claude/skills/` clean kalir)
- Token vergisi sadece eslesme oldugunda
- Prompt 3 kelimeden kisaysa veya match yoksa hook sessizce passes
- `vault` yoksa graceful fallback

## Test plan
- [x] `npm test` — 577/577 green (555 → +22)
- [x] 22 yeni test: matcher edge cases, indexer (FM eksik/null), injection builder, CLI route + auto on/off/status, --json/--inject
- [x] `node bin/badi.js skills route "SEO icin meta tag yaz"` → `seo` matched
- [x] `node bin/badi.js skills route "Tailwind ile login form"` → `design-tokens` matched
- [x] `badi skills auto on` settings.json'a hook'u dogru sekilde ekliyor

## Yeni dosyalar
- `lib/skills-router.js` (matcher + indexer + injection)
- `.claude/hooks/skill-router.sh` (UserPromptSubmit hook, executable)
- `tests/cli.skills-router.test.js` (22 test)

## Degisen
- `lib/commands/skills.js` — `route` ve `auto` subkomutlari
- `lib/harnesses/claude.js` — doctor `skill-router.sh` denetimi

🤖 Generated with [Claude Code](https://claude.com/claude-code)