### PR TITLE
chore: package.json revert 1.26.0 -> 1.25.0 (publish flow icin)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fatihkan/badi",
-  "version": "1.26.0",
+  "version": "1.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fatihkan/badi",
-      "version": "1.26.0",
+      "version": "1.25.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fatihkan/badi",
-  "version": "1.26.0",
+  "version": "1.25.0",
   "description": "Workflow management CLI for Claude Code, Cursor, and Gemini CLI — 21 AI agents, 77 commands, OWASP security scans. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
   "type": "module",
   "main": "bin/badi.js",


### PR DESCRIPTION
PR #158'de erken bump yapildi. `badi publish --version minor` kendi bump'i yapacak (1.25.0 -> 1.26.0).