### PR TITLE
refactor(tasarim): #138 P2 - subLint sadelestir + subExport --write guard

### DIFF
--- a/lib/commands/tasarim.js
+++ b/lib/commands/tasarim.js
@@ -262,6 +262,22 @@ Iskelet baslangici icin: badi tasarim init --force
 	console.log(chalk.dim("  Sonraki: badi tasarim lint"));
 }
 
+/**
+ * Lint ciktisindan exit code'u belirle. process.exit cagrisi yapmaz —
+ * test edilebilir saf fonksiyon. Donus: 0 (basarili) veya >0 (hata).
+ */
+export function resolveLintExit(stdout, status) {
+	try {
+		const parsed = JSON.parse(stdout || "");
+		const errors = parsed?.summary?.errors ?? 0;
+		if (errors > 0 || status !== 0) return status || 1;
+		return 0;
+	} catch {
+		// JSON disi format: paket exit code'una guven
+		return status !== 0 ? status : 0;
+	}
+}
+
 function subLint(flags) {
 	const target = resolve(process.cwd(), flags.out || DEFAULT_PATH);
 	if (!existsSync(target)) {
@@ -274,18 +290,8 @@ function subLint(flags) {
 	const result = runDesignMd(args, { captureStdout: true });
 	const stdout = result.stdout || "";
 	process.stdout.write(stdout);
-	let parsed;
-	try {
-		parsed = JSON.parse(stdout);
-	} catch {
-		// Eger paket JSON disinda format dondurursa exit code'a guven
-		if (result.status !== 0) process.exit(result.status);
-		return;
-	}
-	const errors = parsed?.summary?.errors ?? 0;
-	if (errors > 0 || result.status !== 0) {
-		process.exit(result.status || 1);
-	}
+	const code = resolveLintExit(stdout, result.status);
+	if (code !== 0) process.exit(code);
 }
 
 function subExport(flags) {
@@ -311,11 +317,25 @@ function subExport(flags) {
 	if (flags.write) {
 		const writePath = resolve(process.cwd(), flags.write);
 		const result = runDesignMd(args, { captureStdout: true });
+		const stdout = result.stdout || "";
+		// Empty-on-error guard: paket hata verdi veya bos cikti uretti ise yazma.
+		// Aksi halde bozuk/eksik dosya disk'e basilir.
+		if (result.status !== 0) {
+			console.error(
+				chalk.red(
+					`Export hata verdi (exit ${result.status}); dosya yazilmadi.`,
+				),
+			);
+			process.exit(result.status);
+		}
+		if (!stdout.trim()) {
+			console.error(chalk.red("Export bos cikti dondurdu; dosya yazilmadi."));
+			process.exit(1);
+		}
 		ensureDir(writePath);
-		writeFileSync(writePath, result.stdout || "");
+		writeFileSync(writePath, stdout);
 		console.log(chalk.green(`+ ${writePath}`));
 		console.log(chalk.dim(`  Format: ${flags.format}`));
-		if (result.status !== 0) process.exit(result.status);
 		return;
 	}
 	runDesignMd(args);

--- a/tests/cli.tasarim-lint.test.js
+++ b/tests/cli.tasarim-lint.test.js
@@ -4,11 +4,12 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
+import { resolveLintExit } from "../lib/commands/tasarim.js";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 const REPO_ROOT = resolve(__dirname, "..");
@@ -62,5 +63,72 @@ describe("badi tasarim: yardim akisi", () => {
 		const r = runBadi(["tasarim", "bogus-subcommand"]);
 		// parseFlags + showHelp yolundan ya hata ya help; en azindan crash etmemeli
 		assert.notEqual(r.status, null);
+	});
+});
+
+describe("resolveLintExit: saf exit code mantigi (#138)", () => {
+	it("errors=0 + status=0 -> 0", () => {
+		const stdout = JSON.stringify({ summary: { errors: 0, warnings: 2 } });
+		assert.equal(resolveLintExit(stdout, 0), 0);
+	});
+
+	it("errors>0 + status=0 -> 1", () => {
+		const stdout = JSON.stringify({ summary: { errors: 3 } });
+		assert.equal(resolveLintExit(stdout, 0), 1);
+	});
+
+	it("errors=0 + status!=0 -> status korunur", () => {
+		const stdout = JSON.stringify({ summary: { errors: 0 } });
+		assert.equal(resolveLintExit(stdout, 2), 2);
+	});
+
+	it("errors>0 + status!=0 -> status korunur (paket exit'e oncelik)", () => {
+		const stdout = JSON.stringify({ summary: { errors: 1 } });
+		assert.equal(resolveLintExit(stdout, 5), 5);
+	});
+
+	it("JSON disi cikti + status=0 -> 0", () => {
+		assert.equal(resolveLintExit("plain text", 0), 0);
+	});
+
+	it("JSON disi cikti + status!=0 -> status korunur", () => {
+		assert.equal(resolveLintExit("paket hatasi", 7), 7);
+	});
+
+	it("bos string + status=0 -> 0", () => {
+		assert.equal(resolveLintExit("", 0), 0);
+	});
+
+	it("summary alani eksik -> errors=0 sayilir", () => {
+		assert.equal(resolveLintExit(JSON.stringify({ other: "data" }), 0), 0);
+	});
+});
+
+describe("badi tasarim export --write: empty-on-error guard (#138)", () => {
+	let dir;
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "badi-export-test-"));
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("DESIGN.md yok ise --write dosya yazmaz, exit 1", () => {
+		const target = join(dir, "out.css");
+		const r = runBadi(
+			["tasarim", "export", "--format", "tailwind", "--write", target],
+			{ cwd: dir },
+		);
+		assert.equal(r.status, 1);
+		assert.equal(existsSync(target), false, "Hata durumunda dosya yazilmamali");
+		assert.match(r.stderr, /DESIGN\.md yok/);
+	});
+
+	it("--format eksik ise --write dosya yazmaz, exit 1", () => {
+		const target = join(dir, "out.css");
+		const r = runBadi(["tasarim", "export", "--write", target], { cwd: dir });
+		assert.equal(r.status, 1);
+		assert.equal(existsSync(target), false);
+		assert.match(r.stderr, /--format/);
 	});
 });


