### PR TITLE
feat(harness): outputstyle + statusline komutlari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@
 
 This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantik Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added — `outputstyle` and `statusline` commands (#118)
+
+Two new opt-in commands for Claude Code harness customization:
+
+**`badi outputstyle`** — manage `.claude/output-styles/<name>.md`
+profiles that Claude Code activates with `/output-style <name>`. Three
+built-ins: `terse` (concise, no fluff), `verbose` (detailed rationale +
+trade-offs), `eli5` (plain-language explanations).
+
+```bash
+badi outputstyle available     # list built-ins
+badi outputstyle add terse     # install profile
+badi outputstyle list          # show installed
+badi outputstyle remove terse
+badi outputstyle clear
+```
+
+Then in Claude Code: `/output-style terse`
+
+**`badi statusline`** — write `statusLine` config to
+`.claude/settings.json` and emit the helper script under
+`.claude/status-line/`. Two built-ins: `git` (branch + dirty mark),
+`skill-chip` (branch + active skill count).
+
+```bash
+badi statusline available
+badi statusline set git
+badi statusline list
+badi statusline reset
+```
+
+Restart Claude Code to see the status line update.
+
+### Fixed — lint baseline + dep bump (#119)
+
+- biome lint: 28 errors → 0; refactored 6 `noAssignInExpressions` to
+  `for (const m of str.matchAll(regex))` (modern idiom)
+- biome.json schema 2.4.8 → 2.4.14 (synced with CLI)
+- @biomejs/biome 2.4.13 → 2.4.14
+- vitepress 1.6.3 → 1.6.4
+- Tests: 580 → 595 (15 new for outputstyle + statusline)
+
+### Notes
+
+- Component count: 79 commands (was 77), 22 agents, 13 hooks, 25 skills
+- Three open `npm audit` moderate (transitive `esbuild` via vitepress)
+  remain — upstream "no fix available", dev-only
+
 ## [1.21.0] - 2026-05-03
 
 ### Added — `seo-crawl-budget` skill (#109)

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -4,6 +4,56 @@
 
 Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [Semantik Versiyonlama](https://semver.org/lang/tr/) standardini takip eder.
 
+## [Unreleased]
+
+### Eklendi — `outputstyle` ve `statusline` komutlari (#118)
+
+Iki yeni opt-in komut Claude Code harness ozellestirmesi icin:
+
+**`badi outputstyle`** — `.claude/output-styles/<name>.md` profilleri
+yonetir. Claude Code icinde `/output-style <name>` ile aktive edilir. Uc
+yerlesik profil: `terse` (kisa, gereksiz aciklama yok), `verbose` (detayli
+gerekce + trade-off), `eli5` (basit dilde aciklama).
+
+```bash
+badi outputstyle available     # yerlesik profilleri listele
+badi outputstyle add terse     # profili yukle
+badi outputstyle list          # yuklu profilleri goster
+badi outputstyle remove terse
+badi outputstyle clear
+```
+
+Sonra Claude Code icinde: `/output-style terse`
+
+**`badi statusline`** — `.claude/settings.json`'a `statusLine` alani
+yazar ve `.claude/status-line/` altina helper scripti yerlestirir. Iki
+yerlesik profil: `git` (branch + dirty mark), `skill-chip` (branch +
+aktif skill sayisi).
+
+```bash
+badi statusline available
+badi statusline set git
+badi statusline list
+badi statusline reset
+```
+
+Status line guncellemesini gormek icin Claude Code'u yeniden baslat.
+
+### Duzeltildi — lint baseline + dep bump (#119)
+
+- biome lint: 28 hata → 0; 6 `noAssignInExpressions` modern idyoma
+  refactor edildi (`for (const m of str.matchAll(regex))`)
+- biome.json schema 2.4.8 → 2.4.14 (CLI ile esit)
+- @biomejs/biome 2.4.13 → 2.4.14
+- vitepress 1.6.3 → 1.6.4
+- Tests: 580 → 595 (15 yeni outputstyle + statusline icin)
+
+### Notlar
+
+- Bilesen sayisi: 79 komut (eski 77), 22 ajan, 13 hook, 25 skill
+- 3 acik `npm audit` moderate (transitive `esbuild` via vitepress)
+  duruyor — upstream "no fix available", sadece dev surumde
+
 ## [1.21.0] - 2026-05-03
 
 ### Eklendi — `seo-crawl-budget` skill (#109)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Badi - Is Akisi Yonetim Sistemi
 
-> Claude Code icin yapilandirilmis operasyon yonetimi. 22 ajan, 77 komut, 13 hook, 25 opt-in skill kategorisi (v1.20+ prompt-bilinen auto-router ile).
+> Claude Code icin yapilandirilmis operasyon yonetimi. 22 ajan, 79 komut, 13 hook, 25 opt-in skill kategorisi (v1.20+ prompt-bilinen auto-router ile).
 
 ## Bellek Kurallari
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **22 AI subagents**, **77 slash commands**, **13 automation hooks**, and **25 opt-in skill categories** with **prompt-aware auto-routing** (v1.20+). OWASP Top 10 scans, code review, content production, mobile/web SEO, App Store market research with `wishlist` + `gaps` analysis. Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
+**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **22 AI subagents**, **79 slash commands**, **13 automation hooks**, and **25 opt-in skill categories** with **prompt-aware auto-routing** (v1.20+). OWASP Top 10 scans, code review, content production, mobile/web SEO, App Store market research with `wishlist` + `gaps` analysis. Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
 
 ## Demo
 
@@ -32,7 +32,7 @@
 /plugin install badi@badi-marketplace
 ```
 
-**As an npm CLI (full feature set: 22 agents · 77 commands · 13 hooks · 25 opt-in skill categories with auto-router)**:
+**As an npm CLI (full feature set: 22 agents · 79 commands · 13 hooks · 25 opt-in skill categories with auto-router)**:
 
 ```bash
 npx @fatihkan/badi init                    # interactive harness picker
@@ -56,7 +56,7 @@ Claude is the canonical source. Cursor and Gemini adapters compile from the same
 
 | Feature | Details |
 |---------|---------|
-| **22 expert agents + 77 commands** | Full toolkit from security scanner to performance profiler — read-only agents enforce `disallowedTools` for defense-in-depth |
+| **22 expert agents + 79 commands** | Full toolkit from security scanner to performance profiler — read-only agents enforce `disallowedTools` for defense-in-depth |
 | **13 automation hooks + 25 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants. Skills load zero tokens by default since v1.17; auto-router (v1.20+) injects matching skills per prompt |
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+)** | Claude Code, Cursor, Gemini CLI — same `.claude/` source, different targets |
@@ -141,6 +141,23 @@ badi skills list                                  # aktif skill'leri gor
 ```
 
 Skill aktifken `/start` veya yeni session'da Claude Code SKILL.md govdesini yukler. Auto-router'la fark: kalici aktivasyon yok, sadece SEO konulu prompt'larda devreye girer (token tasarrufu).
+
+### Output Styles + Status Line (v1.22+)
+
+Customize Claude Code response style and the bottom status line:
+
+```bash
+# Output styles — concise/detailed/eli5 response modes
+badi outputstyle available
+badi outputstyle add terse
+# Then in Claude Code: /output-style terse
+
+# Status line — branch + skill chip
+badi statusline set git           # [branch*]
+badi statusline set skill-chip    # [branch] [skills:N]
+```
+
+Both write to `.claude/` (output-styles/, status-line/, settings.json) — opt-in, project-scoped.
 
 ### Software Development
 ```bash

--- a/README.tr.md
+++ b/README.tr.md
@@ -11,7 +11,7 @@
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-**Anthropic Claude Code, Cursor ve Gemini CLI icin is akisi yonetim CLI'i** — **Claude Opus 4.7** ve **Sonnet 4.6** uyumlu. **22 AI subagent**, **77 slash komut**, **13 otomatik hook** ve **25 opt-in skill kategorisi** ile **prompt-bilinen otomatik router** (v1.20+) icerir. OWASP Top 10 tarama, code review, icerik uretimi, mobile/web SEO, App Store pazar arastirmasi (`wishlist` + `gaps` analizi). Tekrarlayan is akislarinda token tuketimini **~%96** azaltir. **v1.12+** ile multi-harness destegi — ayni `.claude/` agaci Cursor ve Gemini CLI hedeflerine derlenir. **v1.16+** CodeQL sertlesmesi (TLS strict-first, DOM bazli HTML parse, URL hostname dogrulamasi).
+**Anthropic Claude Code, Cursor ve Gemini CLI icin is akisi yonetim CLI'i** — **Claude Opus 4.7** ve **Sonnet 4.6** uyumlu. **22 AI subagent**, **79 slash komut**, **13 otomatik hook** ve **25 opt-in skill kategorisi** ile **prompt-bilinen otomatik router** (v1.20+) icerir. OWASP Top 10 tarama, code review, icerik uretimi, mobile/web SEO, App Store pazar arastirmasi (`wishlist` + `gaps` analizi). Tekrarlayan is akislarinda token tuketimini **~%96** azaltir. **v1.12+** ile multi-harness destegi — ayni `.claude/` agaci Cursor ve Gemini CLI hedeflerine derlenir. **v1.16+** CodeQL sertlesmesi (TLS strict-first, DOM bazli HTML parse, URL hostname dogrulamasi).
 
 ## Demo
 
@@ -32,7 +32,7 @@
 /plugin install badi@badi-marketplace
 ```
 
-**npm CLI olarak (tam ozellik seti: 22 ajan · 77 komut · 13 hook · 25 opt-in skill kategorisi + auto-router)**:
+**npm CLI olarak (tam ozellik seti: 22 ajan · 79 komut · 13 hook · 25 opt-in skill kategorisi + auto-router)**:
 
 ```bash
 npx @fatihkan/badi init                    # interaktif harness secim menusu
@@ -56,7 +56,7 @@ Claude kaynak (canonical). Cursor ve Gemini adapter'lari ayni `.claude/` dizinin
 
 | Ozellik | Detay |
 |---------|-------|
-| **22 Uzman Ajan ve 77 Komut** | Guvenlik tarayicidan performans profiler'a kadar genis arac seti — read-only ajanlar `disallowedTools` ile defense-in-depth saglıyor |
+| **22 Uzman Ajan ve 79 Komut** | Guvenlik tarayicidan performans profiler'a kadar genis arac seti — read-only ajanlar `disallowedTools` ile defense-in-depth saglıyor |
 | **13 Otomatik Hook ve 25 Skill Kategorisi** | Branch koruma, yedekleme, OWASP Top 10 taramasi, 9 Frontend Taste varyanti, prompt-bilinen auto-router (v1.20+) |
 | **Multi-harness destegi (v1.12+)** | Claude Code, Cursor, Gemini CLI — ayni `.claude/` kaynagi, farkli hedefler |
 | **398 Onaylanmis Test** | CLI entegrasyon, harness adapter, schema/bundler/publish, watcher/scheduler, market, tasarim |
@@ -138,6 +138,23 @@ badi skills list                                  # aktif skill'leri gor
 ```
 
 Skill aktifken `/start` veya yeni oturumda Claude Code SKILL.md govdesini yukler. Auto-router'la fark: kalici aktivasyon yok, sadece SEO konulu prompt'larda devreye girer (token tasarrufu).
+
+### Output Styles + Status Line (v1.22+)
+
+Claude Code cevap stilini ve alt status satirini ozellestir:
+
+```bash
+# Output styles — kisa/detayli/eli5 cevap modlari
+badi outputstyle available
+badi outputstyle add terse
+# Sonra Claude Code icinde: /output-style terse
+
+# Status line — branch + skill chip
+badi statusline set git           # [branch*]
+badi statusline set skill-chip    # [branch] [skills:N]
+```
+
+Iki komut da `.claude/` altina yazar (output-styles/, status-line/, settings.json) — opt-in, proje bazli.
 
 ### Yazilim Gelistirme
 ```bash

--- a/bin/badi.js
+++ b/bin/badi.js
@@ -32,6 +32,12 @@ function showHelp() {
 		`  ${chalk.cyan("skills")}    Skill'leri opt-in sec/sifirla (vault → aktif)`,
 	);
 	console.log(
+		`  ${chalk.cyan("outputstyle")} Output style profilleri (terse/verbose/eli5) — v1.22+`,
+	);
+	console.log(
+		`  ${chalk.cyan("statusline")} Status line profilleri (git/skill-chip) — v1.22+`,
+	);
+	console.log(
 		`  ${chalk.cyan("wp")}        WordPress site yonetimi (durum/eklenti/tema/guvenlik)`,
 	);
 	console.log(
@@ -275,6 +281,10 @@ const commands = {
 	dev: () => import("../lib/commands/dev.js").then((m) => m.runDev),
 	agent: () => import("../lib/commands/agent.js").then((m) => m.runAgent),
 	skills: () => import("../lib/commands/skills.js").then((m) => m.runSkills),
+	outputstyle: () =>
+		import("../lib/commands/outputstyle.js").then((m) => m.runOutputstyle),
+	statusline: () =>
+		import("../lib/commands/statusline.js").then((m) => m.runStatusline),
 };
 
 // ─── Ana Giris Noktasi ───

--- a/lib/commands/outputstyle.js
+++ b/lib/commands/outputstyle.js
@@ -1,0 +1,198 @@
+// Badi outputstyle komutu — Claude Code output styles yonetimi.
+//
+// .claude/output-styles/<name>.md  → Claude Code per-style prompt extension.
+//
+// Yerlesik profiller (built-in): terse, verbose, eli5.
+// Kullanici `badi outputstyle add <name>` ile yukler, Claude Code'da
+// `/output-style <name>` ile aktive eder.
+
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { chalk, showBanner } from "../cli.js";
+
+const BUILTINS = {
+	terse: {
+		description:
+			"Kisa ve ozlu cevaplar; gereksiz aciklama yok, tek cumle ozet, minimum tablo/bullet.",
+		body: `Cevaplarini kisa ve direkt tut. Tek cumle ile ozetle. Tablo veya bullet kullanma sorulmadikca. Hata mesaji varsa sadece kok neden + cozum yaz. Kod ornegi isterken minimum gerekli olani goster — yorum eklemeden, baslica desen disinda. End-of-turn ozetleri tek cumle olsun.`,
+	},
+	verbose: {
+		description:
+			"Detayli ve contextli cevaplar; karar gerekcelerini, alternatifleri ve trade-off'lari ac.",
+		body: `Cevaplarinda kararlarin arkasindaki gerekceyi ac. En az bir alternatif yaklasim ve neden secilmedigini belirt. Trade-off'lari listele (performans, okunabilirlik, esneklik). Kod degisikliginden once mevcut yapinin neden boyle oldugunu ozetle. End-of-turn'da: ne degisti, neden, takip onerileri.`,
+	},
+	eli5: {
+		description:
+			"Basit dilde ('5 yasinda biri anlasin') aciklamalar; teknik jargonu metafor ile destekle.",
+		body: `Karmasik kavramlari basit dilde anlat. Teknik terim kullanmak zorunda kaldiginda metafor + ornek ile destekle. Her cumlede en fazla bir teknik kavram. Kod gosterirken her satirin altina kisa bir aciklama ekle (gerekiyorsa). Hata aciklarken once 'su olmasi gerekiyordu, ama su oldu' formatinda anlat.`,
+	},
+};
+
+function paths(target) {
+	const dir = join(target, ".claude", "output-styles");
+	return { dir };
+}
+
+function styleFile(name) {
+	const fm = `---
+name: ${name}
+description: ${BUILTINS[name].description}
+---
+
+${BUILTINS[name].body}
+`;
+	return fm;
+}
+
+function listInstalled(dir) {
+	if (!existsSync(dir)) return [];
+	return readdirSync(dir)
+		.filter((f) => f.endsWith(".md"))
+		.map((f) => f.replace(/\.md$/, ""))
+		.sort();
+}
+
+function readDescription(dir, name) {
+	const file = join(dir, `${name}.md`);
+	if (!existsSync(file)) return null;
+	try {
+		const content = readFileSync(file, "utf-8");
+		const m = content.match(/^description:\s*(.+)$/m);
+		return m ? m[1].trim() : null;
+	} catch {
+		return null;
+	}
+}
+
+function showHelp() {
+	console.log(`${chalk.bold("badi outputstyle")} — Claude Code output styles`);
+	console.log("");
+	console.log(
+		"  add <name>      Yerlesik profili .claude/output-styles/'a yukle",
+	);
+	console.log("  remove <name>   Yuklu profili kaldir");
+	console.log("  list            Yuklu profilleri goster");
+	console.log("  available       Yerlesik profilleri goster");
+	console.log("  clear           Tum yuklu profilleri sil");
+	console.log("");
+	console.log(chalk.bold("Yerlesik profiller:"));
+	for (const [name, p] of Object.entries(BUILTINS)) {
+		console.log(`  ${chalk.cyan(name.padEnd(10))} ${chalk.dim(p.description)}`);
+	}
+	console.log("");
+	console.log(
+		chalk.dim(
+			"Kullanim: Claude Code icinde /output-style <name> ile aktif et.",
+		),
+	);
+}
+
+export async function runOutputstyle(args) {
+	const [sub, ...rest] = args;
+	const target = process.cwd();
+	const { dir } = paths(target);
+
+	if (!sub || sub === "--help" || sub === "-h") {
+		showBanner();
+		showHelp();
+		return;
+	}
+
+	if (sub === "available") {
+		console.log(chalk.bold("Yerlesik profiller:"));
+		for (const [name, p] of Object.entries(BUILTINS)) {
+			console.log(`  ${chalk.cyan(name)} — ${p.description}`);
+		}
+		return;
+	}
+
+	if (sub === "list") {
+		const installed = listInstalled(dir);
+		if (installed.length === 0) {
+			console.log(chalk.dim("(yuklu profil yok)"));
+			console.log(
+				chalk.dim(
+					"Yerlesik profilleri gormek icin: badi outputstyle available",
+				),
+			);
+			return;
+		}
+		console.log(chalk.bold(`Yuklu profiller (${installed.length}):`));
+		for (const name of installed) {
+			const desc = readDescription(dir, name) || "";
+			console.log(`  ${chalk.green(name)} ${chalk.dim(desc)}`);
+		}
+		return;
+	}
+
+	if (sub === "add") {
+		const name = rest[0];
+		if (!name) {
+			console.error(chalk.red("Hata: profil adi gerekli"));
+			console.error("Ornek: badi outputstyle add terse");
+			process.exit(1);
+		}
+		if (!BUILTINS[name]) {
+			console.error(chalk.red(`Hata: bilinmeyen profil "${name}"`));
+			console.error(
+				`Mevcut: ${Object.keys(BUILTINS)
+					.map((n) => chalk.cyan(n))
+					.join(", ")}`,
+			);
+			process.exit(1);
+		}
+		mkdirSync(dir, { recursive: true });
+		const file = join(dir, `${name}.md`);
+		const existed = existsSync(file);
+		writeFileSync(file, styleFile(name), "utf-8");
+		console.log(
+			existed
+				? chalk.yellow(`~ guncellendi: .claude/output-styles/${name}.md`)
+				: chalk.green(`+ yuklendi: .claude/output-styles/${name}.md`),
+		);
+		console.log(
+			chalk.dim(`Aktif et: Claude Code icinde /output-style ${name}`),
+		);
+		return;
+	}
+
+	if (sub === "remove") {
+		const name = rest[0];
+		if (!name) {
+			console.error(chalk.red("Hata: profil adi gerekli"));
+			process.exit(1);
+		}
+		const file = join(dir, `${name}.md`);
+		if (!existsSync(file)) {
+			console.error(chalk.red(`Hata: "${name}" yuklu degil`));
+			process.exit(1);
+		}
+		rmSync(file);
+		console.log(chalk.yellow(`- silindi: .claude/output-styles/${name}.md`));
+		return;
+	}
+
+	if (sub === "clear") {
+		if (!existsSync(dir)) {
+			console.log(chalk.dim("(zaten bos)"));
+			return;
+		}
+		const installed = listInstalled(dir);
+		for (const name of installed) {
+			rmSync(join(dir, `${name}.md`));
+		}
+		console.log(chalk.yellow(`- ${installed.length} profil silindi`));
+		return;
+	}
+
+	console.error(chalk.red(`Bilinmeyen alt komut: ${sub}`));
+	showHelp();
+	process.exit(1);
+}

--- a/lib/commands/statusline.js
+++ b/lib/commands/statusline.js
@@ -1,0 +1,163 @@
+// Badi statusline komutu — Claude Code status line yonetimi.
+//
+// settings.json'a statusLine alani yazar/siler.
+// Yerlesik profiller: git, skill-chip.
+
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { chalk, showBanner } from "../cli.js";
+
+const PROFILES = {
+	git: {
+		description: "Git branch + dirty mark (* varsa).",
+		script: `#!/usr/bin/env bash
+# Badi statusline: git
+dir="\${CLAUDE_PROJECT_DIR:-.}"
+branch=$(git -C "$dir" branch --show-current 2>/dev/null || echo "no-git")
+dirty=$(git -C "$dir" status --porcelain 2>/dev/null | head -1)
+mark=""
+[ -n "$dirty" ] && mark="*"
+echo "[$branch$mark]"
+`,
+	},
+	"skill-chip": {
+		description: "Git branch + aktif skill sayisi chip.",
+		script: `#!/usr/bin/env bash
+# Badi statusline: skill-chip
+dir="\${CLAUDE_PROJECT_DIR:-.}"
+branch=$(git -C "$dir" branch --show-current 2>/dev/null || echo "no-git")
+skill_count=$(ls "$dir/.claude/skills/" 2>/dev/null | wc -l | tr -d ' ')
+echo "[$branch] [skills:$skill_count]"
+`,
+	},
+};
+
+function settingsPath(target) {
+	return join(target, ".claude", "settings.json");
+}
+
+function scriptPath(target, name) {
+	return join(target, ".claude", "status-line", `${name}.sh`);
+}
+
+function readSettings(file) {
+	if (!existsSync(file)) return {};
+	try {
+		return JSON.parse(readFileSync(file, "utf-8"));
+	} catch {
+		return {};
+	}
+}
+
+function writeSettings(file, settings) {
+	mkdirSync(join(file, ".."), { recursive: true });
+	writeFileSync(file, `${JSON.stringify(settings, null, "\t")}\n`, "utf-8");
+}
+
+function showHelp() {
+	console.log(`${chalk.bold("badi statusline")} — Claude Code status line`);
+	console.log("");
+	console.log("  set <profile>   settings.json'a statusLine alani ekle");
+	console.log("  list            Mevcut konfigi goster");
+	console.log("  available       Yerlesik profilleri goster");
+	console.log("  reset           statusLine alanini settings.json'dan kaldir");
+	console.log("");
+	console.log(chalk.bold("Yerlesik profiller:"));
+	for (const [name, p] of Object.entries(PROFILES)) {
+		console.log(`  ${chalk.cyan(name.padEnd(12))} ${chalk.dim(p.description)}`);
+	}
+}
+
+export async function runStatusline(args) {
+	const [sub, ...rest] = args;
+	const target = process.cwd();
+	const sFile = settingsPath(target);
+
+	if (!sub || sub === "--help" || sub === "-h") {
+		showBanner();
+		showHelp();
+		return;
+	}
+
+	if (sub === "available") {
+		console.log(chalk.bold("Yerlesik profiller:"));
+		for (const [name, p] of Object.entries(PROFILES)) {
+			console.log(`  ${chalk.cyan(name)} — ${p.description}`);
+		}
+		return;
+	}
+
+	if (sub === "list") {
+		const settings = readSettings(sFile);
+		if (!settings.statusLine) {
+			console.log(chalk.dim("(statusLine konfigure edilmemis)"));
+			return;
+		}
+		console.log(chalk.bold("statusLine:"));
+		console.log(`  type:    ${chalk.cyan(settings.statusLine.type || "?")}`);
+		console.log(`  command: ${chalk.cyan(settings.statusLine.command || "?")}`);
+		return;
+	}
+
+	if (sub === "set") {
+		const name = rest[0];
+		if (!name) {
+			console.error(chalk.red("Hata: profil adi gerekli"));
+			console.error("Ornek: badi statusline set git");
+			process.exit(1);
+		}
+		if (!PROFILES[name]) {
+			console.error(chalk.red(`Hata: bilinmeyen profil "${name}"`));
+			console.error(
+				`Mevcut: ${Object.keys(PROFILES)
+					.map((n) => chalk.cyan(n))
+					.join(", ")}`,
+			);
+			process.exit(1);
+		}
+
+		const sPath = scriptPath(target, name);
+		mkdirSync(join(sPath, ".."), { recursive: true });
+		writeFileSync(sPath, PROFILES[name].script, "utf-8");
+		try {
+			chmodSync(sPath, 0o755);
+		} catch {
+			/* yetki yoksa atla */
+		}
+
+		const settings = readSettings(sFile);
+		settings.statusLine = {
+			type: "command",
+			command: `bash .claude/status-line/${name}.sh`,
+		};
+		writeSettings(sFile, settings);
+		console.log(
+			chalk.green(`+ statusLine ayarlandi: .claude/status-line/${name}.sh`),
+		);
+		console.log(chalk.dim("Claude Code'u yeniden baslatip etkisini gor."));
+		return;
+	}
+
+	if (sub === "reset") {
+		const settings = readSettings(sFile);
+		if (!settings.statusLine) {
+			console.log(chalk.dim("(zaten konfigure edilmemis)"));
+			return;
+		}
+		settings.statusLine = undefined;
+		delete settings.statusLine;
+		writeSettings(sFile, settings);
+		console.log(chalk.yellow("- statusLine kaldirildi"));
+		return;
+	}
+
+	console.error(chalk.red(`Bilinmeyen alt komut: ${sub}`));
+	showHelp();
+	process.exit(1);
+}

--- a/tests/cli.outputstyle.test.js
+++ b/tests/cli.outputstyle.test.js
@@ -1,0 +1,104 @@
+// outputstyle komut testleri.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const CLI = resolve(__dirname, "..", "bin", "badi.js");
+
+function setup() {
+	const dir = mkdtempSync(join(tmpdir(), "badi-outputstyle-test-"));
+	mkdirSync(join(dir, ".claude"), { recursive: true });
+	return dir;
+}
+
+function run(dir, args) {
+	return execFileSync("node", [CLI, "outputstyle", ...args], {
+		cwd: dir,
+		encoding: "utf-8",
+		timeout: 10000,
+	});
+}
+
+describe("outputstyle CLI", () => {
+	let dir;
+	beforeEach(() => {
+		dir = setup();
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("available yerlesik profilleri listeler", () => {
+		const out = run(dir, ["available"]);
+		assert.match(out, /terse/);
+		assert.match(out, /verbose/);
+		assert.match(out, /eli5/);
+	});
+
+	it("list bos durumda nasil davraniyor", () => {
+		const out = run(dir, ["list"]);
+		assert.match(out, /yuklu profil yok/);
+	});
+
+	it("add terse dosya olusturur", () => {
+		run(dir, ["add", "terse"]);
+		const file = join(dir, ".claude", "output-styles", "terse.md");
+		assert.ok(existsSync(file));
+		const content = readFileSync(file, "utf-8");
+		assert.match(content, /^---/);
+		assert.match(content, /name: terse/);
+		assert.match(content, /description:/);
+	});
+
+	it("add bilinmeyen profil hata", () => {
+		assert.throws(() =>
+			execFileSync("node", [CLI, "outputstyle", "add", "xyz"], {
+				cwd: dir,
+				encoding: "utf-8",
+				timeout: 10000,
+				stdio: "pipe",
+			}),
+		);
+	});
+
+	it("list yuklu profili gosterir", () => {
+		run(dir, ["add", "verbose"]);
+		const out = run(dir, ["list"]);
+		assert.match(out, /verbose/);
+	});
+
+	it("remove dosyayi siler", () => {
+		run(dir, ["add", "eli5"]);
+		const file = join(dir, ".claude", "output-styles", "eli5.md");
+		assert.ok(existsSync(file));
+		run(dir, ["remove", "eli5"]);
+		assert.ok(!existsSync(file));
+	});
+
+	it("clear tumunu siler", () => {
+		run(dir, ["add", "terse"]);
+		run(dir, ["add", "verbose"]);
+		run(dir, ["clear"]);
+		const out = run(dir, ["list"]);
+		assert.match(out, /yuklu profil yok/);
+	});
+
+	it("--help banner + komut listesi", () => {
+		const out = run(dir, ["--help"]);
+		assert.match(out, /add/);
+		assert.match(out, /list/);
+		assert.match(out, /available/);
+	});
+});

--- a/tests/cli.statusline.test.js
+++ b/tests/cli.statusline.test.js
@@ -1,0 +1,96 @@
+// statusline komut testleri.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const CLI = resolve(__dirname, "..", "bin", "badi.js");
+
+function setup() {
+	const dir = mkdtempSync(join(tmpdir(), "badi-statusline-test-"));
+	mkdirSync(join(dir, ".claude"), { recursive: true });
+	return dir;
+}
+
+function run(dir, args) {
+	return execFileSync("node", [CLI, "statusline", ...args], {
+		cwd: dir,
+		encoding: "utf-8",
+		timeout: 10000,
+	});
+}
+
+describe("statusline CLI", () => {
+	let dir;
+	beforeEach(() => {
+		dir = setup();
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("available yerlesik profilleri listeler", () => {
+		const out = run(dir, ["available"]);
+		assert.match(out, /git/);
+		assert.match(out, /skill-chip/);
+	});
+
+	it("list konfigure edilmemis durumu gosterir", () => {
+		const out = run(dir, ["list"]);
+		assert.match(out, /konfigure edilmemis/);
+	});
+
+	it("set git settings.json'a yazar", () => {
+		run(dir, ["set", "git"]);
+		const settings = JSON.parse(
+			readFileSync(join(dir, ".claude", "settings.json"), "utf-8"),
+		);
+		assert.equal(settings.statusLine?.type, "command");
+		assert.match(settings.statusLine?.command || "", /git\.sh/);
+		assert.ok(existsSync(join(dir, ".claude", "status-line", "git.sh")));
+	});
+
+	it("set skill-chip script olusturur", () => {
+		run(dir, ["set", "skill-chip"]);
+		assert.ok(existsSync(join(dir, ".claude", "status-line", "skill-chip.sh")));
+	});
+
+	it("set bilinmeyen profil hata", () => {
+		assert.throws(() =>
+			execFileSync("node", [CLI, "statusline", "set", "xyz"], {
+				cwd: dir,
+				encoding: "utf-8",
+				timeout: 10000,
+				stdio: "pipe",
+			}),
+		);
+	});
+
+	it("reset statusLine alanini kaldirir", () => {
+		run(dir, ["set", "git"]);
+		run(dir, ["reset"]);
+		const settings = JSON.parse(
+			readFileSync(join(dir, ".claude", "settings.json"), "utf-8"),
+		);
+		assert.equal(settings.statusLine, undefined);
+	});
+
+	it("--help banner + komut listesi", () => {
+		const out = run(dir, ["--help"]);
+		assert.match(out, /set/);
+		assert.match(out, /list/);
+		assert.match(out, /available/);
+		assert.match(out, /reset/);
+	});
+});


### PR DESCRIPTION
## Summary
İki yeni opt-in komut Claude Code harness özelleştirmesi için:

### `badi outputstyle` — 3 yerleşik profil
- **terse** — kısa ve özlü cevaplar, gereksiz açıklama yok
- **verbose** — detaylı cevaplar, gerekçeler + trade-off'lar
- **eli5** — basit dilde açıklamalar, metafor + örnek

```bash
badi outputstyle add terse        # .claude/output-styles/terse.md
# Claude Code içinde: /output-style terse
```

### `badi statusline` — 2 yerleşik profil
- **git** — `[branch*]` (dirty mark ile)
- **skill-chip** — `[branch] [skills:N]`

```bash
badi statusline set git    # settings.json + .claude/status-line/git.sh
```

## Implementation notes
- `bin/badi.js` commands map + showHelp güncellendi
- 15 yeni test: 8 outputstyle (add/list/available/remove/clear/help/error) + 7 statusline (set/list/available/reset/help/error)
- Komut sayımı 77 → 79
- README/CHANGELOG/CHANGELOG.tr.md/CLAUDE.md sync

## Test plan
- [x] `npm test` → 595/595 yeşil (önceden 580)
- [x] `npx biome check .` → 0 issue
- [x] `badi outputstyle add terse` → `.claude/output-styles/terse.md` oluşur
- [x] `badi statusline set git` → settings.json + script oluşur

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)