### PR TITLE
docs(kb): pentest-* aile dersinden 2 kalici kural

### DIFF
--- a/.claude/knowledge-base.md
+++ b/.claude/knowledge-base.md
@@ -20,5 +20,22 @@
 ## Proje Kaliplari
 <!-- Projede tekrar eden yapi/kaliplar -->
 
+### Skill ailesi eklemede "advisory/defensive" siniri
+Pentest, security, exploit gibi alanlarda yeni skill ailesi eklerken
+Badi yalnizca **advisory/defensive** kapsamla sinirli kalir. Live exploit
+execution, payload crafting, C2 operation, weaponization gibi aktif
+saldiri yetenekleri vault'a EKLENMEZ — bunlar icin yetkili pentest tool
+kullanilir. Skill icerigi: scope-deklare disiplini, OPSEC tagging,
+metodoloji, output analizi, raporlama, detection rule yazimi.
+[Kaynak: 2026-05-15 pentest-* aile karari]
+
+### STACK_MAP entry kalibi: tek tespit, cok skill
+`lib/skills/stack-map.js` icinde bir entry birden cok skill onerebilir.
+Komponent / aile bazli skill curation icin: ana tespit dosyasi
+(scope.md, findings.db gibi) -> 4-5 skill paketi oneren tek entry yaz.
+Bu, kullanicinin `badi skills auto-install` ile bir hamlede ilgili
+tum kategorileri aktive etmesini saglar.
+[Kaynak: 2026-05-15 pentest-engagement entry tasarimi]
+
 ## Bilinen Hata Kaliplari
 <!-- Daha once karsilasilan ve cozulen hatalar -->


### PR DESCRIPTION
Bugun (15.05.2026) pentest-* aile eklenmesinden cikarilan 2 kalici proje kalibi knowledge-base.md'ye eklendi:

1. **Advisory/defensive siniri** — yeni guvenlik skill ailesi eklerken live exploit/payload/C2 yok
2. **STACK_MAP entry kalibi** — tek tespit dosyasi, cok skill onerisi (aile bazli activation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)