### PR DESCRIPTION
## Summary
Issue #138 (P2) implementasyonu.

### `subLint` refactor (`lib/commands/tasarim.js`)
İki kademe `JSON.parse` + `process.exit` dalları yerine saf bir `resolveLintExit(stdout, status) -> code` fonksiyonu çıkarıldı. Davranış aynen korundu, `process.exit` tek noktada çağrılır.

**Davranış tablosu (test edildi):**
- `errors=0, status=0` → `0`
- `errors>0, status=0` → `1`
- `errors=0, status!=0` → `status` korunur
- `errors>0, status!=0` → `status` korunur (paket exit'e öncelik)
- JSON dışı çıktı + `status=0` → `0`
- JSON dışı çıktı + `status!=0` → `status` korunur

### `subExport --write` guard
**Önceden:** paket non-zero status verse veya boş stdout döndürse bile `writeFileSync` çalıştırılıp dosyaya yarı/eksik içerik basılıyordu. Kullanıcı exit code uyarısını kaçırırsa bozuk dosya zannedebilirdi.

**Şimdi:**
- `status != 0` → stderr `"Export hata verdi"`, dosya YAZILMAZ, exit code propagated
- stdout boş → stderr `"Export boş çıktı"`, dosya YAZILMAZ, exit 1
- ikisi de OK → `writeFileSync` + yeşil `+ path` mesajı

### Test
+10 test (`tests/cli.tasarim-lint.test.js`):
- `resolveLintExit`: 8 davranış matrisi (saf fonksiyon, hızlı)
- `subExport --write` empty-on-error guard: 2 subprocess testi

## Test plan
- [x] `npm test`: 658 → 668 (+10)
- [x] `npm run lint`: 0 issue

Closes #138