### PR TITLE
fix(hooks): defensive fail-safe handlers (closes #162)

### DIFF
--- a/.claude/hooks/backup-before-write.mjs
+++ b/.claude/hooks/backup-before-write.mjs
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
+// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
+const _badiFailSafe = (e) => {
+	if (process.env.BADI_HOOK_DEBUG) {
+		try {
+			process.stderr.write(`[badi-hook] ${e?.message || e}\n`);
+		} catch {}
+	}
+	process.exit(0);
+};
+process.on("uncaughtException", _badiFailSafe);
+process.on("unhandledRejection", _badiFailSafe);
+
 // Badi - Yazma Oncesi Yedekleme (PreToolUse - Async)
 // Dosya degisikliklerinden once otomatik yedek olusturur.
 

--- a/.claude/hooks/branch-guard.mjs
+++ b/.claude/hooks/branch-guard.mjs
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
+// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
+const _badiFailSafe = (e) => {
+	if (process.env.BADI_HOOK_DEBUG) {
+		try {
+			process.stderr.write(`[badi-hook] ${e?.message || e}\n`);
+		} catch {}
+	}
+	process.exit(0);
+};
+process.on("uncaughtException", _badiFailSafe);
+process.on("unhandledRejection", _badiFailSafe);
+
 // Badi - Dal Korumasi (PreToolUse - Bash)
 // Korunmus dallara dogrudan commit islemlerini engeller.
 // Push islemi merge sonrasi yayim olarak kabul edilir, engellenmez.

--- a/.claude/hooks/completeness-gate.mjs
+++ b/.claude/hooks/completeness-gate.mjs
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
+// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
+const _badiFailSafe = (e) => {
+	if (process.env.BADI_HOOK_DEBUG) {
+		try {
+			process.stderr.write(`[badi-hook] ${e?.message || e}\n`);
+		} catch {}
+	}
+	process.exit(0);
+};
+process.on("uncaughtException", _badiFailSafe);
+process.on("unhandledRejection", _badiFailSafe);
+
 // Badi - Tamamlanmislik Kapisi (PreToolUse)
 // Kritik dosyalara yazma oncesi icerik dogrulamasi yapar.
 

--- a/.claude/hooks/dependency-audit.mjs
+++ b/.claude/hooks/dependency-audit.mjs
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
+// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
+const _badiFailSafe = (e) => {
+	if (process.env.BADI_HOOK_DEBUG) {
+		try {
+			process.stderr.write(`[badi-hook] ${e?.message || e}\n`);
+		} catch {}
+	}
+	process.exit(0);
+};
+process.on("uncaughtException", _badiFailSafe);
+process.on("unhandledRejection", _badiFailSafe);
+
 // Badi - Bagimlilik Denetimi (SessionStart - New)
 // 24 saat cache ile oturum basinda guvenlik taramasi.
 

--- a/.claude/hooks/guard-bash.mjs
+++ b/.claude/hooks/guard-bash.mjs
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
+// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
+const _badiFailSafe = (e) => {
+	if (process.env.BADI_HOOK_DEBUG) {
+		try {
+			process.stderr.write(`[badi-hook] ${e?.message || e}\n`);
+		} catch {}
+	}
+	process.exit(0);
+};
+process.on("uncaughtException", _badiFailSafe);
+process.on("unhandledRejection", _badiFailSafe);
+
 // Badi - Bash Guvenlik Korumasi (PreToolUse)
 // Tehlikeli komutlari uc katmanli izin sistemiyle denetler.
 

--- a/.claude/hooks/log-changes.mjs
+++ b/.claude/hooks/log-changes.mjs
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
+// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
+const _badiFailSafe = (e) => {
+	if (process.env.BADI_HOOK_DEBUG) {
+		try {
+			process.stderr.write(`[badi-hook] ${e?.message || e}\n`);
+		} catch {}
+	}
+	process.exit(0);
+};
+process.on("uncaughtException", _badiFailSafe);
+process.on("unhandledRejection", _badiFailSafe);
+
 // Badi - Degisiklik Kaydi (PostToolUse - Async)
 // Tum dosya degisikliklerini denetim izine kaydeder.
 

--- a/.claude/hooks/log-failures.mjs
+++ b/.claude/hooks/log-failures.mjs
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
+// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
+const _badiFailSafe = (e) => {
+	if (process.env.BADI_HOOK_DEBUG) {
+		try {
+			process.stderr.write(`[badi-hook] ${e?.message || e}\n`);
+		} catch {}
+	}
+	process.exit(0);
+};
+process.on("uncaughtException", _badiFailSafe);
+process.on("unhandledRejection", _badiFailSafe);
+
 // Badi - Hata Kaydi (PostToolUseFailure - Async)
 // Arac hatalarini kategorize edip kaydeder.
 

--- a/.claude/hooks/log-stop-verdict.mjs
+++ b/.claude/hooks/log-stop-verdict.mjs
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
+// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
+const _badiFailSafe = (e) => {
+	if (process.env.BADI_HOOK_DEBUG) {
+		try {
+			process.stderr.write(`[badi-hook] ${e?.message || e}\n`);
+		} catch {}
+	}
+	process.exit(0);
+};
+process.on("uncaughtException", _badiFailSafe);
+process.on("unhandledRejection", _badiFailSafe);
+
 // Badi - Durak Karari Kaydi (Stop Hook - Async)
 // Oturum sonundaki kararlari ve ogrenimleri kaydeder.
 

--- a/.claude/hooks/post-compact-resume.mjs
+++ b/.claude/hooks/post-compact-resume.mjs
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
+// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
+const _badiFailSafe = (e) => {
+	if (process.env.BADI_HOOK_DEBUG) {
+		try {
+			process.stderr.write(`[badi-hook] ${e?.message || e}\n`);
+		} catch {}
+	}
+	process.exit(0);
+};
+process.on("uncaughtException", _badiFailSafe);
+process.on("unhandledRejection", _badiFailSafe);
+
 // Badi - Sikistirma Sonrasi Devam (SessionStart - Resumed)
 // Sikistirma sonrasi baglami geri yukler.
 

--- a/.claude/hooks/pre-compact-handoff.mjs
+++ b/.claude/hooks/pre-compact-handoff.mjs
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
+// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
+const _badiFailSafe = (e) => {
+	if (process.env.BADI_HOOK_DEBUG) {
+		try {
+			process.stderr.write(`[badi-hook] ${e?.message || e}\n`);
+		} catch {}
+	}
+	process.exit(0);
+};
+process.on("uncaughtException", _badiFailSafe);
+process.on("unhandledRejection", _badiFailSafe);
+
 // Badi - Sikistirma Oncesi Durum Kaydi (PreCompact)
 // Otomatik sikistirma oncesi durumu kaydeder.
 

--- a/.claude/hooks/session-reset.mjs
+++ b/.claude/hooks/session-reset.mjs
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
+// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
+const _badiFailSafe = (e) => {
+	if (process.env.BADI_HOOK_DEBUG) {
+		try {
+			process.stderr.write(`[badi-hook] ${e?.message || e}\n`);
+		} catch {}
+	}
+	process.exit(0);
+};
+process.on("uncaughtException", _badiFailSafe);
+process.on("unhandledRejection", _badiFailSafe);
+
 // Badi - Oturum Sifirlama (SessionStart - New)
 // Yeni oturum baslatildiginda durum temizligi ve butunluk kontrolu yapar.
 

--- a/.claude/hooks/skill-router.mjs
+++ b/.claude/hooks/skill-router.mjs
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
+// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
+const _badiFailSafe = (e) => {
+	if (process.env.BADI_HOOK_DEBUG) {
+		try {
+			process.stderr.write(`[badi-hook] ${e?.message || e}\n`);
+		} catch {}
+	}
+	process.exit(0);
+};
+process.on("uncaughtException", _badiFailSafe);
+process.on("unhandledRejection", _badiFailSafe);
+
 // Badi - UserPromptSubmit Auto-Router
 //
 // Iki vault'tan inject yapar:

--- a/.claude/hooks/track-usage.mjs
+++ b/.claude/hooks/track-usage.mjs
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
+// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
+const _badiFailSafe = (e) => {
+	if (process.env.BADI_HOOK_DEBUG) {
+		try {
+			process.stderr.write(`[badi-hook] ${e?.message || e}\n`);
+		} catch {}
+	}
+	process.exit(0);
+};
+process.on("uncaughtException", _badiFailSafe);
+process.on("unhandledRejection", _badiFailSafe);
+
 // Badi - Kullanim Takip Hook'u (PostToolUse - Async)
 // Her arac kullanimini usage.jsonl'e kaydeder. Cross-platform Node.js.
 

--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -3,7 +3,7 @@
 ## Mevcut Durum
 - Proje: Badi - Claude Code Is Akisi Yonetim Sistemi
 - npm: @fatihkan/badi v1.26.0 (yayinda) — 15.05.2026; v1.27 hazirlik
-- Tests: 815 (Linux+macOS yesil; Windows non-blocking) — v1.27 expo-* aile +10 stack test
+- Tests: 868 (Linux+macOS yesil; Windows non-blocking) — v1.27 expo-* aile +10 stack + #162 fix +53 hook resilience
 - Yan repo: github.com/fatihkan/badi-skills v1.0.0 (25 skill bundle)
 - Engines: Node >=20.11.0
 - CodeQL: tum workflow'lar kaldirildi (10.05.2026, afe099e) — local lint/test + manuel publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,12 +65,29 @@ commands themselves.
   package or `modules/` dir), `expo-notifications`, `expo-dev-client`,
   `expo-config-plugin`.
 
