### PR TITLE
feat(skills): stack-aware auto-install — midudev/autoskills'den ilham

### DIFF
--- a/lib/commands/skills.js
+++ b/lib/commands/skills.js
@@ -211,6 +211,18 @@ async function runAutoInstall({
 		return;
 	}
 
+	if (proposedSet.size === 0) {
+		console.log(
+			chalk.yellow(
+				"Tespit edilen teknolojiler icin vault'ta uygun skill kategorisi yok.",
+			),
+		);
+		console.log(
+			chalk.dim("(stack-map.js'te eslesme yok veya kategori kaldirilmis)"),
+		);
+		return;
+	}
+
 	const toAdd = [...proposedSet].filter((s) => !activeSet.has(s)).sort();
 	if (toAdd.length === 0) {
 		console.log(
@@ -241,15 +253,18 @@ async function runAutoInstall({
 
 	if (!autoYes) {
 		if (!process.stdin.isTTY) {
-			console.log(
-				chalk.dim("Non-TTY: onay icin --yes kullan veya TTY'de calistir."),
+			console.error(
+				chalk.red(
+					"Non-TTY: onay alinamiyor. --yes kullan veya TTY'de calistir.",
+				),
 			);
+			process.exitCode = 1;
 			return;
 		}
 		const ans = await promptChoice(
-			`${toAdd.length} skill aktive edilsin mi? [E/h] `,
+			`${toAdd.length} skill aktive edilsin mi? [e/H] `,
 		);
-		if (!/^(e|y|yes|evet)?$/i.test(ans)) {
+		if (!/^(e|y|yes|evet)$/i.test(ans)) {
 			console.log(chalk.dim("Iptal edildi."));
 			return;
 		}

--- a/lib/commands/skills.js
+++ b/lib/commands/skills.js
@@ -23,6 +23,7 @@ import {
 	buildSkillIndex,
 	routePrompt,
 } from "../skills-router.js";
+import { detectStack } from "../stack-detector.js";
 
 function paths(target) {
 	const claudeDir = join(target, ".claude");
@@ -140,6 +141,138 @@ function printStatusTable({ vaultList, activeSet }) {
 	console.log("");
 }
 
+function summarizeDetection(result, vaultList) {
+	const vaultSet = new Set(vaultList);
+	const proposedSet = new Set();
+	for (const s of result.skills) {
+		if (vaultSet.has(s)) proposedSet.add(s);
+	}
+	return { proposedSet };
+}
+
+function printDetectResult(result, vaultList, activeSet) {
+	const { proposedSet } = summarizeDetection(result, vaultList);
+	console.log(
+		chalk.bold(`Stack tespit: ${result.technologies.length} teknoloji`),
+	);
+	console.log("");
+	if (result.technologies.length === 0) {
+		console.log(
+			chalk.dim(
+				"  (eslesme yok — package.json/configFile/manifest dosyalari taranir)",
+			),
+		);
+		return;
+	}
+	for (const t of result.technologies) {
+		const skillTxt = t.skills.length
+			? chalk.dim(`→ ${t.skills.join(", ")}`)
+			: chalk.dim("→ (skill yok)");
+		console.log(
+			`  ${chalk.green("✓")} ${chalk.cyan(t.name.padEnd(18))} ${chalk.dim(`[${t.source}]`)}  ${skillTxt}`,
+		);
+	}
+	console.log("");
+	console.log(chalk.bold(`Onerilen skill kategorileri: ${proposedSet.size}`));
+	const sorted = [...proposedSet].sort();
+	for (const name of sorted) {
+		const isActive = activeSet.has(name);
+		const marker = isActive ? chalk.green("[v]") : chalk.yellow("[ ]");
+		const tag = isActive
+			? chalk.dim("(zaten aktif)")
+			: chalk.dim("(aktif degil)");
+		console.log(`  ${marker} ${chalk.cyan(name.padEnd(20))} ${tag}`);
+	}
+	const inactive = sorted.filter((n) => !activeSet.has(n));
+	if (inactive.length > 0) {
+		console.log("");
+		console.log(
+			chalk.dim(
+				`Aktive etmek icin: badi skills auto-install  (veya tek tek: badi skills add ${inactive.join(" ")})`,
+			),
+		);
+	}
+}
+
+async function runAutoInstall({
+	target,
+	vault,
+	active,
+	vaultList,
+	activeSet,
+	autoYes,
+	dryRun,
+}) {
+	const result = detectStack(target);
+	const { proposedSet } = summarizeDetection(result, vaultList);
+
+	if (result.technologies.length === 0) {
+		console.log(chalk.dim("Stack tespit edilmedi — degisiklik yok."));
+		return;
+	}
+
+	const toAdd = [...proposedSet].filter((s) => !activeSet.has(s)).sort();
+	if (toAdd.length === 0) {
+		console.log(
+			chalk.green("✓ Onerilen tum skill'ler zaten aktif. Degisiklik yok."),
+		);
+		return;
+	}
+
+	console.log(
+		chalk.bold(`Stack tespit: ${result.technologies.length} teknoloji`),
+	);
+	for (const t of result.technologies) {
+		console.log(
+			`  ${chalk.green("✓")} ${t.name} ${chalk.dim(`[${t.source}]`)}`,
+		);
+	}
+	console.log("");
+	console.log(chalk.bold(`Eklenecek skill'ler (${toAdd.length}):`));
+	for (const name of toAdd) {
+		console.log(`  ${chalk.yellow("+")} ${chalk.cyan(name)}`);
+	}
+	console.log("");
+
+	if (dryRun) {
+		console.log(chalk.dim("--dry-run aktif: dosyaya yazilmadi."));
+		return;
+	}
+
+	if (!autoYes) {
+		if (!process.stdin.isTTY) {
+			console.log(
+				chalk.dim("Non-TTY: onay icin --yes kullan veya TTY'de calistir."),
+			);
+			return;
+		}
+		const ans = await promptChoice(
+			`${toAdd.length} skill aktive edilsin mi? [E/h] `,
+		);
+		if (!/^(e|y|yes|evet)?$/i.test(ans)) {
+			console.log(chalk.dim("Iptal edildi."));
+			return;
+		}
+	}
+
+	let added = 0;
+	for (const name of toAdd) {
+		try {
+			const r = copySkill(vault, active, name);
+			if (r.added) {
+				console.log(`  ${chalk.green("+")} ${name}`);
+				added++;
+			}
+		} catch (err) {
+			console.error(chalk.red(`  ! ${name}: ${err.message}`));
+		}
+	}
+	console.log("");
+	console.log(
+		`${chalk.green(added)} eklendi, toplam aktif: ${activeSet.size + added}/${vaultList.length}`,
+	);
+}
+
 function showHelp() {
 	console.log(chalk.bold("Skills Yonetimi (Opt-in):"));
 	console.log(
@@ -155,6 +288,20 @@ function showHelp() {
 	console.log("  badi skills remove <ad...>      Aktif skill'i kaldir");
 	console.log("  badi skills clear               Tum aktif skill'leri sifirla");
 	console.log("  badi skills reset               clear ile ayni");
+	console.log("");
+	console.log(chalk.bold("Stack-aware kurulum (v1.24+):"));
+	console.log(
+		"  badi skills detect              Projeyi tara, eslesen skill'leri listele (read-only)",
+	);
+	console.log(
+		"  badi skills auto-install        Detect + interaktif onay + skill aktive et",
+	);
+	console.log(
+		"    --yes / -y                    Onay sormadan eslesenleri aktive et",
+	);
+	console.log(
+		"    --dry-run                     Sadece goster, dosyaya dokunma",
+	);
 	console.log("");
 	console.log(chalk.bold("Auto-router (v1.20+):"));
 	console.log(
@@ -491,6 +638,28 @@ export async function runSkills(args) {
 				);
 				process.exit(1);
 			}
+			break;
+		}
+
+		case "detect": {
+			const result = detectStack(target);
+			printDetectResult(result, vaultList, activeSet);
+			break;
+		}
+
+		case "auto-install": {
+			const flags = args.slice(1);
+			const autoYes = flags.includes("--yes") || flags.includes("-y");
+			const dryRun = flags.includes("--dry-run");
+			await runAutoInstall({
+				target,
+				vault,
+				active,
+				vaultList,
+				activeSet,
+				autoYes,
+				dryRun,
+			});
 			break;
 		}
 

--- a/lib/skills/stack-map.js
+++ b/lib/skills/stack-map.js
@@ -136,7 +136,11 @@ export const STACK_MAP = [
 	{
 		id: "swift",
 		name: "Swift",
-		detect: { fileExtensions: [".swift"] },
+		detect: {
+			fileExtensions: [".swift"],
+			configFiles: ["Podfile", "Package.swift"],
+			configDirs: ["ios"],
+		},
 		skills: ["mobile"],
 	},
 	{
@@ -144,7 +148,8 @@ export const STACK_MAP = [
 		name: "Kotlin",
 		detect: {
 			fileExtensions: [".kt"],
-			configFiles: ["build.gradle", "build.gradle.kts"],
+			configFiles: ["build.gradle", "build.gradle.kts", "AndroidManifest.xml"],
+			configDirs: ["android"],
 		},
 		skills: ["mobile"],
 	},
@@ -218,7 +223,7 @@ export const STACK_MAP = [
 		name: "Prisma",
 		detect: {
 			packages: ["prisma", "@prisma/client"],
-			configFiles: ["prisma"],
+			configDirs: ["prisma"],
 		},
 		skills: ["data-analytics"],
 	},
@@ -322,7 +327,7 @@ export const STACK_MAP = [
 	{
 		id: "github-actions",
 		name: "GitHub Actions",
-		detect: { configFiles: [".github"] },
+		detect: { configDirs: [".github"] },
 		skills: ["devops", "testing"],
 	},
 

--- a/lib/skills/stack-map.js
+++ b/lib/skills/stack-map.js
@@ -1,0 +1,392 @@
+// Stack → Badi skill kategori eslestirme manifesti.
+//
+// Her entry:
+//   id              — uniq teknoloji id
+//   name            — gosterim adi
+//   detect          — { packages?, configFiles?, fileExtensions?, manifestKeys?, scripts? }
+//   skills          — eslesince onerilen Badi skill kategorileri
+//                    (.claude/skills-vault/ altindaki klasor adlari)
+//
+// Skills katalogu (vault, v1.23+):
+//   ai-automation, consulting, content, customer-success, data-analytics,
+//   design, design-tokens, development, devops, ecommerce, email, finance,
+//   frontend-taste, marketing, mobile, product, productivity, sales,
+//   security, security-check, seo, seo-crawl-budget, social-media,
+//   startup, testing
+//
+// Eslestirme kurallari:
+//  - Frontend frameworks (react/vue/svelte): design + frontend-taste
+//  - Meta-frameworks (next/nuxt/astro): yukarisi + seo + seo-crawl-budget
+//  - Mobile: mobile
+//  - Backend/API: development
+//  - Test araclari: testing
+//  - DB/ORM: data-analytics
+//  - Auth/Payments: security, finance
+//  - DevOps/Infra: devops
+//  - E-ticaret: ecommerce
+//  - AI SDK'lar: ai-automation
+//  - Email araci: email
+//  - Marketing/social-media araclari: marketing, social-media
+
+export const STACK_MAP = [
+	// ── Frontend frameworks ──────────────────────────────────────────────
+	{
+		id: "react",
+		name: "React",
+		detect: { packages: ["react", "react-dom"] },
+		skills: ["design", "frontend-taste"],
+	},
+	{
+		id: "vue",
+		name: "Vue",
+		detect: { packages: ["vue"] },
+		skills: ["design", "frontend-taste"],
+	},
+	{
+		id: "svelte",
+		name: "Svelte",
+		detect: { packages: ["svelte"] },
+		skills: ["design", "frontend-taste"],
+	},
+	{
+		id: "angular",
+		name: "Angular",
+		detect: { packages: ["@angular/core"] },
+		skills: ["design", "frontend-taste"],
+	},
+
+	// ── Meta-frameworks ──────────────────────────────────────────────────
+	{
+		id: "nextjs",
+		name: "Next.js",
+		detect: {
+			packages: ["next"],
+			configFiles: ["next.config.js", "next.config.mjs", "next.config.ts"],
+		},
+		skills: ["development", "seo", "seo-crawl-budget", "frontend-taste"],
+	},
+	{
+		id: "nuxt",
+		name: "Nuxt",
+		detect: {
+			packages: ["nuxt"],
+			configFiles: ["nuxt.config.js", "nuxt.config.ts"],
+		},
+		skills: ["development", "seo", "seo-crawl-budget", "frontend-taste"],
+	},
+	{
+		id: "astro",
+		name: "Astro",
+		detect: {
+			packages: ["astro"],
+			configFiles: ["astro.config.mjs", "astro.config.js", "astro.config.ts"],
+		},
+		skills: ["development", "seo", "seo-crawl-budget"],
+	},
+	{
+		id: "remix",
+		name: "Remix",
+		detect: {
+			packages: ["@remix-run/react", "@remix-run/node"],
+			configFiles: ["remix.config.js"],
+		},
+		skills: ["development", "seo", "frontend-taste"],
+	},
+
+	// ── Styling / UI kit ──────────────────────────────────────────────────
+	{
+		id: "tailwind",
+		name: "Tailwind CSS",
+		detect: {
+			packages: ["tailwindcss"],
+			configFiles: [
+				"tailwind.config.js",
+				"tailwind.config.ts",
+				"tailwind.config.mjs",
+			],
+		},
+		skills: ["design", "design-tokens", "frontend-taste"],
+	},
+	{
+		id: "shadcn",
+		name: "shadcn/ui",
+		detect: { configFiles: ["components.json"] },
+		skills: ["design", "design-tokens", "frontend-taste"],
+	},
+
+	// ── Mobile ──────────────────────────────────────────────────────────
+	{
+		id: "react-native",
+		name: "React Native",
+		detect: { packages: ["react-native"] },
+		skills: ["mobile"],
+	},
+	{
+		id: "expo",
+		name: "Expo",
+		detect: { packages: ["expo"] },
+		skills: ["mobile"],
+	},
+	{
+		id: "flutter",
+		name: "Flutter",
+		detect: { configFiles: ["pubspec.yaml"] },
+		skills: ["mobile"],
+	},
+	{
+		id: "swift",
+		name: "Swift",
+		detect: { fileExtensions: [".swift"] },
+		skills: ["mobile"],
+	},
+	{
+		id: "kotlin",
+		name: "Kotlin",
+		detect: {
+			fileExtensions: [".kt"],
+			configFiles: ["build.gradle", "build.gradle.kts"],
+		},
+		skills: ["mobile"],
+	},
+
+	// ── Backend ──────────────────────────────────────────────────────────
+	{
+		id: "express",
+		name: "Express",
+		detect: { packages: ["express"] },
+		skills: ["development"],
+	},
+	{
+		id: "hono",
+		name: "Hono",
+		detect: { packages: ["hono"] },
+		skills: ["development"],
+	},
+	{
+		id: "nestjs",
+		name: "NestJS",
+		detect: { packages: ["@nestjs/core"] },
+		skills: ["development", "testing"],
+	},
+	{
+		id: "fastify",
+		name: "Fastify",
+		detect: { packages: ["fastify"] },
+		skills: ["development"],
+	},
+
+	// ── Languages / runtimes ─────────────────────────────────────────────
+	{
+		id: "typescript",
+		name: "TypeScript",
+		detect: {
+			packages: ["typescript"],
+			configFiles: ["tsconfig.json"],
+		},
+		skills: ["development"],
+	},
+	{
+		id: "go",
+		name: "Go",
+		detect: { configFiles: ["go.mod"] },
+		skills: ["development"],
+	},
+	{
+		id: "rust",
+		name: "Rust",
+		detect: { configFiles: ["Cargo.toml"] },
+		skills: ["development"],
+	},
+	{
+		id: "python",
+		name: "Python",
+		detect: {
+			configFiles: ["pyproject.toml", "requirements.txt", "setup.py"],
+		},
+		skills: ["development", "data-analytics"],
+	},
+	{
+		id: "ruby",
+		name: "Ruby",
+		detect: { configFiles: ["Gemfile"] },
+		skills: ["development"],
+	},
+
+	// ── Data / ORM ───────────────────────────────────────────────────────
+	{
+		id: "prisma",
+		name: "Prisma",
+		detect: {
+			packages: ["prisma", "@prisma/client"],
+			configFiles: ["prisma"],
+		},
+		skills: ["data-analytics"],
+	},
+	{
+		id: "drizzle",
+		name: "Drizzle ORM",
+		detect: {
+			packages: ["drizzle-orm"],
+			configFiles: ["drizzle.config.ts", "drizzle.config.js"],
+		},
+		skills: ["data-analytics"],
+	},
+	{
+		id: "supabase",
+		name: "Supabase",
+		detect: { packages: ["@supabase/supabase-js"] },
+		skills: ["data-analytics", "security"],
+	},
+
+	// ── Auth / Payments ──────────────────────────────────────────────────
+	{
+		id: "stripe",
+		name: "Stripe",
+		detect: { packages: ["stripe", "@stripe/stripe-js"] },
+		skills: ["finance"],
+	},
+	{
+		id: "clerk",
+		name: "Clerk",
+		detect: {
+			packages: [
+				"@clerk/nextjs",
+				"@clerk/clerk-react",
+				"@clerk/clerk-sdk-node",
+			],
+		},
+		skills: ["security"],
+	},
+	{
+		id: "better-auth",
+		name: "Better Auth",
+		detect: { packages: ["better-auth"] },
+		skills: ["security"],
+	},
+
+	// ── Testing ──────────────────────────────────────────────────────────
+	{
+		id: "vitest",
+		name: "Vitest",
+		detect: {
+			packages: ["vitest"],
+			configFiles: [
+				"vitest.config.ts",
+				"vitest.config.js",
+				"vitest.config.mjs",
+			],
+		},
+		skills: ["testing"],
+	},
+	{
+		id: "jest",
+		name: "Jest",
+		detect: {
+			packages: ["jest"],
+			configFiles: ["jest.config.js", "jest.config.ts"],
+		},
+		skills: ["testing"],
+	},
+	{
+		id: "playwright",
+		name: "Playwright",
+		detect: {
+			packages: ["@playwright/test"],
+			configFiles: ["playwright.config.ts", "playwright.config.js"],
+		},
+		skills: ["testing"],
+	},
+	{
+		id: "cypress",
+		name: "Cypress",
+		detect: {
+			packages: ["cypress"],
+			configFiles: ["cypress.config.js", "cypress.config.ts"],
+		},
+		skills: ["testing"],
+	},
+
+	// ── DevOps / Infra ───────────────────────────────────────────────────
+	{
+		id: "docker",
+		name: "Docker",
+		detect: { configFiles: ["Dockerfile", "docker-compose.yml"] },
+		skills: ["devops"],
+	},
+	{
+		id: "terraform",
+		name: "Terraform",
+		detect: { fileExtensions: [".tf"] },
+		skills: ["devops"],
+	},
+	{
+		id: "github-actions",
+		name: "GitHub Actions",
+		detect: { configFiles: [".github"] },
+		skills: ["devops", "testing"],
+	},
+
+	// ── AI ───────────────────────────────────────────────────────────────
+	{
+		id: "vercel-ai",
+		name: "Vercel AI SDK",
+		detect: { packages: ["ai"] },
+		skills: ["ai-automation"],
+	},
+	{
+		id: "openai",
+		name: "OpenAI",
+		detect: { packages: ["openai"] },
+		skills: ["ai-automation"],
+	},
+	{
+		id: "anthropic",
+		name: "Anthropic",
+		detect: { packages: ["@anthropic-ai/sdk"] },
+		skills: ["ai-automation"],
+	},
+	{
+		id: "langchain",
+		name: "LangChain",
+		detect: {
+			packages: ["langchain", "@langchain/core", "@langchain/openai"],
+		},
+		skills: ["ai-automation"],
+	},
+
+	// ── E-ticaret ────────────────────────────────────────────────────────
+	{
+		id: "shopify",
+		name: "Shopify",
+		detect: { packages: ["@shopify/hydrogen", "shopify-api-node"] },
+		skills: ["ecommerce", "marketing"],
+	},
+	{
+		id: "woocommerce",
+		name: "WooCommerce",
+		detect: { packages: ["@woocommerce/woocommerce-rest-api"] },
+		skills: ["ecommerce", "marketing"],
+	},
+
+	// ── Email ────────────────────────────────────────────────────────────
+	{
+		id: "resend",
+		name: "Resend",
+		detect: { packages: ["resend"] },
+		skills: ["email", "marketing"],
+	},
+	{
+		id: "nodemailer",
+		name: "Nodemailer",
+		detect: { packages: ["nodemailer"] },
+		skills: ["email"],
+	},
+
+	// ── Media / Content ──────────────────────────────────────────────────
+	{
+		id: "remotion",
+		name: "Remotion",
+		detect: { packages: ["remotion", "@remotion/cli"] },
+		skills: ["content", "social-media"],
+	},
+];

--- a/lib/stack-detector.js
+++ b/lib/stack-detector.js
@@ -1,15 +1,17 @@
 // Stack detector — proje dosyalarindan teknoloji tespiti.
 //
-// Cikti: [{ id: "react", name: "React", source: "package.json:dep:react", confidence: 1.0 }]
+// Cikti: { technologies: Array<{id,name,source,skills}>, skills: Set<string> }
 //
 // Algoritma:
 //  1. Manifest dosyalarini oku (package.json, Cargo.toml, go.mod, ...)
 //  2. Her STACK_MAP entry'sinin detect kuralini test et:
 //     - packages: package.json deps + devDeps
-//     - configFiles: glob existence
-//     - filePatterns: glob existence
+//     - configFiles: root-level glob existence (sadece FILE)
+//     - configDirs: root-level glob existence (sadece DIR)
+//     - fileExtensions: root-level uzanti taramasi
 //     - manifestKeys: pyproject.toml/Cargo.toml/go.mod metin match
-//  3. Eslesen tekniyolojileri uniq + skor + source ile dondur
+//     - scripts: package.json scripts adi
+//  3. Eslesen tekniyolojileri uniq + source ile dondur
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
@@ -36,6 +38,26 @@ function safeJsonParse(content) {
 	}
 }
 
+function safeReaddir(dir) {
+	try {
+		return readdirSync(dir);
+	} catch {
+		return [];
+	}
+}
+
+function isKindAtRoot(target, name, kind) {
+	if (kind === "any") return true;
+	try {
+		const st = statSync(join(target, name));
+		if (kind === "file") return st.isFile();
+		if (kind === "dir") return st.isDirectory();
+	} catch {
+		return false;
+	}
+	return false;
+}
+
 /**
  * package.json oku ve { allDeps: Set, scripts: Set, name } dondur.
  */
@@ -57,17 +79,22 @@ function readPackageJson(target) {
 /**
  * Glob benzeri eslesme: "*.config.*" desenini cwd icinde test eder.
  * Sadece tek dizin seviyesinde calisir, recursive degil.
+ *
+ * @param {string} target — taranacak kok
+ * @param {string[]} patterns — glob desenleri
+ * @param {Object} [opts]
+ * @param {"file"|"dir"|"any"} [opts.kind="any"] — match turu
+ * @param {string[]} [opts.entries] — onceden okunmus dizin listesi (cache)
+ * @returns {string|null} eslesen dosya adi
  */
-function matchAnyFile(target, patterns) {
-	let entries;
-	try {
-		entries = readdirSync(target);
-	} catch {
-		return null;
-	}
+function matchAnyFile(target, patterns, opts = {}) {
+	const { kind = "any", entries = safeReaddir(target) } = opts;
+	if (entries.length === 0) return null;
 	for (const pat of patterns) {
 		const re = globToRegex(pat);
-		const hit = entries.find((e) => re.test(e));
+		const hit = entries.find(
+			(e) => re.test(e) && isKindAtRoot(target, e, kind),
+		);
 		if (hit) return hit;
 	}
 	return null;
@@ -80,9 +107,13 @@ function globToRegex(pat) {
 
 /**
  * Bir teknolojinin detect kurali (DetectRule) tek dosyaya ya da pakete bakar.
+ * @param {Object} detect — STACK_MAP entry'sinin detect alani
+ * @param {Object} ctx — { target, pkg, rootEntries }
  * @returns {{ matched: boolean, source: string|null }}
  */
 function evaluateDetect(detect, ctx) {
+	// rootEntries cache eksikse defansive olarak fresh oku
+	const rootEntries = ctx.rootEntries ?? safeReaddir(ctx.target);
 	// 1. packages (npm)
 	if (detect.packages && ctx.pkg) {
 		for (const p of detect.packages) {
@@ -91,24 +122,30 @@ function evaluateDetect(detect, ctx) {
 			}
 		}
 	}
-	// 2. configFiles (root-level)
+	// 2. configFiles (root-level, sadece FILE)
 	if (detect.configFiles) {
-		const hit = matchAnyFile(ctx.target, detect.configFiles);
+		const hit = matchAnyFile(ctx.target, detect.configFiles, {
+			kind: "file",
+			entries: rootEntries,
+		});
 		if (hit) return { matched: true, source: `configFile:${hit}` };
 	}
-	// 3. fileExtensions (root-level — hizli)
-	if (detect.fileExtensions) {
-		try {
-			const entries = readdirSync(ctx.target);
-			const hit = entries.find((e) =>
-				detect.fileExtensions.some((ext) => e.endsWith(ext)),
-			);
-			if (hit) return { matched: true, source: `fileExt:${hit}` };
-		} catch {
-			/* ignore */
-		}
+	// 3. configDirs (root-level, sadece DIR) — .github, prisma, ios, android
+	if (detect.configDirs) {
+		const hit = matchAnyFile(ctx.target, detect.configDirs, {
+			kind: "dir",
+			entries: rootEntries,
+		});
+		if (hit) return { matched: true, source: `configDir:${hit}` };
 	}
-	// 4. manifestKeys — pyproject.toml/Cargo.toml/go.mod metin tabani
+	// 4. fileExtensions (root-level — hizli)
+	if (detect.fileExtensions) {
+		const hit = rootEntries.find((e) =>
+			detect.fileExtensions.some((ext) => e.endsWith(ext)),
+		);
+		if (hit) return { matched: true, source: `fileExt:${hit}` };
+	}
+	// 5. manifestKeys — pyproject.toml/Cargo.toml/go.mod metin tabani
 	if (detect.manifestKeys) {
 		for (const { file, key } of detect.manifestKeys) {
 			const content = safeRead(join(ctx.target, file));
@@ -124,7 +161,7 @@ function evaluateDetect(detect, ctx) {
 			}
 		}
 	}
-	// 5. scripts (npm scripts)
+	// 6. scripts (npm scripts)
 	if (detect.scripts && ctx.pkg) {
 		for (const s of detect.scripts) {
 			if (ctx.pkg.scripts.has(s)) {
@@ -139,10 +176,17 @@ function evaluateDetect(detect, ctx) {
  * Hedef dizinden tum stack'i tespit et.
  *
  * @param {string} target — proje koku (cwd)
- * @returns {{ technologies: Array<{id, name, source}>, skills: Set<string> }}
+ * @returns {{
+ *   technologies: Array<{id: string, name: string, source: string, skills: string[]}>,
+ *   skills: Set<string>
+ * }}
  */
 export function detectStack(target) {
-	const ctx = { target, pkg: readPackageJson(target) };
+	const ctx = {
+		target,
+		pkg: readPackageJson(target),
+		rootEntries: safeReaddir(target),
+	};
 	const technologies = [];
 	const skills = new Set();
 

--- a/lib/stack-detector.js
+++ b/lib/stack-detector.js
@@ -1,0 +1,165 @@
+// Stack detector — proje dosyalarindan teknoloji tespiti.
+//
+// Cikti: [{ id: "react", name: "React", source: "package.json:dep:react", confidence: 1.0 }]
+//
+// Algoritma:
+//  1. Manifest dosyalarini oku (package.json, Cargo.toml, go.mod, ...)
+//  2. Her STACK_MAP entry'sinin detect kuralini test et:
+//     - packages: package.json deps + devDeps
+//     - configFiles: glob existence
+//     - filePatterns: glob existence
+//     - manifestKeys: pyproject.toml/Cargo.toml/go.mod metin match
+//  3. Eslesen tekniyolojileri uniq + skor + source ile dondur
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { STACK_MAP } from "./skills/stack-map.js";
+
+const MAX_FILE_BYTES = 1024 * 512; // 512KB — buyuk lockfile/yml taramayalim
+
+function safeRead(filePath) {
+	try {
+		const st = statSync(filePath);
+		if (!st.isFile() || st.size > MAX_FILE_BYTES) return null;
+		return readFileSync(filePath, "utf-8");
+	} catch {
+		return null;
+	}
+}
+
+function safeJsonParse(content) {
+	if (!content) return null;
+	try {
+		return JSON.parse(content);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * package.json oku ve { allDeps: Set, scripts: Set, name } dondur.
+ */
+function readPackageJson(target) {
+	const p = join(target, "package.json");
+	const content = safeRead(p);
+	const pkg = safeJsonParse(content);
+	if (!pkg) return null;
+	const allDeps = new Set([
+		...Object.keys(pkg.dependencies || {}),
+		...Object.keys(pkg.devDependencies || {}),
+		...Object.keys(pkg.peerDependencies || {}),
+		...Object.keys(pkg.optionalDependencies || {}),
+	]);
+	const scripts = new Set(Object.keys(pkg.scripts || {}));
+	return { allDeps, scripts, name: pkg.name || null, raw: pkg };
+}
+
+/**
+ * Glob benzeri eslesme: "*.config.*" desenini cwd icinde test eder.
+ * Sadece tek dizin seviyesinde calisir, recursive degil.
+ */
+function matchAnyFile(target, patterns) {
+	let entries;
+	try {
+		entries = readdirSync(target);
+	} catch {
+		return null;
+	}
+	for (const pat of patterns) {
+		const re = globToRegex(pat);
+		const hit = entries.find((e) => re.test(e));
+		if (hit) return hit;
+	}
+	return null;
+}
+
+function globToRegex(pat) {
+	const esc = pat.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+	return new RegExp(`^${esc}$`, "i");
+}
+
+/**
+ * Bir teknolojinin detect kurali (DetectRule) tek dosyaya ya da pakete bakar.
+ * @returns {{ matched: boolean, source: string|null }}
+ */
+function evaluateDetect(detect, ctx) {
+	// 1. packages (npm)
+	if (detect.packages && ctx.pkg) {
+		for (const p of detect.packages) {
+			if (ctx.pkg.allDeps.has(p)) {
+				return { matched: true, source: `package.json:dep:${p}` };
+			}
+		}
+	}
+	// 2. configFiles (root-level)
+	if (detect.configFiles) {
+		const hit = matchAnyFile(ctx.target, detect.configFiles);
+		if (hit) return { matched: true, source: `configFile:${hit}` };
+	}
+	// 3. fileExtensions (root-level — hizli)
+	if (detect.fileExtensions) {
+		try {
+			const entries = readdirSync(ctx.target);
+			const hit = entries.find((e) =>
+				detect.fileExtensions.some((ext) => e.endsWith(ext)),
+			);
+			if (hit) return { matched: true, source: `fileExt:${hit}` };
+		} catch {
+			/* ignore */
+		}
+	}
+	// 4. manifestKeys — pyproject.toml/Cargo.toml/go.mod metin tabani
+	if (detect.manifestKeys) {
+		for (const { file, key } of detect.manifestKeys) {
+			const content = safeRead(join(ctx.target, file));
+			if (!content) continue;
+			if (typeof key === "string") {
+				if (content.includes(key)) {
+					return { matched: true, source: `${file}:${key}` };
+				}
+			} else if (key instanceof RegExp) {
+				if (key.test(content)) {
+					return { matched: true, source: `${file}:regex` };
+				}
+			}
+		}
+	}
+	// 5. scripts (npm scripts)
+	if (detect.scripts && ctx.pkg) {
+		for (const s of detect.scripts) {
+			if (ctx.pkg.scripts.has(s)) {
+				return { matched: true, source: `package.json:script:${s}` };
+			}
+		}
+	}
+	return { matched: false, source: null };
+}
+
+/**
+ * Hedef dizinden tum stack'i tespit et.
+ *
+ * @param {string} target — proje koku (cwd)
+ * @returns {{ technologies: Array<{id, name, source}>, skills: Set<string> }}
+ */
+export function detectStack(target) {
+	const ctx = { target, pkg: readPackageJson(target) };
+	const technologies = [];
+	const skills = new Set();
+
+	for (const tech of STACK_MAP) {
+		const r = evaluateDetect(tech.detect, ctx);
+		if (r.matched) {
+			technologies.push({
+				id: tech.id,
+				name: tech.name,
+				source: r.source,
+				skills: tech.skills,
+			});
+			for (const s of tech.skills) skills.add(s);
+		}
+	}
+
+	return { technologies, skills };
+}
+
+export { evaluateDetect, globToRegex, matchAnyFile, readPackageJson };

--- a/tests/cli.skills.auto.test.js
+++ b/tests/cli.skills.auto.test.js
@@ -1,0 +1,207 @@
+// `badi skills detect` + `badi skills auto-install` subprocess testleri.
+//
+// Vault gerektigi icin geçici proje altinda gerekli skills-vault iskelesini
+// kuruyoruz; gercek vault icerigine bagimli olmadan calisir.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const REPO_ROOT = resolve(__dirname, "..");
+const BADI = join(REPO_ROOT, "bin", "badi.js");
+
+function setupProject({ deps = {}, devDeps = {}, files = {} } = {}) {
+	const dir = mkdtempSync(join(tmpdir(), "badi-skills-auto-"));
+	mkdirSync(join(dir, ".claude", "skills-vault", "design"), {
+		recursive: true,
+	});
+	mkdirSync(join(dir, ".claude", "skills-vault", "frontend-taste"), {
+		recursive: true,
+	});
+	mkdirSync(join(dir, ".claude", "skills-vault", "testing"), {
+		recursive: true,
+	});
+	mkdirSync(join(dir, ".claude", "skills-vault", "finance"), {
+		recursive: true,
+	});
+	mkdirSync(join(dir, ".claude", "skills-vault", "seo"), { recursive: true });
+	mkdirSync(join(dir, ".claude", "skills-vault", "seo-crawl-budget"), {
+		recursive: true,
+	});
+	mkdirSync(join(dir, ".claude", "skills-vault", "development"), {
+		recursive: true,
+	});
+	mkdirSync(join(dir, ".claude", "skills-vault", "mobile"), {
+		recursive: true,
+	});
+	// Minimal SKILL.md frontmatter
+	for (const name of [
+		"design",
+		"frontend-taste",
+		"testing",
+		"finance",
+		"seo",
+		"seo-crawl-budget",
+		"development",
+		"mobile",
+	]) {
+		writeFileSync(
+			join(dir, ".claude", "skills-vault", name, "SKILL.md"),
+			`---\nname: ${name}\ndescription: ${name} skill\n---\n# ${name}\n`,
+		);
+	}
+	// package.json
+	writeFileSync(
+		join(dir, "package.json"),
+		JSON.stringify(
+			{ name: "tst", dependencies: deps, devDependencies: devDeps },
+			null,
+			2,
+		),
+	);
+	// Ek dosyalar
+	for (const [name, content] of Object.entries(files)) {
+		writeFileSync(join(dir, name), content);
+	}
+	return dir;
+}
+
+describe("badi skills detect", () => {
+	let dir;
+	afterEach(() => {
+		if (dir) rmSync(dir, { recursive: true, force: true });
+		dir = null;
+	});
+
+	it("React projesi tespit edilir + onerilen kategoriler listelenir", () => {
+		dir = setupProject({ deps: { react: "^18", "react-dom": "^18" } });
+		const r = spawnSync("node", [BADI, "skills", "detect"], {
+			cwd: dir,
+			encoding: "utf-8",
+		});
+		assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+		assert.match(r.stdout, /Stack tespit: 1 teknoloji/);
+		assert.match(r.stdout, /React/);
+		assert.match(r.stdout, /design/);
+		assert.match(r.stdout, /frontend-taste/);
+	});
+
+	it("bos proje 0 teknoloji mesaji", () => {
+		dir = setupProject();
+		const r = spawnSync("node", [BADI, "skills", "detect"], {
+			cwd: dir,
+			encoding: "utf-8",
+		});
+		assert.equal(r.status, 0);
+		assert.match(r.stdout, /eslesme yok|0 teknoloji/);
+	});
+
+	it("Next.js eklenirse SEO kategorileri gelir", () => {
+		dir = setupProject({
+			deps: { next: "^14" },
+			files: { "next.config.mjs": "" },
+		});
+		const r = spawnSync("node", [BADI, "skills", "detect"], {
+			cwd: dir,
+			encoding: "utf-8",
+		});
+		assert.equal(r.status, 0);
+		assert.match(r.stdout, /Next\.js/);
+		assert.match(r.stdout, /seo-crawl-budget/);
+	});
+});
+
+describe("badi skills auto-install", () => {
+	let dir;
+	afterEach(() => {
+		if (dir) rmSync(dir, { recursive: true, force: true });
+		dir = null;
+	});
+
+	it("--dry-run dosyaya yazmaz", () => {
+		dir = setupProject({ deps: { react: "^18" } });
+		const r = spawnSync("node", [BADI, "skills", "auto-install", "--dry-run"], {
+			cwd: dir,
+			encoding: "utf-8",
+		});
+		assert.equal(r.status, 0);
+		assert.match(r.stdout, /--dry-run aktif/);
+		// .claude/skills/ olusturulmus olabilir ama design KOPYALANMAMIS olmali
+		const installed = join(dir, ".claude", "skills", "design");
+		assert.equal(existsSync(installed), false);
+	});
+
+	it("--yes ile interaktifsiz aktive eder", () => {
+		dir = setupProject({ deps: { react: "^18" } });
+		const r = spawnSync("node", [BADI, "skills", "auto-install", "--yes"], {
+			cwd: dir,
+			encoding: "utf-8",
+		});
+		assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+		assert.match(r.stdout, /\d+ eklendi/);
+		assert.equal(existsSync(join(dir, ".claude", "skills", "design")), true);
+		assert.equal(
+			existsSync(join(dir, ".claude", "skills", "frontend-taste")),
+			true,
+		);
+	});
+
+	it("zaten aktif olan tum skill'ler -> degisiklik yok", () => {
+		dir = setupProject({ deps: { react: "^18" } });
+		// Ilk calistirma
+		spawnSync("node", [BADI, "skills", "auto-install", "--yes"], {
+			cwd: dir,
+			encoding: "utf-8",
+		});
+		// Ikinci
+		const r = spawnSync("node", [BADI, "skills", "auto-install", "--yes"], {
+			cwd: dir,
+			encoding: "utf-8",
+		});
+		assert.equal(r.status, 0);
+		assert.match(r.stdout, /zaten aktif/);
+	});
+
+	it("stack yok -> degisiklik yok mesaji", () => {
+		dir = setupProject();
+		const r = spawnSync("node", [BADI, "skills", "auto-install", "--yes"], {
+			cwd: dir,
+			encoding: "utf-8",
+		});
+		assert.equal(r.status, 0);
+		assert.match(r.stdout, /Stack tespit edilmedi|degisiklik yok/);
+	});
+
+	it("non-TTY + --yes yoksa onay bekleyemez, uyari verir", () => {
+		dir = setupProject({ deps: { react: "^18" } });
+		const r = spawnSync("node", [BADI, "skills", "auto-install"], {
+			cwd: dir,
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		assert.equal(r.status, 0);
+		assert.match(r.stdout, /--yes kullan|TTY/);
+	});
+});
+
+describe("badi skills --help: yeni komutlar gorunur", () => {
+	it("detect ve auto-install help'te listeli", () => {
+		const r = spawnSync("node", [BADI, "skills", "--help"], {
+			encoding: "utf-8",
+		});
+		assert.equal(r.status, 0);
+		assert.match(r.stdout, /badi skills detect/);
+		assert.match(r.stdout, /badi skills auto-install/);
+	});
+});

--- a/tests/cli.skills.auto.test.js
+++ b/tests/cli.skills.auto.test.js
@@ -183,15 +183,46 @@ describe("badi skills auto-install", () => {
 		assert.match(r.stdout, /Stack tespit edilmedi|degisiklik yok/);
 	});
 
-	it("non-TTY + --yes yoksa onay bekleyemez, uyari verir", () => {
+	it("non-TTY + --yes yoksa exit 1 (CI guvenligi)", () => {
 		dir = setupProject({ deps: { react: "^18" } });
 		const r = spawnSync("node", [BADI, "skills", "auto-install"], {
 			cwd: dir,
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "pipe"],
 		});
+		assert.equal(r.status, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+		assert.match(r.stderr, /--yes kullan|TTY/);
+	});
+
+	it("--yes + --dry-run: dry-run kazanir, dosya yazilmaz", () => {
+		dir = setupProject({ deps: { react: "^18" } });
+		const r = spawnSync(
+			"node",
+			[BADI, "skills", "auto-install", "--yes", "--dry-run"],
+			{ cwd: dir, encoding: "utf-8" },
+		);
 		assert.equal(r.status, 0);
-		assert.match(r.stdout, /--yes kullan|TTY/);
+		assert.match(r.stdout, /--dry-run aktif/);
+		assert.equal(existsSync(join(dir, ".claude", "skills", "design")), false);
+	});
+
+	it("stack tespit edildi ama vault'ta uygun kategori yok -> uyari", () => {
+		// React projesi ama vault'tan design ve frontend-taste'i kaldir
+		dir = setupProject({ deps: { react: "^18" } });
+		rmSync(join(dir, ".claude", "skills-vault", "design"), {
+			recursive: true,
+			force: true,
+		});
+		rmSync(join(dir, ".claude", "skills-vault", "frontend-taste"), {
+			recursive: true,
+			force: true,
+		});
+		const r = spawnSync("node", [BADI, "skills", "auto-install", "--yes"], {
+			cwd: dir,
+			encoding: "utf-8",
+		});
+		assert.equal(r.status, 0);
+		assert.match(r.stdout, /vault'ta uygun skill kategorisi yok/);
 	});
 });
 

--- a/tests/stack-detector.test.js
+++ b/tests/stack-detector.test.js
@@ -1,0 +1,259 @@
+// stack-detector birim testleri.
+//
+// detectStack() saf fn; geçici dizinde manifest dosyalari yarat, eslesme bekle.
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+	detectStack,
+	evaluateDetect,
+	globToRegex,
+	matchAnyFile,
+	readPackageJson,
+} from "../lib/stack-detector.js";
+
+function writePkg(dir, pkg) {
+	writeFileSync(join(dir, "package.json"), JSON.stringify(pkg, null, 2));
+}
+
+describe("globToRegex", () => {
+	it("yildiz desteklenir", () => {
+		const re = globToRegex("next.config.*");
+		assert.ok(re.test("next.config.js"));
+		assert.ok(re.test("next.config.mjs"));
+		assert.ok(!re.test("nuxt.config.js"));
+	});
+	it("ozel karakterler escape edilir", () => {
+		const re = globToRegex("tsconfig.json");
+		assert.ok(re.test("tsconfig.json"));
+		assert.ok(!re.test("tsconfigxjson"));
+	});
+});
+
+describe("readPackageJson", () => {
+	let dir;
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "stack-pkg-"));
+	});
+	afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+	it("yok ise null", () => {
+		assert.equal(readPackageJson(dir), null);
+	});
+	it("bozuk JSON null", () => {
+		writeFileSync(join(dir, "package.json"), "{not json}");
+		assert.equal(readPackageJson(dir), null);
+	});
+	it("deps ve devDeps merge edilir", () => {
+		writePkg(dir, {
+			name: "x",
+			dependencies: { react: "^18", express: "^4" },
+			devDependencies: { vitest: "^1" },
+		});
+		const r = readPackageJson(dir);
+		assert.ok(r);
+		assert.ok(r.allDeps.has("react"));
+		assert.ok(r.allDeps.has("express"));
+		assert.ok(r.allDeps.has("vitest"));
+		assert.equal(r.name, "x");
+	});
+	it("scripts uniq Set", () => {
+		writePkg(dir, { scripts: { dev: "vite", build: "vite build" } });
+		const r = readPackageJson(dir);
+		assert.ok(r.scripts.has("dev"));
+		assert.ok(r.scripts.has("build"));
+	});
+});
+
+describe("matchAnyFile", () => {
+	let dir;
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "stack-match-"));
+	});
+	afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+	it("desen yoksa null", () => {
+		assert.equal(matchAnyFile(dir, ["nope.*"]), null);
+	});
+	it("varolan dosyayi tespit eder", () => {
+		writeFileSync(join(dir, "next.config.mjs"), "");
+		assert.equal(matchAnyFile(dir, ["next.config.*"]), "next.config.mjs");
+	});
+	it("birden cok desen — ilk eslesen donulur", () => {
+		writeFileSync(join(dir, "tailwind.config.ts"), "");
+		assert.equal(
+			matchAnyFile(dir, ["postcss.config.*", "tailwind.config.*"]),
+			"tailwind.config.ts",
+		);
+	});
+});
+
+describe("evaluateDetect", () => {
+	let dir;
+	let ctx;
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "stack-eval-"));
+		writePkg(dir, {
+			dependencies: { react: "^18" },
+			devDependencies: { vitest: "^1" },
+		});
+		ctx = { target: dir, pkg: readPackageJson(dir) };
+	});
+	afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+	it("packages eslesirse matched=true", () => {
+		const r = evaluateDetect({ packages: ["react"] }, ctx);
+		assert.equal(r.matched, true);
+		assert.match(r.source, /package\.json:dep:react/);
+	});
+	it("packages eslesmezse matched=false", () => {
+		const r = evaluateDetect({ packages: ["unknown-pkg-xyz"] }, ctx);
+		assert.equal(r.matched, false);
+	});
+	it("configFiles glob eslesir", () => {
+		writeFileSync(join(dir, "vite.config.ts"), "");
+		const r = evaluateDetect({ configFiles: ["vite.config.*"] }, ctx);
+		assert.equal(r.matched, true);
+		assert.match(r.source, /^configFile:vite\.config\.ts/);
+	});
+	it("manifestKeys (string substring) eslesir", () => {
+		writeFileSync(join(dir, "pyproject.toml"), "[tool.poetry]\nname='x'");
+		const r = evaluateDetect(
+			{ manifestKeys: [{ file: "pyproject.toml", key: "[tool.poetry]" }] },
+			ctx,
+		);
+		assert.equal(r.matched, true);
+	});
+	it("scripts eslesir", () => {
+		writePkg(dir, { scripts: { dev: "vite" } });
+		ctx.pkg = readPackageJson(dir);
+		const r = evaluateDetect({ scripts: ["dev"] }, ctx);
+		assert.equal(r.matched, true);
+		assert.match(r.source, /script:dev/);
+	});
+	it("hicbir kural eslesmezse matched=false", () => {
+		const r = evaluateDetect({}, ctx);
+		assert.equal(r.matched, false);
+	});
+});
+
+describe("detectStack: tek tek senaryolar", () => {
+	let dir;
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "stack-full-"));
+	});
+	afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+	it("React projesi -> design + frontend-taste", () => {
+		writePkg(dir, { dependencies: { react: "^18", "react-dom": "^18" } });
+		const r = detectStack(dir);
+		assert.ok(r.technologies.some((t) => t.id === "react"));
+		assert.ok(r.skills.has("design"));
+		assert.ok(r.skills.has("frontend-taste"));
+	});
+
+	it("Next.js (config dosyasi) -> seo + seo-crawl-budget", () => {
+		writePkg(dir, { dependencies: { next: "^14" } });
+		writeFileSync(join(dir, "next.config.mjs"), "");
+		const r = detectStack(dir);
+		const tech = r.technologies.find((t) => t.id === "nextjs");
+		assert.ok(tech);
+		assert.ok(r.skills.has("seo"));
+		assert.ok(r.skills.has("seo-crawl-budget"));
+	});
+
+	it("React Native -> mobile", () => {
+		writePkg(dir, { dependencies: { "react-native": "0.75" } });
+		const r = detectStack(dir);
+		assert.ok(r.technologies.some((t) => t.id === "react-native"));
+		assert.ok(r.skills.has("mobile"));
+	});
+
+	it("Python (requirements.txt) -> development + data-analytics", () => {
+		writeFileSync(join(dir, "requirements.txt"), "requests==2.31\n");
+		const r = detectStack(dir);
+		assert.ok(r.technologies.some((t) => t.id === "python"));
+		assert.ok(r.skills.has("development"));
+		assert.ok(r.skills.has("data-analytics"));
+	});
+
+	it("Rust (Cargo.toml) -> development", () => {
+		writeFileSync(join(dir, "Cargo.toml"), '[package]\nname="x"\n');
+		const r = detectStack(dir);
+		assert.ok(r.technologies.some((t) => t.id === "rust"));
+	});
+
+	it("Stripe deps -> finance", () => {
+		writePkg(dir, { dependencies: { stripe: "^14" } });
+		const r = detectStack(dir);
+		assert.ok(r.skills.has("finance"));
+	});
+
+	it("Vitest dev -> testing", () => {
+		writePkg(dir, { devDependencies: { vitest: "^1" } });
+		const r = detectStack(dir);
+		assert.ok(r.skills.has("testing"));
+	});
+
+	it("Docker (Dockerfile) -> devops", () => {
+		writeFileSync(join(dir, "Dockerfile"), "FROM node:20\n");
+		const r = detectStack(dir);
+		assert.ok(r.skills.has("devops"));
+	});
+
+	it("bos dizin -> 0 teknoloji, 0 skill", () => {
+		const r = detectStack(dir);
+		assert.equal(r.technologies.length, 0);
+		assert.equal(r.skills.size, 0);
+	});
+
+	it("kombinasyon: Next.js + Tailwind + Stripe + Prisma", () => {
+		writePkg(dir, {
+			dependencies: {
+				next: "^14",
+				tailwindcss: "^3",
+				stripe: "^14",
+				"@prisma/client": "^5",
+			},
+		});
+		writeFileSync(join(dir, "next.config.mjs"), "");
+		const r = detectStack(dir);
+		const ids = r.technologies.map((t) => t.id);
+		assert.ok(ids.includes("nextjs"));
+		assert.ok(ids.includes("tailwind"));
+		assert.ok(ids.includes("stripe"));
+		assert.ok(ids.includes("prisma"));
+		assert.ok(r.skills.has("seo"));
+		assert.ok(r.skills.has("design"));
+		assert.ok(r.skills.has("finance"));
+		assert.ok(r.skills.has("data-analytics"));
+	});
+});
+
+describe("detectStack: idempotency + skills set", () => {
+	let dir;
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "stack-idem-"));
+	});
+	afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+	it("ayni dizin iki kez cagrilirsa ayni sonuc", () => {
+		writePkg(dir, { dependencies: { react: "^18" } });
+		const a = detectStack(dir);
+		const b = detectStack(dir);
+		assert.deepEqual(
+			a.technologies.map((t) => t.id),
+			b.technologies.map((t) => t.id),
+		);
+		assert.deepEqual([...a.skills].sort(), [...b.skills].sort());
+	});
+
+	it("skills Set tipi", () => {
+		writePkg(dir, { dependencies: { react: "^18" } });
+		const r = detectStack(dir);
+		assert.ok(r.skills instanceof Set);
+	});
+});

--- a/tests/stack-detector.test.js
+++ b/tests/stack-detector.test.js
@@ -3,7 +3,13 @@
 // detectStack() saf fn; geçici dizinde manifest dosyalari yarat, eslesme bekle.
 
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
@@ -130,12 +136,35 @@ describe("evaluateDetect", () => {
 	it("scripts eslesir", () => {
 		writePkg(dir, { scripts: { dev: "vite" } });
 		ctx.pkg = readPackageJson(dir);
+		ctx.rootEntries = ["package.json"];
 		const r = evaluateDetect({ scripts: ["dev"] }, ctx);
 		assert.equal(r.matched, true);
 		assert.match(r.source, /script:dev/);
 	});
 	it("hicbir kural eslesmezse matched=false", () => {
 		const r = evaluateDetect({}, ctx);
+		assert.equal(r.matched, false);
+	});
+	it("configDirs DIR eslesir, FILE eslesmez", () => {
+		// 'prisma' adinda DIZIN olustur
+		mkdirSync(join(dir, "prisma"));
+		ctx.rootEntries = readdirSync(dir);
+		const r = evaluateDetect({ configDirs: ["prisma"] }, ctx);
+		assert.equal(r.matched, true);
+		assert.match(r.source, /^configDir:prisma/);
+	});
+	it("configDirs sadece DIR — DOSYA reddedilir", () => {
+		// 'prisma' adinda DOSYA olustur (yanlis pozitif testi)
+		writeFileSync(join(dir, "prisma"), "");
+		ctx.rootEntries = readdirSync(dir);
+		const r = evaluateDetect({ configDirs: ["prisma"] }, ctx);
+		assert.equal(r.matched, false);
+	});
+	it("configFiles sadece DOSYA — DIZIN reddedilir", () => {
+		// 'next.config.js' adinda DIZIN olustur
+		mkdirSync(join(dir, "next.config.js"));
+		ctx.rootEntries = readdirSync(dir);
+		const r = evaluateDetect({ configFiles: ["next.config.*"] }, ctx);
 		assert.equal(r.matched, false);
 	});
 });


### PR DESCRIPTION
## Summary

`midudev/autoskills` (npx autoskills) analizinden cikan **install-time stack-aware skill curation** modelini Badi'nin opt-in modeline yerlestirir. Iki yeni alt-komut:

- `badi skills detect` — proje koku taranir, eslesen Badi skill kategorileri listelenir (read-only)
- `badi skills auto-install [--yes|--dry-run]` — detect + interaktif onay + opt-in aktivasyon

## Neden bu fark?

| Boyut | midudev/autoskills | Badi auto-router (mevcut) | **Bu PR** |
|-------|-------------------|--------------------------|-----------|
| Zaman | install-time | runtime (her prompt) | **install-time** |
| Tetik | proje dosyalari | kullanici prompt'u | **proje dosyalari** |
| Cikti | `.claude/skills/` dosya | per-turn context | **`.claude/skills/` opt-in kopya** |

Runtime auto-router (lib/skills-router.js) dokunulmaz. Iki katman birbirini tamamlar — install-time **curation** + runtime **injection**.

## Dosyalar

- `lib/stack-detector.js` (yeni) — saf detector, manifest tabani
- `lib/skills/stack-map.js` (yeni) — 35+ teknoloji → Badi skill kategorisi
- `lib/commands/skills.js` — `detect` + `auto-install` alt-komutlari + helper'lar
- `tests/stack-detector.test.js` (yeni, 27 test) — saf fn birim
- `tests/cli.skills.auto.test.js` (yeni, 9 test) — subprocess + TTY edge

## Algoritma

`evaluateDetect(detect, ctx)` su sinyalleri sirayla tarar:
1. **packages** — package.json deps/devDeps/peerDeps/optionalDeps
2. **configFiles** — root-level glob existence (next.config.*, vite.config.*, ...)
3. **fileExtensions** — root-level (.swift, .kt, .tf)
4. **manifestKeys** — pyproject.toml/Cargo.toml/go.mod metin substring/regex
5. **scripts** — npm scripts adi

Eslesen teknolojiler `stack-map.js` manifestindeki `skills:` listesini Set'e ekler. `auto-install` Set'i mevcut aktif skill'lerle karsilastirir, sadece eksikleri kopyalar (idempotent).

## Desteklenen Stack (35+)

Frontend: React, Vue, Svelte, Angular · Meta: Next.js, Nuxt, Astro, Remix · Styling: Tailwind, shadcn · Mobile: React Native, Expo, Flutter, Swift, Kotlin · Backend: Express, Hono, NestJS, Fastify · Lang: TypeScript, Go, Rust, Python, Ruby · DB: Prisma, Drizzle, Supabase · Auth/Pay: Stripe, Clerk, Better Auth · Test: Vitest, Jest, Playwright, Cypress · DevOps: Docker, Terraform, GitHub Actions · AI: Vercel AI SDK, OpenAI, Anthropic, LangChain · E-ticaret: Shopify, WooCommerce · Email: Resend, Nodemailer · Media: Remotion

## Ornekler

```bash
# Tespit (dosyaya dokunmaz)
$ badi skills detect

# Onayli aktivasyon
$ badi skills auto-install
3 skill aktive edilsin mi? [E/h] E

# Otomatik (CI)
$ badi skills auto-install --yes

# Goz at (yazma)
$ badi skills auto-install --dry-run
```

## Sayilar

- Test: **727 → 763** (+36, hepsi yesil)
- Lint: **0 issue** (biome check)
- Yeni LOC: ~1192 (250 detector + 350 stack-map + 200 cmd helper + 400 test)
- Yeni komut: 2 alt-komut (`detect`, `auto-install`)

## Test plan

- [x] `node --test tests/stack-detector.test.js` (27/27)
- [x] `node --test tests/cli.skills.auto.test.js` (9/9)
- [x] `npm test` (763/763)
- [x] `npx biome check` (0 issue)
- [x] React projesinde elle dogrulama: `badi skills detect` -> React tespit, design + frontend-taste onerisi
- [x] Bos dizinde: 0 teknoloji mesaji
- [x] `--dry-run` dosya yazmiyor; `--yes` yaziyor; non-TTY uyari veriyor

## Sonraki adimlar (bu PR'in disinda)

- Skill SKILL.md frontmatter'ina opsiyonel `stack:` alani — manifest yerine self-describing skill
- `--lock` flag ile skills-lock.json yazma (SHA-256 manifest, supply-chain audit)
- Eslesen ama desteklenmeyen teknolojiler icin telemetri (hangi tech'ler popüler ama henüz yok?)

🤖 Generated with [Claude Code](https://claude.com/claude-code)