### PR TITLE
docs(cli): help completeness audit + README/CHANGELOG drift fix

### DIFF
--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -2,7 +2,7 @@
 
 ## Mevcut Durum
 - Proje: Badi - Claude Code Is Akisi Yonetim Sistemi
-- npm: @fatihkan/badi v1.26.0 (yayinda) — 15.05.2026; v1.27 hazirlik
+- npm: @fatihkan/badi v1.27.0 (yayinda) — 15.05.2026; #162 hook fix dahil
 - Tests: 868 (Linux+macOS yesil; Windows non-blocking) — v1.27 expo-* aile +10 stack + #162 fix +53 hook resilience
 - Yan repo: github.com/fatihkan/badi-skills v1.0.0 (25 skill bundle)
 - Engines: Node >=20.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Fixed — help completeness across CLI surfaces
+
+Deep audit of `badi <cmd> --help` outputs revealed three classes of gaps;
+all are now closed.
+
+- **Top-level `badi --help`**: the `aso` / `market` / `tasarim` lines were
+  rendered on a single concatenated row because `console.log` was called
+  once with three arguments (which inserts spaces, not newlines). Split
+  into three separate calls. (`bin/badi.js`)
+- **`badi commands --help`** (v1.26+): the `route "<prompt>"` subcommand,
+  stdin form, profile flags (`--yes` / `--dry-run` / `--force` /
+  `--verbose`), and route flags (`--top N` / `--inject` / `--json`) were
+  all missing from the help text — only the switch statement knew about
+  them. Help text now mirrors what the code actually accepts, with five
+  example invocations and a note that user-authored commands are
+  preserved on profile switch. (`lib/commands/commands.js`)
+- **`badi skills --help`** (v1.20+): the `--top N` and `--json` route
+  flags were undocumented; the categories footnote was frozen at
+  "v1.25 / 50 categories" even though v1.27 ships 62 categories (25
+  general + 25 `pentest-*` + 12 `expo-*`). Both updated.
+  (`lib/commands/skills.js`)
+
+No behavior change — these are doc-string corrections. The actual
+subcommand and flag parsing already worked; the help text was lagging
+behind. Tests: 868 still passing.
+
+### Changed — README drift
+
+The 1.27 release notes table listed test count as `805 → 815` (a typo —
+real count jumped to 868 because of the 53 hook fail-safe resilience
+tests added in PR #163). README hero rows still said "50 opt-in skill
+categories" and "805 passing tests". All four spots corrected across
+`README.md` and `README.tr.md`. A new "Profile-Based Commands + Command
+Router" subsection was added that documents `badi commands profile/route`
+end-to-end (the v1.26 release shipped without a dedicated README section).
+
 ## [1.27.0] - 2026-05-15
 
 ### Added — expo-* skill family (12 categories, advisory)

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,41 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+### Duzeltildi — CLI yuzeylerinde help eksikligi
+
+`badi <cmd> --help` ciktilarinin derin denetimi uc tur eksiklik ortaya
+cikardi; hepsi kapatildi.
+
+- **Top-level `badi --help`**: `aso` / `market` / `tasarim` satirlari
+  tek birlesik satir olarak basiliyordu cunku `console.log` tek cagriya
+  uc argumanla veriliyordu (bosluk koyar, newline koymaz). Uc ayri
+  cagriya bolundu. (`bin/badi.js`)
+- **`badi commands --help`** (v1.26+): `route "<prompt>"` alt komutu,
+  stdin formu, profil flag'leri (`--yes` / `--dry-run` / `--force` /
+  `--verbose`) ve route flag'leri (`--top N` / `--inject` / `--json`)
+  help metninde yoktu — sadece switch statement biliyordu. Help metni
+  artik kodun kabul ettiklerini yansitir, bes ornek calistirma ve
+  profil degisikliginde kullanici komutlarinin korundugu notu eklendi.
+  (`lib/commands/commands.js`)
+- **`badi skills --help`** (v1.20+): `--top N` ve `--json` route
+  flag'leri belgesizdi; kategoriler dipnotu "v1.25 / 50 kategori"de
+  donuktu — v1.27 artik 62 kategori (25 genel + 25 `pentest-*` + 12
+  `expo-*`). Ikisi de guncellendi. (`lib/commands/skills.js`)
+
+Davranis degisikligi yok — bu doc-string duzeltmeleri. Gercek alt-komut
+ve flag parsing zaten calisiyordu; sadece help metni geride kalmis. Test:
+868 hala yesil.
+
+### Degisti — README drift
+
+1.27 release notes tablosu test sayisini `805 → 815` olarak listelemisti
+(typo — gercek sayi 868'e zipladi cunku PR #163'te 53 hook fail-safe
+resilience testi eklendi). README hero satirlari hala "50 opt-in skill
+kategorisi" ve "805 onaylanmis test" diyordu. `README.md` + `README.tr.md`
+icindeki dort yer duzeltildi. Yeni "Profil Bazli Komutlar + Komut Router"
+alt bolumu eklendi — `badi commands profile/route` uctan uca belgelenmis
+oldu (v1.26 release dedicated bir README bolumu olmadan cikmisti).
+
 ## [1.27.0] - 2026-05-15
 
 ### Eklendi — expo-* skill ailesi (12 kategori, advisory)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 /plugin install badi@badi-marketplace
 ```
 
-**As an npm CLI (full feature set: 22 agents · 77 commands with profile management (v1.26+) · 13 hooks · 50 opt-in skill categories with auto-router)**:
+**As an npm CLI (full feature set: 22 agents · 77 commands with profile management (v1.26+) · 13 hooks · 62 opt-in skill categories with auto-router)**:
 
 ```bash
 npx @fatihkan/badi init                    # interactive harness picker
