### PR TITLE
chore(changelog): v1.29.0 yayin basligi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [1.29.0] - 2026-05-19
+
 ### Added — observability v1.29 (Claude Code transcript bazli)
 
 Five+ new commands and flags that read `~/.claude/projects/*.jsonl`

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,8 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+## [1.29.0] - 2026-05-19
+
 ### Eklendi — observability v1.29 (Claude Code transcript bazli)
 
 Bes+ yeni komut/flag, `~/.claude/projects/*.jsonl` transcript'lerini direk


### PR DESCRIPTION
## Summary
- `[Unreleased]` icindeki v1.29 observability ve onceki seans'tan kalan security hardening icerikleri `[1.29.0] - 2026-05-19` basligi altina alindi
- Yeni bos `[Unreleased]` ust kisma eklendi
- `badi publish --version minor` on-kosul kontrolu icin gerekli

## Notes
- v1.28.1 security hardening section'i organizational debt olarak v1.29.0 altinda gorunur (onceki seansta accept edilmis trade-off)
- Cleanup ileri bir surumde yapilacak

## Test plan
- [x] `grep "^## \\["` her iki dosyada [1.29.0] eksiksiz gozukuyor
- [x] Diff sadece 4 satir (her dosyaya 2 satir ekleme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)