+### Fixed — hook defensive fail-safe (#162)
+
+All 13 `.claude/hooks/*.mjs` files now register top-level
+`uncaughtException` + `unhandledRejection` handlers that force `exit(0)`
+on runtime errors. Claude Code's session will no longer surface
+"Failed with non-blocking status code" warnings for transient hook
+failures. Set `BADI_HOOK_DEBUG=1` in your environment to emit error
+messages to stderr for diagnosis.
+
+This addresses the symptom reported on Node v25.x where Stop hook
+async invocation surfaced module resolution errors. Note: this fix
+hardens runtime error recovery but cannot catch entry-point load
+failures (e.g. missing files); use `badi doctor` to verify hook files
+exist on your install.
+
 ### Tests
 
-- Test count: **805 → 815 (+10)**, all green.
+- Test count: **805 → 868 (+63)**, all green.
 - New `describe("detectStack: expo-* family (v1.27)")` block in
   `tests/stack-detector.test.js`: 10 tests covering package, directory,
   and config file detection signals.
+- New `tests/hooks-failsafe.test.js`: 53 tests verifying every hook
+  exits 0 on empty / malformed / valid stdin, plus marker validation.
 
 ### Vault
 

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -54,10 +54,27 @@ rehberlik eder; gercek build/submit/update komutlarini kullanici calistirir.
   `expo-modules`, `expo-notifications`, `expo-dev-client`,
   `expo-config-plugin`.
 