@@ -70,10 +70,10 @@ Claude is the canonical source. Cursor and Gemini adapters compile from the same
 | Feature | Details |
 |---------|---------|
 | **22 expert agents + 77 commands** | Full toolkit from security scanner to performance profiler — profile-based filtering (core/dev/content/pentest) since v1.26 |
-| **13 automation hooks + 50 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants. Skills load zero tokens by default since v1.17; auto-router (v1.20+) injects matching skills per prompt; pentest-* family (v1.25+ advisory/defensive); command routing (v1.26+) |
+| **13 automation hooks + 62 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants. Skills load zero tokens by default since v1.17; auto-router (v1.20+) injects matching skills per prompt; pentest-* family (v1.25+ advisory/defensive); expo-* family (v1.27+ mobile dev lifecycle); command routing (v1.26+) |
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+)** | Claude Code, Cursor, Gemini CLI — same `.claude/` source, different targets |
-| **805 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, tasarim, profile management |
+| **868 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, tasarim, profile management, hook fail-safe resilience |
 | **TR/EN content engine** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
 | **Modular architecture** | 22 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
@@ -154,6 +154,26 @@ badi skills list                                  # aktif skill'leri gor
 ```
 
 Skill aktifken `/start` veya yeni session'da Claude Code SKILL.md govdesini yukler. Auto-router'la fark: kalici aktivasyon yok, sadece SEO konulu prompt'larda devreye girer (token tasarrufu).
+
+### Profile-Based Commands + Command Router (v1.26+)
+
+Same opt-in philosophy applied to the 77 slash commands. Pick a profile (`core`, `dev`, `content`, `pentest`, `all`) to physically filter `.claude/commands/`; the canonical store lives in `.claude/commands-vault/`. The router additionally scores prompts against command descriptions and surfaces top matches as a lightweight hint blob — your skills router hook calls both routers automatically.
+
+```bash
+# Profile management
+badi commands                              # status: active profile + counts
+badi commands profile content --yes        # switch profile, no prompt
+badi commands profile dev --dry-run -v     # preview which commands change
+badi commands restore                      # back to "all" profile
+badi commands available                    # list every command in the vault
+
+# Prompt-aware command routing
+badi commands route "yeni post yaz"        # ranked matches
+badi commands route "react bug fix" --top 5 --json
+echo "release plan" | badi commands route --inject   # hook-format hint blob
+```
+
+Full flag list: `badi commands --help` (route flags: `--top N`, `--inject`, `--json`; profile flags: `--yes`, `--dry-run`, `--force`, `--verbose`). User-authored commands (not registered in the profile map) are never touched on profile switch.
 
 ### Output Styles + Status Line (v1.22+)
 
@@ -572,7 +592,7 @@ npm run format     # Biome formatting
 
 | Version | Summary |
 |---------|---------|
-| **v1.27.0** | **`expo-*` skill family (12 categories, advisory).** Expo + React Native mobile development lifecycle: `expo-orchestrator` + `expo-router` + EAS triplet (build/submit/update) + `expo-config-plugin` + `expo-prebuild` + `expo-modules` + `expo-dev-client` + `expo-notifications` + `expo-app-config` + `expo-troubleshooting`. Each skill is advisory only — Badi guides configuration, command sequences, and trade-offs; user runs build/submit/update themselves. Stack-map: 6 new detection entries (`eas.json`, `expo-router`, `expo-modules`, `expo-notifications`, `expo-dev-client`, `expo-config-plugin`); existing `expo` entry expanded. 805 → 815 tests. |
+| **v1.27.0** | **`expo-*` skill family (12 categories, advisory) + hook defensive fail-safe (#162).** Expo + React Native mobile development lifecycle: `expo-orchestrator` + `expo-router` + EAS triplet (build/submit/update) + `expo-config-plugin` + `expo-prebuild` + `expo-modules` + `expo-dev-client` + `expo-notifications` + `expo-app-config` + `expo-troubleshooting`. Each skill is advisory only — Badi guides configuration, command sequences, and trade-offs; user runs build/submit/update themselves. Stack-map: 6 new detection entries (`eas.json`, `expo-router`, `expo-modules`, `expo-notifications`, `expo-dev-client`, `expo-config-plugin`); existing `expo` entry expanded. 13 hooks hardened with a defensive `uncaughtException`/`unhandledRejection` handler that exits 0 (`BADI_HOOK_DEBUG=1` for opt-in stderr). 805 → 868 tests (+53 hook fail-safe resilience). |
 | **v1.26.0** | **Profile-based command management + prompt-aware command routing.** New `.claude/commands-vault/` canonical store (77 commands); `badi commands migrate / profile <core\|dev\|content\|all> / restore` filter active commands by profile (core 21 / dev 39 / content 17 / pentest 0). Top 10 verbose commands slimmed ~24% tokens / 45% lines (no info loss). New `badi commands route "<prompt>"` + `--inject` flag; `skill-router.mjs` hook now dispatches to both skills and commands routers. 774 → 805 tests. |
 | **v1.25.0** | **pentest-* skill family (25 categories, advisory/defensive).** Authorized penetration-testing engagement discipline added to the vault: orchestrator + engagement + recon + web + api + bizlogic + bugbounty + ad + cloud + mobile + wireless + cicd + social + llm + privesc + credentials + threat-model + detection + forensics + malware + stig + report + ctf + exploit-chain + opsec-evidence. Live exploit / payload / C2 explicitly excluded — methodology, output analysis, detection rule authoring, reporting only. Inspired by 0xSteph/pentest-ai-agents (MIT) engagement discipline (scope-guard, OPSEC QUIET/MODERATE/LOUD, hard refusal). 768 → 774 tests. |
 | **v1.24.0** | **Stack-aware skill curation (#152).** New `badi skills detect` (read-only project scan) + `badi skills auto-install` (interactive opt-in) — 35+ technologies → Badi skill manifest. Five signal types: packages, configFiles/Dirs, fileExtensions, manifestKeys, scripts. Inspired by midudev/autoskills install-time model. 727 → 768 tests. |

--- a/README.tr.md
+++ b/README.tr.md
@@ -32,7 +32,7 @@
 /plugin install badi@badi-marketplace
 ```
 
