### PR TITLE
chore(release): v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantik Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.21.0] - 2026-05-03
 
 ### Added — `seo-crawl-budget` skill (#109)
 

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -4,7 +4,7 @@
 
 Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [Semantik Versiyonlama](https://semver.org/lang/tr/) standardini takip eder.
 
-## [Unreleased]
+## [1.21.0] - 2026-05-03
 
 ### Eklendi — `seo-crawl-budget` skill (#109)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fatihkan/badi",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fatihkan/badi",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fatihkan/badi",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Workflow management CLI for Claude Code, Cursor, and Gemini CLI — 21 AI agents, 77 commands, OWASP security scans. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
   "type": "module",
   "main": "bin/badi.js",


### PR DESCRIPTION
## Ozet

- npm: [@fatihkan/badi@1.21.0](https://www.npmjs.com/package/@fatihkan/badi/v/1.21.0) yayinda
- GitHub release: https://github.com/fatihkan/badi/releases/tag/v1.21.0
- Yeni: `seo-crawl-budget` skill + auto-router entegrasyonu (#109)

## Icerik

- 25. opt-in skill kategorisi (24 -> 25)
- TR + EN trigger'lar (crawl budget, indexleme, search console, long-tail, internal linking, fast indexing)
- README + CHANGELOG kullanim ornekleri (otomatik / manuel / tek seferlik mod)
- 583/583 test gecer

## Atif

[moneyvadi-prog/crawl-budget-manipulation](https://github.com/moneyvadi-prog/crawl-budget-manipulation) (MIT, Gulsah Arslan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)