### PR TITLE
feat(integration): badi mcp serve — MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Added — `badi mcp serve` Model Context Protocol server (#120)
+
+Badi can now expose itself as an MCP server over stdio. External AI
+clients (Claude Code, Cursor, Continue.dev, Claude Desktop) can plug
+Badi in via `claude mcp add badi -- npx -y @fatihkan/badi mcp serve`
+and call Badi tools/resources from any session.
+
+**Tools** (read-only, safe):
+
+- `badi.skills.route` — score matching skills for a given prompt
+- `badi.skills.list` — list active opt-in skills
+- `badi.skills.available` — list all skill categories in the vault
+- `badi.skills.inject` — return concatenated SKILL.md bodies for a prompt
+
+**Resources**:
+
+- `badi://memory` — `.claude/memory.md`
+- `badi://knowledge-base` — `.claude/knowledge-base.md`
+- `badi://taskboard` — `.claude/workspace/TaskBoard.md`
+
+```bash
+# One-time install for Claude Code
+claude mcp add badi -- npx -y @fatihkan/badi mcp serve
+
+# Or write the snippet manually
+badi mcp config > .mcp.json
+
+# Inspect what's exposed
+badi mcp tools
+badi mcp resources
+```
+
+Zero external dependencies — JSON-RPC over stdio implemented in ~100
+LOC; no `@modelcontextprotocol/sdk` required (which pulls express +
+hono + zod). MCP spec version `2024-11-05`.
+
 ### Added — `outputstyle` and `statusline` commands (#118)
 
 Two new opt-in commands for Claude Code harness customization:

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,42 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+### Eklendi — `badi mcp serve` Model Context Protocol server (#120)
+
+Badi artik kendisini stdio uzerinden MCP server olarak expose edebilir.
+Disardaki AI client'lari (Claude Code, Cursor, Continue.dev, Claude
+Desktop) `claude mcp add badi -- npx -y @fatihkan/badi mcp serve` ile
+bagladiginda Badi tool ve resource'larini her oturumdan cagirabilir.
+
+**Tools** (read-only, guvenli):
+
+- `badi.skills.route` — verilen prompt icin eslesen skill'leri puanlar
+- `badi.skills.list` — aktif (opt-in) skill kategorileri
+- `badi.skills.available` — vault'taki tum skill kategorileri
+- `badi.skills.inject` — eslesen SKILL.md govdelerini birlestirip dondurur
+
+**Resources**:
+
+- `badi://memory` — `.claude/memory.md`
+- `badi://knowledge-base` — `.claude/knowledge-base.md`
+- `badi://taskboard` — `.claude/workspace/TaskBoard.md`
+
+```bash
+# Tek seferlik kurulum (Claude Code)
+claude mcp add badi -- npx -y @fatihkan/badi mcp serve
+
+# Ya da snippet'i manuel yaz
+badi mcp config > .mcp.json
+
+# Acik tool/resource'lari incele
+badi mcp tools
+badi mcp resources
+```
+
+Sifir disa bagimlilik — JSON-RPC over stdio ~100 LOC ile elle implemente
+edildi; `@modelcontextprotocol/sdk` (express + hono + zod baglar) gerekli
+degil. MCP spec versiyonu `2024-11-05`.
+
 ### Eklendi — `outputstyle` ve `statusline` komutlari (#118)
 
 Iki yeni opt-in komut Claude Code harness ozellestirmesi icin:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Badi - Is Akisi Yonetim Sistemi
 
-> Claude Code icin yapilandirilmis operasyon yonetimi. 22 ajan, 79 komut, 13 hook, 25 opt-in skill kategorisi (v1.20+ prompt-bilinen auto-router ile).
+> Claude Code icin yapilandirilmis operasyon yonetimi. 22 ajan, 80 komut, 13 hook, 25 opt-in skill kategorisi (v1.20+ prompt-bilinen auto-router ile).
 
 ## Bellek Kurallari
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **22 AI subagents**, **79 slash commands**, **13 automation hooks**, and **25 opt-in skill categories** with **prompt-aware auto-routing** (v1.20+). OWASP Top 10 scans, code review, content production, mobile/web SEO, App Store market research with `wishlist` + `gaps` analysis. Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
+**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **22 AI subagents**, **80 slash commands**, **13 automation hooks**, and **25 opt-in skill categories** with **prompt-aware auto-routing** (v1.20+). OWASP Top 10 scans, code review, content production, mobile/web SEO, App Store market research with `wishlist` + `gaps` analysis. Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
 
 ## Demo
 
