### PR TITLE
chore(release): v1.26.0 hazirlik

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fatihkan/badi",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fatihkan/badi",
-      "version": "1.25.0",
+      "version": "1.26.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fatihkan/badi",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "Workflow management CLI for Claude Code, Cursor, and Gemini CLI — 21 AI agents, 77 commands, OWASP security scans. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
   "type": "module",
   "main": "bin/badi.js",


### PR DESCRIPTION
## Summary

v1.26.0 release prep: `package.json` + `package-lock.json` version bump (1.25.0 -> 1.26.0).

## Test plan
- [x] `npm test` — 805/805 yesil (PR #157'da)
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)