### PR TITLE
chore(release): v1.27.1 hazirlik

### DIFF
--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -2,7 +2,7 @@
 
 ## Mevcut Durum
 - Proje: Badi - Claude Code Is Akisi Yonetim Sistemi
-- npm: @fatihkan/badi v1.27.0 (yayinda) — 15.05.2026; #162 hook fix dahil
+- npm: @fatihkan/badi v1.27.1 (hazirlik) — 16.05.2026 help-completeness + README drift fix
 - Tests: 868 (Linux+macOS yesil; Windows non-blocking) — v1.27 expo-* aile +10 stack + #162 fix +53 hook resilience
 - Yan repo: github.com/fatihkan/badi-skills v1.0.0 (25 skill bundle)
 - Engines: Node >=20.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [1.27.1] - 2026-05-16
+
 ### Fixed — help completeness across CLI surfaces
 
 Deep audit of `badi <cmd> --help` outputs revealed three classes of gaps;

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,8 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+## [1.27.1] - 2026-05-16
+
 ### Duzeltildi — CLI yuzeylerinde help eksikligi
 
 `badi <cmd> --help` ciktilarinin derin denetimi uc tur eksiklik ortaya


### PR DESCRIPTION
## Summary

- CHANGELOG.md / CHANGELOG.tr.md: `[Unreleased]` → `[1.27.1] - 2026-05-16`
- .claude/memory.md: v1.27.0 → v1.27.1 (hazirlik)
- package.json NOT touched — `badi publish --version patch` will bump it

## Test plan

- [x] CHANGELOG entries already validated in PR #164
- [x] `npm test` (already 868 on main)
- [ ] After merge: `badi publish --version patch` (user OTP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)