+### Duzeltildi — hook defensive fail-safe (#162)
+
+Tum 13 `.claude/hooks/*.mjs` dosyasi artik top-level
+`uncaughtException` + `unhandledRejection` handler kaydeder; runtime
+hatasinda zorla `exit(0)` doner. Claude Code session'i artik gecici
+hook hatalari icin "Failed with non-blocking status code" uyarisi
+gostermez. Hata mesajlarini stderr'a goruntulemek icin
+`BADI_HOOK_DEBUG=1` env ile calistir.
+
+Bu fix Node v25.x'te Stop hook async invocation'inda goruldu raporlanan
+modul cozumleme hatasini yumusatir. Not: bu fix runtime hata
+toparlanmasini guclendirir ama entry-point yukleme hatalarini (orn.
+eksik dosya) yakalayamaz; hook dosyalarinin var oldugunu dogrulamak
+icin `badi doctor` calistir.
+
 ### Testler
 
-- Test sayisi: **805 → 815 (+10)**, hepsi yesil.
+- Test sayisi: **805 → 868 (+63)**, hepsi yesil.
 - Yeni `describe("detectStack: expo-* family (v1.27)")` blok 10 test.
+- Yeni `tests/hooks-failsafe.test.js`: her hook icin bos/bozuk/gecerli
+  stdin'de exit 0 dogrulamasi + marker kontrolu (53 test).
 
 ### Vault
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img src="https://img.shields.io/npm/dm/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm downloads per month" />
   <img src="https://img.shields.io/npm/dt/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm total downloads" />
   <img src="https://img.shields.io/npm/l/@fatihkan/badi?color=00d4ff&style=flat-square" alt="license" />
-  <img src="https://img.shields.io/badge/tests-815%20passing-00d4ff?style=flat-square" alt="tests" />
+  <img src="https://img.shields.io/badge/tests-868%20passing-00d4ff?style=flat-square" alt="tests" />
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -7,7 +7,7 @@
   <img src="https://img.shields.io/npm/dm/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm downloads per month" />
   <img src="https://img.shields.io/npm/dt/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm total downloads" />
   <img src="https://img.shields.io/npm/l/@fatihkan/badi?color=00d4ff&style=flat-square" alt="license" />
-  <img src="https://img.shields.io/badge/tests-815%20passing-00d4ff?style=flat-square" alt="tests" />
+  <img src="https://img.shields.io/badge/tests-868%20passing-00d4ff?style=flat-square" alt="tests" />
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 