@@ -32,7 +32,7 @@
 /plugin install badi@badi-marketplace
 ```
 
-**As an npm CLI (full feature set: 22 agents · 79 commands · 13 hooks · 25 opt-in skill categories with auto-router)**:
+**As an npm CLI (full feature set: 22 agents · 80 commands · 13 hooks · 25 opt-in skill categories with auto-router)**:
 
 ```bash
 npx @fatihkan/badi init                    # interactive harness picker
@@ -56,7 +56,7 @@ Claude is the canonical source. Cursor and Gemini adapters compile from the same
 
 | Feature | Details |
 |---------|---------|
-| **22 expert agents + 79 commands** | Full toolkit from security scanner to performance profiler — read-only agents enforce `disallowedTools` for defense-in-depth |
+| **22 expert agents + 80 commands** | Full toolkit from security scanner to performance profiler — read-only agents enforce `disallowedTools` for defense-in-depth |
 | **13 automation hooks + 25 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants. Skills load zero tokens by default since v1.17; auto-router (v1.20+) injects matching skills per prompt |
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+)** | Claude Code, Cursor, Gemini CLI — same `.claude/` source, different targets |
@@ -158,6 +158,24 @@ badi statusline set skill-chip    # [branch] [skills:N]
 ```
 
 Both write to `.claude/` (output-styles/, status-line/, settings.json) — opt-in, project-scoped.
+
+### MCP Server (v1.23+)
+
+Expose Badi as a [Model Context Protocol](https://modelcontextprotocol.io/) server. Any MCP-compatible client (Claude Code, Cursor, Continue.dev, Claude Desktop) can call Badi tools/resources from any project:
+
+```bash
+# One-time install for Claude Code
+claude mcp add badi -- npx -y @fatihkan/badi mcp serve
+
+# Or write the .mcp.json snippet manually
+badi mcp config > .mcp.json
+
+# Inspect what's exposed
+badi mcp tools         # 4 read-only tools
+badi mcp resources     # memory, knowledge-base, taskboard
+```
+
+Zero external dependencies (JSON-RPC over stdio, ~100 LOC). Tools cover the auto-router (`badi.skills.route`, `.list`, `.available`, `.inject`) — perfect for piping prompt-aware skill injection into other agents.
 
 ### Software Development
 ```bash

--- a/README.tr.md
+++ b/README.tr.md
@@ -11,7 +11,7 @@
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-**Anthropic Claude Code, Cursor ve Gemini CLI icin is akisi yonetim CLI'i** — **Claude Opus 4.7** ve **Sonnet 4.6** uyumlu. **22 AI subagent**, **79 slash komut**, **13 otomatik hook** ve **25 opt-in skill kategorisi** ile **prompt-bilinen otomatik router** (v1.20+) icerir. OWASP Top 10 tarama, code review, icerik uretimi, mobile/web SEO, App Store pazar arastirmasi (`wishlist` + `gaps` analizi). Tekrarlayan is akislarinda token tuketimini **~%96** azaltir. **v1.12+** ile multi-harness destegi — ayni `.claude/` agaci Cursor ve Gemini CLI hedeflerine derlenir. **v1.16+** CodeQL sertlesmesi (TLS strict-first, DOM bazli HTML parse, URL hostname dogrulamasi).
+**Anthropic Claude Code, Cursor ve Gemini CLI icin is akisi yonetim CLI'i** — **Claude Opus 4.7** ve **Sonnet 4.6** uyumlu. **22 AI subagent**, **80 slash komut**, **13 otomatik hook** ve **25 opt-in skill kategorisi** ile **prompt-bilinen otomatik router** (v1.20+) icerir. OWASP Top 10 tarama, code review, icerik uretimi, mobile/web SEO, App Store pazar arastirmasi (`wishlist` + `gaps` analizi). Tekrarlayan is akislarinda token tuketimini **~%96** azaltir. **v1.12+** ile multi-harness destegi — ayni `.claude/` agaci Cursor ve Gemini CLI hedeflerine derlenir. **v1.16+** CodeQL sertlesmesi (TLS strict-first, DOM bazli HTML parse, URL hostname dogrulamasi).
 
 ## Demo
 
