### PR TITLE
feat(gh): badi gh sync MVP - issue -> TaskBoard (#11)

### DIFF
--- a/.claude/workspace/TaskBoard.md
+++ b/.claude/workspace/TaskBoard.md
@@ -4,10 +4,19 @@
 - [ ] (henuz gorev yok)
 
 ## Bu Hafta
-- [ ] (henuz gorev yok)
+
+- [ ] #33 (P2) Awesome Claude Code listesine basvuru
 
 ## Bekleyen Isler
-- [ ] (henuz gorev yok)
+
+- [ ] #52 (P3) feat(mobile): badi mobile crash + analytics - monitoring
+- [ ] #15 (P4) feat(ai): proaktif akilli asistan - badi ai
+- [ ] #14 (P4) feat(integration): ekip isbirligi - badi team
+- [ ] #13 (P4) feat(cli): sesli giris/cikti - badi voice
+- [ ] #12 (P3) feat(ui): bilgi grafigi - badi kb graph
+- [ ] #11 (P3) feat(integration): GitHub derin entegrasyon - badi gh
+- [ ] #10 (P3) feat(plugin): plugin marketplace - kesif ve kurulum
+- [ ] #9 (P3) feat(ui): badi serve - lokal web dashboard
 
 ## Tamamlanan
 - (henuz yok)

--- a/bin/badi.js
+++ b/bin/badi.js
@@ -93,6 +93,9 @@ function showHelp() {
 	console.log(
 		`  ${chalk.cyan("changelog")} Commit gecmisinden CHANGELOG.md uretimi`,
 	);
+	console.log(
+		`  ${chalk.cyan("gh")}        GitHub derin entegrasyon (sync issue -> TaskBoard) — v1.23+`,
+	);
 	console.log("");
 	console.log(chalk.bold("AI/LLM + DevOps:"));
 	console.log(
@@ -289,6 +292,7 @@ const commands = {
 	statusline: () =>
 		import("../lib/commands/statusline.js").then((m) => m.runStatusline),
 	mcp: () => import("../lib/commands/mcp.js").then((m) => m.runMcp),
+	gh: () => import("../lib/commands/gh.js").then((m) => m.runGh),
 };
 
 // ─── Ana Giris Noktasi ───

--- a/lib/commands/gh.js
+++ b/lib/commands/gh.js
@@ -1,0 +1,310 @@
+// `badi gh` — GitHub derin entegrasyon komut ailesi (#11 MVP).
+//
+// MVP scope: 'badi gh sync' — acik issue'lari .claude/workspace/TaskBoard.md
+// dosyasina priority label'lara gore kategorize ederek senkronize eder.
+//
+// Kategorizasyon:
+//   - priority:p1-high   -> ## Bugun
+//   - priority:p2-medium -> ## Bu Hafta
+//   - priority:p3-large  -> ## Bekleyen Isler
+//   - priority:p4-future -> ## Bekleyen Isler
+//   - etiket yok         -> ## Bekleyen Isler
+//
+// Idempotent: zaten TaskBoard'da olan issue numaralari tekrar eklenmez.
+// Manuel eklenen "- [ ] (henuz gorev yok)" gibi placeholder'lar issue
+// varsa kaldirilir; manuel gorevler korunur.
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { chalk, showBanner } from "../cli.js";
+
+const SECTIONS = ["Bugun", "Bu Hafta", "Bekleyen Isler", "Tamamlanan"];
+const PRIORITY_TO_SECTION = {
+	"priority:p1-high": "Bugun",
+	"priority:p2-medium": "Bu Hafta",
+	"priority:p3-large": "Bekleyen Isler",
+	"priority:p4-future": "Bekleyen Isler",
+};
+const PRIORITY_SHORT = {
+	"priority:p1-high": "P1",
+	"priority:p2-medium": "P2",
+	"priority:p3-large": "P3",
+	"priority:p4-future": "P4",
+};
+
+function parseFlags(args) {
+	const flags = { dryRun: false, repo: null, state: "open", limit: 100 };
+	for (let i = 0; i < args.length; i++) {
+		const a = args[i];
+		if (a === "--dry-run") flags.dryRun = true;
+		else if (a === "--repo") flags.repo = args[++i];
+		else if (a === "--state") flags.state = args[++i];
+		else if (a === "--limit") flags.limit = Number.parseInt(args[++i], 10);
+	}
+	return flags;
+}
+
+function showHelp() {
+	showBanner();
+	console.log(chalk.bold("Badi GitHub — Derin Entegrasyon"));
+	console.log("");
+	console.log(chalk.bold("Kullanim:"));
+	console.log(
+		`  ${chalk.cyan("badi gh sync")}              Acik issue'lari TaskBoard'a senkronize et`,
+	);
+	console.log("");
+	console.log(chalk.bold("Secenekler:"));
+	console.log("  --dry-run        Diski degistirme, plan goster");
+	console.log("  --repo owner/N   Belirli repo (varsayilan: git remote)");
+	console.log("  --state STATE    open|closed|all (varsayilan: open)");
+	console.log("  --limit N        Max issue sayisi (varsayilan: 100)");
+	console.log("");
+	console.log(chalk.bold("Gereksinimler:"));
+	console.log("  gh CLI kurulu ve authenticated olmali");
+}
+
+/**
+ * Aktif GitHub repo'sunu git remote'undan tahmin eder.
+ * gh CLI --repo flag'i bos birakildiginda kendi default'u var; biz
+ * sadece raporlama icin tahmin ediyoruz.
+ */
+export function detectRepo(cwd) {
+	const result = spawnSync(
+		"git",
+		["-C", cwd || process.cwd(), "remote", "get-url", "origin"],
+		{ encoding: "utf-8" },
+	);
+	if (result.status !== 0) return null;
+	const url = (result.stdout || "").trim();
+	// SSH: git@github.com:owner/repo.git  -> owner/repo
+	// HTTPS: https://github.com/owner/repo(.git)?  -> owner/repo
+	const m =
+		url.match(/github\.com[:/]([^/]+)\/([^/.]+)(?:\.git)?$/) ||
+		url.match(/github\.com[:/]([^/]+)\/(.+?)(?:\.git)?$/);
+	return m ? `${m[1]}/${m[2]}` : null;
+}
+
+/**
+ * Issue listesi -> gh CLI uzerinden cekilir. JSON dondurur.
+ */
+function fetchIssues(flags) {
+	const args = [
+		"issue",
+		"list",
+		"--state",
+		flags.state,
+		"--limit",
+		String(flags.limit),
+		"--json",
+		"number,title,labels,state",
+	];
+	if (flags.repo) args.push("--repo", flags.repo);
+	const result = spawnSync("gh", args, { encoding: "utf-8" });
+	if (result.status !== 0) {
+		throw new Error(
+			`gh CLI hatasi (exit ${result.status}): ${result.stderr || "bilinmeyen hata"}`,
+		);
+	}
+	try {
+		return JSON.parse(result.stdout || "[]");
+	} catch (e) {
+		throw new Error(`gh JSON parse hatasi: ${e.message}`);
+	}
+}
+
+/**
+ * Bir issue icin TaskBoard satirini olusturur:
+ *   - [ ] #11 (P3) feat(integration): GitHub derin entegrasyon — github
+ *
+ * Etiket yoksa "P?" yerine bos string, bolum default Bekleyen Isler.
+ */
+export function formatIssueLine(issue) {
+	const labelNames = (issue.labels || []).map((l) => l.name);
+	const priority = labelNames.find((n) => PRIORITY_TO_SECTION[n]);
+	const tag = priority ? `(${PRIORITY_SHORT[priority]}) ` : "";
+	return `- [ ] #${issue.number} ${tag}${issue.title}`;
+}
+
+/**
+ * Issue'yu hangi bolume yazacagimizi belirler. Etiket yoksa
+ * 'Bekleyen Isler' default'una dusen.
+ */
+export function sectionForIssue(issue) {
+	const labelNames = (issue.labels || []).map((l) => l.name);
+	for (const label of labelNames) {
+		if (PRIORITY_TO_SECTION[label]) return PRIORITY_TO_SECTION[label];
+	}
+	return "Bekleyen Isler";
+}
+
+/**
+ * TaskBoard.md'yi bolumlere ayirir. Donus:
+ *   { sections: { 'Bugun': ['- [ ] ...', ...], ... }, order: [...] }
+ *
+ * 'order' baslik sirasini korur (rewrite icin onemli).
+ */
+export function parseTaskBoard(content) {
+	const lines = content.replace(/\r\n/g, "\n").split("\n");
+	const sections = {};
+	const order = [];
+	let header = null;
+	let current = [];
+	const flush = () => {
+		if (header !== null) {
+			sections[header] = current;
+			order.push(header);
+		}
+	};
+	for (const line of lines) {
+		const m = line.match(/^## (.+)$/);
+		if (m) {
+			flush();
+			header = m[1].trim();
+			current = [];
+			continue;
+		}
+		if (header === null) continue; // intro/title lines disrarda kalir
+		current.push(line);
+	}
+	flush();
+	return { sections, order };
+}
+
+/**
+ * Issue'lari TaskBoard.md icerigine merge eder. Idempotent:
+ * mevcut '#N' iceren satirlara dokunmaz, yenileri ekler.
+ *
+ * Donus: { newContent, added: [{number, section}], skipped: [...] }
+ */
+export function mergeIssuesIntoTaskBoard(content, issues) {
+	const { sections, order } = parseTaskBoard(content);
+	for (const s of SECTIONS) {
+		if (!sections[s]) {
+			sections[s] = [];
+			if (!order.includes(s)) order.push(s);
+		}
+	}
+
+	const existingIssueNums = new Set();
+	for (const lines of Object.values(sections)) {
+		for (const line of lines) {
+			const m = line.match(/#(\d+)\b/);
+			if (m) existingIssueNums.add(Number.parseInt(m[1], 10));
+		}
+	}
+
+	const added = [];
+	const skipped = [];
+	for (const issue of issues) {
+		if (existingIssueNums.has(issue.number)) {
+			skipped.push({ number: issue.number, reason: "zaten mevcut" });
+			continue;
+		}
+		const target = sectionForIssue(issue);
+		const line = formatIssueLine(issue);
+		// Placeholder "(henuz gorev yok)" satirini temizle
+		sections[target] = sections[target].filter(
+			(l) => !/\(henuz gorev yok\)/.test(l),
+		);
+		sections[target].push(line);
+		added.push({ number: issue.number, section: target });
+	}
+
+	// Bos bolumlere placeholder geri koy. Tamamlanan farkli format:
+	// checkbox yerine sade "- (henuz yok)" konvansiyonu kullanir.
+	for (const s of SECTIONS) {
+		const hasItem = sections[s].some((l) => /^\s*-\s+/.test(l));
+		if (!hasItem) {
+			sections[s] =
+				s === "Tamamlanan"
+					? ["- (henuz yok)", ""]
+					: ["- [ ] (henuz gorev yok)", ""];
+		}
+	}
+
+	// Yeniden ins et
+	const out = ["# Gorev Panosu", ""];
+	for (const s of order) {
+		out.push(`## ${s}`);
+		for (const l of sections[s]) {
+			out.push(l);
+		}
+		// Bolum sonu bos satir garantisi
+		if (out[out.length - 1] !== "") out.push("");
+	}
+
+	return { newContent: `${out.join("\n").trimEnd()}\n`, added, skipped };
+}
+
+function subSync(flags) {
+	const cwd = process.cwd();
+	const taskBoardPath = join(cwd, ".claude", "workspace", "TaskBoard.md");
+	if (!existsSync(taskBoardPath)) {
+		console.error(chalk.red(`TaskBoard yok: ${taskBoardPath}`));
+		console.log(chalk.dim("  Once: badi init"));
+		process.exit(1);
+	}
+
+	let issues;
+	try {
+		issues = fetchIssues(flags);
+	} catch (e) {
+		console.error(chalk.red(e.message));
+		process.exit(1);
+	}
+
+	const repo = flags.repo || detectRepo(cwd) || "(yerel git remote)";
+	showBanner();
+	console.log(chalk.bold(`GitHub Issue Senkronizasyonu — ${repo}`));
+	console.log("");
+
+	const content = readFileSync(taskBoardPath, "utf-8");
+	const { newContent, added, skipped } = mergeIssuesIntoTaskBoard(
+		content,
+		issues,
+	);
+
+	if (added.length === 0) {
+		console.log(
+			chalk.dim(`  ${issues.length} issue cekildi, hepsi zaten mevcut.`),
+		);
+		console.log("");
+		console.log(chalk.green("  Hicbir degisiklik gerekmedi."));
+		return;
+	}
+
+	for (const a of added) {
+		console.log(`  ${chalk.green("+")} #${a.number} -> ${a.section}`);
+	}
+	console.log("");
+	console.log(`  Yeni:           ${chalk.bold(added.length)}`);
+	console.log(`  Zaten mevcut:   ${chalk.dim(skipped.length)}`);
+
+	if (flags.dryRun) {
+		console.log("");
+		console.log(chalk.yellow("  [dry-run] TaskBoard.md degistirilmedi."));
+		return;
+	}
+
+	writeFileSync(taskBoardPath, newContent);
+	console.log("");
+	console.log(chalk.green(`  ${taskBoardPath} guncellendi.`));
+}
+
+export async function runGh(args) {
+	const sub = args[0];
+	if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+		showHelp();
+		return;
+	}
+	const flags = parseFlags(args.slice(1));
+	switch (sub) {
+		case "sync":
+			return subSync(flags);
+		default:
+			console.error(chalk.red(`Bilinmeyen alt-komut: ${sub}`));
+			showHelp();
+			process.exit(1);
+	}
+}

--- a/tests/cli.gh.test.js
+++ b/tests/cli.gh.test.js
@@ -1,0 +1,254 @@
+// `badi gh sync` testleri (#11 MVP).
+// Saf fonksiyonlar (formatIssueLine, sectionForIssue, parseTaskBoard,
+// mergeIssuesIntoTaskBoard) birim test edilir; gh CLI external bagimli
+// oldugu icin subprocess testleri sadece help + missing-taskboard yolu.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+	formatIssueLine,
+	mergeIssuesIntoTaskBoard,
+	parseTaskBoard,
+	sectionForIssue,
+} from "../lib/commands/gh.js";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const REPO_ROOT = resolve(__dirname, "..");
+const BADI = join(REPO_ROOT, "bin", "badi.js");
+
+const issue = (number, title, labels = []) => ({
+	number,
+	title,
+	labels: labels.map((name) => ({ name })),
+	state: "OPEN",
+});
+
+describe("formatIssueLine", () => {
+	it("P1 etiketi 'P1' kisalmasi olarak gosterir", () => {
+		const line = formatIssueLine(
+			issue(137, "subLint test", ["priority:p1-high"]),
+		);
+		assert.equal(line, "- [ ] #137 (P1) subLint test");
+	});
+
+	it("etiket yoksa basligi direkt yazar", () => {
+		const line = formatIssueLine(issue(42, "no label", []));
+		assert.equal(line, "- [ ] #42 no label");
+	});
+
+	it("P3 etiketi 'P3' kisalmasi olarak gosterir", () => {
+		const line = formatIssueLine(
+			issue(11, "feat: gh", ["enhancement", "priority:p3-large"]),
+		);
+		assert.equal(line, "- [ ] #11 (P3) feat: gh");
+	});
+});
+
+describe("sectionForIssue", () => {
+	it("p1-high -> Bugun", () => {
+		assert.equal(sectionForIssue(issue(1, "x", ["priority:p1-high"])), "Bugun");
+	});
+	it("p2-medium -> Bu Hafta", () => {
+		assert.equal(
+			sectionForIssue(issue(2, "x", ["priority:p2-medium"])),
+			"Bu Hafta",
+		);
+	});
+	it("p3-large -> Bekleyen Isler", () => {
+		assert.equal(
+			sectionForIssue(issue(3, "x", ["priority:p3-large"])),
+			"Bekleyen Isler",
+		);
+	});
+	it("p4-future -> Bekleyen Isler", () => {
+		assert.equal(
+			sectionForIssue(issue(4, "x", ["priority:p4-future"])),
+			"Bekleyen Isler",
+		);
+	});
+	it("etiket yok -> Bekleyen Isler", () => {
+		assert.equal(sectionForIssue(issue(5, "x", [])), "Bekleyen Isler");
+	});
+	it("birden cok etiket: ilk priority kazanir", () => {
+		assert.equal(
+			sectionForIssue(issue(6, "x", ["bug", "priority:p2-medium", "ui"])),
+			"Bu Hafta",
+		);
+	});
+});
+
+describe("parseTaskBoard", () => {
+	it("4 bolum tanir", () => {
+		const content = `# Gorev Panosu
+
+## Bugun
+- [ ] (henuz gorev yok)
+
+## Bu Hafta
+- [ ] (henuz gorev yok)
+
+## Bekleyen Isler
+- [ ] (henuz gorev yok)
+
+## Tamamlanan
+- (henuz yok)
+`;
+		const { sections, order } = parseTaskBoard(content);
+		assert.deepEqual(order, [
+			"Bugun",
+			"Bu Hafta",
+			"Bekleyen Isler",
+			"Tamamlanan",
+		]);
+		assert.equal(sections.Bugun.length, 2); // satir + bos
+	});
+
+	it("CRLF satir sonu kabul eder", () => {
+		const content = "## Bugun\r\n- [ ] item\r\n\r\n## Bu Hafta\r\n- [ ] x\r\n";
+		const { sections } = parseTaskBoard(content);
+		assert.ok(sections.Bugun.some((l) => l.includes("item")));
+		assert.ok(sections["Bu Hafta"].some((l) => l.includes("x")));
+	});
+});
+
+describe("mergeIssuesIntoTaskBoard", () => {
+	const emptyBoard = `# Gorev Panosu
+
+## Bugun
+- [ ] (henuz gorev yok)
+
+## Bu Hafta
+- [ ] (henuz gorev yok)
+
+## Bekleyen Isler
+- [ ] (henuz gorev yok)
+
+## Tamamlanan
+- (henuz yok)
+`;
+
+	it("bos board'a yeni issue ekler", () => {
+		const issues = [issue(1, "important", ["priority:p1-high"])];
+		const { newContent, added, skipped } = mergeIssuesIntoTaskBoard(
+			emptyBoard,
+			issues,
+		);
+		assert.equal(added.length, 1);
+		assert.equal(skipped.length, 0);
+		assert.match(newContent, /#1 \(P1\) important/);
+		// Bugun'de placeholder kaldirildi; diger ikisinde "(henuz gorev yok)"
+		// hala duruyor. Tamamlanan ayri format kullanir ("(henuz yok)").
+		assert.equal((newContent.match(/\(henuz gorev yok\)/g) || []).length, 2);
+		assert.match(newContent, /\(henuz yok\)/);
+	});
+
+	it("zaten mevcut #N atlanir (idempotent)", () => {
+		const board = `# Gorev Panosu
+
+## Bugun
+- [ ] #1 (P1) old line
+
+## Bu Hafta
+- [ ] (henuz gorev yok)
+
+## Bekleyen Isler
+- [ ] (henuz gorev yok)
+
+## Tamamlanan
+- (henuz yok)
+`;
+		const issues = [issue(1, "yeni baslik", ["priority:p1-high"])];
+		const { added, skipped } = mergeIssuesIntoTaskBoard(board, issues);
+		assert.equal(added.length, 0);
+		assert.equal(skipped.length, 1);
+		assert.equal(skipped[0].number, 1);
+	});
+
+	it("manuel gorev korunur, issue eklendiginde silinmez", () => {
+		const board = `# Gorev Panosu
+
+## Bugun
+- [ ] manuel: README guncelle
+
+## Bu Hafta
+- [ ] (henuz gorev yok)
+
+## Bekleyen Isler
+- [ ] (henuz gorev yok)
+
+## Tamamlanan
+- (henuz yok)
+`;
+		const issues = [issue(42, "yeni p1", ["priority:p1-high"])];
+		const { newContent, added } = mergeIssuesIntoTaskBoard(board, issues);
+		assert.equal(added.length, 1);
+		assert.match(newContent, /manuel: README guncelle/);
+		assert.match(newContent, /#42 \(P1\) yeni p1/);
+	});
+
+	it("uretilen icerik tekrar parse edilince ayni issue'lar bulunur", () => {
+		const issues = [
+			issue(1, "p1 task", ["priority:p1-high"]),
+			issue(2, "p2 task", ["priority:p2-medium"]),
+			issue(3, "p3 task", ["priority:p3-large"]),
+		];
+		const { newContent } = mergeIssuesIntoTaskBoard(emptyBoard, issues);
+		// Tekrar uygulanirsa hicbir sey eklememeli
+		const second = mergeIssuesIntoTaskBoard(newContent, issues);
+		assert.equal(second.added.length, 0);
+		assert.equal(second.skipped.length, 3);
+	});
+
+	it("placeholder satirini sadece o bolume issue eklendiyse kaldirir", () => {
+		const issues = [issue(7, "only-bugun", ["priority:p1-high"])];
+		const { newContent } = mergeIssuesIntoTaskBoard(emptyBoard, issues);
+		const { sections } = parseTaskBoard(newContent);
+		// Bugun -> placeholder yok
+		assert.ok(
+			!sections.Bugun.some((l) => /\(henuz gorev yok\)/.test(l)),
+			"Bugun bolumunde placeholder kalmis",
+		);
+		// Bu Hafta -> placeholder hala var
+		assert.ok(
+			sections["Bu Hafta"].some((l) => /\(henuz gorev yok\)/.test(l)),
+			"Bu Hafta placeholder eksik",
+		);
+	});
+});
+
+describe("badi gh: subprocess akisi", () => {
+	let dir;
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "badi-gh-test-"));
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("--help help mesaji gosterir", () => {
+		const r = spawnSync("node", [BADI, "gh", "--help"], { encoding: "utf-8" });
+		assert.equal(r.status, 0);
+		assert.match(r.stdout, /badi gh sync/);
+		assert.match(r.stdout, /TaskBoard/);
+	});
+
+	it("TaskBoard yok ise exit 1", () => {
+		const r = spawnSync("node", [BADI, "gh", "sync", "--dry-run"], {
+			cwd: dir,
+			encoding: "utf-8",
+		});
+		assert.equal(r.status, 1);
+		assert.match(r.stderr, /TaskBoard yok/);
+	});
+
+	it("bilinmeyen alt-komut exit 1 + help", () => {
+		const r = spawnSync("node", [BADI, "gh", "bogus"], { encoding: "utf-8" });
+		assert.equal(r.status, 1);
+		assert.match(r.stderr, /Bilinmeyen alt-komut/);
+	});
+});


### PR DESCRIPTION
## Summary
Issue #11 (P3) MVP scope: \`badi gh sync\` GitHub açık issue'larını \`.claude/workspace/TaskBoard.md\`'ye priority etiketlerine göre kategorize ederek senkronize eder.

### Kategorizasyon
| Etiket | Bölüm |
|---|---|
| \`priority:p1-high\` | ## Bugün |
| \`priority:p2-medium\` | ## Bu Hafta |
| \`priority:p3-large\` | ## Bekleyen İşler |
| \`priority:p4-future\` | ## Bekleyen İşler |
| (yok) | ## Bekleyen İşler |

### Davranış
- **Idempotent:** zaten TaskBoard'da olan \`#N\` tekrar eklenmez
- **Manuel görevler korunur:** issue olmayan checkbox satırlar dokunulmaz
- **Placeholder yönetimi:** issue eklenince \`(henuz gorev yok)\` temizlenir, boş kalan bölüme geri konur
- **Tamamlanan bölümü:** ayrı format (\`- (henuz yok)\` checkbox'sız) korunur

### Komut yüzeyi
\`\`\`
badi gh sync                Default: open issue'lar, mevcut repo
badi gh sync --dry-run      Diski değiştirme, planlanan eklemeleri göster
badi gh sync --repo o/n     Belirli repo
badi gh sync --state STATE  open|closed|all
badi gh sync --limit N      Max 100 (default)
\`\`\`

### Implementasyon
\`gh\` CLI üzerinden \`issue list --json\` çağrısı. Sıfır runtime bağımlılık.

### Sonraki adımlar (#11 scope, future PR'lar)
- \`badi gh pr draft\` — commit'lerden PR açıklaması üretimi
- \`badi gh release draft <ver>\` — release note üretimi
- Issue label/status ↔ TaskBoard durumu iki yönlü

## Test plan
- [x] \`npm test\`: 668 → 687 (+19)
- [x] \`npm run lint\`: 0 issue
- [x] Manuel: \`badi gh sync --dry-run\` 9 issue tespit etti, doğru bölümlere atadı
- [x] Idempotency: ikinci sync \`Hicbir degisiklik gerekmedi\` raporladı

Tracks #11