### PR TITLE
test(frontmatter,tasarim): #137 P1 - parseFrontmatter + tasarim lint smoke

### DIFF
--- a/tests/cli.tasarim-lint.test.js
+++ b/tests/cli.tasarim-lint.test.js
@@ -1,0 +1,66 @@
+// `badi tasarim lint` smoke testleri (#137).
+// Asil davranis (npx @google/design.md) external bagimliyla, test
+// sadece wrapper'in error path'lerini kapsiyor.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const REPO_ROOT = resolve(__dirname, "..");
+const BADI = join(REPO_ROOT, "bin", "badi.js");
+
+function runBadi(args, opts = {}) {
+	return spawnSync("node", [BADI, ...args], {
+		encoding: "utf-8",
+		timeout: 10000,
+		cwd: opts.cwd || REPO_ROOT,
+		env: { ...process.env, ...(opts.env || {}) },
+	});
+}
+
+describe("badi tasarim lint: DESIGN.md yok ise", () => {
+	let dir;
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "badi-tasarim-test-"));
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("exit 1 dondurur + stderr 'DESIGN.md yok' icerir", () => {
+		const r = runBadi(["tasarim", "lint"], { cwd: dir });
+		assert.equal(r.status, 1, `expected exit 1, got ${r.status}`);
+		assert.match(r.stderr, /DESIGN\.md yok/);
+		assert.match(r.stdout, /badi tasarim init/);
+	});
+
+	it("--out flag custom path icin de error path tetikler", () => {
+		const r = runBadi(["tasarim", "lint", "--out", "missing/path.md"], {
+			cwd: dir,
+		});
+		assert.equal(r.status, 1);
+		assert.match(r.stderr, /DESIGN\.md yok/);
+		assert.match(r.stderr, /missing\/path\.md/);
+	});
+});
+
+describe("badi tasarim: yardim akisi", () => {
+	it("--help help mesaji gosterir", () => {
+		const r = runBadi(["tasarim", "--help"]);
+		assert.equal(r.status, 0);
+		assert.match(r.stdout, /tasarim/);
+		assert.match(r.stdout, /lint/);
+		assert.match(r.stdout, /export/);
+	});
+
+	it("bilinmeyen alt-komut yardim doner", () => {
+		const r = runBadi(["tasarim", "bogus-subcommand"]);
+		// parseFlags + showHelp yolundan ya hata ya help; en azindan crash etmemeli
+		assert.notEqual(r.status, null);
+	});
+});