-**npm CLI olarak (tam ozellik seti: 22 ajan · 77 komut (profil yonetimi v1.26+) · 13 hook · 50 opt-in skill kategorisi + auto-router)**:
+**npm CLI olarak (tam ozellik seti: 22 ajan · 77 komut (profil yonetimi v1.26+) · 13 hook · 62 opt-in skill kategorisi + auto-router)**:
 
 ```bash
 npx @fatihkan/badi init                    # interaktif harness secim menusu
@@ -70,9 +70,9 @@ Claude kaynak (canonical). Cursor ve Gemini adapter'lari ayni `.claude/` dizinin
 | Ozellik | Detay |
 |---------|-------|
 | **22 Uzman Ajan ve 77 Komut** | Guvenlik tarayicidan performans profiler'a kadar; profil bazli filtreleme (core/dev/content/pentest) v1.26+ |
-| **13 Otomatik Hook ve 50 Skill Kategorisi** | Branch koruma, yedekleme, OWASP Top 10 taramasi, 9 Frontend Taste varyanti, prompt-bilinen auto-router (v1.20+), pentest-* aile (v1.25+ advisory/defensive) |
+| **13 Otomatik Hook ve 62 Skill Kategorisi** | Branch koruma, yedekleme, OWASP Top 10 taramasi, 9 Frontend Taste varyanti, prompt-bilinen auto-router (v1.20+), pentest-* aile (v1.25+ advisory/defensive), expo-* aile (v1.27+ mobil dev lifecycle), command routing (v1.26+) |
 | **Multi-harness destegi (v1.12+)** | Claude Code, Cursor, Gemini CLI — ayni `.claude/` kaynagi, farkli hedefler |
-| **805 Onaylanmis Test** | CLI entegrasyon, harness adapter, schema/bundler/publish, watcher/scheduler, market, tasarim, profil yonetimi |
+| **868 Onaylanmis Test** | CLI entegrasyon, harness adapter, schema/bundler/publish, watcher/scheduler, market, tasarim, profil yonetimi, hook fail-safe |
 | **TR/EN Icerik Motoru** | Sablon mirasi ile post, thread, bulten, podcast, case-study uretimi |
 | **WordPress + SEO + ASO + Mobile Modulleri** | WP-CLI/REST, 20+ SEO kontrolu, App Store + Play Store, crash/deeplink/OTA iskelesi |
 | **Modular Mimari** | 22 komut modulu, `lib/harnesses/` adapter katmani, ~6MB `.claude/` agaci |
@@ -151,6 +151,26 @@ badi skills list                                  # aktif skill'leri gor
 ```
 
 Skill aktifken `/start` veya yeni oturumda Claude Code SKILL.md govdesini yukler. Auto-router'la fark: kalici aktivasyon yok, sadece SEO konulu prompt'larda devreye girer (token tasarrufu).
