### PR TITLE
feat(observability): v1.29 — session/search/plan/cost komutlari

### DIFF
--- a/.claude/help-doctor.allow.json
+++ b/.claude/help-doctor.allow.json
@@ -19,7 +19,11 @@
 	},
 	"list.js": {
 		"_why": "list.js --help top-level menuye dusuyor; flag'ler bin/badi.js'de gozukur.",
-		"flags": ["--target", "--agents", "--commands", "--hooks", "--skills"]
+		"flags": ["--target", "--agents", "--commands", "--hooks", "--skills", "--mcp"]
+	},
+	"stats.js": {
+		"_why": "--sessions, --session'in cogul aliasidir; --session zaten help'te belgelidir.",
+		"flags": ["--sessions"]
 	},
 	"market.js": {
 		"_why": "'full' subcommand'i bir alias-formu; default behavior ile aynidir (badi market <appId> == badi market full <appId>).",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Added — observability v1.29 (Claude Code transcript bazli)
+
+Five+ new commands and flags that read `~/.claude/projects/*.jsonl`
+transcripts directly. Privacy-preserving: nothing leaves your machine.
+
+- **`badi stats --session [--limit N]`** — last-N sessions: id (8-char),
+  project, branch, model class, duration, prompts, tools, $cost.
+- **`badi stats --models`** — per-model session count + USD breakdown +
+  global cache hit rate.
+- **`badi stats --cost`** — total USD across all transcripts + top-10
+  projects.
+- **`badi stats --since DATE --until DATE`** — ISO/YYYY-MM-DD range filter
+  (applies to `--session`/`--models`/`--cost`).
+- **`badi stats --branch <name>`** — git branch filter using transcript
+  `gitBranch` field.
+- **`badi search "<query>"`** — multi-token AND search across all
+  transcripts (user prompts + last-prompt events). Supports
+  `--since/--until/--branch/--limit`.
+- **`badi session <id-or-prefix>`** — single-session detail: header
+  (model/tokens/cost/duration), tool breakdown, files touched, chronological
+  timeline (prompts + tool_use + thinking). `--full` for full timeline,
+  `--tools` / `--files` for focused views.
+- **`badi plan list/new/show/status/approve/deny/reset`** — local
+  file-based plan approval workflow. Markers in
+  `.claude/plans/<slug>.{approved,denied}`.
+  `badi plan status <slug> --format json` exits 0 only if approved (hook-friendly).
+  Slug validated against `/^[a-z0-9][a-z0-9-]{0,63}$/` (path traversal safe).
+- **`badi plugin show <name>`** — manifest detail: version, description,
+  agent/command/hook/skill counts with full per-item listing.
+- **`badi list --mcp`** — aggregate MCP server invocations across all
+  transcripts; per-server call count + unique tool count.
+
+Internals: new `lib/data/transcript-reader.js` (parseSession,
+parseSessionWithEvents, applyFilters, MODEL_PRICING, costForUsage,
+findSession, formatDuration, shortSessionId). Pricing table for
+Opus/Sonnet/Haiku 4.x with family-name fallback for unknown variants.
+
+Tests: 934 → **967** (+33 across `tests/transcript-reader.test.js`,
+`tests/cli.plan.test.js`, `tests/cli.observability.test.js`).
+
 ### Fixed — security hardening pass (`/security-scan` 6 findings)
 
 A `/security-scan` run on v1.28.0 surfaced 1 YUKSEK + 3 ORTA + 2 DUSUK

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,44 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+### Eklendi — observability v1.29 (Claude Code transcript bazli)
+
+Bes+ yeni komut/flag, `~/.claude/projects/*.jsonl` transcript'lerini direk
+okur. Hicbir veri makineden cikmaz.
+
+- **`badi stats --session [--limit N]`** — son N session: id (8 karakter),
+  proje, branch, model sinifi, sure, prompt sayisi, tool sayisi, $maliyet.
+- **`badi stats --models`** — model bazli session sayisi + USD breakdown +
+  global cache hit rate.
+- **`badi stats --cost`** — tum transcript USD toplam + ilk 10 proje.
+- **`badi stats --since DATE --until DATE`** — ISO/YYYY-MM-DD tarih
+  araligi (`--session`/`--models`/`--cost` icin gecerli).
+- **`badi stats --branch <ad>`** — transcript'in `gitBranch` alani ile
+  git branch filtresi.
+- **`badi search "<sorgu>"`** — tum transcript'lerde multi-token AND
+  arama (user prompt + last-prompt event). `--since/--until/--branch/--limit`.
+- **`badi session <id-veya-prefix>`** — tek session detayi: baslik
+  (model/token/maliyet/sure), tool dagilimi, dokunulan dosyalar,
+  kronolojik timeline (prompt + tool_use + thinking). `--full` tam
+  timeline, `--tools` / `--files` odakli gorunumler.
+- **`badi plan list/new/show/status/approve/deny/reset`** — lokal
+  dosya-bazli plan onay akisi. Marker'lar
+  `.claude/plans/<slug>.{approved,denied}`.
+  `badi plan status <slug> --format json` sadece approved ise exit 0
+  (hook-dostu). Slug `/^[a-z0-9][a-z0-9-]{0,63}$/` ile dogrulanir.
+- **`badi plugin show <ad>`** — manifest detayi: version, aciklama,
+  ajan/komut/hook/skill sayisi + tam isim listesi.
+- **`badi list --mcp`** — tum transcript'lerde MCP server cagri toplami;
+  server bazli cagri + unique tool sayisi.
+
+Icerik: yeni `lib/data/transcript-reader.js` (parseSession,
+parseSessionWithEvents, applyFilters, MODEL_PRICING, costForUsage,
+findSession, formatDuration, shortSessionId). Opus/Sonnet/Haiku 4.x icin
+fiyat tablosu, bilinmeyen variant'lar icin family-name fallback.
+
+Test: 934 → **967** (+33 — `tests/transcript-reader.test.js`,
+`tests/cli.plan.test.js`, `tests/cli.observability.test.js`).
+
 ### Duzeltildi — guvenlik sertlestirme (`/security-scan` 6 bulgu)
 
 v1.28.0 uzerinde `/security-scan` calistirildi: 1 YUKSEK + 3 ORTA + 2

--- a/bin/badi.js
+++ b/bin/badi.js
@@ -144,6 +144,9 @@ function showHelp() {
 	console.log("  --commands       Sadece komutlari listele");
 	console.log("  --hooks          Sadece hook'lari listele");
 	console.log("  --skills         Sadece skill kategorilerini listele");
+	console.log(
+		"  --mcp            MCP server kullanimi (v1.29+, transcript bazli)",
+	);
 	console.log("");
 	console.log(chalk.bold("Doctor Subcommand'leri (v1.28+):"));
 	console.log("  badi doctor                 Tum Badi kurulumunu denetler");
@@ -316,6 +319,9 @@ const commands = {
 	mcp: () => import("../lib/commands/mcp.js").then((m) => m.runMcp),
 	gh: () => import("../lib/commands/gh.js").then((m) => m.runGh),
 	kb: () => import("../lib/commands/kb.js").then((m) => m.runKb),
+	search: () => import("../lib/commands/search.js").then((m) => m.runSearch),
+	session: () => import("../lib/commands/session.js").then((m) => m.runSession),
+	plan: () => import("../lib/commands/plan.js").then((m) => m.runPlan),
 };
 
 // ─── Ana Giris Noktasi ───

--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -1,13 +1,61 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { chalk, showBanner } from "../cli.js";
+import {
+	listTranscriptFiles,
+	parseSession,
+} from "../data/transcript-reader.js";
 import { countFiles, listDirs, listMdFiles } from "../helpers.js";
+
+function renderMcpUsage() {
+	const files = listTranscriptFiles();
+	if (files.length === 0) {
+		console.log(
+			chalk.dim("  ~/.claude/projects/ icinde transcript bulunamadi."),
+		);
+		return;
+	}
+	const agg = {};
+	let sessionsWithMcp = 0;
+	let totalSessions = 0;
+	for (const f of files) {
+		const s = parseSession(f.path);
+		if (!s) continue;
+		totalSessions++;
+		const keys = Object.keys(s.mcpToolCounts);
+		if (keys.length > 0) sessionsWithMcp++;
+		for (const [k, v] of Object.entries(s.mcpToolCounts)) {
+			// "mcp__servername__toolname" formati — server adini cikar
+			const m = k.match(/^mcp__([^_]+(?:_[^_]+)*?)__/);
+			const server = m ? m[1] : k;
+			agg[server] = agg[server] || { calls: 0, tools: new Set() };
+			agg[server].calls += v;
+			agg[server].tools.add(k);
+		}
+	}
+	const rows = Object.entries(agg).sort((a, b) => b[1].calls - a[1].calls);
+	if (rows.length === 0) {
+		console.log(chalk.dim("  MCP tool kullanimi yok."));
+		return;
+	}
+	const maxLabel = Math.max(...rows.map(([k]) => k.length));
+	for (const [server, info] of rows) {
+		console.log(
+			`  ${chalk.magenta("⚙")} ${server.padEnd(maxLabel)}  ${chalk.yellow(String(info.calls).padStart(5))} cagri  ${chalk.dim(`${info.tools.size} tool`)}`,
+		);
+	}
+	console.log("");
+	console.log(
+		chalk.dim(`  ${sessionsWithMcp}/${totalSessions} session MCP kullaniyor`),
+	);
+}
 
 export function runList(args, { showHelp }) {
 	let showAgents = false;
 	let showCommands = false;
 	let showHooks = false;
 	let showSkills = false;
+	let showMcp = false;
 	let target = process.cwd();
 
 	for (let i = 0; i < args.length; i++) {
@@ -24,6 +72,9 @@ export function runList(args, { showHelp }) {
 			case "--skills":
 				showSkills = true;
 				break;
+			case "--mcp":
+				showMcp = true;
+				break;
 			case "--target":
 				target = resolve(args[++i] || ".");
 				break;
@@ -34,7 +85,8 @@ export function runList(args, { showHelp }) {
 		}
 	}
 
-	const showAll = !showAgents && !showCommands && !showHooks && !showSkills;
+	const showAll =
+		!showAgents && !showCommands && !showHooks && !showSkills && !showMcp;
 	const claudeDir = join(target, ".claude");
 
 	showBanner();
@@ -85,6 +137,13 @@ export function runList(args, { showHelp }) {
 			console.log(`  ${chalk.cyan("-")} ${cat} (${count} skill)`);
 		}
 		console.log("");
+	}
+
+	if (showMcp) {
+		console.log(chalk.bold("MCP Server Kullanimi (transcript bazli):"));
+		renderMcpUsage();
+		console.log("");
+		return;
 	}
 
 	const pluginsDir = join(claudeDir, "plugins");

--- a/lib/commands/plan.js
+++ b/lib/commands/plan.js
@@ -1,0 +1,305 @@
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { basename, join } from "node:path";
+import { chalk } from "../cli.js";
+
+// Local file-based plan approval workflow.
+// Plan dosyalari .claude/plans/ altinda yasar; .approved/.denied marker
+// dosyalari onay durumunu ifade eder. Hook (badi-plan-gate) ExitPlanMode
+// cagrildiginda bu dosyalari kontrol edebilir.
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+function isValidSlug(slug) {
+	return typeof slug === "string" && SLUG_RE.test(slug);
+}
+
+function plansDir(cwd) {
+	return join(cwd || process.cwd(), ".claude", "plans");
+}
+
+function ensureDir(dir) {
+	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+export function listPlans(cwd) {
+	const dir = plansDir(cwd);
+	if (!existsSync(dir)) return [];
+	const files = readdirSync(dir);
+	const slugs = new Set();
+	for (const f of files) {
+		if (f.endsWith(".md")) slugs.add(f.replace(/\.md$/, ""));
+		else if (f.endsWith(".approved")) slugs.add(f.replace(/\.approved$/, ""));
+		else if (f.endsWith(".denied")) slugs.add(f.replace(/\.denied$/, ""));
+	}
+	const out = [];
+	for (const slug of slugs) {
+		out.push(planStatus(slug, cwd));
+	}
+	return out.sort((a, b) => (b.mtimeMs || 0) - (a.mtimeMs || 0));
+}
+
+export function planStatus(slug, cwd) {
+	if (!isValidSlug(slug)) throw new Error(`Gecersiz plan slug: ${slug}`);
+	const dir = plansDir(cwd);
+	const md = join(dir, `${slug}.md`);
+	const ap = join(dir, `${slug}.approved`);
+	const dn = join(dir, `${slug}.denied`);
+	let state = "pending";
+	let reason = null;
+	let mtimeMs = 0;
+	if (existsSync(ap)) {
+		state = "approved";
+		try {
+			const st = statSync(ap);
+			mtimeMs = st.mtimeMs;
+		} catch {}
+	} else if (existsSync(dn)) {
+		state = "denied";
+		try {
+			const raw = readFileSync(dn, "utf-8");
+			const lines = raw.split("\n");
+			// 1. satir timestamp, sonrasi reason (bos ise null).
+			const r = lines.slice(1).join("\n").trim();
+			reason = r || null;
+			const st = statSync(dn);
+			mtimeMs = st.mtimeMs;
+		} catch {}
+	}
+	if (existsSync(md)) {
+		try {
+			const st = statSync(md);
+			if (st.mtimeMs > mtimeMs) mtimeMs = st.mtimeMs;
+		} catch {}
+	}
+	return {
+		slug,
+		state,
+		reason,
+		mtimeMs,
+		hasPlan: existsSync(md),
+		planPath: md,
+	};
+}
+
+function printHelp() {
+	console.log(chalk.bold("Plan Approval Workflow:"));
+	console.log("");
+	console.log(
+		`  badi plan list                ${chalk.dim("Tum planlar + durum")}`,
+	);
+	console.log(
+		`  badi plan new <slug>          ${chalk.dim("Plan iskelet markdown olustur")}`,
+	);
+	console.log(`  badi plan show <slug>         ${chalk.dim("Plan icerigi")}`);
+	console.log(
+		`  badi plan status <slug>       ${chalk.dim("Onay durumu (hook icin --format json)")}`,
+	);
+	console.log(
+		`  badi plan approve <slug>      ${chalk.dim("Onayla (.approved marker)")}`,
+	);
+	console.log(
+		`  badi plan deny <slug> [neden] ${chalk.dim("Reddet (.denied marker)")}`,
+	);
+	console.log(
+		`  badi plan reset <slug>        ${chalk.dim("Onay/red marker'larini sil")}`,
+	);
+	console.log("");
+	console.log(
+		chalk.dim("  Marker dosyalari .claude/plans/<slug>.{approved,denied}"),
+	);
+}
+
+function cmdList(cwd) {
+	const plans = listPlans(cwd);
+	if (plans.length === 0) {
+		console.log(chalk.dim("Plan yok. `badi plan new <slug>` ile baslayin."));
+		return;
+	}
+	console.log(chalk.bold("Planlar:"));
+	const maxLabel = Math.max(...plans.map((p) => p.slug.length));
+	for (const p of plans) {
+		const stateColor =
+			p.state === "approved"
+				? chalk.green("approved")
+				: p.state === "denied"
+					? chalk.red("denied  ")
+					: chalk.yellow("pending ");
+		const date = p.mtimeMs
+			? new Date(p.mtimeMs).toISOString().slice(0, 16).replace("T", " ")
+			: "-";
+		const planMark = p.hasPlan ? "" : chalk.dim(" (no .md)");
+		console.log(
+			`  ${p.slug.padEnd(maxLabel)}  ${stateColor}  ${chalk.dim(date)}${planMark}`,
+		);
+		if (p.reason) console.log(chalk.dim(`    Reason: ${p.reason}`));
+	}
+}
+
+function cmdNew(slug, cwd) {
+	if (!isValidSlug(slug)) {
+		console.error(chalk.red(`Gecersiz slug: ${slug} (kebab-case, [a-z0-9-])`));
+		process.exit(1);
+	}
+	const dir = plansDir(cwd);
+	ensureDir(dir);
+	const path = join(dir, `${slug}.md`);
+	if (existsSync(path)) {
+		console.error(chalk.yellow(`Zaten var: ${path}`));
+		process.exit(1);
+	}
+	const template = `# Plan: ${slug}
+
+> Olusturma: ${new Date().toISOString()}
+> Durum: pending — \`badi plan approve ${slug}\` ile onayla, \`badi plan deny ${slug}\` ile reddet.
+
+## Hedef
+<!-- Ne yapilacak? -->
+
+## Adimlar
+1. ...
+2. ...
+
+## Test plani
+- [ ] ...
+
+## Riskler
+- ...
+`;
+	writeFileSync(path, template);
+	console.log(chalk.green(`Plan olusturuldu: ${path}`));
+}
+
+function cmdShow(slug, cwd) {
+	if (!isValidSlug(slug)) {
+		console.error(chalk.red(`Gecersiz slug: ${slug}`));
+		process.exit(1);
+	}
+	const p = planStatus(slug, cwd);
+	if (!p.hasPlan) {
+		console.error(chalk.red(`Plan dosyasi yok: ${p.planPath}`));
+		process.exit(1);
+	}
+	console.log(readFileSync(p.planPath, "utf-8"));
+}
+
+function cmdStatus(slug, cwd, format) {
+	if (!isValidSlug(slug)) {
+		console.error(chalk.red(`Gecersiz slug: ${slug}`));
+		process.exit(1);
+	}
+	const p = planStatus(slug, cwd);
+	if (format === "json") {
+		console.log(JSON.stringify(p));
+		process.exit(p.state === "approved" ? 0 : 1);
+	}
+	const color =
+		p.state === "approved"
+			? chalk.green
+			: p.state === "denied"
+				? chalk.red
+				: chalk.yellow;
+	console.log(`${slug}: ${color(p.state)}`);
+	if (p.reason) console.log(chalk.dim(`  Reason: ${p.reason}`));
+	process.exit(p.state === "approved" ? 0 : 1);
+}
+
+function cmdApprove(slug, cwd) {
+	if (!isValidSlug(slug)) {
+		console.error(chalk.red(`Gecersiz slug: ${slug}`));
+		process.exit(1);
+	}
+	const dir = plansDir(cwd);
+	ensureDir(dir);
+	const ap = join(dir, `${slug}.approved`);
+	const dn = join(dir, `${slug}.denied`);
+	if (existsSync(dn)) unlinkSync(dn);
+	writeFileSync(ap, `${new Date().toISOString()}\n`);
+	console.log(chalk.green(`Approved: ${slug}`));
+}
+
+function cmdDeny(slug, reason, cwd) {
+	if (!isValidSlug(slug)) {
+		console.error(chalk.red(`Gecersiz slug: ${slug}`));
+		process.exit(1);
+	}
+	const dir = plansDir(cwd);
+	ensureDir(dir);
+	const ap = join(dir, `${slug}.approved`);
+	const dn = join(dir, `${slug}.denied`);
+	if (existsSync(ap)) unlinkSync(ap);
+	writeFileSync(dn, `${new Date().toISOString()}\n${reason || ""}`);
+	console.log(chalk.red(`Denied: ${slug}${reason ? ` — ${reason}` : ""}`));
+}
+
+function cmdReset(slug, cwd) {
+	if (!isValidSlug(slug)) {
+		console.error(chalk.red(`Gecersiz slug: ${slug}`));
+		process.exit(1);
+	}
+	const dir = plansDir(cwd);
+	const ap = join(dir, `${slug}.approved`);
+	const dn = join(dir, `${slug}.denied`);
+	let removed = 0;
+	if (existsSync(ap)) {
+		unlinkSync(ap);
+		removed++;
+	}
+	if (existsSync(dn)) {
+		unlinkSync(dn);
+		removed++;
+	}
+	console.log(chalk.dim(`Reset: ${slug} (${removed} marker silindi)`));
+}
+
+export function runPlan(args) {
+	const sub = args[0];
+	const cwd = process.cwd();
+
+	if (!sub || sub === "--help" || sub === "-h") {
+		printHelp();
+		return;
+	}
+
+	switch (sub) {
+		case "list":
+			return cmdList(cwd);
+		case "new":
+			return cmdNew(args[1], cwd);
+		case "show":
+			return cmdShow(args[1], cwd);
+		case "status": {
+			const format = args.includes("--format")
+				? args[args.indexOf("--format") + 1]
+				: null;
+			return cmdStatus(args[1], cwd, format);
+		}
+		case "approve":
+			return cmdApprove(args[1], cwd);
+		case "deny": {
+			// reason: 2. argumandan sonrasi (boslukla join)
+			const reason = args
+				.slice(2)
+				.filter((a) => !a.startsWith("--"))
+				.join(" ");
+			return cmdDeny(args[1], reason, cwd);
+		}
+		case "reset":
+			return cmdReset(args[1], cwd);
+		default:
+			console.error(chalk.red(`Bilinmeyen plan komutu: ${sub}`));
+			printHelp();
+			process.exit(1);
+	}
+}
+
+// Export for test
+// basename re-export icin (test sade kalsin)
+export { basename, isValidSlug, plansDir };

--- a/lib/commands/plugin.js
+++ b/lib/commands/plugin.js
@@ -12,6 +12,7 @@ export function runPlugin(args) {
 		console.log(`  badi plugin install <kaynak>   Plugin yukle`);
 		console.log(`  badi plugin remove <isim>      Plugin kaldir`);
 		console.log(`  badi plugin list               Yuklu plugin'leri listele`);
+		console.log(`  badi plugin show <isim>        Plugin detayi (v1.29+)`);
 		return;
 	}
 
@@ -161,6 +162,66 @@ export function runPlugin(args) {
 			}
 			rmSync(pluginDir, { recursive: true });
 			console.log(chalk.green(`Plugin '${name}' basariyla kaldirildi.`));
+			break;
+		}
+
+		case "show": {
+			const name = args[1];
+			if (!name) {
+				console.error(chalk.red("Hata: Plugin adi belirtilmedi."));
+				console.log("Kullanim: badi plugin show <isim>");
+				process.exit(1);
+			}
+			const pluginDir = join(pluginsDir, name);
+			if (!existsSync(pluginDir)) {
+				console.error(chalk.red(`Plugin '${name}' bulunamadi.`));
+				process.exit(1);
+			}
+			const manifestPath = join(pluginDir, "badi-plugin.json");
+			let manifest = null;
+			if (existsSync(manifestPath)) {
+				try {
+					manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+				} catch (e) {
+					console.error(chalk.red(`Manifest parse hatasi: ${e.message}`));
+				}
+			}
+			console.log(chalk.bold(`Plugin: ${manifest?.name || name}`));
+			if (manifest?.version)
+				console.log(chalk.dim(`  Version:     ${manifest.version}`));
+			if (manifest?.description)
+				console.log(chalk.dim(`  Description: ${manifest.description}`));
+			console.log(chalk.dim(`  Path:        ${pluginDir}`));
+			console.log("");
+			const agentCount = manifest?.agents?.length || 0;
+			const commandCount = manifest?.commands?.length || 0;
+			const hookCount = manifest?.hooks?.length || 0;
+			const skillCount = manifest?.skills
+				? Object.keys(manifest.skills).length
+				: 0;
+			console.log(chalk.bold("Icerik:"));
+			console.log(`  ${chalk.cyan("Ajanlar")}:  ${agentCount}`);
+			if (manifest?.agents?.length) {
+				for (const a of manifest.agents) console.log(`    - ${a}`);
+			}
+			console.log(`  ${chalk.cyan("Komutlar")}: ${commandCount}`);
+			if (manifest?.commands?.length) {
+				for (const c of manifest.commands) console.log(`    - ${c}`);
+			}
+			console.log(`  ${chalk.cyan("Hook'lar")}: ${hookCount}`);
+			if (manifest?.hooks?.length) {
+				for (const h of manifest.hooks) console.log(`    - ${h}`);
+			}
+			console.log(`  ${chalk.cyan("Skill'ler")}: ${skillCount}`);
+			if (manifest?.skills) {
+				for (const [cat, items] of Object.entries(manifest.skills)) {
+					const count = Array.isArray(items) ? items.length : 0;
+					console.log(`    - ${cat} (${count})`);
+				}
+			}
+			if (!manifest) {
+				console.log(chalk.yellow("  badi-plugin.json bulunamadi"));
+			}
 			break;
 		}
 

--- a/lib/commands/search.js
+++ b/lib/commands/search.js
@@ -1,0 +1,162 @@
+import { readFileSync } from "node:fs";
+import { chalk, showBanner } from "../cli.js";
+import {
+	applyFilters,
+	formatDuration,
+	listTranscriptFiles,
+	parseSession,
+	shortSessionId,
+} from "../data/transcript-reader.js";
+
+// AND-match multi-token search across session prompts + last-prompt + project name.
+// Karma'nin "multi-token AND search" semantigi: tum token'lar gecmek zorunda.
+function tokenize(q) {
+	return q.toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+function buildSearchIndex(filePath) {
+	let raw;
+	try {
+		raw = readFileSync(filePath, "utf-8");
+	} catch {
+		return "";
+	}
+	const lines = raw.split("\n");
+	const parts = [];
+	for (const line of lines) {
+		if (!line) continue;
+		let o;
+		try {
+			o = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		if (o.type === "user" && typeof o.message?.content === "string") {
+			parts.push(o.message.content);
+		} else if (o.type === "last-prompt" && typeof o.prompt === "string") {
+			parts.push(o.prompt);
+		}
+	}
+	return parts.join("\n").toLowerCase();
+}
+
+function matchAll(haystack, tokens) {
+	for (const t of tokens) {
+		if (!haystack.includes(t)) return false;
+	}
+	return true;
+}
+
+function snippet(haystack, tokens, max = 120) {
+	for (const t of tokens) {
+		const idx = haystack.indexOf(t);
+		if (idx >= 0) {
+			const start = Math.max(0, idx - 30);
+			const end = Math.min(haystack.length, idx + max - 30);
+			return (
+				(start > 0 ? "..." : "") +
+				haystack.slice(start, end).replace(/\s+/g, " ") +
+				(end < haystack.length ? "..." : "")
+			);
+		}
+	}
+	return haystack.slice(0, max);
+}
+
+export function runSearch(args) {
+	let query = null;
+	let since = null;
+	let until = null;
+	let branch = null;
+	let limit = 20;
+	let showHelp = false;
+
+	for (let i = 0; i < args.length; i++) {
+		switch (args[i]) {
+			case "--since":
+				since = args[++i];
+				break;
+			case "--until":
+				until = args[++i];
+				break;
+			case "--branch":
+				branch = args[++i];
+				break;
+			case "--limit":
+				limit = Math.max(1, parseInt(args[++i], 10) || 20);
+				break;
+			case "--help":
+			case "-h":
+				showHelp = true;
+				break;
+			default:
+				if (!query && !args[i].startsWith("-")) query = args[i];
+				else if (query && !args[i].startsWith("-")) query += ` ${args[i]}`;
+		}
+	}
+
+	if (showHelp || !query) {
+		console.log(chalk.bold("Session-level Transcript Arama:"));
+		console.log("");
+		console.log(
+			`  badi search "<query>"           ${chalk.dim('Multi-token AND search (ornek: "secret-scan refactor")')}`,
+		);
+		console.log(
+			`  badi search "<q>" --since DATE  ${chalk.dim("Tarih filtre basi")}`,
+		);
+		console.log(
+			`  badi search "<q>" --until DATE  ${chalk.dim("Tarih filtre sonu")}`,
+		);
+		console.log(
+			`  badi search "<q>" --branch X    ${chalk.dim("Git branch filtre")}`,
+		);
+		console.log(
+			`  badi search "<q>" --limit N     ${chalk.dim("Sonuc sayisi (default 20)")}`,
+		);
+		return;
+	}
+
+	const tokens = tokenize(query);
+	const files = listTranscriptFiles();
+	const matches = [];
+	for (const f of files) {
+		const summary = parseSession(f.path);
+		if (!summary) continue;
+		const filtered = applyFilters([summary], { since, until, branch });
+		if (filtered.length === 0) continue;
+		const haystack = buildSearchIndex(f.path);
+		if (!haystack) continue;
+		if (!matchAll(haystack, tokens)) continue;
+		matches.push({
+			session: filtered[0],
+			snippet: snippet(haystack, tokens),
+		});
+	}
+
+	matches.sort(
+		(a, b) =>
+			new Date(b.session.lastTs || 0).getTime() -
+			new Date(a.session.lastTs || 0).getTime(),
+	);
+
+	showBanner();
+	console.log(chalk.bold(`Arama: "${query}"`));
+	console.log(chalk.dim(`${matches.length} session eslesti`));
+	console.log("");
+
+	for (const m of matches.slice(0, limit)) {
+		const s = m.session;
+		const date = (s.lastTs || "").slice(0, 10);
+		console.log(
+			`  ${chalk.cyan(shortSessionId(s.sessionId))} ${chalk.dim(date)} ${chalk.yellow((s.project || "?").slice(0, 18).padEnd(18))} ${chalk.dim(s.gitBranch || "-")} ${chalk.dim(formatDuration(s.durationMs))}`,
+		);
+		console.log(`    ${chalk.dim(m.snippet)}`);
+	}
+	if (matches.length > limit) {
+		console.log(
+			chalk.dim(
+				`\n  ... ${matches.length - limit} sonuc daha (--limit ile arttir)`,
+			),
+		);
+	}
+}

--- a/lib/commands/session.js
+++ b/lib/commands/session.js
@@ -1,0 +1,172 @@
+import { chalk, showBanner } from "../cli.js";
+import {
+	findSession,
+	formatDuration,
+	parseSessionWithEvents,
+	shortSessionId,
+} from "../data/transcript-reader.js";
+
+function truncate(s, n = 80) {
+	if (!s) return "";
+	const flat = s.replace(/\s+/g, " ").trim();
+	return flat.length > n ? `${flat.slice(0, n - 1)}…` : flat;
+}
+
+function renderHeader(s) {
+	console.log(chalk.bold(`Session ${chalk.cyan(shortSessionId(s.sessionId))}`));
+	console.log(chalk.dim(`  Tam ID: ${s.sessionId}`));
+	console.log(chalk.dim(`  Proje:  ${s.project || "?"}  (${s.cwd || "?"})`));
+	console.log(chalk.dim(`  Branch: ${s.gitBranch || "-"}`));
+	console.log(
+		chalk.dim(
+			`  Zaman:  ${(s.firstTs || "?").slice(0, 19)} → ${(s.lastTs || "?").slice(0, 19)} (${formatDuration(s.durationMs)})`,
+		),
+	);
+	console.log(
+		chalk.dim(
+			`  Model:  ${s.models.filter((m) => m && m !== "<synthetic>").join(", ") || "-"}`,
+		),
+	);
+	console.log(
+		chalk.dim(
+			`  Token:  in=${s.usage.input.toLocaleString()} out=${s.usage.output.toLocaleString()} cacheR=${s.usage.cacheRead.toLocaleString()} cacheW=${s.usage.cacheCreate.toLocaleString()}`,
+		),
+	);
+	console.log(chalk.dim(`  Cost:   $${s.costUsd.toFixed(2)}`));
+	console.log(
+		chalk.dim(
+			`  Promptlar: ${s.promptCount}  Tool kullanim: ${s.toolUseCount}`,
+		),
+	);
+}
+
+function renderToolBreakdown(s) {
+	const rows = Object.entries(s.toolCounts).sort((a, b) => b[1] - a[1]);
+	if (rows.length === 0) {
+		console.log(chalk.dim("  Tool kullanimi yok."));
+		return;
+	}
+	const maxLabel = Math.max(...rows.map(([k]) => k.length));
+	for (const [name, count] of rows.slice(0, 15)) {
+		console.log(`  ${name.padEnd(maxLabel)}  ${chalk.yellow(count)}`);
+	}
+	if (rows.length > 15)
+		console.log(chalk.dim(`  ... ${rows.length - 15} tool daha`));
+}
+
+function renderFilesTouched(s) {
+	if (s.filesTouched.length === 0) {
+		console.log(chalk.dim("  Dosya islemi yok."));
+		return;
+	}
+	const list = s.filesTouched.slice(0, 20);
+	for (const f of list) {
+		console.log(`  ${chalk.dim(f)}`);
+	}
+	if (s.filesTouched.length > 20)
+		console.log(chalk.dim(`  ... ${s.filesTouched.length - 20} dosya daha`));
+}
+
+function renderTimeline(events, limit) {
+	if (events.length === 0) {
+		console.log(chalk.dim("  Timeline bos."));
+		return;
+	}
+	const slice = events.slice(0, limit);
+	for (const e of slice) {
+		const ts = (e.ts || "?").slice(11, 19);
+		if (e.kind === "prompt") {
+			console.log(
+				`  ${chalk.dim(ts)} ${chalk.green("►")} ${truncate(e.text, 100)}`,
+			);
+		} else if (e.kind === "tool") {
+			const fp = e.input?.file_path || e.input?.path || e.input?.command || "";
+			console.log(
+				`  ${chalk.dim(ts)} ${chalk.yellow("⚙")} ${chalk.cyan(e.name)}${fp ? ` ${chalk.dim(truncate(String(fp), 60))}` : ""}`,
+			);
+		} else if (e.kind === "thinking") {
+			console.log(
+				`  ${chalk.dim(ts)} ${chalk.magenta("∿")} ${chalk.dim("thinking")}`,
+			);
+		}
+	}
+	if (events.length > limit)
+		console.log(
+			chalk.dim(
+				`  ... ${events.length - limit} event daha (--full ile tum timeline)`,
+			),
+		);
+}
+
+export function runSession(args) {
+	if (!args[0] || args[0] === "--help" || args[0] === "-h") {
+		console.log(chalk.bold("Session Detay:"));
+		console.log("");
+		console.log(
+			`  badi session <id>           ${chalk.dim("Tek session ozet + timeline (ilk 30 event)")}`,
+		);
+		console.log(`  badi session <id> --full    ${chalk.dim("Tam timeline")}`);
+		console.log(
+			`  badi session <id> --tools   ${chalk.dim("Sadece tool dagilimi")}`,
+		);
+		console.log(
+			`  badi session <id> --files   ${chalk.dim("Sadece dokunulan dosyalar")}`,
+		);
+		console.log("");
+		console.log(chalk.dim("  ID kismi prefix de olabilir (orn. c026ac75)"));
+		return;
+	}
+
+	const idOrPrefix = args[0];
+	const opts = {
+		full: args.includes("--full"),
+		toolsOnly: args.includes("--tools"),
+		filesOnly: args.includes("--files"),
+	};
+
+	let entry;
+	try {
+		entry = findSession(idOrPrefix);
+	} catch (e) {
+		if (e.code === "AMBIGUOUS") {
+			console.error(chalk.red(e.message));
+			process.exit(1);
+		}
+		throw e;
+	}
+	if (!entry) {
+		console.error(chalk.red(`Session bulunamadi: ${idOrPrefix}`));
+		console.log(chalk.dim("Mevcut session'lari listele: badi stats --session"));
+		process.exit(1);
+	}
+
+	const s = parseSessionWithEvents(entry.path);
+	if (!s) {
+		console.error(chalk.red(`Session okunamadi: ${entry.path}`));
+		process.exit(1);
+	}
+
+	showBanner();
+	renderHeader(s);
+	console.log("");
+
+	if (opts.toolsOnly) {
+		console.log(chalk.bold("Tool Dagilimi:"));
+		renderToolBreakdown(s);
+		return;
+	}
+	if (opts.filesOnly) {
+		console.log(chalk.bold("Dokunulan Dosyalar:"));
+		renderFilesTouched(s);
+		return;
+	}
+
+	console.log(chalk.bold("Tool Dagilimi:"));
+	renderToolBreakdown(s);
+	console.log("");
+	console.log(chalk.bold("Dokunulan Dosyalar:"));
+	renderFilesTouched(s);
+	console.log("");
+	console.log(chalk.bold("Timeline:"));
+	renderTimeline(s.events, opts.full ? s.events.length : 30);
+}

--- a/lib/commands/stats.js
+++ b/lib/commands/stats.js
@@ -1,6 +1,13 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { chalk, showBanner } from "../cli.js";
+import {
+	applyFilters,
+	formatDuration,
+	listTranscriptFiles,
+	parseSession,
+	shortSessionId,
+} from "../data/transcript-reader.js";
 
 export function parseUsageLog(cwd) {
 	const logFile = join(cwd || process.cwd(), ".claude", "logs", "usage.jsonl");
@@ -122,12 +129,153 @@ export function renderHabitStreaks(dailyCounts) {
 	console.log(`  Bu hafta:      ${chalk.bold(weekActive)}/7 gun aktif`);
 }
 
+// v1.29+ Claude Code transcript bazli session istatistikleri.
+// Mevcut "tool usage from .claude/logs/usage.jsonl" akisi degismeden korunur;
+// yeni flag'lar (--session, --models, --cost, --since, --until, --branch) ise
+// ~/.claude/projects/*.jsonl transcript'lerini okur.
+function loadFilteredSessions(opts) {
+	const files = listTranscriptFiles();
+	const sessions = [];
+	for (const f of files) {
+		const s = parseSession(f.path);
+		if (!s) continue;
+		s.mtimeMs = f.mtimeMs;
+		s.projectSlug = f.projectSlug;
+		sessions.push(s);
+	}
+	return applyFilters(sessions, opts);
+}
+
+function renderSessionList(sessions, limit) {
+	const sorted = sessions
+		.slice()
+		.sort(
+			(a, b) =>
+				new Date(b.lastTs || 0).getTime() - new Date(a.lastTs || 0).getTime(),
+		)
+		.slice(0, limit);
+	if (sorted.length === 0) {
+		console.log(chalk.dim("  Filtreye uyan session yok."));
+		return;
+	}
+	const header = [
+		"ID",
+		"Project",
+		"Branch",
+		"Model",
+		"Duration",
+		"Prompts",
+		"Tools",
+		"Cost",
+	];
+	console.log(
+		"  " +
+			chalk.dim(
+				`${header[0].padEnd(9)} ${header[1].padEnd(20)} ${header[2].padEnd(12)} ${header[3].padEnd(10)} ${header[4].padEnd(8)} ${header[5].padEnd(7)} ${header[6].padEnd(6)} ${header[7]}`,
+			),
+	);
+	for (const s of sorted) {
+		const id = shortSessionId(s.sessionId);
+		const proj = (s.project || "?").slice(0, 19).padEnd(20);
+		const br = (s.gitBranch || "-").slice(0, 11).padEnd(12);
+		const modelClass = modelClassFor(s.models);
+		const dur = formatDuration(s.durationMs).padEnd(8);
+		const cost = `$${s.costUsd.toFixed(2)}`;
+		console.log(
+			`  ${chalk.cyan(id.padEnd(9))} ${proj} ${chalk.dim(br)} ${chalk.yellow(modelClass.padEnd(10))} ${dur} ${String(s.promptCount).padEnd(7)} ${String(s.toolUseCount).padEnd(6)} ${chalk.green(cost)}`,
+		);
+	}
+}
+
+function modelClassFor(models) {
+	if (!Array.isArray(models) || models.length === 0) return "-";
+	const real = models.filter((m) => m && m !== "<synthetic>");
+	if (real.length === 0) return "synth";
+	const first = real[0];
+	if (first.includes("opus")) return "opus";
+	if (first.includes("sonnet")) return "sonnet";
+	if (first.includes("haiku")) return "haiku";
+	return first.slice(0, 10);
+}
+
+function renderModelStats(sessions) {
+	const byModel = {};
+	let totalCacheRead = 0;
+	let totalCacheCreate = 0;
+	let totalInput = 0;
+	for (const s of sessions) {
+		totalInput += s.usage.input;
+		totalCacheRead += s.usage.cacheRead;
+		totalCacheCreate += s.usage.cacheCreate;
+		for (const m of s.models) {
+			if (m === "<synthetic>") continue;
+			byModel[m] = byModel[m] || { sessions: 0, cost: 0 };
+			byModel[m].sessions += 1;
+			byModel[m].cost += s.costUsd / Math.max(1, s.models.length);
+		}
+	}
+	const rows = Object.entries(byModel).sort(
+		(a, b) => b[1].sessions - a[1].sessions,
+	);
+	if (rows.length === 0) {
+		console.log(chalk.dim("  Model verisi yok."));
+		return;
+	}
+	const maxLabel = Math.max(...rows.map(([k]) => k.length));
+	for (const [m, v] of rows) {
+		console.log(
+			`  ${m.padEnd(maxLabel)}  ${chalk.yellow(String(v.sessions).padStart(4))} session  ${chalk.green(`$${v.cost.toFixed(2)}`)}`,
+		);
+	}
+	const totalReadable = totalCacheRead + totalCacheCreate + totalInput;
+	const hitRate =
+		totalReadable > 0 ? (totalCacheRead / totalReadable) * 100 : 0;
+	console.log("");
+	console.log(
+		`  ${chalk.bold("Cache hit rate")}: ${chalk.cyan(`${hitRate.toFixed(1)}%`)}  ${chalk.dim(`(${totalCacheRead.toLocaleString()} read / ${totalReadable.toLocaleString()} total)`)}`,
+	);
+}
+
+function renderCostBreakdown(sessions) {
+	let total = 0;
+	const byProj = {};
+	const byBranch = {};
+	for (const s of sessions) {
+		total += s.costUsd;
+		const p = s.project || "?";
+		byProj[p] = (byProj[p] || 0) + s.costUsd;
+		const b = s.gitBranch || "-";
+		byBranch[b] = (byBranch[b] || 0) + s.costUsd;
+	}
+	console.log(
+		`  ${chalk.bold("Toplam")}: ${chalk.green(`$${total.toFixed(2)}`)}  ${chalk.dim(`(${sessions.length} session)`)}`,
+	);
+	console.log("");
+	console.log(chalk.bold("  Proje bazli:"));
+	const projs = Object.entries(byProj)
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, 10);
+	const maxLabel = projs.length ? Math.max(...projs.map(([k]) => k.length)) : 0;
+	for (const [p, c] of projs) {
+		console.log(
+			`    ${p.padEnd(maxLabel)}  ${chalk.green(`$${c.toFixed(2)}`)}`,
+		);
+	}
+}
+
 export function runStats(args) {
 	let period = "week";
 	let commandFilter = null;
 	let showHabits = false;
 	let exportFormat = null;
 	let showHelp = false;
+	let showSession = false;
+	let showModels = false;
+	let showCost = false;
+	let since = null;
+	let until = null;
+	let branchFilter = null;
+	let limit = 20;
 
 	for (let i = 0; i < args.length; i++) {
 		switch (args[i]) {
@@ -148,6 +296,28 @@ export function runStats(args) {
 				break;
 			case "--export":
 				exportFormat = args[++i];
+				break;
+			case "--session":
+			case "--sessions":
+				showSession = true;
+				break;
+			case "--models":
+				showModels = true;
+				break;
+			case "--cost":
+				showCost = true;
+				break;
+			case "--since":
+				since = args[++i];
+				break;
+			case "--until":
+				until = args[++i];
+				break;
+			case "--branch":
+				branchFilter = args[++i];
+				break;
+			case "--limit":
+				limit = Math.max(1, parseInt(args[++i], 10) || 20);
 				break;
 			case "--help":
 			case "-h":
@@ -174,6 +344,63 @@ export function runStats(args) {
 		console.log(
 			`  badi stats --export csv ${chalk.dim("CSV olarak disa aktar")}`,
 		);
+		console.log("");
+		console.log(chalk.bold("  Claude Code transcript analizi (v1.29+):"));
+		console.log(
+			`  badi stats --session    ${chalk.dim("Son N session listesi (--limit ile sayi)")}`,
+		);
+		console.log(
+			`  badi stats --models     ${chalk.dim("Model dagilimi + cache hit rate")}`,
+		);
+		console.log(
+			`  badi stats --cost       ${chalk.dim("Token bazli USD maliyet (proje breakdown)")}`,
+		);
+		console.log(
+			`  badi stats --since DATE ${chalk.dim("Tarih araligi basi (ISO veya YYYY-MM-DD)")}`,
+		);
+		console.log(`  badi stats --until DATE ${chalk.dim("Tarih araligi sonu")}`);
+		console.log(
+			`  badi stats --branch X   ${chalk.dim("Git branch filtre (transcript modlari icin)")}`,
+		);
+		console.log(
+			`  badi stats --limit N    ${chalk.dim("--session icin satir sayisi (default 20)")}`,
+		);
+		return;
+	}
+
+	// Yeni transcript-bazli akis (--session/--models/--cost)
+	if (showSession || showModels || showCost) {
+		const sessions = loadFilteredSessions({
+			since,
+			until,
+			branch: branchFilter,
+		});
+		showBanner();
+		console.log(chalk.bold("Claude Code Session Analitik"));
+		const filterParts = [];
+		if (since) filterParts.push(`since=${since}`);
+		if (until) filterParts.push(`until=${until}`);
+		if (branchFilter) filterParts.push(`branch=${branchFilter}`);
+		if (filterParts.length)
+			console.log(chalk.dim(`Filtre: ${filterParts.join(" ")}`));
+		console.log(chalk.dim(`Bulunan: ${sessions.length} session`));
+		console.log("");
+
+		if (showSession) {
+			console.log(chalk.bold(`Son ${limit} Session:`));
+			renderSessionList(sessions, limit);
+			console.log("");
+		}
+		if (showModels) {
+			console.log(chalk.bold("Model Dagilimi:"));
+			renderModelStats(sessions);
+			console.log("");
+		}
+		if (showCost) {
+			console.log(chalk.bold("Maliyet Ozeti:"));
+			renderCostBreakdown(sessions);
+			console.log("");
+		}
 		return;
 	}
 

--- a/lib/data/transcript-reader.js
+++ b/lib/data/transcript-reader.js
@@ -1,0 +1,343 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+
+// Claude Code transcript JSONL'lerinin kanonik konumu.
+// override edilebilir (test icin).
+export function transcriptsRoot(override) {
+	return override || join(homedir(), ".claude", "projects");
+}
+
+// Per-1M-token approximate pricing (USD). Public Anthropic listesi.
+// Kullanim aciklamasi: bu tablo sabit degil, model adi degisirse fallback uygulanir.
+export const MODEL_PRICING = {
+	"claude-opus-4-7": {
+		input: 15,
+		output: 75,
+		cacheWrite: 18.75,
+		cacheRead: 1.5,
+	},
+	"claude-opus-4-6": {
+		input: 15,
+		output: 75,
+		cacheWrite: 18.75,
+		cacheRead: 1.5,
+	},
+	"claude-opus-4-5": {
+		input: 15,
+		output: 75,
+		cacheWrite: 18.75,
+		cacheRead: 1.5,
+	},
+	"claude-sonnet-4-6": {
+		input: 3,
+		output: 15,
+		cacheWrite: 3.75,
+		cacheRead: 0.3,
+	},
+	"claude-sonnet-4-5": {
+		input: 3,
+		output: 15,
+		cacheWrite: 3.75,
+		cacheRead: 0.3,
+	},
+	"claude-haiku-4-5": { input: 1, output: 5, cacheWrite: 1.25, cacheRead: 0.1 },
+	"claude-haiku-4-5-20251001": {
+		input: 1,
+		output: 5,
+		cacheWrite: 1.25,
+		cacheRead: 0.1,
+	},
+};
+
+function classifyModel(model) {
+	if (!model) return "unknown";
+	if (model.includes("opus")) return "opus";
+	if (model.includes("sonnet")) return "sonnet";
+	if (model.includes("haiku")) return "haiku";
+	return "other";
+}
+
+function pricingFor(model) {
+	if (MODEL_PRICING[model]) return MODEL_PRICING[model];
+	const family = classifyModel(model);
+	if (family === "opus")
+		return { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.5 };
+	if (family === "sonnet")
+		return { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 };
+	if (family === "haiku")
+		return { input: 1, output: 5, cacheWrite: 1.25, cacheRead: 0.1 };
+	return null;
+}
+
+export function costForUsage(model, usage) {
+	const p = pricingFor(model);
+	if (!p || !usage) return 0;
+	const inp = usage.input_tokens || 0;
+	const out = usage.output_tokens || 0;
+	const cw = usage.cache_creation_input_tokens || 0;
+	const cr = usage.cache_read_input_tokens || 0;
+	return (
+		(inp * p.input + out * p.output + cw * p.cacheWrite + cr * p.cacheRead) /
+		1_000_000
+	);
+}
+
+export function listTranscriptFiles(root) {
+	const base = transcriptsRoot(root);
+	let dirs;
+	try {
+		dirs = readdirSync(base);
+	} catch {
+		return [];
+	}
+	const out = [];
+	for (const d of dirs) {
+		const projectDir = join(base, d);
+		let files;
+		try {
+			files = readdirSync(projectDir);
+		} catch {
+			continue;
+		}
+		for (const f of files) {
+			if (!f.endsWith(".jsonl")) continue;
+			const full = join(projectDir, f);
+			let st;
+			try {
+				st = statSync(full);
+			} catch {
+				continue;
+			}
+			if (!st.isFile()) continue;
+			out.push({
+				path: full,
+				projectSlug: d,
+				sessionId: f.replace(/\.jsonl$/, ""),
+				mtimeMs: st.mtimeMs,
+				size: st.size,
+			});
+		}
+	}
+	return out;
+}
+
+// Tek JSONL'i okuyup minimal session ozetine cevirir.
+// Bu hot-path; gerekli olan minimum alanlari toplar.
+export function parseSession(filePath) {
+	let raw;
+	try {
+		raw = readFileSync(filePath, "utf-8");
+	} catch {
+		return null;
+	}
+	const lines = raw.split("\n");
+	const session = {
+		sessionId: basename(filePath, ".jsonl"),
+		path: filePath,
+		cwd: null,
+		project: null,
+		gitBranch: null,
+		models: new Set(),
+		firstTs: null,
+		lastTs: null,
+		promptCount: 0,
+		assistantCount: 0,
+		toolUseCount: 0,
+		toolCounts: {},
+		filesTouched: new Set(),
+		mcpToolCounts: {},
+		usage: {
+			input: 0,
+			output: 0,
+			cacheCreate: 0,
+			cacheRead: 0,
+		},
+		costUsd: 0,
+		lastPromptText: "",
+		firstPromptText: "",
+		events: [], // sadece istenirse doldurulur (parseSession(path, {events:true}))
+	};
+
+	for (const line of lines) {
+		if (!line) continue;
+		let o;
+		try {
+			o = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		const ts = o.timestamp;
+		if (ts) {
+			if (!session.firstTs || ts < session.firstTs) session.firstTs = ts;
+			if (!session.lastTs || ts > session.lastTs) session.lastTs = ts;
+		}
+		if (o.cwd && !session.cwd) {
+			session.cwd = o.cwd;
+			session.project = basename(o.cwd);
+		}
+		if (o.gitBranch && !session.gitBranch) session.gitBranch = o.gitBranch;
+
+		if (o.type === "user") {
+			session.promptCount += 1;
+			const c = o.message?.content;
+			if (typeof c === "string") {
+				if (!session.firstPromptText) session.firstPromptText = c.slice(0, 500);
+				session.lastPromptText = c.slice(0, 500);
+			}
+		} else if (o.type === "last-prompt") {
+			if (typeof o.prompt === "string")
+				session.lastPromptText = o.prompt.slice(0, 500);
+		} else if (o.type === "assistant") {
+			session.assistantCount += 1;
+			const m = o.message?.model;
+			if (m) session.models.add(m);
+			const u = o.message?.usage;
+			if (u) {
+				session.usage.input += u.input_tokens || 0;
+				session.usage.output += u.output_tokens || 0;
+				session.usage.cacheCreate += u.cache_creation_input_tokens || 0;
+				session.usage.cacheRead += u.cache_read_input_tokens || 0;
+				session.costUsd += costForUsage(m, u);
+			}
+			const content = o.message?.content;
+			if (Array.isArray(content)) {
+				for (const b of content) {
+					if (b?.type === "tool_use") {
+						session.toolUseCount += 1;
+						const name = b.name || "unknown";
+						session.toolCounts[name] = (session.toolCounts[name] || 0) + 1;
+						if (name.startsWith("mcp__")) {
+							session.mcpToolCounts[name] =
+								(session.mcpToolCounts[name] || 0) + 1;
+						}
+						const inp = b.input || {};
+						const fp = inp.file_path || inp.path;
+						if (typeof fp === "string") session.filesTouched.add(fp);
+					}
+				}
+			}
+		}
+	}
+
+	session.models = [...session.models];
+	session.filesTouched = [...session.filesTouched];
+	session.durationMs =
+		session.firstTs && session.lastTs
+			? new Date(session.lastTs).getTime() - new Date(session.firstTs).getTime()
+			: 0;
+	return session;
+}
+
+// Detayli timeline icin — events da doldurur.
+export function parseSessionWithEvents(filePath) {
+	let raw;
+	try {
+		raw = readFileSync(filePath, "utf-8");
+	} catch {
+		return null;
+	}
+	const base = parseSession(filePath);
+	if (!base) return null;
+	const lines = raw.split("\n");
+	const events = [];
+	for (const line of lines) {
+		if (!line) continue;
+		let o;
+		try {
+			o = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		if (o.type === "user" && typeof o.message?.content === "string") {
+			events.push({
+				ts: o.timestamp,
+				kind: "prompt",
+				text: o.message.content.slice(0, 200),
+			});
+		} else if (o.type === "assistant" && Array.isArray(o.message?.content)) {
+			for (const b of o.message.content) {
+				if (b?.type === "tool_use") {
+					events.push({
+						ts: o.timestamp,
+						kind: "tool",
+						name: b.name,
+						input: b.input,
+					});
+				} else if (b?.type === "thinking") {
+					events.push({ ts: o.timestamp, kind: "thinking" });
+				}
+			}
+		}
+	}
+	events.sort((a, b) => (a.ts || "").localeCompare(b.ts || ""));
+	base.events = events;
+	return base;
+}
+
+export function loadSessions(opts = {}) {
+	const files = listTranscriptFiles(opts.root);
+	const sessions = [];
+	for (const f of files) {
+		const s = parseSession(f.path);
+		if (!s) continue;
+		s.mtimeMs = f.mtimeMs;
+		s.projectSlug = f.projectSlug;
+		sessions.push(s);
+	}
+	return applyFilters(sessions, opts);
+}
+
+export function applyFilters(sessions, opts = {}) {
+	let out = sessions;
+	if (opts.since) {
+		const t = new Date(opts.since).getTime();
+		if (!Number.isNaN(t))
+			out = out.filter((s) => new Date(s.lastTs || 0).getTime() >= t);
+	}
+	if (opts.until) {
+		const t = new Date(opts.until).getTime();
+		if (!Number.isNaN(t))
+			out = out.filter((s) => new Date(s.firstTs || 0).getTime() <= t);
+	}
+	if (opts.branch) {
+		out = out.filter((s) => s.gitBranch === opts.branch);
+	}
+	if (opts.project) {
+		out = out.filter((s) => s.project === opts.project);
+	}
+	return out;
+}
+
+export function formatDuration(ms) {
+	if (!ms || ms < 0) return "0s";
+	const s = Math.floor(ms / 1000);
+	if (s < 60) return `${s}s`;
+	const m = Math.floor(s / 60);
+	if (m < 60) return `${m}m`;
+	const h = Math.floor(m / 60);
+	const rm = m % 60;
+	return rm ? `${h}h${rm}m` : `${h}h`;
+}
+
+export function shortSessionId(id) {
+	if (!id) return "????????";
+	return id.slice(0, 8);
+}
+
+export function findSession(idOrPrefix, opts = {}) {
+	const files = listTranscriptFiles(opts.root);
+	const exact = files.find((f) => f.sessionId === idOrPrefix);
+	if (exact) return exact;
+	const prefix = files.filter((f) => f.sessionId.startsWith(idOrPrefix));
+	if (prefix.length === 1) return prefix[0];
+	if (prefix.length > 1) {
+		const err = new Error(
+			`Birden fazla session eslesiyor: ${prefix.map((p) => shortSessionId(p.sessionId)).join(", ")}`,
+		);
+		err.code = "AMBIGUOUS";
+		err.matches = prefix;
+		throw err;
+	}
+	return null;
+}

--- a/tests/cli.observability.test.js
+++ b/tests/cli.observability.test.js
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const CLI = resolve(__dirname, "..", "bin", "badi.js");
+
+function run(args = []) {
+	try {
+		return {
+			stdout: execFileSync("node", [CLI, ...args], {
+				encoding: "utf-8",
+				timeout: 15000,
+			}),
+			code: 0,
+		};
+	} catch (e) {
+		return {
+			stdout: e.stdout?.toString() || "",
+			stderr: e.stderr?.toString() || "",
+			code: e.status ?? 1,
+		};
+	}
+}
+
+describe("stats v1.29+ flag'lari", () => {
+	it("stats --help yeni flag'lari listeler", () => {
+		const r = run(["stats", "--help"]);
+		assert.equal(r.code, 0);
+		assert.ok(r.stdout.includes("--session"));
+		assert.ok(r.stdout.includes("--models"));
+		assert.ok(r.stdout.includes("--cost"));
+		assert.ok(r.stdout.includes("--since"));
+		assert.ok(r.stdout.includes("--until"));
+		assert.ok(r.stdout.includes("--branch"));
+	});
+
+	// Asagidaki testler ~/.claude/projects/ verisine bagli; CI'da transcript
+	// yoksa "Bulunan: 0 session" cikar — invariant olarak banner ve baslik
+	// her zaman dolar.
+	it("stats --session calisir (transcript yoksa bile)", () => {
+		const r = run(["stats", "--session", "--limit", "1"]);
+		assert.equal(r.code, 0);
+		assert.ok(r.stdout.includes("Session Analitik"));
+	});
+
+	it("stats --models calisir", () => {
+		const r = run(["stats", "--models"]);
+		assert.equal(r.code, 0);
+		assert.ok(r.stdout.includes("Model Dagilimi"));
+	});
+
+	it("stats --cost calisir", () => {
+		const r = run(["stats", "--cost"]);
+		assert.equal(r.code, 0);
+		assert.ok(r.stdout.includes("Maliyet"));
+	});
+});
+
+describe("badi search", () => {
+	it("argumansiz help gosterir", () => {
+		const r = run(["search"]);
+		assert.equal(r.code, 0);
+		assert.ok(
+			r.stdout.includes("AND search") || r.stdout.includes("Transcript Arama"),
+		);
+	});
+
+	it("--help calisir", () => {
+		const r = run(["search", "--help"]);
+		assert.equal(r.code, 0);
+		assert.ok(r.stdout.includes("--since"));
+	});
+});
+
+describe("badi session", () => {
+	it("argumansiz help gosterir", () => {
+		const r = run(["session"]);
+		assert.equal(r.code, 0);
+		assert.ok(r.stdout.includes("Session Detay"));
+	});
+
+	it("bilinmeyen ID hatasi exit 1", () => {
+		const r = run(["session", "zzzzzzzz"]);
+		assert.notEqual(r.code, 0);
+		assert.ok((r.stderr || r.stdout).includes("bulunamadi"));
+	});
+});
+
+describe("badi list --mcp", () => {
+	it("MCP kullanim bolumunu cikarir", () => {
+		const r = run(["list", "--mcp"]);
+		assert.equal(r.code, 0);
+		assert.ok(r.stdout.includes("MCP Server Kullanimi"));
+	});
+});
+
+describe("badi plugin show", () => {
+	it("bilinmeyen plugin hatasi exit 1", () => {
+		const r = run(["plugin", "show", "nonexistent-xyz"]);
+		assert.notEqual(r.code, 0);
+	});
+
+	it("isim verilmezse exit 1", () => {
+		const r = run(["plugin", "show"]);
+		assert.notEqual(r.code, 0);
+	});
+});

--- a/tests/cli.plan.test.js
+++ b/tests/cli.plan.test.js
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const CLI = resolve(__dirname, "..", "bin", "badi.js");
+
+function run(args = [], opts = {}) {
+	try {
+		return {
+			stdout: execFileSync("node", [CLI, ...args], {
+				encoding: "utf-8",
+				timeout: 10000,
+				cwd: opts.cwd,
+			}),
+			code: 0,
+		};
+	} catch (e) {
+		return {
+			stdout: e.stdout?.toString() || "",
+			stderr: e.stderr?.toString() || "",
+			code: e.status ?? 1,
+		};
+	}
+}
+
+let tmp;
+before(() => {
+	tmp = mkdtempSync(join(tmpdir(), "badi-plan-"));
+});
+after(() => {
+	try {
+		rmSync(tmp, { recursive: true, force: true });
+	} catch {}
+});
+
+describe("badi plan", () => {
+	it("new bir plan dosyasi olusturur", () => {
+		const r = run(["plan", "new", "alpha"], { cwd: tmp });
+		assert.equal(r.code, 0);
+		assert.ok(existsSync(join(tmp, ".claude", "plans", "alpha.md")));
+	});
+
+	it("list pending durumu gosterir", () => {
+		const r = run(["plan", "list"], { cwd: tmp });
+		assert.equal(r.code, 0);
+		assert.ok(r.stdout.includes("alpha"));
+		assert.ok(r.stdout.includes("pending"));
+	});
+
+	it("status pending icin exit 1", () => {
+		const r = run(["plan", "status", "alpha"], { cwd: tmp });
+		assert.equal(r.code, 1);
+	});
+
+	it("approve sonrasi status exit 0 + json formatlanir", () => {
+		const r1 = run(["plan", "approve", "alpha"], { cwd: tmp });
+		assert.equal(r1.code, 0);
+		const r2 = run(["plan", "status", "alpha", "--format", "json"], {
+			cwd: tmp,
+		});
+		assert.equal(r2.code, 0);
+		const obj = JSON.parse(r2.stdout.trim());
+		assert.equal(obj.state, "approved");
+		assert.equal(obj.slug, "alpha");
+	});
+
+	it("deny reason'i kaydet, status exit 1", () => {
+		const r1 = run(["plan", "deny", "alpha", "scope cok genis"], {
+			cwd: tmp,
+		});
+		assert.equal(r1.code, 0);
+		const r2 = run(["plan", "status", "alpha", "--format", "json"], {
+			cwd: tmp,
+		});
+		assert.equal(r2.code, 1);
+		const obj = JSON.parse(r2.stdout.trim());
+		assert.equal(obj.state, "denied");
+		assert.equal(obj.reason, "scope cok genis");
+	});
+
+	it("reset markerleri siler -> pending", () => {
+		run(["plan", "reset", "alpha"], { cwd: tmp });
+		const r = run(["plan", "status", "alpha", "--format", "json"], {
+			cwd: tmp,
+		});
+		const obj = JSON.parse(r.stdout.trim());
+		assert.equal(obj.state, "pending");
+	});
+
+	it("gecersiz slug reddedilir (path traversal koruma)", () => {
+		const r = run(["plan", "new", "../evil"], { cwd: tmp });
+		assert.notEqual(r.code, 0);
+	});
+
+	it("help argumansiz gosterilir", () => {
+		const r = run(["plan"]);
+		assert.equal(r.code, 0);
+		assert.ok(r.stdout.includes("Plan Approval"));
+	});
+});

--- a/tests/transcript-reader.test.js
+++ b/tests/transcript-reader.test.js
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import {
+	applyFilters,
+	costForUsage,
+	findSession,
+	formatDuration,
+	listTranscriptFiles,
+	MODEL_PRICING,
+	parseSession,
+	parseSessionWithEvents,
+	shortSessionId,
+} from "../lib/data/transcript-reader.js";
+
+function jsonl(arr) {
+	return arr.map((o) => JSON.stringify(o)).join("\n");
+}
+
+let tmp;
+let root;
+
+const SAMPLE_SESSION_ID = "11111111-2222-3333-4444-555555555555";
+const SAMPLE_SLUG = "-tmp-test-project";
+
+before(() => {
+	tmp = mkdtempSync(join(tmpdir(), "badi-transcript-"));
+	root = join(tmp, "projects");
+	mkdirSync(join(root, SAMPLE_SLUG), { recursive: true });
+	const lines = jsonl([
+		{
+			type: "user",
+			timestamp: "2026-05-15T10:00:00Z",
+			cwd: "/tmp/test-project",
+			gitBranch: "main",
+			sessionId: SAMPLE_SESSION_ID,
+			message: { role: "user", content: "secret-scan refactor planla" },
+		},
+		{
+			type: "assistant",
+			timestamp: "2026-05-15T10:00:05Z",
+			cwd: "/tmp/test-project",
+			gitBranch: "main",
+			sessionId: SAMPLE_SESSION_ID,
+			message: {
+				model: "claude-opus-4-7",
+				role: "assistant",
+				content: [
+					{ type: "text", text: "ok" },
+					{
+						type: "tool_use",
+						name: "Edit",
+						input: { file_path: "/tmp/test-project/foo.js" },
+					},
+					{
+						type: "tool_use",
+						name: "mcp__context7__query-docs",
+						input: {},
+					},
+				],
+				usage: {
+					input_tokens: 100,
+					output_tokens: 200,
+					cache_creation_input_tokens: 50,
+					cache_read_input_tokens: 1000,
+				},
+			},
+		},
+		{
+			type: "assistant",
+			timestamp: "2026-05-15T10:05:00Z",
+			cwd: "/tmp/test-project",
+			gitBranch: "main",
+			sessionId: SAMPLE_SESSION_ID,
+			message: {
+				model: "claude-sonnet-4-6",
+				role: "assistant",
+				content: [{ type: "tool_use", name: "Bash", input: { command: "ls" } }],
+				usage: { input_tokens: 10, output_tokens: 20 },
+			},
+		},
+		{ type: "last-prompt", prompt: "search bunu da bul" },
+	]);
+	writeFileSync(join(root, SAMPLE_SLUG, `${SAMPLE_SESSION_ID}.jsonl`), lines);
+});
+
+after(() => {
+	try {
+		rmSync(tmp, { recursive: true, force: true });
+	} catch {}
+});
+
+describe("transcript-reader", () => {
+	it("listTranscriptFiles transcript bulur", () => {
+		const files = listTranscriptFiles(root);
+		assert.equal(files.length, 1);
+		assert.equal(files[0].sessionId, SAMPLE_SESSION_ID);
+	});
+
+	it("parseSession metadata + token + tool toplar", () => {
+		const files = listTranscriptFiles(root);
+		const s = parseSession(files[0].path);
+		assert.equal(s.project, "test-project");
+		assert.equal(s.gitBranch, "main");
+		assert.equal(s.promptCount, 1);
+		assert.equal(s.toolUseCount, 3);
+		assert.deepEqual(s.toolCounts, {
+			Edit: 1,
+			"mcp__context7__query-docs": 1,
+			Bash: 1,
+		});
+		assert.deepEqual(s.mcpToolCounts, { "mcp__context7__query-docs": 1 });
+		assert.equal(s.usage.input, 110);
+		assert.equal(s.usage.output, 220);
+		assert.equal(s.usage.cacheCreate, 50);
+		assert.equal(s.usage.cacheRead, 1000);
+		assert.equal(s.filesTouched.length, 1);
+		assert.ok(s.models.includes("claude-opus-4-7"));
+		assert.ok(s.models.includes("claude-sonnet-4-6"));
+	});
+
+	it("last-prompt event lastPromptText'i overwrite eder", () => {
+		const files = listTranscriptFiles(root);
+		const s = parseSession(files[0].path);
+		assert.equal(s.lastPromptText, "search bunu da bul");
+	});
+
+	it("costForUsage opus ve sonnet farkli ucretlendirir", () => {
+		const usage = {
+			input_tokens: 1_000_000,
+			output_tokens: 1_000_000,
+		};
+		const opus = costForUsage("claude-opus-4-7", usage);
+		const sonnet = costForUsage("claude-sonnet-4-6", usage);
+		assert.equal(opus, 15 + 75);
+		assert.equal(sonnet, 3 + 15);
+		assert.ok(opus > sonnet);
+	});
+
+	it("costForUsage bilinmeyen model icin fallback yapar", () => {
+		const c = costForUsage("claude-opus-4-99", {
+			input_tokens: 1_000_000,
+		});
+		assert.equal(c, 15);
+	});
+
+	it("costForUsage tamamen bilinmeyen icin 0 doner", () => {
+		const c = costForUsage("gpt-4", { input_tokens: 1_000_000 });
+		assert.equal(c, 0);
+	});
+
+	it("MODEL_PRICING ana modelleri kapsar", () => {
+		assert.ok(MODEL_PRICING["claude-opus-4-7"]);
+		assert.ok(MODEL_PRICING["claude-sonnet-4-6"]);
+		assert.ok(MODEL_PRICING["claude-haiku-4-5"]);
+	});
+
+	it("applyFilters --since session'i filtreler", () => {
+		const sessions = listTranscriptFiles(root).map((f) => parseSession(f.path));
+		const after = applyFilters(sessions, { since: "2026-06-01" });
+		assert.equal(after.length, 0);
+		const before = applyFilters(sessions, { since: "2026-05-01" });
+		assert.equal(before.length, 1);
+	});
+
+	it("applyFilters --until session'i filtreler", () => {
+		const sessions = listTranscriptFiles(root).map((f) => parseSession(f.path));
+		const before = applyFilters(sessions, { until: "2026-05-01" });
+		assert.equal(before.length, 0);
+		const after = applyFilters(sessions, { until: "2026-06-01" });
+		assert.equal(after.length, 1);
+	});
+
+	it("applyFilters --branch session'i filtreler", () => {
+		const sessions = listTranscriptFiles(root).map((f) => parseSession(f.path));
+		assert.equal(applyFilters(sessions, { branch: "main" }).length, 1);
+		assert.equal(applyFilters(sessions, { branch: "feature/x" }).length, 0);
+	});
+
+	it("findSession exact + prefix calisir", () => {
+		const exact = findSession(SAMPLE_SESSION_ID, { root });
+		assert.ok(exact);
+		const prefix = findSession(SAMPLE_SESSION_ID.slice(0, 8), { root });
+		assert.ok(prefix);
+		const none = findSession("zzzzzzzz", { root });
+		assert.equal(none, null);
+	});
+
+	it("parseSessionWithEvents tool + prompt event'leri sirasiyla doldurur", () => {
+		const files = listTranscriptFiles(root);
+		const s = parseSessionWithEvents(files[0].path);
+		assert.ok(s.events.length >= 4);
+		const kinds = s.events.map((e) => e.kind);
+		assert.ok(kinds.includes("prompt"));
+		assert.ok(kinds.includes("tool"));
+	});
+
+	it("formatDuration 0/saniye/dakika/saat formatlar", () => {
+		assert.equal(formatDuration(0), "0s");
+		assert.equal(formatDuration(45_000), "45s");
+		assert.equal(formatDuration(120_000), "2m");
+		assert.equal(formatDuration(3_600_000), "1h");
+		assert.equal(formatDuration(3_900_000), "1h5m");
+	});
+
+	it("shortSessionId 8 karakter alir", () => {
+		assert.equal(shortSessionId("abcdef0123456789"), "abcdef01");
+		assert.equal(shortSessionId(""), "????????");
+		assert.equal(shortSessionId(null), "????????");
+	});
+});


### PR DESCRIPTION
## Summary

Karma-equivalent observability — **Claude Code transcript bazli** (privacy-preserving, hicbir veri makineden cikmaz).

`~/.claude/projects/*.jsonl` transcript'lerini direk okuyup CLI'da gosterir.

### Yeni komutlar / flag'lar

| Komut | Ne yapar |
|---|---|
| `badi stats --session [--limit N]` | Son N session: id/proje/branch/model/duration/prompts/tools/$cost |
| `badi stats --models` | Model bazli session sayisi + USD + global cache hit rate |
| `badi stats --cost` | Toplam USD + ilk 10 proje breakdown |
| `badi stats --since DATE --until DATE` | ISO/YYYY-MM-DD tarih araligi (transcript modlari icin) |
| `badi stats --branch <ad>` | gitBranch filtresi |
| `badi search "<query>"` | Multi-token AND search; --since/--until/--branch/--limit |
| `badi session <id-prefix>` | Tek session detay (header + tools + files + timeline) |
| `badi plan list/new/show/status/approve/deny/reset` | Lokal dosya bazli plan onay akisi |
| `badi plugin show <name>` | Manifest detayi |
| `badi list --mcp` | MCP server cagri toplami (transcript bazli) |

### Internals
- `lib/data/transcript-reader.js` — paylasimli okuma katmani (parseSession, parseSessionWithEvents, applyFilters, MODEL_PRICING, costForUsage, findSession, formatDuration, shortSessionId)
- Opus/Sonnet/Haiku 4.x icin fiyat tablosu + family-name fallback
- Slug validation `/^[a-z0-9][a-z0-9-]{0,63}$/` (plan komutlarinda path traversal guvenli)

### Tests
- 934 → **967** (+33)
- `tests/transcript-reader.test.js` (14 unit)
- `tests/cli.plan.test.js` (8 CLI integration)
- `tests/cli.observability.test.js` (11 smoke)

## Test plan
- [x] `npm test` 967/967 yesil
- [x] `npm run lint` temiz (biome --write --unsafe)
- [x] Help-doctor: 0 unexplained drift (--mcp + --sessions allowlist'e eklendi, _why ile)
- [x] Smoke: `badi stats --session/--models/--cost` gercek transcript'lerde dogru sayilar uretir
- [x] Smoke: `badi plan new/approve/deny/status` exit code'lari dogru (approved=0, denied=1, pending=1)
- [x] Smoke: `badi search "secret-scan"` matches found
- [x] Smoke: `badi session <prefix>` tools + files + timeline gosterdi
- [x] Smoke: `badi list --mcp` cagrilari topladi

🤖 Generated with [Claude Code](https://claude.com/claude-code)