### PR TITLE
feat(compat): Windows phase 3+4 + /review bulgulari (#126)

### DIFF
--- a/.claude/hooks/_util.mjs
+++ b/.claude/hooks/_util.mjs
@@ -1,5 +1,10 @@
 // Badi hook utility module — cross-platform replacement for bash hooks.
 //
+// Bu dosya .claude/hooks/_util.mjs olarak hook dizinine yerlestirildi
+// cunku npm-installed user'larda hook'lar `<proje>/.claude/hooks/X.mjs`
+// konumunda olur ve `lib/hooks/util.js`'e ulasamaz (paket node_modules'ta).
+// Self-contained tutuldu: import yolu './_util.mjs' her zaman cozumlenir.
+//
 // Sifir disa bagimlilik. JSON stdin okur, log dizinleri olusturur,
 // proje koku tespit eder. Tum hook'lar bu modulu paylasir.
 
@@ -9,9 +14,11 @@ import {
 	existsSync,
 	mkdirSync,
 	readFileSync,
+	renameSync,
 	statSync,
 	writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 /**
@@ -50,18 +57,26 @@ export function isoTimestamp() {
 	return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
 }
 
+// Module-level cache: hook process tek seferlik calisir, projectRoot da
+// degismez. Birden fazla logPath()/projectRoot() cagrisinda git spawn'i
+// tekrarlamamak icin (review bulgu #3).
+let _projectRootCache = null;
+
 /**
  * Proje kokunu tespit et. git rev-parse --show-toplevel; basarisizsa cwd.
+ * Memoize edilir.
  */
 export function projectRoot() {
+	if (_projectRootCache !== null) return _projectRootCache;
 	try {
-		return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+		_projectRootCache = execFileSync("git", ["rev-parse", "--show-toplevel"], {
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "ignore"],
 		}).trim();
 	} catch {
-		return process.cwd();
+		_projectRootCache = process.cwd();
 	}
+	return _projectRootCache;
 }
 
 /**
@@ -132,18 +147,26 @@ export function writeContextInjection(text) {
 
 /**
  * Dosya satir sayisini dondur. Yoksa 0.
+ * CRLF/LF normalize ederek son satir bos ise sayilmaz (bulgu #5).
  */
 export function lineCount(file) {
 	if (!existsSync(file)) return 0;
 	try {
-		return readFileSync(file, "utf-8").split("\n").length;
+		const content = readFileSync(file, "utf-8");
+		if (content.length === 0) return 0;
+		const matches = content.match(/\n/g);
+		const newlines = matches ? matches.length : 0;
+		// Son karakter \n ise satir sayisi = \n sayisi
+		// Aksi halde son satir +1
+		return content.endsWith("\n") ? newlines : newlines + 1;
 	} catch {
 		return 0;
 	}
 }
 
 /**
- * Bir log dosyasini son N satirla kirp (in-place).
+ * Bir log dosyasini son N satirla kirp. Atomik: tmp dosyaya yaz, rename.
+ * Crash sirasinda kismi yazma olmaz (bulgu #4).
  */
 export function truncateLog(file, maxLines, keepLines) {
 	if (!existsSync(file)) return false;
@@ -152,7 +175,9 @@ export function truncateLog(file, maxLines, keepLines) {
 		const lines = content.split("\n");
 		if (lines.length <= maxLines) return false;
 		const kept = lines.slice(-keepLines).join("\n");
-		writeFileSync(file, kept, "utf-8");
+		const tmp = `${file}.tmp.${process.pid}`;
+		writeFileSync(tmp, kept, "utf-8");
+		renameSync(tmp, file);
 		return true;
 	} catch {
 		return false;
@@ -169,7 +194,7 @@ export function shorten(str, max = 200) {
 }
 
 /**
- * Dosyayi 7+ gun once degistirildiyse sil. mtime tabanli.
+ * Dosyayi N+ gun once degistirildiyse true. mtime tabanli.
  */
 export function olderThan(filePath, days) {
 	try {
@@ -181,15 +206,34 @@ export function olderThan(filePath, days) {
 }
 
 /**
- * Komut PATH'te mi? execFileSync ile probe.
+ * Komut PATH'te mi? Pure PATH probe — shell built-in 'command -v' yerine
+ * (Linux'ta executable degil, bulgu #2).
+ *
+ * Windows: PATHEXT (.exe/.cmd/.bat) + PATH; Unix: PATH.
+ * lib/platform.js commandExists ile aynidir.
  */
 export function commandAvailable(cmd) {
-	try {
-		const probe = process.platform === "win32" ? "where" : "command";
-		const args = process.platform === "win32" ? [cmd] : ["-v", cmd];
-		execFileSync(probe, args, { stdio: "ignore" });
-		return true;
-	} catch {
-		return false;
+	const isWindows = process.platform === "win32";
+	const PATH = process.env.PATH || process.env.Path || "";
+	const sep = isWindows ? ";" : ":";
+	const exts = isWindows
+		? (process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD").split(";")
+		: [""];
+	for (const dir of PATH.split(sep)) {
+		if (!dir) continue;
+		for (const ext of exts) {
+			const candidate = `${dir}${isWindows ? "\\" : "/"}${cmd}${ext}`;
+			if (existsSync(candidate)) return true;
+		}
 	}
+	return false;
+}
+
+/**
+ * XDG_CONFIG_HOME-aware config directory. Linux/Mac/Windows hepsinde
+ * Standard yol (bulgu #10). Windows'ta env yoksa homedir/.config kullanir.
+ */
+export function configDir(app) {
+	const base = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+	return join(base, app);
 }

--- a/.claude/hooks/backup-before-write.mjs
+++ b/.claude/hooks/backup-before-write.mjs
@@ -11,7 +11,7 @@ import {
 	statSync,
 } from "node:fs";
 import { basename, join } from "node:path";
-import { olderThan, projectRoot, readStdinJson } from "../../lib/hooks/util.js";
+import { olderThan, projectRoot, readStdinJson } from "./_util.mjs";
 
 const input = await readStdinJson();
 const filePath = input.tool_input?.file_path || input.tool_input?.path || "";

--- a/.claude/hooks/branch-guard.mjs
+++ b/.claude/hooks/branch-guard.mjs
@@ -10,7 +10,7 @@ import {
 	logPath,
 	readStdinJson,
 	writeDecision,
-} from "../../lib/hooks/util.js";
+} from "./_util.mjs";
 
 const input = await readStdinJson();
 const command = input.tool_input?.command || "";
@@ -19,7 +19,8 @@ if (!command) process.exit(0);
 const branch = currentBranch();
 
 // Force push: main/master/release/* dallarinda engelle
-if (/git\s+push.*--force\b/.test(command)) {
+// --force | --force-with-lease | -f flag (bulgu #8).
+if (/git\s+push.*(--force\b|\s-f\b)/.test(command)) {
 	if (branch === "main" || branch === "master" || /^release\//.test(branch)) {
 		appendLog(
 			logPath("incident-log.md"),

--- a/.claude/hooks/completeness-gate.mjs
+++ b/.claude/hooks/completeness-gate.mjs
@@ -3,7 +3,7 @@
 // Kritik dosyalara yazma oncesi icerik dogrulamasi yapar.
 
 import { basename } from "node:path";
-import { readStdinJson, writeDecision } from "../../lib/hooks/util.js";
+import { readStdinJson, writeDecision } from "./_util.mjs";
 
 const input = await readStdinJson();
 const toolName = input.tool_name || "";
@@ -20,15 +20,32 @@ if (filePath.includes(".test-tmp-") || filePath.startsWith("/tmp/")) {
 const fileName = basename(filePath);
 
 // ─── Gizli Bilgi Tespiti (.env haricinde) ───
+// Modern token formatlari dahil (bulgu #9).
 if (!fileName.startsWith(".env")) {
 	const secretPatterns = [
+		// Stripe
 		/sk_live_[a-zA-Z0-9]+/,
 		/sk_test_[a-zA-Z0-9]+/,
-		/ghp_[a-zA-Z0-9]+/,
-		/gho_[a-zA-Z0-9]+/,
+		/rk_live_[a-zA-Z0-9]+/, // restricted keys
+		/rk_test_[a-zA-Z0-9]+/,
+		// GitHub
+		/ghp_[a-zA-Z0-9]+/, // personal access token
+		/gho_[a-zA-Z0-9]+/, // OAuth
+		/ghu_[a-zA-Z0-9]+/, // user-to-server
+		/ghs_[a-zA-Z0-9]+/, // server-to-server
+		/ghr_[a-zA-Z0-9]+/, // refresh
+		// AWS
 		/AKIA[A-Z0-9]{16}/,
+		// Slack
 		/xox[bpsar]-[a-zA-Z0-9-]+/,
+		// JWT
 		/eyJ[a-zA-Z0-9_-]+\.eyJ[a-zA-Z0-9_-]+/,
+		// GitLab PAT
+		/glpat-[a-zA-Z0-9_-]{20,}/,
+		// Google API key
+		/AIza[a-zA-Z0-9_-]{35}/,
+		// OpenAI / Anthropic API key prefix patterns
+		/sk-[a-zA-Z0-9]{20,}/, // OpenAI old format catches Anthropic-style too
 	];
 	for (const re of secretPatterns) {
 		if (re.test(content)) {

--- a/.claude/hooks/dependency-audit.mjs
+++ b/.claude/hooks/dependency-audit.mjs
@@ -5,21 +5,22 @@
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import {
 	appendLog,
+	configDir,
 	incidentLine,
 	isoTimestamp,
 	logPath,
 	projectRoot,
 	timestamp,
-} from "../../lib/hooks/util.js";
+} from "./_util.mjs";
 
 const root = projectRoot();
-const cacheDir = join(homedir(), ".config", "badi");
-const cacheFile = join(cacheDir, "dep-audit-cache.json");
-mkdirSync(cacheDir, { recursive: true });
+// XDG_CONFIG_HOME-aware (bulgu #10).
+const cacheDirPath = configDir("badi");
+const cacheFile = join(cacheDirPath, "dep-audit-cache.json");
+mkdirSync(cacheDirPath, { recursive: true });
 
 // Paket yoneticisi tespit
 let manager = "";

--- a/.claude/hooks/guard-bash.mjs
+++ b/.claude/hooks/guard-bash.mjs
@@ -9,7 +9,7 @@ import {
 	projectRoot,
 	readStdinJson,
 	writeDecision,
-} from "../../lib/hooks/util.js";
+} from "./_util.mjs";
 
 const input = await readStdinJson();
 const command = input.tool_input?.command || "";

--- a/.claude/hooks/log-changes.mjs
+++ b/.claude/hooks/log-changes.mjs
@@ -9,7 +9,7 @@ import {
 	projectRoot,
 	readStdinJson,
 	timestamp,
-} from "../../lib/hooks/util.js";
+} from "./_util.mjs";
 
 const input = await readStdinJson();
 const tool = input.tool_name || "unknown";

--- a/.claude/hooks/log-failures.mjs
+++ b/.claude/hooks/log-failures.mjs
@@ -8,7 +8,7 @@ import {
 	readStdinJson,
 	shorten,
 	timestamp,
-} from "../../lib/hooks/util.js";
+} from "./_util.mjs";
 
 const input = await readStdinJson();
 const tool = input.tool_name || "unknown";

--- a/.claude/hooks/log-stop-verdict.mjs
+++ b/.claude/hooks/log-stop-verdict.mjs
@@ -17,7 +17,7 @@ import {
 	readStdinJson,
 	shorten,
 	timestamp,
-} from "../../lib/hooks/util.js";
+} from "./_util.mjs";
 
 const input = await readStdinJson();
 const ts = timestamp();

--- a/.claude/hooks/post-compact-resume.mjs
+++ b/.claude/hooks/post-compact-resume.mjs
@@ -4,7 +4,7 @@
 
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { projectRoot } from "../../lib/hooks/util.js";
+import { projectRoot } from "./_util.mjs";
 
 const root = projectRoot();
 const marker = join(root, ".claude", ".compaction-occurred");

--- a/.claude/hooks/pre-compact-handoff.mjs
+++ b/.claude/hooks/pre-compact-handoff.mjs
@@ -10,7 +10,7 @@ import {
 	logPath,
 	projectRoot,
 	timestamp,
-} from "../../lib/hooks/util.js";
+} from "./_util.mjs";
 
 const root = projectRoot();
 const claudeDir = join(root, ".claude");

--- a/.claude/hooks/session-reset.mjs
+++ b/.claude/hooks/session-reset.mjs
@@ -17,7 +17,7 @@ import {
 	logPath,
 	projectRoot,
 	truncateLog,
-} from "../../lib/hooks/util.js";
+} from "./_util.mjs";
 
 const root = projectRoot();
 const logDir = join(root, ".claude", "logs");

--- a/.claude/hooks/skill-router.mjs
+++ b/.claude/hooks/skill-router.mjs
@@ -16,7 +16,7 @@ import {
 	projectRoot,
 	readStdinJson,
 	writeContextInjection,
-} from "../../lib/hooks/util.js";
+} from "./_util.mjs";
 
 const input = await readStdinJson();
 const prompt = input.prompt || "";

--- a/.claude/hooks/track-usage.mjs
+++ b/.claude/hooks/track-usage.mjs
@@ -2,12 +2,7 @@
 // Badi - Kullanim Takip Hook'u (PostToolUse - Async)
 // Her arac kullanimini usage.jsonl'e kaydeder. Cross-platform Node.js.
 
-import {
-	appendLog,
-	isoTimestamp,
-	logPath,
-	readStdinJson,
-} from "../../lib/hooks/util.js";
+import { appendLog, isoTimestamp, logPath, readStdinJson } from "./_util.mjs";
 
 const input = await readStdinJson();
 const tool = input.tool_name || "unknown";

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -90,7 +90,7 @@
 					{
 						"type": "command",
 						"command": "node .claude/hooks/dependency-audit.mjs",
-						"timeout": 15000
+						"timeout": 30000
 					}
 				]
 			},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Fixed — Windows ESM URL scheme + chmod assertion (#126 phase 3)
+
+Phase 2 sonrasi kalan iki Windows test failure kategorisi temizlendi:
+
+**ESM URL scheme**: `tests/harness.test.js` icindeki iki dynamic import
+Windows absolute path (`D:\...`) ile cagriliyordu. Node 22 ESM loader
+reddediyordu (`Received protocol 'd:'`). `pathToFileURL` ile `file://`
+URL'e cevrildi.
+
+**chmod assertion**: Eski test `install hook'lari +x yapar` chmod mode
+bit'lerini kontrol ediyordu (Windows'ta no-op). Phase 2'de hook'lar
+.mjs olduktan sonra +x bit zaten gerekmiyordu; test sadece dosya
+varligini kontrol etmeye guncellendi (`statSync` import'u temizlendi).
+
+### Added — Windows kurulum bolumu (README) (#126 phase 4)
+
+README.md ve README.tr.md'ye yeni "Windows install" bolumu eklendi:
+- `npm install -g @fatihkan/badi` + `badi init --harness claude`
+- `chcp 65001` ipucu (Turkce karakter destegi)
+- WSL otomatik tespit notu
+
 ### Changed — Bash hooks ported to Node.js (#126 phase 2)
 
 Tum 13 hook script'i `.sh` -> `.mjs` cevrildi. Bash artik gerekli degil;

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,27 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+### Duzeltildi — Windows ESM URL scheme + chmod assertion (#126 phase 3)
+
+Phase 2 sonrasi kalan iki Windows test failure kategorisi temizlendi:
+
+**ESM URL scheme**: `tests/harness.test.js` icindeki iki dynamic import
+Windows absolute path (`D:\...`) ile cagriliyordu. Node 22 ESM loader
+reddediyor (`Received protocol 'd:'`). `pathToFileURL` ile `file://`
+URL'e cevrildi.
+
+**chmod assertion**: Eski test `install hook'lari +x yapar` chmod mode
+bit'lerini kontrol ediyordu (Windows'ta no-op). Phase 2'de hook'lar
+.mjs olduktan sonra +x bit zaten gerekmiyordu; test sadece dosya
+varligini kontrol etmeye guncellendi (`statSync` import'u temizlendi).
+
+### Eklendi — Windows kurulum bolumu (README) (#126 phase 4)
+
+README.md ve README.tr.md'ye yeni "Windows install" bolumu eklendi:
+- `npm install -g @fatihkan/badi` + `badi init --harness claude`
+- `chcp 65001` ipucu (Turkce karakter destegi)
+- WSL otomatik tespit notu
+
 ### Degistirildi — Bash hook'lari Node.js'e cevrildi (#126 phase 2)
 
 Tum 13 hook script'i `.sh` -> `.mjs` cevrildi. Bash artik gerekli degil;

--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ npx @fatihkan/badi init --harness all      # write files for every supported har
 
 > The plugin path ships agents, slash commands, and skills via `/plugin install`. The npm path adds hooks, the multi-harness compiler (Cursor / Gemini CLI), and the full `badi` CLI toolchain.
 
+### Windows install (v1.23+)
+
+Badi runs on Windows out of the box: hooks are pure Node.js (no bash required), the scheduler uses Windows Task Scheduler, and `badi doctor` reports OS-aware status.
+
+```powershell
+# PowerShell or cmd
+npm install -g @fatihkan/badi
+badi init --harness claude
+badi doctor                    # OS / Bash / Sched / UTF-8 status
+```
+
+For Turkish/UTF-8 output in cmd, run `chcp 65001` once or use Windows Terminal / PowerShell 7+. WSL users can install normally — Linux path is auto-detected.
+
 ### Supported harnesses (v1.12+)
 
 | Harness | Rules | Commands | MCP | Subagents | Hooks | Skills |

--- a/README.tr.md
+++ b/README.tr.md
@@ -42,6 +42,19 @@ npx @fatihkan/badi init --harness all      # tum desteklenen harness'lar
 
 > Plugin yolu ajanlari, slash komutlari ve skill'leri `/plugin install` ile dagitir. npm yolu hook'lar, multi-harness derleyici (Cursor / Gemini CLI) ve tam `badi` CLI takim aletini ekler.
 
+### Windows kurulumu (v1.23+)
+
+Badi Windows'ta kutudan cikar cikmaz calisir: hook'lar saf Node.js (bash gerekmiyor), scheduler Windows Task Scheduler kullanir, `badi doctor` OS-bilinen durum raporlar.
+
+```powershell
+# PowerShell veya cmd
+npm install -g @fatihkan/badi
+badi init --harness claude
+badi doctor                    # OS / Bash / Sched / UTF-8 durumu
+```
+
+cmd'de Turkce/UTF-8 cikti icin bir defa `chcp 65001` calistir veya Windows Terminal / PowerShell 7+ kullan. WSL kullanicilari normal sekilde kurabilir — Linux yolu otomatik tespit edilir.
+
 ### Desteklenen harness'lar (v1.12+)
 
 | Harness | Kurallar | Komutlar | MCP | Subagents | Hooks | Skills |

--- a/lib/harnesses/cursor.js
+++ b/lib/harnesses/cursor.js
@@ -62,9 +62,8 @@ function countSourceSkills(src) {
 function countSourceHooks(src) {
 	const dir = join(src, "hooks");
 	if (!existsSync(dir)) return 0;
-	return readdirSync(dir).filter(
-		(f) => f.endsWith(".mjs") || f.endsWith(".sh"),
-	).length;
+	return readdirSync(dir).filter((f) => f.endsWith(".mjs") || f.endsWith(".sh"))
+		.length;
 }
 
 /**

--- a/lib/harnesses/gemini.js
+++ b/lib/harnesses/gemini.js
@@ -32,9 +32,8 @@ function countSourceCommands(src) {
 function countSourceHooks(src) {
 	const dir = join(src, "hooks");
 	if (!existsSync(dir)) return 0;
-	return readdirSync(dir).filter(
-		(f) => f.endsWith(".mjs") || f.endsWith(".sh"),
-	).length;
+	return readdirSync(dir).filter((f) => f.endsWith(".mjs") || f.endsWith(".sh"))
+		.length;
 }
 
 function countSourceSkills(src) {

--- a/tests/harness.test.js
+++ b/tests/harness.test.js
@@ -7,13 +7,12 @@ import {
 	readdirSync,
 	readFileSync,
 	rmSync,
-	statSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { after, before, describe, it } from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { parseMenuAnswer } from "../lib/commands/init.js";
 import claudeAdapter from "../lib/harnesses/claude.js";
 import cursorAdapter, { transformCommand } from "../lib/harnesses/cursor.js";
@@ -514,6 +513,12 @@ describe("parseMenuAnswer (offline)", () => {
 });
 
 describe("preferences env var isolation", () => {
+	// Windows ESM loader absolute path'leri kabul etmez ('Received protocol d:').
+	// pathToFileURL ile file:// URL'e cevir.
+	const PREFS_URL = pathToFileURL(
+		resolve(__dirname, "..", "lib", "preferences.js"),
+	).href;
+
 	it("BADI_PREFS_HOME tests icin home dizinini override eder", async () => {
 		const tmp = mkTmp();
 		try {
@@ -524,7 +529,7 @@ describe("preferences env var isolation", () => {
 				[
 					"-e",
 					`(async () => {
-						const m = await import("${resolve(__dirname, "..", "lib", "preferences.js")}");
+						const m = await import("${PREFS_URL}");
 						m.setPreference("defaultHarness", "cursor");
 						console.log(m.getPreference("defaultHarness"));
 						console.log(m.PREFS_PATH);
@@ -556,7 +561,7 @@ describe("preferences env var isolation", () => {
 					[
 						"-e",
 						`(async () => {
-							const m = await import("${resolve(__dirname, "..", "lib", "preferences.js")}");
+							const m = await import("${PREFS_URL}");
 							m.setPreference("defaultHarness", "bogus");
 						})();`,
 					],


### PR DESCRIPTION
## Ozet
PR #129 (phase 2) merge edildikten sonra acilan devam PR'i. Iki commit:

1. **Phase 3+4** (50574e7 cherry-pick): ESM URL scheme (pathToFileURL) + chmod assertion temizligi + README Windows kurulum bolumu
2. **/review bulgu fixleri** (2e14d95 cherry-pick): 1 kritik + 2 yuksek + 3 orta + 3 dusuk

## Kritik fix
**Hook'lar user install'da ERR_MODULE_NOT_FOUND patliyordu.** `lib/hooks/util.js` -> `.claude/hooks/_util.mjs` olarak tasindi. Tum 13 hook artik `./_util.mjs` import ediyor — paket disindaki kullaniciya da ulasiyor (dogrulanmis: /tmp simulasyonu EXIT=0).

## Yuksek fixler
- `commandAvailable` shell built-in `command -v` yerine pure PATH probe (Linux'ta executable degildi, phase 1'deki PR #128 fix'i geri donmustu)
- `projectRoot` module-level memoize (her hook'ta tek git spawn)

## Orta fixler
- `truncateLog` atomic (tmp + renameSync, crash-safe)
- `lineCount` CRLF/no-trailing-newline off-by-one fix
- `dependency-audit` timeout 15s -> 30s (npm audit cold cache margin)

## Dusuk fixler
- `branch-guard` `-f` kisa flag eklendi (--force ile birlikte)
- `completeness-gate` modern token patterns: `rk_`, `ghu_`, `ghs_`, `ghr_`, `glpat-`, `AIza`, `sk-`
- `configDir(app)` XDG_CONFIG_HOME-aware

## Test
- [x] 642/642 yesil
- [x] biome 0 issue
- [x] User-install simulasyonu: hook EXIT=0 (onceden EXIT=1)

Closes #126 phase 3+4

🤖 Generated with [Claude Code](https://claude.com/claude-code)