@@ -32,7 +32,7 @@
 /plugin install badi@badi-marketplace
 ```
 
-**npm CLI olarak (tam ozellik seti: 22 ajan · 79 komut · 13 hook · 25 opt-in skill kategorisi + auto-router)**:
+**npm CLI olarak (tam ozellik seti: 22 ajan · 80 komut · 13 hook · 25 opt-in skill kategorisi + auto-router)**:
 
 ```bash
 npx @fatihkan/badi init                    # interaktif harness secim menusu
@@ -56,7 +56,7 @@ Claude kaynak (canonical). Cursor ve Gemini adapter'lari ayni `.claude/` dizinin
 
 | Ozellik | Detay |
 |---------|-------|
-| **22 Uzman Ajan ve 79 Komut** | Guvenlik tarayicidan performans profiler'a kadar genis arac seti — read-only ajanlar `disallowedTools` ile defense-in-depth saglıyor |
+| **22 Uzman Ajan ve 80 Komut** | Guvenlik tarayicidan performans profiler'a kadar genis arac seti — read-only ajanlar `disallowedTools` ile defense-in-depth saglıyor |
 | **13 Otomatik Hook ve 25 Skill Kategorisi** | Branch koruma, yedekleme, OWASP Top 10 taramasi, 9 Frontend Taste varyanti, prompt-bilinen auto-router (v1.20+) |
 | **Multi-harness destegi (v1.12+)** | Claude Code, Cursor, Gemini CLI — ayni `.claude/` kaynagi, farkli hedefler |
 | **398 Onaylanmis Test** | CLI entegrasyon, harness adapter, schema/bundler/publish, watcher/scheduler, market, tasarim |
@@ -155,6 +155,24 @@ badi statusline set skill-chip    # [branch] [skills:N]
 ```
 
 Iki komut da `.claude/` altina yazar (output-styles/, status-line/, settings.json) — opt-in, proje bazli.
+
+### MCP Server (v1.23+)
+
+Badi'yi [Model Context Protocol](https://modelcontextprotocol.io/) server olarak expose et. MCP uyumlu istemciler (Claude Code, Cursor, Continue.dev, Claude Desktop) Badi tool ve resource'larini her projeden cagirabilir:
+
+```bash
+# Tek seferlik kurulum (Claude Code)
+claude mcp add badi -- npx -y @fatihkan/badi mcp serve
+
+# Ya da .mcp.json snippet'i manuel yaz
+badi mcp config > .mcp.json
+
+# Acik tool/resource listesi
+badi mcp tools         # 4 read-only tool
+badi mcp resources     # memory, knowledge-base, taskboard
+```
+
+Sifir disa bagimlilik (JSON-RPC over stdio, ~100 LOC). Tool seti auto-router'i kapsar (`badi.skills.route`, `.list`, `.available`, `.inject`) — prompt-bilinen skill injection'i baska agent'lara pipe etmek icin ideal.
 
 ### Yazilim Gelistirme
 ```bash