--- a/tests/frontmatter.test.js
+++ b/tests/frontmatter.test.js
@@ -1,0 +1,141 @@
+// lib/frontmatter.js parseFrontmatter unit testleri (#137).
+// badi-skills CI workflow'u bu dosyayi ana repo'dan curl ile cektigi icin
+// regression koruma kritik. Aksi halde sessizce kirik schema validate olur.
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseFrontmatter } from "../lib/frontmatter.js";
+
+describe("parseFrontmatter: tipik kullanim", () => {
+	it("frontmatter + body ayrimi", () => {
+		const input = `---
+name: example
+version: 1.0
+---
+
+# Body
+
+Some content.`;
+		const { meta, body } = parseFrontmatter(input);
+		assert.equal(meta.name, "example");
+		assert.equal(meta.version, "1.0");
+		assert.match(body, /^# Body/);
+		assert.match(body, /Some content\./);
+	});
+
+	it("frontmatter olmadan tum icerigi body dondurur", () => {
+		const input = "# Just a heading\n\nNo frontmatter here.";
+		const { meta, body } = parseFrontmatter(input);
+		assert.deepEqual(meta, {});
+		assert.equal(body, input);
+	});
+
+	it("bos frontmatter", () => {
+		const input = `---
+---
+
+Body only.`;
+		const { meta, body } = parseFrontmatter(input);
+		assert.deepEqual(meta, {});
+		assert.equal(body, "Body only.");
+	});
+
+	it("kapatilmamis frontmatter tum icerigi body sayar", () => {
+		// Acilmis ama --- ile kapatilmamis: orijinal icerik aynen donmeli
+		const input = `---
+name: broken
+
+# This should be treated as raw content
+`;
+		const { meta, body } = parseFrontmatter(input);
+		assert.deepEqual(meta, {});
+		assert.equal(body, input);
+	});
+});
+
+describe("parseFrontmatter: bicim toleransi", () => {
+	it("CRLF satir sonu (Windows core.autocrlf)", () => {
+		const input = "---\r\nname: win\r\nversion: 2\r\n---\r\n\r\nBody.\r\n";
+		const { meta, body } = parseFrontmatter(input);
+		assert.equal(meta.name, "win");
+		assert.equal(meta.version, "2");
+		assert.match(body, /Body\./);
+	});
+
+	it("anahtar/deger etrafindaki bosluklari trim eder", () => {
+		const input = `---
+name:    spaced value
+description:   another one
+---
+body`;
+		const { meta } = parseFrontmatter(input);
+		assert.equal(meta.name, "spaced value");
+		assert.equal(meta.description, "another one");
+	});
+
+	it("colon olmadan satirlari atlar", () => {
+		const input = `---
+name: ok
+just-a-flag
+description: also ok
+---
+body`;
+		const { meta } = parseFrontmatter(input);
+		assert.equal(meta.name, "ok");
+		assert.equal(meta.description, "also ok");
+		assert.equal(meta["just-a-flag"], undefined);
+	});
+
+	it("URL gibi degerlerde ilk ': ' ayraci kullanilir", () => {
+		// "https://example.com" iki nokta iceriyor ama ': ' (colon+space) sadece
+		// anahtarin sonunda var. Parser bunu dogru ayirmali.
+		const input = `---
+homepage: https://example.com/path
+ratio: 16:9
+---
+body`;
+		const { meta } = parseFrontmatter(input);
+		assert.equal(meta.homepage, "https://example.com/path");
+		// "ratio: 16:9" - ilk ': ' ratio'dan sonra
+		assert.equal(meta.ratio, "16:9");
+	});
+});
+
+describe("parseFrontmatter: edge case'ler", () => {
+	it("frontmatter sonrasi cift newline'i body trim eder", () => {
+		const input = `---
+name: x
+---
+
+
+body with leading newlines`;
+		const { body } = parseFrontmatter(input);
+		assert.equal(body, "body with leading newlines");
+	});
+
+	it("bos string", () => {
+		const { meta, body } = parseFrontmatter("");
+		assert.deepEqual(meta, {});
+		assert.equal(body, "");
+	});
+
+	it("sadece frontmatter, body yok", () => {
+		const input = `---
+name: standalone
+---`;
+		const { meta, body } = parseFrontmatter(input);
+		assert.equal(meta.name, "standalone");
+		assert.equal(body, "");
+	});
+
+	it("ilk satir --- degil ise frontmatter yok", () => {
+		const input = `# Heading
+---
+name: nope
+---
+body`;
+		const { meta, body } = parseFrontmatter(input);
+		assert.deepEqual(meta, {});
+		assert.equal(body, input);
+	});
+});


### PR DESCRIPTION
## Summary
Issue #137 (P1) implementasyonu — `lib/frontmatter.js::parseFrontmatter` ve `badi tasarim lint` için regression koruma eksiği kapatıldı.

### `tests/frontmatter.test.js` (12 test)
- **Tipik kullanım:** frontmatter+body, sadece body, boş frontmatter, kapatılmamış
- **Biçim toleransı:** CRLF (Windows `core.autocrlf`), boşluk trim, colon'suz satır, URL/ratio değerler
- **Edge case'ler:** çift newline body, boş string, sadece frontmatter, ilk satır non-`---`

### `tests/cli.tasarim-lint.test.js` (4 test)
- DESIGN.md yok → exit 1 + stderr `"DESIGN.md yok"`
- `--out` missing path da error path tetikler
- `--help` mesajı
- Bilinmeyen alt-komut crash etmez

### Notlar
- `lib/frontmatter.js` artık `badi-skills` CI workflow'unun (curl ile çeker) tükettiği canonical kaynak — sessiz schema drift'e karşı koruma altında
- `subLint` wrapper'ın error path'leri subprocess test edildi; asıl `npx @google/design.md` davranışı external bağımlı olduğu için dış tutuldu, refactor sonrası #138'de ele alınacak

## Test plan
- [x] `npm test`: 642 → 658 (+16)
- [x] `npm run lint`: 0 issue

Closes #137