### PR TITLE
chore(biome): schema 2.4.15 + branch-guard testi izolasyonu

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/tests/cli.hooks-node.test.js
+++ b/tests/cli.hooks-node.test.js
@@ -107,18 +107,31 @@ describe("hooks-node: log-changes", () => {
 });
 
 describe("hooks-node: branch-guard", () => {
+	let dir;
+	beforeEach(() => {
+		dir = setupTempProject();
+		spawnSync("git", ["init", "-b", "feature/test"], { cwd: dir });
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
 	it("feature branch icin pas (bos cikti)", () => {
-		const r = runHook("branch-guard", {
-			tool_input: { command: "git commit -m 'x'" },
-		});
+		const r = runHook(
+			"branch-guard",
+			{ tool_input: { command: "git commit -m 'x'" } },
+			{ cwd: dir },
+		);
 		assert.equal(r.status, 0);
 		assert.equal(r.stdout.trim(), "");
 	});
 
 	it("commit olmayan komut atlar", () => {
-		const r = runHook("branch-guard", {
-			tool_input: { command: "ls" },
-		});
+		const r = runHook(
+			"branch-guard",
+			{ tool_input: { command: "ls" } },
+			{ cwd: dir },
+		);
 		assert.equal(r.status, 0);
 		assert.equal(r.stdout.trim(), "");
 	});


### PR DESCRIPTION
## Summary
- Biome 2.4.15 sonrası `biome.json` `\$schema` URL'i hala 2.4.14'ü referans alıyordu — `info` uyarısını sustur
- `tests/cli.hooks-node.test.js::branch-guard` ana repo cwd'sinde çalışıyordu → main branch → hook block → test fail
- Test setupTempProject + `git init -b feature/test` ile izole edildi

## Test plan
- [x] `npm test`: 642/642 yeşil (önceden 641/642 — branch-guard testi cwd'ye bağımlı)
- [x] `npm run lint`: 0 issue (info dahil)
- [x] `biome check --diagnostic-level=info`: temiz