--- a/bin/badi.js
+++ b/bin/badi.js
@@ -38,6 +38,9 @@ function showHelp() {
 		`  ${chalk.cyan("statusline")} Status line profilleri (git/skill-chip) — v1.22+`,
 	);
 	console.log(
+		`  ${chalk.cyan("mcp")}       Model Context Protocol server (serve/tools/config) — v1.23+`,
+	);
+	console.log(
 		`  ${chalk.cyan("wp")}        WordPress site yonetimi (durum/eklenti/tema/guvenlik)`,
 	);
 	console.log(
@@ -285,6 +288,7 @@ const commands = {
 		import("../lib/commands/outputstyle.js").then((m) => m.runOutputstyle),
 	statusline: () =>
 		import("../lib/commands/statusline.js").then((m) => m.runStatusline),
+	mcp: () => import("../lib/commands/mcp.js").then((m) => m.runMcp),
 };
 
 // ─── Ana Giris Noktasi ───

--- a/lib/commands/mcp.js
+++ b/lib/commands/mcp.js
@@ -1,0 +1,355 @@
+// Badi mcp komutu — Model Context Protocol server.
+//
+// `badi mcp serve` stdio uzerinden minimal MCP server baslar. Disardaki
+// AI client'lari (Claude Code, Cursor, Continue.dev) `claude mcp add badi`
+// ile bagladiginda tools/resources Badi koprusu uzerinden cagrilabilir.
+//
+// Sifir disa bagimlilik: JSON-RPC over stdio elle implemente edildi.
+// MCP spec: https://modelcontextprotocol.io/
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { chalk, showBanner } from "../cli.js";
+
+const MCP_VERSION = "2024-11-05";
+const SERVER_NAME = "badi";
+
+// ─── Tool ve resource tanimlari (read-only, guvenli) ───
+
+const TOOLS = [
+	{
+		name: "badi.skills.route",
+		description:
+			"Verilen prompt icin eslesen skill'leri puanlar (auto-router). Donus: matched skill listesi + skor.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				prompt: { type: "string", description: "Kullanici prompt'u" },
+				top: {
+					type: "number",
+					description: "En cok N skill (default 3)",
+					default: 3,
+				},
+			},
+			required: ["prompt"],
+		},
+	},
+	{
+		name: "badi.skills.list",
+		description: "Aktif (opt-in) skill kategorilerini listeler.",
+		inputSchema: { type: "object", properties: {} },
+	},
+	{
+		name: "badi.skills.available",
+		description:
+			"Vault'taki tum skill kategorilerini listeler (yuklu olmasa da).",
+		inputSchema: { type: "object", properties: {} },
+	},
+	{
+		name: "badi.skills.inject",
+		description:
+			"Verilen prompt icin eslesen skill'lerin SKILL.md govdesini birlestirip donderir (context injection).",
+		inputSchema: {
+			type: "object",
+			properties: {
+				prompt: { type: "string" },
+			},
+			required: ["prompt"],
+		},
+	},
+];
+
+const RESOURCES = [
+	{
+		uri: "badi://memory",
+		name: "memory.md",
+		description: "Oturum bellegi (kararlar, notlar, mevcut durum)",
+		mimeType: "text/markdown",
+		path: ".claude/memory.md",
+	},
+	{
+		uri: "badi://knowledge-base",
+		name: "knowledge-base.md",
+		description: "Proje bilgi tabani (kalici kurallar, kaliplari)",
+		mimeType: "text/markdown",
+		path: ".claude/knowledge-base.md",
+	},
+	{
+		uri: "badi://taskboard",
+		name: "TaskBoard.md",
+		description: "Gorev panosu (acik/bekleyen isler)",
+		mimeType: "text/markdown",
+		path: ".claude/workspace/TaskBoard.md",
+	},
+];
+
+// ─── JSON-RPC helpers ───
+
+function jsonRpcResponse(id, result) {
+	return JSON.stringify({ jsonrpc: "2.0", id, result });
+}
+
+function jsonRpcError(id, code, message) {
+	return JSON.stringify({
+		jsonrpc: "2.0",
+		id,
+		error: { code, message },
+	});
+}
+
+// ─── Tool calistirma ───
+
+async function callTool(name, args, target) {
+	if (name === "badi.skills.route") {
+		const { buildSkillIndex, routePrompt } = await import(
+			"../skills-router.js"
+		);
+		const idx = buildSkillIndex(join(target, ".claude", "skills-vault"));
+		const matched = routePrompt(args.prompt || "", idx, {
+			top: args.top || 3,
+		});
+		return {
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({ matched }, null, 2),
+				},
+			],
+		};
+	}
+
+	if (name === "badi.skills.list") {
+		const { listDirs } = await import("../helpers.js");
+		const active = join(target, ".claude", "skills");
+		const skills = existsSync(active) ? listDirs(active).sort() : [];
+		return {
+			content: [
+				{ type: "text", text: JSON.stringify({ active: skills }, null, 2) },
+			],
+		};
+	}
+
+	if (name === "badi.skills.available") {
+		const { listDirs } = await import("../helpers.js");
+		const vault = join(target, ".claude", "skills-vault");
+		const skills = existsSync(vault) ? listDirs(vault).sort() : [];
+		return {
+			content: [
+				{ type: "text", text: JSON.stringify({ available: skills }, null, 2) },
+			],
+		};
+	}
+
+	if (name === "badi.skills.inject") {
+		const { buildContextInjection, buildSkillIndex, routePrompt } =
+			await import("../skills-router.js");
+		const idx = buildSkillIndex(join(target, ".claude", "skills-vault"));
+		const matched = routePrompt(args.prompt || "", idx);
+		const blob = buildContextInjection(matched, idx);
+		return {
+			content: [{ type: "text", text: blob || "(eslesme yok)" }],
+		};
+	}
+
+	throw new Error(`Bilinmeyen tool: ${name}`);
+}
+
+async function readResource(uri, target) {
+	const res = RESOURCES.find((r) => r.uri === uri);
+	if (!res) throw new Error(`Bilinmeyen resource: ${uri}`);
+	const file = join(target, res.path);
+	const text = existsSync(file) ? readFileSync(file, "utf-8") : "(dosya yok)";
+	return {
+		contents: [{ uri, mimeType: res.mimeType, text }],
+	};
+}
+
+// ─── Request handler ───
+
+async function handleRequest(req, target) {
+	const { id, method, params = {} } = req;
+
+	try {
+		if (method === "initialize") {
+			return jsonRpcResponse(id, {
+				protocolVersion: MCP_VERSION,
+				capabilities: { tools: {}, resources: {} },
+				serverInfo: { name: SERVER_NAME, version: getBadiVersion() },
+			});
+		}
+
+		if (method === "tools/list") {
+			return jsonRpcResponse(id, { tools: TOOLS });
+		}
+
+		if (method === "tools/call") {
+			const result = await callTool(
+				params.name,
+				params.arguments || {},
+				target,
+			);
+			return jsonRpcResponse(id, result);
+		}
+
+		if (method === "resources/list") {
+			return jsonRpcResponse(id, {
+				resources: RESOURCES.map((r) => ({
+					uri: r.uri,
+					name: r.name,
+					description: r.description,
+					mimeType: r.mimeType,
+				})),
+			});
+		}
+
+		if (method === "resources/read") {
+			const result = await readResource(params.uri, target);
+			return jsonRpcResponse(id, result);
+		}
+
+		if (method === "ping") {
+			return jsonRpcResponse(id, {});
+		}
+
+		// notifications (initialized vb.) cevap istemez
+		if (method.startsWith("notifications/")) {
+			return null;
+		}
+
+		return jsonRpcError(id, -32601, `Method not found: ${method}`);
+	} catch (e) {
+		return jsonRpcError(id, -32603, e.message);
+	}
+}
+
+function getBadiVersion() {
+	try {
+		const pkg = JSON.parse(
+			readFileSync(new URL("../../package.json", import.meta.url), "utf-8"),
+		);
+		return pkg.version;
+	} catch {
+		return "unknown";
+	}
+}
+
+// ─── Stdio server ───
+
+export async function serveMcp(target) {
+	let buffer = "";
+	let pending = 0;
+	let stdinEnded = false;
+
+	const tryExit = () => {
+		if (stdinEnded && pending === 0) {
+			process.exit(0);
+		}
+	};
+
+	const processLine = async (line) => {
+		pending++;
+		try {
+			const req = JSON.parse(line);
+			const resp = await handleRequest(req, target);
+			if (resp !== null) {
+				process.stdout.write(`${resp}\n`);
+			}
+		} catch (e) {
+			const errResp = jsonRpcError(null, -32700, `Parse error: ${e.message}`);
+			process.stdout.write(`${errResp}\n`);
+		} finally {
+			pending--;
+			tryExit();
+		}
+	};
+
+	process.stdin.setEncoding("utf-8");
+	process.stdin.on("data", (chunk) => {
+		buffer += chunk;
+		let nl = buffer.indexOf("\n");
+		while (nl !== -1) {
+			const line = buffer.slice(0, nl).trim();
+			buffer = buffer.slice(nl + 1);
+			if (line) processLine(line);
+			nl = buffer.indexOf("\n");
+		}
+	});
+
+	process.stdin.on("end", () => {
+		stdinEnded = true;
+		tryExit();
+	});
+}
+
+// ─── CLI yardimcilari ───
+
+function manifestSnippet() {
+	return JSON.stringify(
+		{
+			mcpServers: {
+				badi: {
+					command: "npx",
+					args: ["-y", "@fatihkan/badi", "mcp", "serve"],
+				},
+			},
+		},
+		null,
+		2,
+	);
+}
+
+function showHelp() {
+	console.log(`${chalk.bold("badi mcp")} — Model Context Protocol server`);
+	console.log("");
+	console.log("  serve         Stdio MCP server baslar");
+	console.log("  tools         Acik tool listesini goster");
+	console.log("  resources     Acik resource listesini goster");
+	console.log("  config        Claude Code/Cursor icin .mcp.json snippet'i");
+	console.log("");
+	console.log(chalk.bold("Kurulum (Claude Code):"));
+	console.log("  claude mcp add badi -- npx -y @fatihkan/badi mcp serve");
+	console.log("");
+	console.log(chalk.bold("Manuel (.mcp.json):"));
+	console.log(chalk.dim("  badi mcp config > .mcp.json"));
+}
+
+export async function runMcp(args) {
+	const [sub] = args;
+	const target = process.cwd();
+
+	if (!sub || sub === "--help" || sub === "-h") {
+		showBanner();
+		showHelp();
+		return;
+	}
+
+	if (sub === "serve") {
+		await serveMcp(target);
+		return;
+	}
+
+	if (sub === "tools") {
+		console.log(chalk.bold(`Tools (${TOOLS.length}):`));
+		for (const t of TOOLS) {
+			console.log(`  ${chalk.cyan(t.name)} — ${t.description}`);
+		}
+		return;
+	}
+
+	if (sub === "resources") {
+		console.log(chalk.bold(`Resources (${RESOURCES.length}):`));
+		for (const r of RESOURCES) {
+			console.log(`  ${chalk.cyan(r.uri)} — ${r.description}`);
+		}
+		return;
+	}
+
+	if (sub === "config") {
+		console.log(manifestSnippet());
+		return;
+	}
+
+	console.error(chalk.red(`Bilinmeyen alt komut: ${sub}`));
+	showHelp();
+	process.exit(1);
+}

