### PR TITLE
docs(changelog): v1.23.0 release hazirligi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-05-11
+
+### Security — XSS guard + tooltip DOM API in `badi kb graph` (#149)
+
+`renderHtml` was embedding `JSON.stringify` output directly into an inline
+`<script>` block. A markdown H1 title containing `</script>` could close
+the script tag early and inject DOM. Now `<` is unicode-escaped before
+embedding, and the hover tooltip uses `textContent` + DOM API instead of
+`innerHTML`. Includes a regression test that asserts no unescaped
+`</script>` ever lands in the output.
+
+### Performance — `buildGraph` O(n²) → O(1) link resolution (#149)
+
+`resolveLink` was scanning the full file list per link (`includes` + per-call
+`basename` map). On 1000+ file workspaces this caused visible latency.
+`buildGraph` now pre-computes `Set<file>` and `Map<basename → paths>` once,
+giving constant-time lookups. Same pass also caches `safeRead` results so
+each file is read exactly once instead of twice.
+
+### Changed — review hardening (#149)
+
+Other small follow-ups from the #147 review:
+
+- `gh` `spawnSync` `maxBuffer` raised to 50 MB (was 1 MB default)
+- `detectRepo` collapsed to a single regex with 6 variant tests
+- `extractLinks` tolerates nested parens in URLs
+  (`[Wiki](https://x.com/Foo_(bar))` is now a single link)
+- `subSync` dry-run notice moved up under the header
+- `subSync` repo fallback string: `(otomatik tespit basarisiz)`
+
 ### Added — `badi kb` knowledge graph (#12 MVP)
 
 New `badi kb` subcommand family that builds a directed graph from

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,35 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-05-11
+
+### Guvenlik — XSS guard + tooltip DOM API `badi kb graph` (#149)
+
+`renderHtml` `JSON.stringify` ciktisini dogrudan inline `<script>` bloguna
+gomuyordu. Bir markdown H1 basligi `</script>` icerirse script tag erken
+kapanip DOM-XSS olusturabilirdi. Artik `<` karakteri Unicode escape ile
+gizleniyor ve hover tooltip `innerHTML` yerine `textContent` + DOM API
+kullaniyor. Regression test eklendi.
+
+### Performans — `buildGraph` O(n²) → O(1) link cozumu (#149)
+
+`resolveLink` her link icin tum dosya listesini tariyordu (`includes` +
+per-call `basename` map). 1000+ dosyali workspace'lerde gorunur gecikme
+yaratiyordu. `buildGraph` simdi basta `Set<file>` + `Map<basename → paths>`
+on-hesaplamasi yapiyor, sabit zamanli lookup. Ayni pass'te `safeRead`
+sonuclari da cache'leniyor — her dosya 2 kez yerine 1 kez okunuyor.
+
+### Degistirildi — Review sertlestirmeleri (#149)
+
+#147 review'sundan kucuk takipler:
+
+- `gh` `spawnSync` `maxBuffer` 50 MB'a yukseltildi (default 1 MB idi)
+- `detectRepo` tek regex'e indirildi, 6 variant testi eklendi
+- `extractLinks` URL icinde nested paren tolere ediyor
+  (`[w](https://x.com/Foo_(bar))` artik tek link)
+- `subSync` dry-run notu header altina alindi
+- `subSync` repo fallback string'i: `(otomatik tespit basarisiz)`
+
 ### Eklendi — `badi kb` bilgi grafigi (#12 MVP)
 
 Yeni `badi kb` alt-komut ailesi. `.claude/` icindeki markdown link ve


### PR DESCRIPTION
## Summary
\`[Unreleased]\` altındaki 6 entry \`[1.23.0] - 2026-05-11\` başlığı altına taşındı + #149 hotfix entry'si eklendi (CHANGELOG'da unutulmuştu).

### v1.23.0 içeriği
- **Security:** XSS guard \`kb renderHtml\` (#149)
- **Performance:** \`buildGraph\` O(1) link çözümü (#149)
- **Added:** \`badi kb graph\` MVP (#12)
- **Added:** \`badi gh sync\` MVP (#11)
- **Added:** tasarim + frontmatter test coverage (#137)
- **Changed:** subLint refactor + subExport guard (#138)
- **Changed:** review hardening (#149)
- **Changed:** Biome 2.4.14 → 2.4.15 (#136)

Test: 624 → 727 (+103). Lint: 0 issue. 17 PR (#132-#149).

## Test plan
- [ ] Merge sonrası: \`badi publish --version minor\` (1.22.1 → 1.23.0)
- [ ] memory.md güncelle (v1.22.1 → v1.23.0)