### PR TITLE
chore(release): v1.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-## [1.23.0] - 2026-05-11
+## [1.22.1] - 2026-05-11
 
 ### Fixed — Windows ESM URL scheme + chmod assertion (#126 phase 3)
 

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,7 +6,7 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
-## [1.23.0] - 2026-05-11
+## [1.22.1] - 2026-05-11
 
 ### Duzeltildi — Windows ESM URL scheme + chmod assertion (#126 phase 3)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fatihkan/badi",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "Workflow management CLI for Claude Code, Cursor, and Gemini CLI — 21 AI agents, 77 commands, OWASP security scans. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
   "type": "module",
   "main": "bin/badi.js",


### PR DESCRIPTION
## Summary
- npm'de `@fatihkan/badi@1.22.1` olarak yayınlandı (publish komutu flagsiz default `patch` ile çalıştı)
- CHANGELOG başlığı `[1.23.0]` → `[1.22.1]` olarak hizalandı
- package.json version bump `1.22.0 → 1.22.1`
- İçerik aynı: #126 phase 2/3/4 (Node.js hooks, Windows ESM URL, chmod assertion, README)

## Test plan
- [ ] Merge sonrası `git tag v1.22.1` + push + `gh release create`
- [ ] memory.md `v1.22.0` → `v1.22.1` güncelle