--- a/tests/cli.mcp.test.js
+++ b/tests/cli.mcp.test.js
@@ -1,0 +1,215 @@
+// MCP server testleri — JSON-RPC roundtrip ve CLI metadata.
+
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const CLI = resolve(__dirname, "..", "bin", "badi.js");
+
+function setupVault() {
+	const dir = mkdtempSync(join(tmpdir(), "badi-mcp-test-"));
+	const claudeDir = join(dir, ".claude");
+	const vault = join(claudeDir, "skills-vault");
+	const active = join(claudeDir, "skills");
+	mkdirSync(vault, { recursive: true });
+	mkdirSync(active, { recursive: true });
+	mkdirSync(join(claudeDir, "workspace"), { recursive: true });
+
+	mkdirSync(join(vault, "seo"), { recursive: true });
+	writeFileSync(
+		join(vault, "seo", "SKILL.md"),
+		"---\nname: seo\ndescription: SEO. Triggers on: schema, keyword, meta.\n---\n\nSEO body.\n",
+	);
+	mkdirSync(join(active, "seo"), { recursive: true });
+	writeFileSync(
+		join(active, "seo", "SKILL.md"),
+		"---\nname: seo\ndescription: SEO active.\n---\n\nactive\n",
+	);
+
+	writeFileSync(join(claudeDir, "memory.md"), "# Memory\nTest content.\n");
+	writeFileSync(join(claudeDir, "knowledge-base.md"), "# KB\nTest content.\n");
+	writeFileSync(
+		join(claudeDir, "workspace", "TaskBoard.md"),
+		"# Tasks\nTest.\n",
+	);
+
+	return dir;
+}
+
+async function rpc(dir, requests) {
+	return new Promise((resolve, reject) => {
+		const child = spawn("node", [CLI, "mcp", "serve"], {
+			cwd: dir,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		child.stdout.on("data", (c) => {
+			stdout += c.toString();
+		});
+		child.stderr.on("data", (c) => {
+			stderr += c.toString();
+		});
+		child.on("error", reject);
+		child.on("exit", () => {
+			const lines = stdout.split("\n").filter(Boolean);
+			const responses = lines.map((l) => JSON.parse(l));
+			resolve({ responses, stderr });
+		});
+
+		for (const req of requests) {
+			child.stdin.write(`${JSON.stringify(req)}\n`);
+		}
+		child.stdin.end();
+
+		setTimeout(() => {
+			child.kill("SIGTERM");
+			reject(new Error("MCP server timeout"));
+		}, 8000).unref();
+	});
+}
+
+describe("mcp CLI metadata", () => {
+	let dir;
+	beforeEach(() => {
+		dir = setupVault();
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("--help banner + komut listesi", () => {
+		const out = execFileSync("node", [CLI, "mcp", "--help"], {
+			cwd: dir,
+			encoding: "utf-8",
+			timeout: 10000,
+		});
+		assert.match(out, /serve/);
+		assert.match(out, /tools/);
+		assert.match(out, /config/);
+	});
+
+	it("tools alt komutu tool listesi yazar", () => {
+		const out = execFileSync("node", [CLI, "mcp", "tools"], {
+			cwd: dir,
+			encoding: "utf-8",
+			timeout: 10000,
+		});
+		assert.match(out, /badi\.skills\.route/);
+		assert.match(out, /badi\.skills\.list/);
+	});
+
+	it("resources alt komutu resource listesi yazar", () => {
+		const out = execFileSync("node", [CLI, "mcp", "resources"], {
+			cwd: dir,
+			encoding: "utf-8",
+			timeout: 10000,
+		});
+		assert.match(out, /badi:\/\/memory/);
+		assert.match(out, /badi:\/\/knowledge-base/);
+	});
+
+	it("config gecerli .mcp.json snippet'i yazar", () => {
+		const out = execFileSync("node", [CLI, "mcp", "config"], {
+			cwd: dir,
+			encoding: "utf-8",
+			timeout: 10000,
+		});
+		const parsed = JSON.parse(out);
+		assert.ok(parsed.mcpServers);
+		assert.ok(parsed.mcpServers.badi);
+		assert.equal(parsed.mcpServers.badi.command, "npx");
+	});
+});
+
+describe("mcp serve JSON-RPC", () => {
+	let dir;
+	beforeEach(() => {
+		dir = setupVault();
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("initialize cevap dondurur", async () => {
+		const { responses } = await rpc(dir, [
+			{ jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+		]);
+		assert.equal(responses.length, 1);
+		assert.equal(responses[0].id, 1);
+		assert.ok(responses[0].result.protocolVersion);
+		assert.equal(responses[0].result.serverInfo.name, "badi");
+	});
+
+	it("tools/list MCP tool listesi", async () => {
+		const { responses } = await rpc(dir, [
+			{ jsonrpc: "2.0", id: 1, method: "tools/list" },
+		]);
+		assert.ok(responses[0].result.tools.length >= 4);
+		const names = responses[0].result.tools.map((t) => t.name);
+		assert.ok(names.includes("badi.skills.route"));
+	});
+
+	it("resources/list MCP resource listesi", async () => {
+		const { responses } = await rpc(dir, [
+			{ jsonrpc: "2.0", id: 1, method: "resources/list" },
+		]);
+		assert.ok(responses[0].result.resources.length >= 3);
+	});
+
+	it("tools/call badi.skills.route eslesen skill", async () => {
+		const { responses } = await rpc(dir, [
+			{
+				jsonrpc: "2.0",
+				id: 1,
+				method: "tools/call",
+				params: {
+					name: "badi.skills.route",
+					arguments: { prompt: "schema markup keyword" },
+				},
+			},
+		]);
+		assert.ok(responses[0].result.content);
+		const text = responses[0].result.content[0].text;
+		assert.match(text, /seo/);
+	});
+
+	it("tools/call badi.skills.list aktif listesi", async () => {
+		const { responses } = await rpc(dir, [
+			{
+				jsonrpc: "2.0",
+				id: 1,
+				method: "tools/call",
+				params: { name: "badi.skills.list", arguments: {} },
+			},
+		]);
+		const text = responses[0].result.content[0].text;
+		assert.match(text, /seo/);
+	});
+
+	it("resources/read badi://memory dosyasi okur", async () => {
+		const { responses } = await rpc(dir, [
+			{
+				jsonrpc: "2.0",
+				id: 1,
+				method: "resources/read",
+				params: { uri: "badi://memory" },
+			},
+		]);
+		assert.ok(responses[0].result.contents);
+		assert.match(responses[0].result.contents[0].text, /Memory/);
+	});
+
+	it("bilinmeyen method JSON-RPC error", async () => {
+		const { responses } = await rpc(dir, [
+			{ jsonrpc: "2.0", id: 1, method: "frobnicate" },
+		]);
+		assert.ok(responses[0].error);
+		assert.equal(responses[0].error.code, -32601);
+	});
+});


### PR DESCRIPTION
## Summary
Badi artık kendisini stdio üzerinden MCP server olarak expose edebilir. Dışarıdaki AI client'ları (Claude Code, Cursor, Continue.dev, Claude Desktop) Badi'yi `claude mcp add` ile bağladığında tool/resource'lara her oturumdan erişebilir.

## Açılan tools (read-only, güvenli)
- `badi.skills.route` — verilen prompt için eşleşen skill'leri puanlar
- `badi.skills.list` — aktif (opt-in) skill kategorileri
- `badi.skills.available` — vault'taki tüm skill kategorileri
- `badi.skills.inject` — eşleşen SKILL.md gövdelerini birleştirip döndürür

## Resources
- `badi://memory` — `.claude/memory.md`
- `badi://knowledge-base` — `.claude/knowledge-base.md`
- `badi://taskboard` — `.claude/workspace/TaskBoard.md`

## Implementation notes
- **Sıfır dış bağımlılık** — JSON-RPC over stdio elle implemente edildi (~100 LOC). `@modelcontextprotocol/sdk` express + hono + zod gibi ağır bağımlılıklar getiriyor; opt-in CLI özelliği için ölçüsüz büyük.
- MCP spec versiyonu `2024-11-05`
- Komut sayımı 79 → 80
- Test 595 → 606 (11 yeni: 4 metadata + 7 JSON-RPC roundtrip)

## Kullanım

```bash
claude mcp add badi -- npx -y @fatihkan/badi mcp serve
# Veya manuel
badi mcp config > .mcp.json
```

## Test plan
- [x] `npm test` → 606/606 yeşil
- [x] `npx biome check .` → 0 issue
- [x] `node bin/badi.js mcp serve` < initialize/tools-list/tools-call → cevap döndürüyor
- [x] `badi mcp config` parse edilebilir JSON

## Notlar
v1.22.0 release PR (#123) hâlâ açık (npm publish 2FA bekliyor). Bu PR onun ardından merge edilirse v1.23.0 minor olur. Eğer #123 öncesi merge edilirse v1.22.0'da çıkar.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)