+
+### Profil Bazli Komutlar + Komut Router (v1.26+)
+
+Ayni opt-in felsefesi 77 slash komuta uygulandi. Profil sec (`core`, `dev`, `content`, `pentest`, `all`) — `.claude/commands/` fiziksel olarak filtrelenir; canonical store `.claude/commands-vault/` altinda durur. Router prompt'lari komut aciklamalarina karsi da puanlar ve hafif bir hint blob'u uretir — skill router hook'u her iki router'i otomatik cagirir.
+
+```bash
+# Profil yonetimi
+badi commands                              # durum: aktif profil + sayilar
+badi commands profile content --yes        # profil degistir, onay sorma
+badi commands profile dev --dry-run -v     # hangi komutlar degisecek? preview
+badi commands restore                      # tum 'all' profiline don
+badi commands available                    # vault'taki tum komutlari listele
+
+# Prompt-aware komut yonlendirme
+badi commands route "yeni post yaz"        # siralanmis eslesmeler
+badi commands route "react bug fix" --top 5 --json
+echo "release plan" | badi commands route --inject   # hook formatinda hint blob
+```
+
+Tum flag listesi: `badi commands --help` (route flag'leri: `--top N`, `--inject`, `--json`; profil flag'leri: `--yes`, `--dry-run`, `--force`, `--verbose`). Kullanici-yazdigi komutlar (profil map'inde tanimli olmayan) profil degisikliginde dokunulmaz.
 
 ### Output Styles + Status Line (v1.22+)
 
@@ -538,7 +558,7 @@ npm run format     # Biome ile formatlama
 
 | Surum | Icerik |
 |-------|--------|
-| **v1.27.0** | **`expo-*` skill ailesi (12 kategori, advisory).** Expo + React Native mobil gelistirme yasam dongusu: `expo-orchestrator` + `expo-router` + EAS uclu (build/submit/update) + `expo-config-plugin` + `expo-prebuild` + `expo-modules` + `expo-dev-client` + `expo-notifications` + `expo-app-config` + `expo-troubleshooting`. Her skill advisory only — Badi yapilandirma, komut sirasi ve trade-off rehberlik eder; gercek build/submit/update kullanici tarafindan calistirilir. Stack-map: 6 yeni detection entry (`eas.json`, `expo-router`, `expo-modules`, `expo-notifications`, `expo-dev-client`, `expo-config-plugin`); mevcut `expo` entry genisledi. 805 → 815 test. |
+| **v1.27.0** | **`expo-*` skill ailesi (12 kategori, advisory) + hook defensive fail-safe (#162).** Expo + React Native mobil gelistirme yasam dongusu: `expo-orchestrator` + `expo-router` + EAS uclu (build/submit/update) + `expo-config-plugin` + `expo-prebuild` + `expo-modules` + `expo-dev-client` + `expo-notifications` + `expo-app-config` + `expo-troubleshooting`. Her skill advisory only — Badi yapilandirma, komut sirasi ve trade-off rehberlik eder; gercek build/submit/update kullanici tarafindan calistirilir. Stack-map: 6 yeni detection entry (`eas.json`, `expo-router`, `expo-modules`, `expo-notifications`, `expo-dev-client`, `expo-config-plugin`); mevcut `expo` entry genisledi. 13 hook'a defensive `uncaughtException`/`unhandledRejection` handler eklendi (exit 0; `BADI_HOOK_DEBUG=1` opt-in stderr). 805 → 868 test (+53 hook fail-safe). |
 | **v1.26.0** | **Profil bazli komut yonetimi + prompt-aware komut routing.** Yeni `.claude/commands-vault/` canonical store (77 komut); `badi commands migrate / profile <core\|dev\|content\|all> / restore` aktif komutlari profile gore filtreler (core 21 / dev 39 / content 17 / pentest 0). Top 10 sisman komut slim'lendi (~%24 token / %45 satir azalisi, bilgi kaybi yok). Yeni `badi commands route "<prompt>"` + `--inject` flag; `skill-router.mjs` hook hem skills hem commands router'i cagiriyor. 774 → 805 test. |
 | **v1.25.0** | **pentest-* skill ailesi (25 kategori, advisory/defensive).** Yetkili penetration-testing engagement disiplini vault'a eklendi: orchestrator + engagement + recon + web + api + bizlogic + bugbounty + ad + cloud + mobile + wireless + cicd + social + llm + privesc + credentials + threat-model + detection + forensics + malware + stig + report + ctf + exploit-chain + opsec-evidence. Live exploit / payload / C2 acikca disarida — metodoloji, output analiz, detection rule, raporlama. 0xSteph/pentest-ai-agents (MIT) engagement disiplini esin kaynagi (scope-guard, OPSEC QUIET/MODERATE/LOUD, hard refusal). 768 → 774 test. |
 | **v1.24.0** | **Stack-aware skill curation (#152).** Yeni `badi skills detect` (read-only proje tarama) + `badi skills auto-install` (interaktif onay) — 35+ teknoloji → Badi skill manifesti. Bes sinyal turu: packages, configFiles/Dirs, fileExtensions, manifestKeys, scripts. midudev/autoskills install-time modelinden esin. 727 → 768 test. |

--- a/bin/badi.js
+++ b/bin/badi.js
@@ -51,7 +51,11 @@ function showHelp() {
 	);
 	console.log(
 		`  ${chalk.cyan("aso")}       App Store Optimization (audit/playstore/keywords/reviews/screenshots)`,
+	);
+	console.log(
 		`  ${chalk.cyan("market")}    App Store pazar arastirmasi (discover/reviews/difficulty + tam rapor) — v1.15+`,
+	);
+	console.log(
 		`  ${chalk.cyan("tasarim")}   Gorsel kimlik komutu (init/lint/export/show — DESIGN.md) — v1.16+`,
 	);
 	console.log(

--- a/lib/commands/commands.js
+++ b/lib/commands/commands.js
@@ -149,6 +149,7 @@ function promptChoice(message) {
 function showHelp() {
 	console.log(chalk.bold("Commands Yonetimi (Profil bazli, v1.26+):"));
 	console.log("");
+	console.log(chalk.bold("Durum / Listeleme:"));
 	console.log(
 		"  badi commands                    Aktif profil + komut sayilari",
 	);
@@ -161,6 +162,9 @@ function showHelp() {
 	console.log(
 		"  badi commands profiles           Profil tanimlarini ve sayilarini goster",
 	);
+	console.log("");
+	console.log(chalk.bold("Profil Yonetimi:"));
+	console.log(`  badi commands profile            Aktif profili goster`);
 	console.log(
 		`  badi commands profile <ad>       Profili degistir (${PROFILES.join("|")})`,
 	);
@@ -171,12 +175,46 @@ function showHelp() {
 		"  badi commands restore            Tum profili 'all'a sifirla (commands/'a tum vault'u koy)",
 	);
 	console.log("");
+	console.log(chalk.bold("Prompt-Aware Routing (v1.26+):"));
+	console.log(
+		'  badi commands route "<prompt>"   Prompt\'a uyan komutlari skorla',
+	);
+	console.log("  badi commands route < file.txt   Stdin'den prompt oku");
+	console.log("");
+	console.log(chalk.bold("Profil komutu flag'leri:"));
+	console.log(
+		"  --yes, -y          Onay sormadan uygula (CI/non-TTY icin gerekli)",
+	);
+	console.log("  --dry-run          Sadece preview, dosyaya yazma");
+	console.log(
+		"  --force            Ayni profile yeniden uygula (cache temizleme)",
+	);
+	console.log(
+		"  --verbose, -v      Eklenecek/silinecek komutlari isim-isim listele",
+	);
+	console.log("");
+	console.log(chalk.bold("Route komutu flag'leri:"));
+	console.log("  --top N            En iyi N eslesme (default: 3)");
+	console.log("  --inject           Hook formatinda hint blob'u stdout'a yaz");
+	console.log(
+		"  --json             JSON cikti (matched/contextLength alanlari)",
+	);
+	console.log("");
 	console.log(chalk.bold("Profil mantigi:"));
 	console.log("  core    — her zaman aktif (oturum, olcum, audit)");
 	console.log("  dev     — kod, devops, security, audit araclari");
 	console.log("  content — sosyal medya, marka, icerik takvimi");
 	console.log("  pentest — yetkili pentest engagement (gelecek)");
 	console.log("  all     — hepsi (default)");
+	console.log("");
+	console.log(chalk.bold("Ornekler:"));
+	console.log(chalk.dim("  badi commands profile content --yes"));
+	console.log(chalk.dim("  badi commands profile dev --dry-run --verbose"));
+	console.log(chalk.dim('  badi commands route "yeni post yaz" --top 5'));
+	console.log(chalk.dim('  badi commands route "react bug fix" --json'));
+	console.log(
+		chalk.dim('  echo "release plan" | badi commands route --inject'),
+	);
 	console.log("");
 	console.log(
 		chalk.dim(
@@ -187,6 +225,9 @@ function showHelp() {
 		chalk.dim(
 			"     Vault canonical kalir; profili her zaman 'all'a geri dondurebilirsin.",
 		),
+	);
+	console.log(
+		chalk.dim("     Vault disindaki (kullanici) komutlara dokunulmaz."),
 	);
 }
 

--- a/lib/commands/skills.js
+++ b/lib/commands/skills.js
@@ -322,37 +322,49 @@ function showHelp() {
 	console.log(
 		'  badi skills route "<prompt>"    Prompt → eslesen skill\'leri puanla',
 	);
-	console.log(
-		"  badi skills route --inject      Match'lenenleri SKILL.md govdesi olarak yaz (hook icin)",
-	);
+	console.log("  badi skills route < file.txt    Stdin'den prompt oku");
 	console.log(
 		"  badi skills auto on             UserPromptSubmit hook'unu aktif et",
 	);
 	console.log("  badi skills auto off            Hook'u kaldir");
 	console.log("  badi skills auto status         Hook durumunu goster");
 	console.log("");
+	console.log(chalk.bold("Route komutu flag'leri:"));
+	console.log(
+		"    --top N                       En iyi N eslesme (default: 3)",
+	);
+	console.log(
+		"    --inject                      Match'lenenleri SKILL.md govdesi olarak yaz (hook icin)",
+	);
+	console.log(
+		"    --json                        JSON cikti (matched/contextLength)",
+	);
+	console.log("");
 	console.log(chalk.dim("Ornek:"));
 	console.log(chalk.dim("  badi skills add seo marketing security"));
 	console.log(chalk.dim('  badi skills route "Instagram post yaz"'));
+	console.log(chalk.dim('  badi skills route "expo eas build" --top 5'));
+	console.log(chalk.dim('  echo "react bug" | badi skills route --inject'));
 	console.log(
 		chalk.dim("  badi skills auto on   # her prompt'tan once otomatik route"),
 	);
 	console.log("");
-	console.log(chalk.bold("Kategoriler (v1.25):"));
+	console.log(chalk.bold("Kategoriler (v1.27):"));
 	console.log(
 		chalk.dim(
-			"  25 genel kategori (design, seo, security, marketing, mobile, vb.) +",
+			"  25 genel + 25 pentest-* + 12 expo-* = 62 kategori (opt-in vault).",
 		),
 	);
 	console.log(
-		chalk.dim(
-			"  25 pentest-* kategori (advisory/defensive — yetkili pentest engagement disiplini).",
-		),
+		chalk.dim("  pentest-*: advisory/defensive, yetkili engagement disiplini."),
 	);
 	console.log(
 		chalk.dim(
-			"  Pentest ailesini gormek icin: badi skills available | grep pentest",
+			"  expo-*:    React Native + cross-platform mobile dev lifecycle.",
 		),
+	);
+	console.log(
+		chalk.dim("  Aile gormek icin: badi skills available | grep <prefix>"),
 	);
 }
 


### PR DESCRIPTION
## Summary

Deep audit of every `badi <cmd> --help` surface revealed three gap classes; all now closed. **No behavior change** — the actual subcommand and flag parsing already worked; only the help text was lagging.

### Help text gaps fixed

- **Top-level `badi --help`** — `aso` / `market` / `tasarim` rendered as one concatenated row because `console.log` was called once with three args (which inserts spaces, not newlines). Split into three calls. (`bin/badi.js`)
- **`badi commands --help`** (v1.26+) — the `route "<prompt>"` subcommand, stdin form, profile flags (`--yes` / `--dry-run` / `--force` / `--verbose`), and route flags (`--top N` / `--inject` / `--json`) were all missing from help. Help now mirrors actual parsing, with five example invocations. (`lib/commands/commands.js`)
- **`badi skills --help`** (v1.20+) — `--top N` / `--json` route flags undocumented; categories footnote stale at "v1.25 / 50". Updated to v1.27 / 62 (25 + 25 `pentest-*` + 12 `expo-*`). (`lib/commands/skills.js`)

### README drift fixed

The v1.27 release prep left stale numbers:

- 4 spots `50 opt-in skill categories` → `62` (README.md, README.tr.md hero rows)
- 1 spot `805 passing tests` → `868`
- v1.27 version-history row typo `805 → 815 tests` → `805 → 868 tests` (the +53 hook fail-safe resilience tests from PR #163 weren't reflected)
- Added new **"Profile-Based Commands + Command Router"** subsection — v1.26 shipped without a dedicated README section for `badi commands profile/route`

## Test plan

- [x] `npm test` — 868/868 passing
- [x] `npx biome check` — 0 errors (1 info)
- [x] `node bin/badi.js --help` — `aso` / `market` / `tasarim` print on separate lines
- [x] `node bin/badi.js commands --help` — route + all flags documented
- [x] `node bin/badi.js skills --help` — `--top` / `--json` + v1.27 / 62 footnote
- [ ] Reader sanity check: README v1.27 row test count + Profile-Based Commands subsection

🤖 Generated with [Claude Code](https://claude.com/claude-code)