### PR TITLE
feat(skills): seo-crawl-budget skill + auto-router entegrasyonu (#109)

### DIFF
--- a/.claude/skills-vault/seo-crawl-budget/SKILL.md
+++ b/.claude/skills-vault/seo-crawl-budget/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: seo-crawl-budget
+description: Dusuk rekabetli long-tail keyword'ler icin 6-24 saatte indexlenme metodolojisi. 20 makalelik kampanya, dongusel ic-link matrisi, Search Console manuel tetikleme. Triggers on: crawl budget, crawl butcesi, long-tail, long tail, indexleme, search console, internal linking, ic linkleme, sitemap, hizli index, fast indexing, SEO kampanya, kampanya plani.
+license: MIT
+compatibility: Works with Claude Code, Cursor, or any compatible AI coding agent.
+allowed-tools: Read Write Edit Grep
+metadata:
+  author: fatihkan
+  homepage: https://github.com/fatihkan/badi/tree/main/.claude/skills-vault/seo-crawl-budget
+  badi-version: ">=1.20.0"
+  category: seo
+  upstream: https://github.com/moneyvadi-prog/crawl-budget-manipulation
+  upstream-license: MIT
+---
+
+# SEO Crawl Budget Manipulation
+
+Dusuk rekabetli long-tail keyword'lerde 6-24 saat icinde indexlenme ve ilk sayfa siralamasi hedefleyen sistematik SEO kampanya metodolojisi.
+
+> **Atif:** Bu skill, [moneyvadi-prog/crawl-budget-manipulation](https://github.com/moneyvadi-prog/crawl-budget-manipulation) (MIT) reposundaki metodolojiden adapte edilmistir. Orijinal yazari Gulsah Arslan / [seodanismanlikhizmeti.com.tr](https://www.seodanismanlikhizmeti.com.tr/crawl-budget-manipulation-deneyi-gulsah-arslan/).
+
+## Ne Zaman Kullanilir
+
+**Uygun:**
+- KD (keyword difficulty) < 20 olan long-tail sorgular
+- Soru bazli, bilgi amacli veya yumusak ticari niyet
+- Yeni ya da orta otorite domain'ler
+- Hizli indexlenme test edilmek isteniyor
+
+**Uygun degil:**
+- Yuksek rekabetli ticari kelimeler
+- Yuksek hacimli marka aramalari
+- Domain otoritesi gerektiren kisa-tail sorgular
+
+## Calisma Prensibi
+
+Uc esgudumlu sinyal ile crawl butcesi yonlendirilir:
+
+1. **Manuel crawl tetikleme** — Search Console "Indexle iste" + guncel sitemap
+2. **Dongusel ic linkleme** — her makale 3 baska makaleye link verir
+3. **Dusuk rekabetli niyet net keyword'ler** — KD < 20
+
+Bu kombinasyon Google'a sitenin **aktif ve degerli** oldugu sinyalini verir, crawl frekansini artirir.
+
+## 6 Fazli Kampanya Yapisi
+
+### Faz 1 — Keyword Uretimi (Gun 0)
+- 20 long-tail keyword: 10 esit yayin (Group A) + 10 zaman serpiştirilmis (Group B)
+- Her keyword icin: arama hacmi (tahmini), KD, niyet (informational/commercial), SERP yapisi
+- Ciktilar: `keywords-A.json`, `keywords-B.json`
+
+### Faz 2 — Icerik Brief'leri (Gun 0-1)
+- Tum 20 makale icin standart sablon
+- Hedef: 800-900 kelime, ayni H2 yapisi
+- Brief alanlari: title, slug, primary keyword, secondary keywords (2-3), H2 listesi (4-6), TLDR, FAQ (3-5 soru), iç-link hedefleri (3 makale)
+
+### Faz 3 — Ic Link Matrisi (Gun 1)
+- 20 makale icin dongusel link grafi (her dugum cikis derecesi = 3, gelis derecesi = 3)
+- Group A icindeki 10 makale kendi arasinda + Group B'ye 1 link
+- CSV/Markdown matris ciktisi: `linking-matrix.md`
+
+### Faz 4 — Yayin Takvimi (Gun 1-6)
+- **Group A**: tek gun icinde 2-3 saat penceresinde 10 makale yayinlanir
+- **Group B**: 5 gune yayilmis, gunde 2 makale
+- Yayin saati onerisi: hedef pazarin pik saatlerine yakin (TR icin 10:00-12:00, 19:00-21:00)
+
+### Faz 5 — Search Console Aksiyonlari (Yayin gunu)
+- XML sitemap guncellenir + Search Console'a tekrar gonderilir
+- Her URL icin "URL incele" → "Indexle iste" (gunluk kota: ~10-12)
+- robots.txt + canonical tag dogrulamasi
+
+### Faz 6 — Takip Metrikleri (14-28 gun)
+- Crawl frekansi (Search Console > Settings > Crawl stats)
+- Indexlenme hizi (yayindan kac saat sonra indexlendi?)
+- Coverage durumu (Indexed / Discovered-not-indexed)
+- Anahtar kelime siralama trendi (manuel veya rank-tracker)
+- Hedef: %70-90 makale 6-24 saatte indexli; %40-60 long-tail keyword ilk sayfada
+
+## Veri Kontaminasyon Riskleri
+
+Deney suresince **degistirme**:
+- Yeni backlink kampanyasi
+- Site mimarisi degisiklikleri
+- Mevcut iceriklerin guncellenmesi
+- Robot/canonical/redirect kurallari
+
+Bu risk faktorleri kontrol grubu temizligini bozar.
+
+## Cikti Sablonu
+
+Bu skill aktifken ajan asagidaki dosyalari uretir/onerir:
+
+```
+seo-campaign-<slug>/
+├── keywords-A.json          # 10 esit yayin
+├── keywords-B.json          # 10 zamanlanmis
+├── briefs/                  # 20 makale brief'i
+├── linking-matrix.md        # Dongusel grafik
+├── publication-schedule.csv # Tarih + saat
+├── search-console-checklist.md
+└── tracking-template.md     # 14-28 gun metrik
+```
+
+## Sinirlilik
+
+- **Kara sapka degil** — sadece kalite-iceriksel + teknik tetikleme. Spam, gizleme, link agi yok.
+- **Uzun vadeli degil** — kampanya bitiminde (28 gun) icerik ekosistemi normal SEO kurallarina doner.
+- **Domain hassasiyeti** — yeni domain'lerde sandbox etkisi gorulebilir.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantik Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added — `seo-crawl-budget` skill (#109)
+
+Yeni opt-in skill: dusuk rekabetli long-tail keyword'ler icin 6-24
+saatte indexlenme metodolojisi. 20 makalelik kampanya, dongusel
+ic-link matrisi, Search Console manuel tetikleme, 6 fazli yapi
+(keyword uretimi, brief sablonlari, link matrisi, yayin takvimi,
+GSC aksiyonlari, takip metrikleri).
+
+[moneyvadi-prog/crawl-budget-manipulation](https://github.com/moneyvadi-prog/crawl-budget-manipulation)
+(MIT, Gulsah Arslan) reposundan adapte edildi.
+
+v1.20 auto-router ile entegre: `badi skills auto on` aktifken
+"crawl budget", "long-tail", "search console", "indexleme",
+"internal linking" gibi TR/EN trigger'lar prompt'ta gectiginde
+SKILL.md govdesi otomatik enjekte edilir.
+
+```
+badi skills available             # listede gorur (25 kategori)
+badi skills add seo-crawl-budget  # opt-in
+```
+
+**Yeni dosyalar**: `.claude/skills-vault/seo-crawl-budget/SKILL.md`.
+Test: `tests/cli.skills-router.test.js` TR + EN trigger eslesme
+case'leri (3 yeni test, 583 toplam).
+
+Skill kategorileri sayisi: 24 -> 25.
+
 ## [1.20.0] - 2026-05-02
 
 ### Added — auto skill router (`badi skills route` + `auto on/off`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,50 @@ v1.20 auto-router ile entegre: `badi skills auto on` aktifken
 "internal linking" gibi TR/EN trigger'lar prompt'ta gectiginde
 SKILL.md govdesi otomatik enjekte edilir.
 
+#### Kullanim — Otomatik mod (onerilir)
+
+```bash
+# Bir kerelik kurulum
+badi skills auto on
 ```
-badi skills available             # listede gorur (25 kategori)
-badi skills add seo-crawl-budget  # opt-in
+
+Sonrasinda Claude Code icinde dogrudan istersin:
+
+```
+You ▸ Yeni blog yazilarim indexlenmiyor, crawl budget yonetimi nasil?
+[Badi auto-router]
+  - seo-crawl-budget (skor 12) — triggers: crawl budget, indexleme
+Claude ▸ {SKILL.md gomulu} 20 makalelik kampanya planliyorum...
+```
+
+#### Kullanim — Manuel mod
+
+```bash
+badi skills available | grep seo-crawl-budget   # listede mevcut
+badi skills add seo-crawl-budget                  # kalici opt-in
+badi skills list                                  # aktif skill'leri gor
+```
+
+#### Kullanim — Tek seferlik (router olmadan, opt-in olmadan)
+
+```bash
+badi skills route --inject "long-tail keyword indexlenme problemi"
+# SKILL.md govdesini stdout'a yazar — pipe edip baska araca verebilirsin
+```
+
+#### Skill ne uretiyor
+
+Aktif olunca ajan asagidaki dosyalari onerir / sablon olarak verir:
+
+```
+seo-campaign-<slug>/
+├── keywords-A.json          # 10 esit yayinlanan
+├── keywords-B.json          # 10 zamanlanmis
+├── briefs/                  # 20 makale brief'i
+├── linking-matrix.md        # Dongusel ic-link grafi
+├── publication-schedule.csv # Tarih + saat
+├── search-console-checklist.md
+└── tracking-template.md     # 14-28 gun metrik
 ```
 
 **Yeni dosyalar**: `.claude/skills-vault/seo-crawl-budget/SKILL.md`.

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -4,6 +4,35 @@
 
 Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [Semantik Versiyonlama](https://semver.org/lang/tr/) standardini takip eder.
 
+## [Unreleased]
+
+### Eklendi — `seo-crawl-budget` skill (#109)
+
+Yeni opt-in skill: dusuk rekabetli long-tail keyword'ler icin 6-24
+saatte indexlenme metodolojisi. 20 makalelik kampanya, dongusel
+ic-link matrisi, Search Console manuel tetikleme, 6 fazli yapi
+(keyword uretimi, brief sablonlari, link matrisi, yayin takvimi,
+GSC aksiyonlari, takip metrikleri).
+
+[moneyvadi-prog/crawl-budget-manipulation](https://github.com/moneyvadi-prog/crawl-budget-manipulation)
+(MIT, Gulsah Arslan) reposundan adapte edildi.
+
+v1.20 auto-router ile entegre: `badi skills auto on` aktifken
+"crawl budget", "long-tail", "search console", "indexleme",
+"internal linking" gibi TR/EN trigger'lar prompt'ta gectiginde
+SKILL.md govdesi otomatik enjekte edilir.
+
+```
+badi skills available             # listede gorur (25 kategori)
+badi skills add seo-crawl-budget  # opt-in
+```
+
+**Yeni dosyalar**: `.claude/skills-vault/seo-crawl-budget/SKILL.md`.
+Test: `tests/cli.skills-router.test.js` TR + EN trigger eslesme
+case'leri (3 yeni test, 583 toplam).
+
+Skill kategorileri sayisi: 24 -> 25.
+
 ## [1.20.0] - 2026-05-02
 
 ### Eklendi — otomatik skill router (`badi skills route` + `auto on/off`)

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -22,9 +22,50 @@ v1.20 auto-router ile entegre: `badi skills auto on` aktifken
 "internal linking" gibi TR/EN trigger'lar prompt'ta gectiginde
 SKILL.md govdesi otomatik enjekte edilir.
 
+#### Kullanim — Otomatik mod (onerilir)
+
+```bash
+# Bir kerelik kurulum
+badi skills auto on
 ```
-badi skills available             # listede gorur (25 kategori)
-badi skills add seo-crawl-budget  # opt-in
+
+Sonrasinda Claude Code icinde dogrudan istersin:
+
+```
+You ▸ Yeni blog yazilarim indexlenmiyor, crawl budget yonetimi nasil?
+[Badi auto-router]
+  - seo-crawl-budget (skor 12) — triggers: crawl budget, indexleme
+Claude ▸ {SKILL.md gomulu} 20 makalelik kampanya planliyorum...
+```
+
+#### Kullanim — Manuel mod
+
+```bash
+badi skills available | grep seo-crawl-budget   # listede mevcut
+badi skills add seo-crawl-budget                  # kalici opt-in
+badi skills list                                  # aktif skill'leri gor
+```
+
+#### Kullanim — Tek seferlik (router olmadan, opt-in olmadan)
+
+```bash
+badi skills route --inject "long-tail keyword indexlenme problemi"
+# SKILL.md govdesini stdout'a yazar
+```
+
+#### Skill ne uretiyor
+
+Aktif olunca ajan asagidaki dosyalari onerir / sablon olarak verir:
+
+```
+seo-campaign-<slug>/
+├── keywords-A.json          # 10 esit yayinlanan
+├── keywords-B.json          # 10 zamanlanmis
+├── briefs/                  # 20 makale brief'i
+├── linking-matrix.md        # Dongusel ic-link grafi
+├── publication-schedule.csv # Tarih + saat
+├── search-console-checklist.md
+└── tracking-template.md     # 14-28 gun metrik
 ```
 
 **Yeni dosyalar**: `.claude/skills-vault/seo-crawl-budget/SKILL.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Badi - Is Akisi Yonetim Sistemi
 
-> Claude Code icin yapilandirilmis operasyon yonetimi. 22 ajan, 77 komut, 13 hook, 24 opt-in skill kategorisi (v1.20+ prompt-bilinen auto-router ile).
+> Claude Code icin yapilandirilmis operasyon yonetimi. 22 ajan, 77 komut, 13 hook, 25 opt-in skill kategorisi (v1.20+ prompt-bilinen auto-router ile).
 
 ## Bellek Kurallari
 
@@ -9,7 +9,7 @@
 | Oturum | `.claude/memory.md` | 100 satir, astiginda `/clear` |
 | Bilgi Tabani | `.claude/knowledge-base.md` | 200 satir, Auditor onayiyla |
 | Gorev Panosu | `.claude/workspace/TaskBoard.md` | Sinir yok |
-| Skills Vault | `.claude/skills-vault/` | 24 kategori, yuklenmez (opt-in) |
+| Skills Vault | `.claude/skills-vault/` | 25 kategori, yuklenmez (opt-in) |
 | Aktif Skills | `.claude/skills/` | Kullanici secimi (`badi skills`) |
 
 - `knowledge-base.md` icinde TBD/TODO/FIXME **YASAK**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **22 AI subagents**, **77 slash commands**, **13 automation hooks**, and **24 opt-in skill categories** with **prompt-aware auto-routing** (v1.20+). OWASP Top 10 scans, code review, content production, mobile/web SEO, App Store market research with `wishlist` + `gaps` analysis. Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
+**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **22 AI subagents**, **77 slash commands**, **13 automation hooks**, and **25 opt-in skill categories** with **prompt-aware auto-routing** (v1.20+). OWASP Top 10 scans, code review, content production, mobile/web SEO, App Store market research with `wishlist` + `gaps` analysis. Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
 
 ## Demo
 
@@ -32,7 +32,7 @@
 /plugin install badi@badi-marketplace
 ```
 
-**As an npm CLI (full feature set: 22 agents · 77 commands · 13 hooks · 24 opt-in skill categories with auto-router)**:
+**As an npm CLI (full feature set: 22 agents · 77 commands · 13 hooks · 25 opt-in skill categories with auto-router)**:
 
 ```bash
 npx @fatihkan/badi init                    # interactive harness picker
@@ -46,7 +46,7 @@ npx @fatihkan/badi init --harness all      # write files for every supported har
 
 | Harness | Rules | Commands | MCP | Subagents | Hooks | Skills |
 |---------|:-----:|:--------:|:---:|:---------:|:-----:|:------:|
-| Claude Code | `CLAUDE.md` | 77 | `.mcp.json` | 22 | 12 | 24 |
+| Claude Code | `CLAUDE.md` | 77 | `.mcp.json` | 22 | 13 | 25 |
 | Cursor | `.cursor/rules/badi-main.mdc` | 77 | `.cursor/mcp.json` | — | — | — |
 | Gemini CLI | `GEMINI.md` (merged) | inline | `.gemini/settings.json` | — | — | — |
 
@@ -57,7 +57,7 @@ Claude is the canonical source. Cursor and Gemini adapters compile from the same
 | Feature | Details |
 |---------|---------|
 | **22 expert agents + 77 commands** | Full toolkit from security scanner to performance profiler — read-only agents enforce `disallowedTools` for defense-in-depth |
-| **13 automation hooks + 24 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants. Skills load zero tokens by default since v1.17; auto-router (v1.20+) injects matching skills per prompt |
+| **13 automation hooks + 25 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants. Skills load zero tokens by default since v1.17; auto-router (v1.20+) injects matching skills per prompt |
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+)** | Claude Code, Cursor, Gemini CLI — same `.claude/` source, different targets |
 | **398 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, tasarim |

--- a/README.md
+++ b/README.md
@@ -113,6 +113,35 @@ Claude ▸ {social-media + content skill'lerinin SKILL.md govdesi context'e
 
 Per-turn injection: hook **filesystem'e yazmaz**, sadece o turun context'ine ekler. Token vergisi yalnizca eslesme oldugunda — kisa prompt veya match yoksa hook sessizce passes.
 
+#### Example 2 — `seo-crawl-budget` skill auto-trigger
+
+```
+You ▸ Yeni domain'imdeki blog yazilarim 24 saatte indexlenmiyor,
+       crawl budget'i nasil yonetebilirim? long-tail keyword listesi var.
+
+[Badi auto-router]
+  Prompt'unuza gore otomatik olarak su skill'ler aktiflestirildi:
+  - seo-crawl-budget (skor 12) — triggers: crawl budget, indexleme,
+    long-tail, search console
+  - seo (skor 4) — triggers: SEO, keyword
+
+Claude ▸ {seo-crawl-budget SKILL.md inject edildi: 6 fazli kampanya
+         metodolojisi, 20 makalelik plan, dongusel ic-link matrisi,
+         Search Console aksiyonlari yuklendi.}
+         20 makalelik kampanya planliyorum: 10 makale Group A
+         (esit yayin), 10 makale Group B (5 gune yayilmis)...
+```
+
+**Manuel kullanim** (auto-router'siz):
+
+```bash
+badi skills available | grep seo-crawl-budget   # listede mevcut
+badi skills add seo-crawl-budget                  # opt-in (kalici)
+badi skills list                                  # aktif skill'leri gor
+```
+
+Skill aktifken `/start` veya yeni session'da Claude Code SKILL.md govdesini yukler. Auto-router'la fark: kalici aktivasyon yok, sadece SEO konulu prompt'larda devreye girer (token tasarrufu).
+
 ### Software Development
 ```bash
 /start                 # Start the day

--- a/README.tr.md
+++ b/README.tr.md
@@ -110,6 +110,35 @@ Claude ▸ {social-media + content skill'lerinin SKILL.md govdesi context'e
 
 Per-turn injection: hook **filesystem'e yazmaz**, sadece o turun context'ine ekler. Token vergisi yalnizca eslesme aninda — kisa prompt veya match yoksa hook sessizce passes.
 
+#### Ornek 2 — `seo-crawl-budget` skill otomatik tetiklenmesi
+
+```
+You ▸ Yeni domain'imdeki blog yazilarim 24 saatte indexlenmiyor,
+       crawl budget'i nasil yonetebilirim? long-tail keyword listesi var.
+
+[Badi auto-router]
+  Prompt'unuza gore otomatik olarak su skill'ler aktiflestirildi:
+  - seo-crawl-budget (skor 12) — triggers: crawl budget, indexleme,
+    long-tail, search console
+  - seo (skor 4) — triggers: SEO, keyword
+
+Claude ▸ {seo-crawl-budget SKILL.md inject edildi: 6 fazli kampanya
+         metodolojisi, 20 makalelik plan, dongusel ic-link matrisi,
+         Search Console aksiyonlari yuklendi.}
+         20 makalelik kampanya planliyorum: 10 makale Group A
+         (esit yayin), 10 makale Group B (5 gune yayilmis)...
+```
+
+**Manuel kullanim** (auto-router'siz):
+
+```bash
+badi skills available | grep seo-crawl-budget   # listede mevcut
+badi skills add seo-crawl-budget                  # kalici opt-in
+badi skills list                                  # aktif skill'leri gor
+```
+
+Skill aktifken `/start` veya yeni oturumda Claude Code SKILL.md govdesini yukler. Auto-router'la fark: kalici aktivasyon yok, sadece SEO konulu prompt'larda devreye girer (token tasarrufu).
+
 ### Yazilim Gelistirme
 ```bash
 /start                 # Gune basla

--- a/README.tr.md
+++ b/README.tr.md
@@ -11,7 +11,7 @@
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-**Anthropic Claude Code, Cursor ve Gemini CLI icin is akisi yonetim CLI'i** — **Claude Opus 4.7** ve **Sonnet 4.6** uyumlu. **22 AI subagent**, **77 slash komut**, **13 otomatik hook** ve **24 opt-in skill kategorisi** ile **prompt-bilinen otomatik router** (v1.20+) icerir. OWASP Top 10 tarama, code review, icerik uretimi, mobile/web SEO, App Store pazar arastirmasi (`wishlist` + `gaps` analizi). Tekrarlayan is akislarinda token tuketimini **~%96** azaltir. **v1.12+** ile multi-harness destegi — ayni `.claude/` agaci Cursor ve Gemini CLI hedeflerine derlenir. **v1.16+** CodeQL sertlesmesi (TLS strict-first, DOM bazli HTML parse, URL hostname dogrulamasi).
+**Anthropic Claude Code, Cursor ve Gemini CLI icin is akisi yonetim CLI'i** — **Claude Opus 4.7** ve **Sonnet 4.6** uyumlu. **22 AI subagent**, **77 slash komut**, **13 otomatik hook** ve **25 opt-in skill kategorisi** ile **prompt-bilinen otomatik router** (v1.20+) icerir. OWASP Top 10 tarama, code review, icerik uretimi, mobile/web SEO, App Store pazar arastirmasi (`wishlist` + `gaps` analizi). Tekrarlayan is akislarinda token tuketimini **~%96** azaltir. **v1.12+** ile multi-harness destegi — ayni `.claude/` agaci Cursor ve Gemini CLI hedeflerine derlenir. **v1.16+** CodeQL sertlesmesi (TLS strict-first, DOM bazli HTML parse, URL hostname dogrulamasi).
 
 ## Demo
 
@@ -32,7 +32,7 @@
 /plugin install badi@badi-marketplace
 ```
 
-**npm CLI olarak (tam ozellik seti: 22 ajan · 77 komut · 13 hook · 24 opt-in skill kategorisi + auto-router)**:
+**npm CLI olarak (tam ozellik seti: 22 ajan · 77 komut · 13 hook · 25 opt-in skill kategorisi + auto-router)**:
 
 ```bash
 npx @fatihkan/badi init                    # interaktif harness secim menusu
@@ -46,7 +46,7 @@ npx @fatihkan/badi init --harness all      # tum desteklenen harness'lar
 
 | Harness | Kurallar | Komutlar | MCP | Subagents | Hooks | Skills |
 |---------|:--------:|:--------:|:---:|:---------:|:-----:|:------:|
-| Claude Code | `CLAUDE.md` | 77 | `.mcp.json` | 22 | 12 | 24 |
+| Claude Code | `CLAUDE.md` | 77 | `.mcp.json` | 22 | 13 | 25 |
 | Cursor | `.cursor/rules/badi-main.mdc` | 77 | `.cursor/mcp.json` | — | — | — |
 | Gemini CLI | `GEMINI.md` (birlesik) | inline | `.gemini/settings.json` | — | — | — |
 
@@ -57,7 +57,7 @@ Claude kaynak (canonical). Cursor ve Gemini adapter'lari ayni `.claude/` dizinin
 | Ozellik | Detay |
 |---------|-------|
 | **22 Uzman Ajan ve 77 Komut** | Guvenlik tarayicidan performans profiler'a kadar genis arac seti — read-only ajanlar `disallowedTools` ile defense-in-depth saglıyor |
-| **12 Otomatik Hook ve 23 Skill Kategorisi** | Branch koruma, yedekleme, OWASP Top 10 taramasi, 9 Frontend Taste varyanti |
+| **13 Otomatik Hook ve 25 Skill Kategorisi** | Branch koruma, yedekleme, OWASP Top 10 taramasi, 9 Frontend Taste varyanti, prompt-bilinen auto-router (v1.20+) |
 | **Multi-harness destegi (v1.12+)** | Claude Code, Cursor, Gemini CLI — ayni `.claude/` kaynagi, farkli hedefler |
 | **398 Onaylanmis Test** | CLI entegrasyon, harness adapter, schema/bundler/publish, watcher/scheduler, market, tasarim |
 | **TR/EN Icerik Motoru** | Sablon mirasi ile post, thread, bulten, podcast, case-study uretimi |

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,6 +1,6 @@
 # Skills
 
-23 skill categories live in `.claude/skills-vault/`. Since v1.17, **none are auto-loaded** — opt in to only the ones you need.
+25 skill categories live in `.claude/skills-vault/`. Since v1.17, **none are auto-loaded** — opt in to only the ones you need. Since v1.20, an **auto-router** can inject matching skills per prompt without permanent activation (`badi skills auto on`).
 
 ## Quick start
 
@@ -23,12 +23,12 @@ badi skills clear
 
 ## Why opt-in?
 
-Auto-loading 23 skill categories used to cost ~10–15k tokens per turn even when no skill was triggered. v1.17 moved them to a vault that Claude Code does **not** scan, then exposed an explicit picker.
+Auto-loading 25 skill categories used to cost ~10–15k tokens per turn even when no skill was triggered. v1.17 moved them to a vault that Claude Code does **not** scan, then exposed an explicit picker.
 
 After opting in, the active set lives in `.claude/skills/` (only the ones you picked) and Claude Code loads them as before.
 
 ## Categories
 
-`ai-automation`, `consulting`, `content`, `customer-success`, `data-analytics`, `design`, `development`, `devops`, `ecommerce`, `email`, `finance`, `frontend-taste`, `marketing`, `mobile`, `product`, `productivity`, `sales`, `security`, `security-check`, `seo`, `social-media`, `startup`, `testing`
+`ai-automation`, `consulting`, `content`, `customer-success`, `data-analytics`, `design`, `design-tokens`, `development`, `devops`, `ecommerce`, `email`, `finance`, `frontend-taste`, `marketing`, `mobile`, `product`, `productivity`, `sales`, `security`, `security-check`, `seo`, `seo-crawl-budget`, `social-media`, `startup`, `testing`
 
 Each category contains one or more `SKILL.md` files. Browse the [vault on GitHub](https://github.com/fatihkan/badi/tree/main/.claude/skills-vault) to see what's inside.

--- a/tests/cli.skills-router.test.js
+++ b/tests/cli.skills-router.test.js
@@ -32,8 +32,12 @@ function setupVault() {
 
 	const skills = {
 		seo: "Technical SEO and content SEO. Triggers on: SEO, schema, keyword research, meta tags.",
-		marketing: "Email marketing, social media, growth. Triggers on: campaign, marketing, growth.",
-		design: "UI design and prototyping. Triggers on: UI, prototype, wireframe, figma.",
+		marketing:
+			"Email marketing, social media, growth. Triggers on: campaign, marketing, growth.",
+		design:
+			"UI design and prototyping. Triggers on: UI, prototype, wireframe, figma.",
+		"seo-crawl-budget":
+			"Dusuk rekabetli long-tail keyword'ler icin 6-24 saatte indexlenme metodolojisi. Triggers on: crawl budget, crawl butcesi, long-tail, indexleme, search console, internal linking, ic linkleme, sitemap, hizli index, fast indexing.",
 	};
 	for (const [name, desc] of Object.entries(skills)) {
 		mkdirSync(join(vault, name), { recursive: true });
@@ -109,6 +113,36 @@ describe("skills-router: routePrompt", () => {
 		const idx = buildSkillIndex(fixture.vault);
 		const matched = routePrompt("schema markup", idx);
 		assert.ok(matched[0].matched.triggers.includes("schema"));
+	});
+
+	it("seo-crawl-budget TR prompt tetikler (indexleme + search console)", () => {
+		const idx = buildSkillIndex(fixture.vault);
+		const matched = routePrompt(
+			"blog yazilarim 24 saatte indexlenmiyor, search console crawl ne diyor",
+			idx,
+		);
+		assert.ok(matched.length > 0);
+		assert.equal(matched[0].name, "seo-crawl-budget");
+	});
+
+	it("seo-crawl-budget EN prompt tetikler (long-tail + fast indexing)", () => {
+		const idx = buildSkillIndex(fixture.vault);
+		const matched = routePrompt(
+			"need fast indexing for long-tail keywords on new site",
+			idx,
+		);
+		assert.ok(matched.length > 0);
+		assert.equal(matched[0].name, "seo-crawl-budget");
+	});
+
+	it("seo-crawl-budget 'crawl budget' iki kelimeli ifadeyi yakalar", () => {
+		const idx = buildSkillIndex(fixture.vault);
+		const matched = routePrompt(
+			"crawl budget optimizasyonu yapmak istiyorum",
+			idx,
+		);
+		assert.ok(matched.length > 0);
+		assert.equal(matched[0].name, "seo-crawl-budget");
 	});
 });
 


### PR DESCRIPTION
## Ozet

- Yeni opt-in skill: `seo-crawl-budget` — dusuk rekabetli long-tail keyword'ler icin 6-24 saatte indexlenme metodolojisi (20 makalelik kampanya, dongusel ic-link matrisi, Search Console manuel tetikleme, 6 fazli yapi)
- v1.20 auto-router ile entegre: TR + EN trigger'lar prompt'ta gectiginde SKILL.md govdesi otomatik enjekte
- Skill kategorileri 24 -> 25; testler 580 -> 583

## Atif

[moneyvadi-prog/crawl-budget-manipulation](https://github.com/moneyvadi-prog/crawl-budget-manipulation) (MIT, Gulsah Arslan / [seodanismanlikhizmeti.com.tr](https://www.seodanismanlikhizmeti.com.tr/crawl-budget-manipulation-deneyi-gulsah-arslan/)). Atif SKILL.md, CHANGELOG ve issue'da gorunur.

## Trigger ornekleri (auto-router)

`badi skills auto on` aktifken asagidaki promptlar otomatik tetikler:
- "blog yazilarim 24 saatte indexlenmiyor, search console crawl ne diyor"
- "need fast indexing for long-tail keywords on new site"
- "crawl budget optimizasyonu yapmak istiyorum"

## Test plan

- [x] `npm test` 583/583 gecer (3 yeni TR/EN trigger case)
- [x] `npx biome check tests/cli.skills-router.test.js` temiz
- [x] Vault'ta `.claude/skills-vault/seo-crawl-budget/SKILL.md` mevcut
- [x] CHANGELOG (TR + EN), README (TR + EN), CLAUDE.md, docs/skills sayilari guncel (24 -> 25)

## Kapsam disi

- `badi schedule` ile periyodik SEO check trigger'i — issue #109'da opsiyonel olarak listelendi, ayri PR'a birakildi.
- Mevcut umbrella `seo` skill'inin `crawl-butcesi` alt becerisi dokunulmadi; bu skill spesifik 6-fazli kampanya metodolojisini kapsulluyor.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)