--- a/tests/hooks-failsafe.test.js
+++ b/tests/hooks-failsafe.test.js
@@ -1,0 +1,89 @@
+// Hook defensive fail-safe testleri (#162).
+//
+// Tum .mjs hook'lari runtime hatasi durumunda exit 0 ile cikmali,
+// Claude Code session'i etkilenmemeli.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HOOKS_DIR = resolve(__dirname, "../.claude/hooks");
+const MARKER = "Badi v1.27+ defensive fail-safe (#162)";
+
+function listHooks() {
+	return readdirSync(HOOKS_DIR)
+		.filter((f) => f.endsWith(".mjs") && f !== "_util.mjs")
+		.map((f) => join(HOOKS_DIR, f));
+}
+
+function runHook(hookPath, stdin = "", env = {}) {
+	return spawnSync(process.execPath, [hookPath], {
+		input: stdin,
+		encoding: "utf-8",
+		timeout: 5000,
+		env: { ...process.env, ...env },
+	});
+}
+
+describe("hooks fail-safe header (#162)", () => {
+	const hooks = listHooks();
+
+	it("13 .mjs hook bulunmali", () => {
+		assert.equal(hooks.length, 13, `Beklenen 13, bulunan ${hooks.length}`);
+	});
+
+	for (const hookPath of hooks) {
+		const name = hookPath.split("/").pop();
+		it(`${name} marker icerir`, () => {
+			const content = readFileSync(hookPath, "utf-8");
+			assert.ok(content.includes(MARKER), `${name} icinde "${MARKER}" yok`);
+		});
+	}
+});
+
+describe("hooks runtime resilience (#162)", () => {
+	const hooks = listHooks();
+
+	for (const hookPath of hooks) {
+		const name = hookPath.split("/").pop();
+		it(`${name} bos stdin'de exit 0`, () => {
+			const r = runHook(hookPath, "");
+			assert.equal(
+				r.status,
+				0,
+				`${name} exit ${r.status}, stderr: ${r.stderr}`,
+			);
+		});
+
+		it(`${name} bozuk JSON stdin'de exit 0`, () => {
+			const r = runHook(hookPath, "{not valid json}");
+			assert.equal(
+				r.status,
+				0,
+				`${name} exit ${r.status}, stderr: ${r.stderr}`,
+			);
+		});
+
+		it(`${name} minimal valid JSON ile exit 0`, () => {
+			const r = runHook(
+				hookPath,
+				JSON.stringify({
+					session_id: "test",
+					transcript_path: "/tmp/x.jsonl",
+					tool_name: "Bash",
+					tool_input: { command: "ls" },
+					prompt: "test prompt",
+				}),
+			);
+			assert.equal(
+				r.status,
+				0,
+				`${name} exit ${r.status}, stderr: ${r.stderr}`,
+			);
+		});
+	}
+});


### PR DESCRIPTION
## Summary

Tum 13 `.claude/hooks/*.mjs` dosyasi top-level `uncaughtException` + `unhandledRejection` handler kaydeder; runtime hatasinda zorla `exit(0)` doner. Claude Code session'i artik gecici hook hatalari icin **"Failed with non-blocking status code"** uyarisi gostermez.

Closes #162.

## Pattern

Her hook'un shebang'inden hemen sonra inline 9-satir defensive header:

```js
// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
const _badiFailSafe = (e) => {
	if (process.env.BADI_HOOK_DEBUG) {
		try { process.stderr.write(`[badi-hook] ${e?.message || e}\n`); } catch {}
	}
	process.exit(0);
};
process.on("uncaughtException", _badiFailSafe);
process.on("unhandledRejection", _badiFailSafe);
```

## Sinir

Bu fix RUNTIME hata toparlanmasini guclendirir ama **entry-point yukleme** hatalarini (orn. dosya bulunmuyor) yakalayamaz — Node bizim handler'larimiz register edilemeden once duser. Kullanici raporundaki tam senaryoyu (MODULE_NOT_FOUND of entry .mjs) cozemez, ancak runtime hatalari icin universally robust hale getirir.

Eksik dosya senaryosunda: `badi doctor` 42 kontrolden hook varlik kontrolunu yapar.

## Test plan

- [x] `tests/hooks-failsafe.test.js` — yeni dosya, 53 test:
  - 14 marker dogrulamasi (her hook icinde defensive header var mi?)
  - 13 × 3 = 39 runtime smoke (bos / bozuk JSON / minimal valid stdin -> her durumda exit 0)
- [x] `npm test` — 815 → **868** (+53, hepsi yesil)
- [x] `npm run lint` — clean
- [x] Manual smoke: `echo '{}' | node .claude/hooks/log-stop-verdict.mjs; echo $?` -> `0`

## Files

- 13 hook .mjs dosyasi — defensive header eklendi
- `tests/hooks-failsafe.test.js` — yeni resilience test
- `CHANGELOG.md` + `.tr.md` — Fixed bolumu eklendi
- `README.md` + `.tr.md` — test badge 815 → 868
- `.claude/memory.md` — test sayisi guncellendi

## v1.27.0 release

v1.27.0 hala yayinlanmadi — bu fix v1.27.0 release'ine dahil olacak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)