### PR TITLE
feat(v1.30): 5-feature bundle (#177 #178 #179 #180 #181)

### DIFF
--- a/.claude/hooks/inject-active-plan.mjs
+++ b/.claude/hooks/inject-active-plan.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// Badi v1.27+ defensive fail-safe (#162): runtime errors -> exit 0; set BADI_HOOK_DEBUG=1 for stderr.
+const _badiFailSafe = (e) => {
+	if (process.env.BADI_HOOK_DEBUG) {
+		try {
+			process.stderr.write(`[badi-hook] ${e?.message || e}\n`);
+		} catch {}
+	}
+	process.exit(0);
+};
+process.on("uncaughtException", _badiFailSafe);
+process.on("unhandledRejection", _badiFailSafe);
+
+// Badi v1.30+ — Plan Injection Hook
+//
+// UserPromptSubmit'te tetiklenir. `.claude/plans/` icinde `<slug>.approved`
+// marker'i olan planlari okur, plan markdown icerigini Claude'a inject eder.
+//
+// Aktif etmek icin settings.json'a UserPromptSubmit hook olarak ekle:
+//   "command": "node .claude/hooks/inject-active-plan.mjs"
+//
+// Tasarim notlari:
+//   - denied / pending planlar inject edilmez
+//   - hicbir plan yoksa sessiz cik (no-op)
+//   - max 5 plan inject (gurultuyu sinirla); fazlasi varsa en yeni 5
+//   - 200KB total cap (Claude context disciplini)
+//   - BADI_HOOK_DEBUG=1 ile stderr trace
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { projectRoot, writeContextInjection } from "./_util.mjs";
+
+const MAX_PLANS_TO_INJECT = 5;
+const MAX_TOTAL_BYTES = 200 * 1024;
+
+function listApprovedPlans(plansDir) {
+	if (!existsSync(plansDir)) return [];
+	const out = [];
+	for (const f of readdirSync(plansDir)) {
+		if (!f.endsWith(".approved")) continue;
+		const slug = f.replace(/\.approved$/, "");
+		const md = join(plansDir, `${slug}.md`);
+		if (!existsSync(md)) continue;
+		let approvedAt = null;
+		try {
+			const raw = readFileSync(join(plansDir, f), "utf-8").trim();
+			// Marker dosyasi 1. satir ISO timestamp.
+			approvedAt = raw.split("\n")[0] || null;
+		} catch {}
+		let mtimeMs = 0;
+		try {
+			mtimeMs = statSync(md).mtimeMs;
+		} catch {}
+		out.push({ slug, mdPath: md, approvedAt, mtimeMs });
+	}
+	// En yeni once (mtime desc).
+	out.sort((a, b) => b.mtimeMs - a.mtimeMs);
+	return out;
+}
+
+function buildInjection(plans) {
+	if (plans.length === 0) return null;
+	const blocks = [];
+	let totalBytes = 0;
+	let injected = 0;
+	for (const p of plans) {
+		if (injected >= MAX_PLANS_TO_INJECT) break;
+		let body = "";
+		try {
+			body = readFileSync(p.mdPath, "utf-8");
+		} catch {
+			continue;
+		}
+		const block = [
+			`<active-plan slug="${p.slug}" state="approved"${p.approvedAt ? ` approved-at="${p.approvedAt}"` : ""}>`,
+			body.trim(),
+			"</active-plan>",
+		].join("\n");
+		if (totalBytes + block.length > MAX_TOTAL_BYTES) break;
+		blocks.push(block);
+		totalBytes += block.length;
+		injected++;
+	}
+	if (blocks.length === 0) return null;
+	const header =
+		blocks.length === 1
+			? "Onayli aktif plan (badi plan):"
+			: `Onayli aktif planlar (${blocks.length} — badi plan):`;
+	return `${header}\n\n${blocks.join("\n\n")}`;
+}
+
+async function main() {
+	const root = projectRoot();
+	const plansDir = join(root, ".claude", "plans");
+	const plans = listApprovedPlans(plansDir);
+	const injection = buildInjection(plans);
+	if (injection) {
+		writeContextInjection(injection);
+	}
+	process.exit(0);
+}
+
+main();

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -116,6 +116,18 @@
 					}
 				]
 			}
+		],
+		"UserPromptSubmit": [
+			{
+				"matcher": "",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "node .claude/hooks/inject-active-plan.mjs",
+						"timeout": 2000
+					}
+				]
+			}
 		]
 	}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,141 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [1.30.0] - 2026-05-19
+
+### Added — agent-agnostic context export (`init` / `update`)
+
+Two new harness adapters extend Badi's multi-agent reach. The canonical
+CLAUDE.md + memory + knowledge-base content can now be compiled into:
+
+- **Windsurf** — `.windsurfrules` single-file rules. Detected via
+  `existsSync(".windsurfrules")`. `badi init --harness windsurf`.
+- **AGENTS.md (Generic)** — neutral fallback for OpenAI Codex CLI, Aider,
+  and any tool that reads project-level AGENTS.md. `badi init --harness agents`.
+
+Combine: `badi init --harness all` now emits 5 outputs (Claude Code, Cursor,
+Gemini, Windsurf, AGENTS.md). Other harnesses (Claude/Cursor/Gemini) were
+already shipped in earlier versions; this release adds the missing two.
+
+### Added — `badi release check` pre-flight verifier
+
+New standalone command that validates publish readiness without mutating
+state. Performs 7-9 checks: git cleanliness, branch, `package.json`
+presence, CHANGELOG.md + CHANGELOG.tr.md version entry, `npm test`
+exit status, `gh` CLI presence, `npm pack --dry-run` tarball size.
+
+```bash
+badi release check                       # full check (incl. npm test)
+badi release check --bump minor          # compute target version from package.json
+badi release check --version 1.30.0      # check for explicit version
+badi release check --strict              # warnings → errors (CI mode)
+badi release check --skip-test           # quick check, no npm test
+```
+
+Reduces the publish-fails-late feedback cycle (dirty tree / missing
+CHANGELOG / failing tests) from "discovered during `badi publish`" to
+"caught before publish".
+
+### Added — `inject-active-plan` hook (UserPromptSubmit)
+
+New hook at `.claude/hooks/inject-active-plan.mjs`. Registered in
+`.claude/settings.json` as a UserPromptSubmit hook. On every user prompt:
+
+1. Scans `.claude/plans/<slug>.approved` markers
+2. Loads each approved plan's `.md` body
+3. Injects up to 5 plans into Claude's context as
+   `<active-plan slug="X" state="approved">…</active-plan>` blocks
+4. Hard cap: 200KB total per injection
+
+Pending/denied plans are not injected. No-op when no approved plan
+exists. Couples `badi plan approve` to active Claude context — the plan
+isn't just gated, it's recalled every prompt.
+
+### Added — plugin manifest `apiVersion` + dependency graph
+
+`badi-plugin.json` gains a `badi` field for forward-compat:
+
+```json
+{
+  "name": "my-plugin",
+  "version": "0.3.0",
+  "badi": {
+    "apiVersion": "1.x",
+    "dependsOn": ["other-plugin@>=0.2"]
+  }
+}
+```
+
+Range syntax supports `*`, `X.x`, `X.Y.x`, `X.Y.Z`, `>=X.Y[.Z]`. Default
+when omitted: `1.x` (covers existing plugins). On install, mismatched
+apiVersion surfaces a warning (non-blocking — empirical compat preferred
+over hard gate).
+
+Two new subcommands:
+
+- **`badi plugin doctor`** — audits all installed plugins: manifest
+  validity, apiVersion compat, missing/version-mismatched deps. Exits 1
+  on any issue (CI-friendly).
+- **`badi plugin graph`** — prints topologically sorted load order:
+  ```
+  ├─ base-plugin v1.0.0
+  └─ derived-plugin v0.3.0 ← base-plugin
+  ```
+
+Internals: new `lib/data/plugin-manifest.js` (`parseRange`,
+`validateManifest`, `checkApiCompat`, `topoSort`, `findUnsatisfied`).
+Cycle detection in `topoSort` throws explicit error.
+
+### Added — `badi events` self-telemetry
+
+Badi now emits its own typed events alongside reading Claude Code
+transcripts. Every CLI invocation emits:
+
+- `badi.command.started` (cmd, args_count)
+- `badi.command.completed` (cmd, duration_ms, exit_code: 0)
+- `badi.command.failed` (cmd, duration_ms, error_message, exit_code: 1)
+
+Events land in `~/.claude/projects/<project>/badi-events.jsonl` (same
+directory Badi already reads for stats/session). **Privacy:**
+
+- Append-only JSONL, **local only** — no network calls
+- Whitelisted event types (`ALLOWED_TYPES`); unknown types dropped
+- Arg values are NOT stored (only `args_count`), preventing accidental
+  secret leakage
+- String fields capped at 200 chars, arrays at 50 elements
+- `BADI_TELEMETRY=off` (or `0`/`false`) completely disables emission
+
+New reader command:
+
+```bash
+badi events list [--limit N]            # last N events
+badi events stats                       # per-command count + avg duration + fail count
+badi events tail                        # list --limit 10
+badi events status                      # telemetry on/off + log size
+badi events path                        # log file path
+```
+
+Filters: `--since DATE`, `--until DATE`, `--cmd <name>`, `--type
+<badi.command.completed>`.
+
+Hot reload pattern: pure-function emitter (`emit(type, data)`) → file
+append; reader (`readEvents()`) → parse + reverse. Wired into
+`bin/badi.js` dispatcher so all commands instrument identically without
+per-command changes.
+
+### Tests
+
+967 → **1021** (+54 across the new feature set):
+- `tests/harness-extras.test.js` (10) — windsurf/agents harness
+- `tests/cli.release.test.js` (3) — release help / subcommand routing
+- `tests/cli.events.test.js` (6) — events status/list/path CLI
+- `tests/plugin-manifest.test.js` (24) — parseRange/validateManifest/
+  checkApiCompat/topoSort/findUnsatisfied
+- `tests/event-emitter.test.js` (4) — ALLOWED_TYPES, emit safety
+
+Existing test updates: harness registry test now expects 5 ids (was 3),
+hooks fail-safe test now expects 14 hooks (was 13).
+
 ## [1.29.0] - 2026-05-19
 
 ### Added — observability v1.29 (Claude Code transcript bazli)

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,140 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+## [1.30.0] - 2026-05-19
+
+### Eklendi — ajan-bagimsiz baglam ihraci (`init` / `update`)
+
+Iki yeni harness adapteri Badi'nin coklu ajan menzilini genisletir. Canonical
+CLAUDE.md + memory + knowledge-base icerigi su ciktilara derlenebilir:
+
+- **Windsurf** — `.windsurfrules` tek dosya kurali. Detect:
+  `existsSync(".windsurfrules")`. Kullanim: `badi init --harness windsurf`.
+- **AGENTS.md (Generic)** — OpenAI Codex CLI, Aider ve proje seviyesi
+  AGENTS.md okuyan herhangi bir arac icin notr fallback. Kullanim:
+  `badi init --harness agents`.
+
+Birlestirme: `badi init --harness all` artik 5 cikti yazar (Claude Code,
+Cursor, Gemini, Windsurf, AGENTS.md). Diger harness'lar (Claude/Cursor/Gemini)
+onceki surumlerde mevcuttu; bu surum eksik iki tanesini ekler.
+
+### Eklendi — `badi release check` pre-flight verifier
+
+State degistirmeden publish hazirligi denetleyen yeni bagimsiz komut.
+7-9 kontrol yapar: git temizligi, branch, `package.json` mevcudiyeti,
+CHANGELOG.md + CHANGELOG.tr.md version girdisi, `npm test` cikis kodu,
+`gh` CLI mevcudiyeti, `npm pack --dry-run` tarball boyutu.
+
+```bash
+badi release check                       # tam kontrol (npm test dahil)
+badi release check --bump minor          # package.json'dan hedef surum hesapla
+badi release check --version 1.30.0      # spesifik surum kontrolu
+badi release check --strict              # uyari → hata (CI modu)
+badi release check --skip-test           # hizli kontrol, npm test atla
+```
+
+Publish-gec-feedback dongusunu (kirli tree / eksik CHANGELOG / kirik test)
+"badi publish sirasinda kesfedildi"den "publish'tan once yakalandi"ya
+indirir.
+
+### Eklendi — `inject-active-plan` hook (UserPromptSubmit)
+
+Yeni hook `.claude/hooks/inject-active-plan.mjs`. `.claude/settings.json`'da
+UserPromptSubmit hook olarak kayitli. Her kullanici prompt'unda:
+
+1. `.claude/plans/<slug>.approved` marker'larini tarar
+2. Her onayli plan'in `.md` icerigini okur
+3. Claude context'ine `<active-plan slug="X" state="approved">…</active-plan>`
+   bloklari olarak en fazla 5 plan inject eder
+4. Sert sinir: injection basina toplam 200KB
+
+Pending/denied planlar inject edilmez. Onayli plan yoksa no-op. Bu
+`badi plan approve`'u aktif Claude context'ine baglar — plan sadece
+gate'lenmez, her prompt'ta hatirlatilir.
+
+### Eklendi — plugin manifest `apiVersion` + bagimlilik agaci
+
+`badi-plugin.json` ileri-uyumluluk icin `badi` alani kazandi:
+
+```json
+{
+  "name": "my-plugin",
+  "version": "0.3.0",
+  "badi": {
+    "apiVersion": "1.x",
+    "dependsOn": ["other-plugin@>=0.2"]
+  }
+}
+```
+
+Range soz dizimi: `*`, `X.x`, `X.Y.x`, `X.Y.Z`, `>=X.Y[.Z]`. Yokken default:
+`1.x` (mevcut plugin'leri kapsar). Install sirasinda uyumsuz apiVersion
+uyari uretir (bloklamaz — empirik uyum kati gate yerine tercih edildi).
+
+Iki yeni subcommand:
+
+- **`badi plugin doctor`** — tum yuklu plugin'leri denetler: manifest
+  gecerligi, apiVersion uyumu, eksik/version-uyumsuz dep'ler. Herhangi
+  bir sorunda exit 1 (CI uyumlu).
+- **`badi plugin graph`** — topolojik sirayla load duzenini yazdirir:
+  ```
+  ├─ base-plugin v1.0.0
+  └─ derived-plugin v0.3.0 ← base-plugin
+  ```
+
+Icerik: yeni `lib/data/plugin-manifest.js` (`parseRange`,
+`validateManifest`, `checkApiCompat`, `topoSort`, `findUnsatisfied`).
+`topoSort` icinde cycle algilama acik hata firlatir.
+
+### Eklendi — `badi events` self-telemetry
+
+Badi artik Claude Code transcript'lerini okumakla birlikte kendi tipli
+event'lerini de yayinlar. Her CLI cagrisi su event'leri uretir:
+
+- `badi.command.started` (cmd, args_count)
+- `badi.command.completed` (cmd, duration_ms, exit_code: 0)
+- `badi.command.failed` (cmd, duration_ms, error_message, exit_code: 1)
+
+Event'ler `~/.claude/projects/<project>/badi-events.jsonl` dizinine yazilir
+(Badi'nin stats/session icin zaten okudugu dizin). **Privacy:**
+
+- Append-only JSONL, **sadece lokal** — network call yok
+- Whitelist'lenmis event tipleri (`ALLOWED_TYPES`); bilinmeyen tipler droppe
+- Arg degerleri DEPOLANMAZ (sadece `args_count`), kazara sir sizmasi yok
+- String alanlar 200 karakter, array'ler 50 elemanla sinirli
+- `BADI_TELEMETRY=off` (veya `0`/`false`) emission'i tamamen kapatir
+
+Yeni reader komutu:
+
+```bash
+badi events list [--limit N]            # son N event
+badi events stats                       # komut bazli sayim + ortalama sure + fail sayisi
+badi events tail                        # list --limit 10
+badi events status                      # telemetry on/off + log boyutu
+badi events path                        # log dosyasi yolu
+```
+
+Filtreler: `--since DATE`, `--until DATE`, `--cmd <ad>`, `--type
+<badi.command.completed>`.
+
+Hot-reload pattern: pure-function emitter (`emit(type, data)`) → dosya
+append; reader (`readEvents()`) → parse + reverse. `bin/badi.js`
+dispatcher'a baglandi; her komut komut-bazli degisiklik gerekmeden ayni
+sekilde instrument edilir.
+
+### Test
+
+967 → **1021** (+54 yeni feature set genelinde):
+- `tests/harness-extras.test.js` (10) — windsurf/agents harness
+- `tests/cli.release.test.js` (3) — release help / subcommand routing
+- `tests/cli.events.test.js` (6) — events status/list/path CLI
+- `tests/plugin-manifest.test.js` (24) — parseRange/validateManifest/
+  checkApiCompat/topoSort/findUnsatisfied
+- `tests/event-emitter.test.js` (4) — ALLOWED_TYPES, emit safety
+
+Mevcut test guncellemeleri: harness registry test'i artik 5 id bekler
+(eskiden 3), hooks fail-safe test'i 14 hook bekler (eskiden 13).
+
 ## [1.29.0] - 2026-05-19
 
 ### Eklendi — observability v1.29 (Claude Code transcript bazli)

--- a/README.md
+++ b/README.md
@@ -59,21 +59,24 @@ For Turkish/UTF-8 output in cmd, run `chcp 65001` once or use Windows Terminal /
 
 | Harness | Rules | Commands | MCP | Subagents | Hooks | Skills |
 |---------|:-----:|:--------:|:---:|:---------:|:-----:|:------:|
-| Claude Code | `CLAUDE.md` | 77 | `.mcp.json` | 22 | 13 | 25 |
+| Claude Code | `CLAUDE.md` | 77 | `.mcp.json` | 22 | 14 | 62 |
 | Cursor | `.cursor/rules/badi-main.mdc` | 77 | `.cursor/mcp.json` | — | — | — |
 | Gemini CLI | `GEMINI.md` (merged) | inline | `.gemini/settings.json` | — | — | — |
+| Windsurf (v1.30+) | `.windsurfrules` (merged) | inline | — | — | — | — |
+| AGENTS.md (v1.30+) | `AGENTS.md` (merged) | inline | — | — | — | — |
 
-Claude is the canonical source. Cursor and Gemini adapters compile from the same `.claude/` tree. Components a target harness does not support (hooks/skills/subagents on Cursor; commands+everything-else on Gemini) are listed in the `badi init` output under `skippedComponents`.
+Claude is the canonical source. Cursor/Gemini/Windsurf/AGENTS.md adapters compile from the same `.claude/` tree. Components a target harness does not support (hooks/skills/subagents) are listed in the `badi init` output under `skippedComponents`. AGENTS.md is the neutral fallback for OpenAI Codex CLI, Aider, and any other tool that reads project-level agent context.
 
 ## What You Get
 
 | Feature | Details |
 |---------|---------|
 | **22 expert agents + 77 commands** | Full toolkit from security scanner to performance profiler — profile-based filtering (core/dev/content/pentest) since v1.26 |
-| **13 automation hooks + 62 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants. Skills load zero tokens by default since v1.17; auto-router (v1.20+) injects matching skills per prompt; pentest-* family (v1.25+ advisory/defensive); expo-* family (v1.27+ mobile dev lifecycle); command routing (v1.26+) |
+| **14 automation hooks + 62 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants. Skills load zero tokens by default since v1.17; auto-router (v1.20+) injects matching skills per prompt; pentest-* family (v1.25+ advisory/defensive); expo-* family (v1.27+ mobile dev lifecycle); command routing (v1.26+); plan-injection hook (v1.30+) |
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
-| **Multi-harness support (v1.12+)** | Claude Code, Cursor, Gemini CLI — same `.claude/` source, different targets |
-| **915 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, tasarim, profile management, hook fail-safe resilience, secret-scan hardening (51 tests) |
+| **Multi-harness support (v1.12+, expanded v1.30+)** | Claude Code, Cursor, Gemini CLI, Windsurf, AGENTS.md — same `.claude/` source, 5 targets |
+| **Observability (v1.29+) + self-telemetry (v1.30+)** | Read Claude Code transcripts (`badi stats --session/--models/--cost`, `badi search`, `badi session`) + emit own command events (`badi events list/stats`, BADI_TELEMETRY=off to disable) |
+| **1021 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, tasarim, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter |
 | **TR/EN content engine** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
 | **Modular architecture** | 22 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
@@ -435,12 +438,12 @@ Comprehensive scanning with 48 security skills:
 ## CLI Commands
 
 ```bash
-badi init [--target DIR] [--force] [--dry-run] [--harness ID]  # Configure project (v1.12+: harness picker)
+badi init [--target DIR] [--force] [--dry-run] [--harness ID]  # Configure (v1.12+: harness; v1.30+: windsurf, agents)
 badi update [--target DIR] [--force] [--harness ID]            # Update (--force overwrites)
 badi doctor [--target DIR] [--harness ID]                      # Verify setup (auto-detects installed harnesses)
-badi list [--agents|--commands|--hooks|--skills]     # List components
-badi plugin [install|remove|list]                    # Plugin management
-badi stats [--week|--month|--habits|--export csv]    # Usage analytics
+badi list [--agents|--commands|--hooks|--skills|--mcp]  # List components
+badi plugin [install|remove|list|show|doctor|graph]     # Plugin management (v1.30+: apiVersion + dep graph)
+badi stats [--week|--month|--habits|--export csv|--session|--models|--cost]   # Usage + transcript analytics
 badi completion [bash|zsh|fish]                      # Shell completion
 badi schedule [add|list|remove|check]                # Reminders
 badi icerik [post|karousel|video|gorsel|takvim|marka|ara|sablon|perf]
@@ -450,7 +453,12 @@ badi aso [audit|playstore|keywords|metadata|review|reviews|compete|screenshots|s
 badi mobile [init|version|build|release|assets|crash-setup|deeplink|ota]  # v1.5+ (crash-setup/deeplink/ota v1.11+)
 badi taste [list|show|prompt|status]                              # v1.10+
 badi publish [check|--version|--dry-run]                          # v1.11+
+badi release check [--bump|--strict|--skip-test]                  # v1.30+ pre-flight verifier
 badi agent [create|list|run|install|uninstall|tail|status|remove] # v1.13+
+badi plan [list|new|show|status|approve|deny|reset]               # v1.29+ local plan approval
+badi search "<query>"                                             # v1.29+ AND search across transcripts
+badi session <id-prefix> [--full|--tools|--files]                 # v1.29+ single Claude Code session detail
+badi events [list|stats|tail|path|status]                         # v1.30+ self-telemetry (BADI_TELEMETRY=off to disable)
 badi ssl|dns|whois [domain]                                       # v1.6+
 badi lighthouse|a11y [url]                                        # v1.6+
 badi secret-scan [--git]                                          # v1.6+

--- a/bin/badi.js
+++ b/bin/badi.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { chalk, showBanner, showVersion } from "../lib/cli.js";
+import { emit } from "../lib/observability/event-emitter.js";
 import { checkForUpdate, showUpdateBanner } from "../lib/update-check.js";
 
 function showHelp() {
@@ -68,7 +69,22 @@ function showHelp() {
 		`  ${chalk.cyan("publish")}   Release orkestratoru — bump + commit + tag + push + gh + npm (v1.11+)`,
 	);
 	console.log(
+		`  ${chalk.cyan("release")}   Publish-oncesi pre-flight verifier (check) — v1.30+`,
+	);
+	console.log(
 		`  ${chalk.cyan("agent")}     Arka plan watcher (create/list/run/install/status) — v1.13+`,
+	);
+	console.log(
+		`  ${chalk.cyan("plan")}      Lokal plan onay akisi (list/new/approve/deny) — v1.29+`,
+	);
+	console.log(
+		`  ${chalk.cyan("session")}   Tek Claude Code session detayi (id-prefix) — v1.29+`,
+	);
+	console.log(
+		`  ${chalk.cyan("search")}    Tum transcript'lerde multi-token AND arama — v1.29+`,
+	);
+	console.log(
+		`  ${chalk.cyan("events")}    Badi self-telemetry (komut sayaclari, durations) — v1.30+`,
 	);
 	console.log("");
 	console.log(chalk.bold("Domain & Altyapi:"));
@@ -172,6 +188,19 @@ function showHelp() {
 	);
 	console.log("  badi plugin remove <isim>      Plugin kaldir");
 	console.log("  badi plugin list               Yuklu plugin'leri listele");
+	console.log("  badi plugin show <isim>        Plugin detayi + apiVersion (v1.29+)");
+	console.log("  badi plugin doctor             Saglik denetimi (v1.30+)");
+	console.log("  badi plugin graph              Bagimlilik agaci (v1.30+)");
+	console.log("");
+	console.log(chalk.bold("Release / Events Secenekleri (v1.30+):"));
+	console.log("  badi release check             Publish-oncesi 9 pre-flight kontrol");
+	console.log("    --bump <patch|minor|major>     Otomatik hedef surum hesapla");
+	console.log("    --strict                       Uyariyi hata say (CI icin)");
+	console.log("    --skip-test                    Test asamasini atla");
+	console.log("  badi events list                Son N olay (--limit, --since/--until)");
+	console.log("  badi events stats               Komut bazli sayim + ortalama sure");
+	console.log("  badi events path / status       Log dosyasi yolu / telemetry durumu");
+	console.log(chalk.dim("    Kapatma: export BADI_TELEMETRY=off"));
 	console.log("");
 	console.log(chalk.bold("Icerik Alt Komutlari:"));
 	console.log(
@@ -322,6 +351,9 @@ const commands = {
 	search: () => import("../lib/commands/search.js").then((m) => m.runSearch),
 	session: () => import("../lib/commands/session.js").then((m) => m.runSession),
 	plan: () => import("../lib/commands/plan.js").then((m) => m.runPlan),
+	release: () => import("../lib/commands/release.js").then((m) => m.runRelease),
+	events: () =>
+		import("../lib/commands/events.js").then((m) => m.runEvents),
 };
 
 // ─── Ana Giris Noktasi ───
@@ -356,7 +388,25 @@ async function main() {
 	const run = await loader();
 	// init/update/doctor/list showHelp gerekiyor
 	const needsDeps = ["init", "update", "doctor", "list"].includes(command);
-	await run(args, needsDeps ? deps : undefined);
+	const startMs = Date.now();
+	// v1.30+ self-telemetry: command.started/completed/failed (BADI_TELEMETRY=off ile kapanir)
+	emit("badi.command.started", { cmd: command, args_count: args.length });
+	try {
+		await run(args, needsDeps ? deps : undefined);
+		emit("badi.command.completed", {
+			cmd: command,
+			duration_ms: Date.now() - startMs,
+			exit_code: 0,
+		});
+	} catch (e) {
+		emit("badi.command.failed", {
+			cmd: command,
+			duration_ms: Date.now() - startMs,
+			error_message: e?.message || String(e),
+			exit_code: 1,
+		});
+		throw e;
+	}
 }
 
 main()

--- a/lib/commands/events.js
+++ b/lib/commands/events.js
@@ -1,0 +1,221 @@
+import { chalk } from "../cli.js";
+import {
+	eventsFileSize,
+	getEventsPath,
+	isEnabled,
+	readEvents,
+} from "../observability/event-emitter.js";
+
+function parseDateArg(s) {
+	if (!s) return null;
+	const m = s.match(/^(\d{4}-\d{2}-\d{2})$/);
+	if (m) return new Date(`${m[1]}T00:00:00Z`).getTime();
+	const t = Date.parse(s);
+	return Number.isNaN(t) ? null : t;
+}
+
+function formatDuration(ms) {
+	if (ms == null) return "-";
+	if (ms < 1000) return `${ms}ms`;
+	if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+	return `${Math.floor(ms / 60_000)}m${Math.floor((ms % 60_000) / 1000)}s`;
+}
+
+function printHelp() {
+	console.log(chalk.bold("Badi Self-Telemetry (Events):"));
+	console.log("");
+	console.log(
+		`  badi events list [--limit N]    ${chalk.dim("Son N olay (default 30)")}`,
+	);
+	console.log(
+		`  badi events stats               ${chalk.dim("Komut bazli sayim + ortalama sure")}`,
+	);
+	console.log(
+		`  badi events tail                ${chalk.dim("list --limit 10 kisaltma")}`,
+	);
+	console.log("");
+	console.log(chalk.bold("Filtreler (list/stats):"));
+	console.log(`  --since YYYY-MM-DD              Bu tarihten itibaren`);
+	console.log(`  --until YYYY-MM-DD              Bu tarihe kadar`);
+	console.log(`  --cmd <ad>                      Sadece bu komut`);
+	console.log(
+		`  --type <event.type>             Sadece bu olay tipi (orn. badi.command.completed)`,
+	);
+	console.log("");
+	console.log(chalk.bold("Diagnostik:"));
+	console.log(`  badi events path                Log dosyasi yolu`);
+	console.log(`  badi events status              Telemetry on/off + log boyutu`);
+	console.log("");
+	console.log(
+		chalk.dim(
+			"Telemetry kapatma: export BADI_TELEMETRY=off  (her cagri no-op)",
+		),
+	);
+	console.log(
+		chalk.dim("Tum veri lokal: ~/.claude/projects/<slug>/badi-events.jsonl"),
+	);
+}
+
+function parseFlags(args) {
+	const out = { limit: 30, since: null, until: null, cmd: null, type: null };
+	for (let i = 0; i < args.length; i++) {
+		const a = args[i];
+		if (a === "--limit") out.limit = Number(args[++i] || 30);
+		else if (a === "--since") out.since = parseDateArg(args[++i]);
+		else if (a === "--until") out.until = parseDateArg(args[++i]);
+		else if (a === "--cmd") out.cmd = args[++i];
+		else if (a === "--type") out.type = args[++i];
+	}
+	return out;
+}
+
+function applyFilters(events, flags) {
+	let out = events;
+	if (flags.since != null) {
+		out = out.filter((e) => new Date(e.ts).getTime() >= flags.since);
+	}
+	if (flags.until != null) {
+		out = out.filter((e) => new Date(e.ts).getTime() <= flags.until);
+	}
+	if (flags.cmd) {
+		out = out.filter((e) => e.cmd === flags.cmd);
+	}
+	if (flags.type) {
+		out = out.filter((e) => e.type === flags.type);
+	}
+	return out;
+}
+
+async function cmdList(args, limitOverride) {
+	const flags = parseFlags(args);
+	if (limitOverride != null) flags.limit = limitOverride;
+	const events = await readEvents();
+	if (events.length === 0) {
+		console.log(chalk.dim("Olay yok. Komut calistirin, sonra tekrar deneyin."));
+		return;
+	}
+	const filtered = applyFilters(events, flags);
+	const shown = filtered.slice(0, flags.limit);
+	console.log(
+		chalk.bold(
+			`Son ${shown.length} olay (toplam ${filtered.length}${filtered.length !== events.length ? `, filtreli ${events.length} olay` : ""}):`,
+		),
+	);
+	console.log("");
+	for (const e of shown) {
+		const ts = e.ts ? new Date(e.ts).toISOString().slice(0, 19).replace("T", " ") : "?";
+		const dur = e.duration_ms != null ? ` ${chalk.dim(formatDuration(e.duration_ms))}` : "";
+		const exit =
+			e.exit_code != null
+				? e.exit_code === 0
+					? chalk.green(` exit:${e.exit_code}`)
+					: chalk.red(` exit:${e.exit_code}`)
+				: "";
+		const type = e.type?.replace(/^badi\./, "") || "(unknown)";
+		const cmd = e.cmd ? ` ${chalk.cyan(e.cmd)}` : "";
+		console.log(`  ${chalk.dim(ts)}  ${type}${cmd}${dur}${exit}`);
+	}
+}
+
+async function cmdStats(args) {
+	const flags = parseFlags(args);
+	const events = await readEvents();
+	if (events.length === 0) {
+		console.log(chalk.dim("Olay yok."));
+		return;
+	}
+	const filtered = applyFilters(events, flags);
+	const completedByCmd = new Map();
+	for (const e of filtered) {
+		if (e.type !== "badi.command.completed") continue;
+		const key = e.cmd || "(unknown)";
+		const entry = completedByCmd.get(key) || { count: 0, totalMs: 0 };
+		entry.count++;
+		if (typeof e.duration_ms === "number") entry.totalMs += e.duration_ms;
+		completedByCmd.set(key, entry);
+	}
+	const failedByCmd = new Map();
+	for (const e of filtered) {
+		if (e.type !== "badi.command.failed") continue;
+		const key = e.cmd || "(unknown)";
+		failedByCmd.set(key, (failedByCmd.get(key) || 0) + 1);
+	}
+
+	console.log(
+		chalk.bold(`Badi Self-Telemetry — Komut Istatistikleri (${filtered.length} olay)`),
+	);
+	console.log("");
+
+	if (completedByCmd.size === 0 && failedByCmd.size === 0) {
+		console.log(chalk.dim("Komut olayi yok."));
+		return;
+	}
+
+	const allCmds = new Set([...completedByCmd.keys(), ...failedByCmd.keys()]);
+	const rows = [];
+	for (const cmd of allCmds) {
+		const c = completedByCmd.get(cmd) || { count: 0, totalMs: 0 };
+		const f = failedByCmd.get(cmd) || 0;
+		const avg = c.count > 0 ? c.totalMs / c.count : 0;
+		rows.push({ cmd, ok: c.count, fail: f, avg });
+	}
+	rows.sort((a, b) => b.ok + b.fail - (a.ok + a.fail));
+
+	const maxCmd = Math.max(8, ...rows.map((r) => r.cmd.length));
+	console.log(
+		`  ${chalk.bold("Komut".padEnd(maxCmd))}  ${chalk.bold("OK")}  ${chalk.bold("Fail")}  ${chalk.bold("Avg sure")}`,
+	);
+	for (const r of rows) {
+		const failColor = r.fail > 0 ? chalk.red(String(r.fail).padStart(4)) : chalk.dim("   0");
+		console.log(
+			`  ${r.cmd.padEnd(maxCmd)}  ${String(r.ok).padStart(3)}  ${failColor}  ${chalk.dim(formatDuration(r.avg))}`,
+		);
+	}
+}
+
+async function cmdPath() {
+	const p = getEventsPath();
+	console.log(p || chalk.dim("(yol cozulemedi)"));
+}
+
+async function cmdStatus() {
+	const enabled = isEnabled();
+	const size = eventsFileSize();
+	const sizeKb = (size / 1024).toFixed(1);
+	console.log(
+		`Telemetry: ${enabled ? chalk.green("on") : chalk.yellow("off (BADI_TELEMETRY=off)")}`,
+	);
+	console.log(`Log dosyasi: ${getEventsPath()}`);
+	console.log(`Boyut: ${size > 0 ? `${sizeKb} KB` : chalk.dim("(bos veya yok)")}`);
+	if (size > 5 * 1024 * 1024) {
+		console.log(
+			chalk.yellow(
+				"Uyari: log dosyasi 5MB ustunde. Kullanici manuel rotate edebilir (mv ...jsonl ...jsonl.1).",
+			),
+		);
+	}
+}
+
+export async function runEvents(args = []) {
+	const sub = args[0];
+	if (!sub || sub === "--help" || sub === "-h") {
+		printHelp();
+		return;
+	}
+	switch (sub) {
+		case "list":
+			return cmdList(args.slice(1), null);
+		case "tail":
+			return cmdList(args.slice(1), 10);
+		case "stats":
+			return cmdStats(args.slice(1));
+		case "path":
+			return cmdPath();
+		case "status":
+			return cmdStatus();
+		default:
+			console.error(chalk.red(`Bilinmeyen events komutu: ${sub}`));
+			printHelp();
+			process.exit(1);
+	}
+}

--- a/lib/commands/plugin.js
+++ b/lib/commands/plugin.js
@@ -1,8 +1,31 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { basename, join } from "node:path";
-import { chalk } from "../cli.js";
+import { chalk, VERSION } from "../cli.js";
+import {
+	BADI_DEFAULT_API_VERSION,
+	checkApiCompat,
+	findUnsatisfied,
+	topoSort,
+	validateManifest,
+} from "../data/plugin-manifest.js";
 import { listDirs } from "../helpers.js";
+
+function loadAllPluginManifests(pluginsDir) {
+	if (!existsSync(pluginsDir)) return [];
+	const out = [];
+	for (const dir of listDirs(pluginsDir)) {
+		const manifestPath = join(pluginsDir, dir, "badi-plugin.json");
+		if (!existsSync(manifestPath)) continue;
+		try {
+			const m = JSON.parse(readFileSync(manifestPath, "utf-8"));
+			out.push({ ...m, _path: join(pluginsDir, dir) });
+		} catch {
+			// skip unreadable
+		}
+	}
+	return out;
+}
 
 export function runPlugin(args) {
 	const subcommand = args[0];
@@ -13,6 +36,12 @@ export function runPlugin(args) {
 		console.log(`  badi plugin remove <isim>      Plugin kaldir`);
 		console.log(`  badi plugin list               Yuklu plugin'leri listele`);
 		console.log(`  badi plugin show <isim>        Plugin detayi (v1.29+)`);
+		console.log(
+			`  badi plugin doctor             Tum plugin'lerin saglik denetimi (v1.30+)`,
+		);
+		console.log(
+			`  badi plugin graph              Plugin bagimlilik agacini yazdir (v1.30+)`,
+		);
 		return;
 	}
 
@@ -124,6 +153,25 @@ export function runPlugin(args) {
 			if (existsSync(manifestPath)) {
 				try {
 					const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+					// apiVersion + manifest validation (v1.30+)
+					const validation = validateManifest(manifest);
+					if (!validation.valid) {
+						console.log("");
+						console.log(chalk.yellow("Manifest validation uyarilari:"));
+						for (const err of validation.errors) {
+							console.log(chalk.yellow(`  - ${err}`));
+						}
+					}
+					const compat = checkApiCompat(manifest, VERSION);
+					if (!compat.ok) {
+						console.log("");
+						console.log(
+							chalk.yellow(
+								`Uyari: Plugin apiVersion='${compat.range}' Badi v${VERSION} ile uyumsuz olabilir. Test edip raporlayin.`,
+							),
+						);
+					}
+
 					console.log("");
 					console.log(chalk.bold("Plugin icerigi:"));
 					if (manifest.agents?.length)
@@ -136,6 +184,16 @@ export function runPlugin(args) {
 						console.log(
 							`  Skill'ler: ${Object.keys(manifest.skills).join(", ")}`,
 						);
+					if (manifest.badi?.apiVersion) {
+						console.log(
+							chalk.dim(`  apiVersion: ${manifest.badi.apiVersion}`),
+						);
+					}
+					if (manifest.badi?.dependsOn?.length) {
+						console.log(
+							chalk.dim(`  dependsOn:  ${manifest.badi.dependsOn.join(", ")}`),
+						);
+					}
 				} catch {
 					// manifest okunamadiysa ses cikarma
 				}
@@ -192,6 +250,24 @@ export function runPlugin(args) {
 			if (manifest?.description)
 				console.log(chalk.dim(`  Description: ${manifest.description}`));
 			console.log(chalk.dim(`  Path:        ${pluginDir}`));
+			if (manifest?.badi?.apiVersion) {
+				const compat = checkApiCompat(manifest, VERSION);
+				const tag = compat.ok ? chalk.green("uyumlu") : chalk.red("UYUMSUZ");
+				console.log(
+					chalk.dim(`  apiVersion:  ${manifest.badi.apiVersion}`) + ` (${tag})`,
+				);
+			} else if (manifest) {
+				console.log(
+					chalk.dim(
+						`  apiVersion:  (belirtilmemis, ${BADI_DEFAULT_API_VERSION} varsayilir)`,
+					),
+				);
+			}
+			if (manifest?.badi?.dependsOn?.length) {
+				console.log(
+					chalk.dim(`  dependsOn:   ${manifest.badi.dependsOn.join(", ")}`),
+				);
+			}
 			console.log("");
 			const agentCount = manifest?.agents?.length || 0;
 			const commandCount = manifest?.commands?.length || 0;
@@ -254,9 +330,98 @@ export function runPlugin(args) {
 			break;
 		}
 
+		case "doctor": {
+			const plugins = loadAllPluginManifests(pluginsDir);
+			if (plugins.length === 0) {
+				console.log(chalk.dim("Yuklu plugin yok."));
+				return;
+			}
+			console.log(chalk.bold(`Plugin Doctor (${plugins.length} plugin):`));
+			console.log("");
+			let issues = 0;
+			for (const p of plugins) {
+				const v = validateManifest(p);
+				const c = checkApiCompat(p, VERSION);
+				const okMark = v.valid && c.ok ? chalk.green("OK") : chalk.red("XX");
+				console.log(
+					`  ${okMark}  ${p.name || "(noname)"}  ${chalk.dim(`v${p.version || "?"}`)}`,
+				);
+				if (!v.valid) {
+					for (const e of v.errors) {
+						console.log(chalk.red(`       - ${e}`));
+						issues++;
+					}
+				}
+				for (const w of v.warnings) {
+					console.log(chalk.yellow(`       - ${w}`));
+				}
+				if (!c.ok) {
+					console.log(chalk.red(`       - ${c.reason}`));
+					issues++;
+				}
+				if (p.badi?.apiVersion) {
+					console.log(
+						chalk.dim(
+							`       apiVersion: ${p.badi.apiVersion} (Badi v${VERSION})`,
+						),
+					);
+				}
+			}
+			const unsat = findUnsatisfied(plugins);
+			if (unsat.length) {
+				console.log("");
+				console.log(chalk.bold("Bagimlilik sorunlari:"));
+				for (const u of unsat) {
+					console.log(
+						chalk.red(
+							`  - ${u.plugin}: ${u.dep}@${u.requested} ${u.reason === "missing" ? "(yuklu degil)" : `(yuklu ${u.installed})`}`,
+						),
+					);
+					issues++;
+				}
+			}
+			console.log("");
+			if (issues > 0) {
+				console.log(chalk.red(`${issues} sorun tespit edildi.`));
+				process.exit(1);
+			}
+			console.log(chalk.green("Tum plugin'ler saglikli."));
+			break;
+		}
+
+		case "graph": {
+			const plugins = loadAllPluginManifests(pluginsDir);
+			if (plugins.length === 0) {
+				console.log(chalk.dim("Yuklu plugin yok."));
+				return;
+			}
+			let sorted;
+			try {
+				sorted = topoSort(plugins);
+			} catch (e) {
+				console.error(chalk.red(e.message));
+				process.exit(1);
+			}
+			console.log(chalk.bold("Plugin Bagimlilik Agaci (load sirasi):"));
+			console.log("");
+			for (let i = 0; i < sorted.length; i++) {
+				const p = sorted[i];
+				const deps = p.badi?.dependsOn || [];
+				const arrow = deps.length
+					? chalk.dim(` ← ${deps.join(", ")}`)
+					: "";
+				const isLast = i === sorted.length - 1;
+				const branch = isLast ? "└─" : "├─";
+				console.log(
+					`  ${branch} ${p.name} ${chalk.dim(`v${p.version || "?"}`)}${arrow}`,
+				);
+			}
+			break;
+		}
+
 		default:
 			console.error(chalk.red(`Bilinmeyen plugin komutu: ${subcommand}`));
-			console.log("Kullanim: badi plugin [install|remove|list]");
+			console.log("Kullanim: badi plugin [install|remove|list|show|doctor|graph]");
 			process.exit(1);
 	}
 }

--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -1,0 +1,318 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { chalk, showBanner } from "../cli.js";
+import { hasCommand, shCapture as sh } from "../helpers.js";
+
+// Release pre-flight verifier.
+//
+// `badi release check` calistirir, ekrana raporlar — dosya yazmaz, commit
+// etmez, bump etmez. Publish-oncesi durumu standalone kontrol etmek icin.
+
+function gitClean() {
+	try {
+		return sh("git", ["status", "--porcelain"]) === "";
+	} catch {
+		return false;
+	}
+}
+
+function currentBranch() {
+	try {
+		return sh("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+	} catch {
+		return null;
+	}
+}
+
+function bumpVersion(version, type) {
+	const [major, minor, patch] = version.split(".").map(Number);
+	if (type === "major") return `${major + 1}.0.0`;
+	if (type === "minor") return `${major}.${minor + 1}.0`;
+	return `${major}.${minor}.${patch + 1}`;
+}
+
+function readPackageJson() {
+	if (!existsSync("package.json")) return null;
+	try {
+		return JSON.parse(readFileSync("package.json", "utf-8"));
+	} catch {
+		return null;
+	}
+}
+
+function changelogHasVersion(file, version) {
+	if (!existsSync(file)) return null;
+	const body = readFileSync(file, "utf-8");
+	return body.includes(`[${version}]`);
+}
+
+function runNpmTest() {
+	const r = spawnSync("npm", ["test", "--silent"], {
+		encoding: "utf-8",
+		timeout: 120_000,
+	});
+	const out = `${r.stdout || ""}${r.stderr || ""}`;
+	const passMatch = out.match(/pass\s+(\d+)/i);
+	const failMatch = out.match(/fail\s+(\d+)/i);
+	return {
+		exitCode: r.status,
+		out,
+		passed: passMatch ? Number(passMatch[1]) : null,
+		failed: failMatch ? Number(failMatch[1]) : 0,
+	};
+}
+
+function npmPackDryRun() {
+	const r = spawnSync("npm", ["pack", "--dry-run", "--json"], {
+		encoding: "utf-8",
+		timeout: 30_000,
+	});
+	if (r.status !== 0) return { ok: false, size: null };
+	try {
+		const arr = JSON.parse(r.stdout);
+		const pkg = arr?.[0];
+		const size = pkg?.size || null;
+		return { ok: true, size, unpackedSize: pkg?.unpackedSize || null };
+	} catch {
+		return { ok: false, size: null };
+	}
+}
+
+function status(label, ok, hint) {
+	const mark = ok ? chalk.green("OK") : chalk.red("XX");
+	const tail = hint ? chalk.dim(`  (${hint})`) : "";
+	console.log(`  ${mark}  ${label}${tail}`);
+}
+
+function warn(label, hint) {
+	console.log(
+		`  ${chalk.yellow("!!")}  ${label}${hint ? chalk.dim(`  (${hint})`) : ""}`,
+	);
+}
+
+export function runReleaseCheck(args = []) {
+	let strict = false;
+	let versionFlag = null;
+	let skipTest = false;
+	let nextVersionType = null; // patch/minor/major
+
+	for (let i = 0; i < args.length; i++) {
+		const a = args[i];
+		if (a === "--strict") strict = true;
+		else if (a === "--skip-test") skipTest = true;
+		else if (a === "--version") {
+			versionFlag = args[++i] ?? null;
+		} else if (a === "--bump") {
+			nextVersionType = args[++i] ?? null;
+		} else if (a === "--help" || a === "-h") {
+			printHelp();
+			return;
+		}
+	}
+
+	showBanner();
+	console.log(chalk.bold("Release Check"));
+	console.log("");
+
+	let pass = 0;
+	let warnings = 0;
+	let fail = 0;
+
+	// 1. Git temizligi
+	const clean = gitClean();
+	if (clean) {
+		status("Git durumu temiz", true);
+		pass++;
+	} else {
+		status("Git durumu temiz", false, "git status -s");
+		fail++;
+	}
+
+	// 2. Branch
+	const branch = currentBranch();
+	const onMain = branch === "main" || branch === "master";
+	if (onMain) {
+		status(`Branch main/master (${branch})`, true);
+		pass++;
+	} else {
+		warn(`Branch main/master degil (${branch ?? "?"})`);
+		warnings++;
+	}
+
+	// 3. package.json
+	const pkg = readPackageJson();
+	if (!pkg) {
+		status("package.json okunabilir", false);
+		fail++;
+		printSummary(pass, warnings, fail, strict);
+		return;
+	}
+	status(`package.json mevcut (${pkg.name} v${pkg.version})`, true);
+	pass++;
+
+	// 4. Target version belirleme
+	let targetVersion = versionFlag;
+	if (!targetVersion && nextVersionType) {
+		targetVersion = bumpVersion(pkg.version, nextVersionType);
+	}
+	if (!targetVersion) targetVersion = pkg.version;
+
+	// 5. CHANGELOG.md
+	const enOk = changelogHasVersion("CHANGELOG.md", targetVersion);
+	if (enOk === null) {
+		status("CHANGELOG.md mevcut", false, "dosya yok");
+		fail++;
+	} else if (enOk) {
+		status(`CHANGELOG.md icinde [${targetVersion}]`, true);
+		pass++;
+	} else {
+		status(
+			`CHANGELOG.md icinde [${targetVersion}]`,
+			false,
+			"yeni surum girdisi eksik",
+		);
+		fail++;
+	}
+
+	// 6. CHANGELOG.tr.md
+	if (existsSync("CHANGELOG.tr.md")) {
+		const trOk = changelogHasVersion("CHANGELOG.tr.md", targetVersion);
+		if (trOk) {
+			status(`CHANGELOG.tr.md icinde [${targetVersion}]`, true);
+			pass++;
+		} else {
+			warn(
+				`CHANGELOG.tr.md icinde [${targetVersion}] eksik`,
+				"TR cevirisi de gunceleyin",
+			);
+			warnings++;
+		}
+	}
+
+	// 7. Test
+	if (skipTest) {
+		warn("Test atlandi (--skip-test)");
+		warnings++;
+	} else {
+		console.log(chalk.dim("  ...  npm test calisiyor"));
+		const t = runNpmTest();
+		if (t.exitCode === 0 && t.failed === 0) {
+			status(
+				"Test (npm test)",
+				true,
+				t.passed != null ? `${t.passed} test gecti` : null,
+			);
+			pass++;
+		} else {
+			status(
+				"Test (npm test)",
+				false,
+				`exit ${t.exitCode}${t.failed ? `, ${t.failed} fail` : ""}`,
+			);
+			fail++;
+		}
+	}
+
+	// 8. gh CLI
+	if (hasCommand("gh")) {
+		status("gh CLI kurulu", true);
+		pass++;
+	} else {
+		warn("gh CLI kurulu degil", "brew install gh");
+		warnings++;
+	}
+
+	// 9. npm pack dry-run
+	const pack = npmPackDryRun();
+	if (pack.ok) {
+		const sizeKb = pack.size ? (pack.size / 1024).toFixed(1) : "?";
+		status(`npm pack dry-run`, true, `${sizeKb} KB tarball`);
+		pass++;
+		if (pack.size && pack.size > 5 * 1024 * 1024) {
+			warn(
+				`Paket boyutu buyuk (${sizeKb} KB)`,
+				"package.json files array kontrol edin",
+			);
+			warnings++;
+		}
+	} else {
+		warn("npm pack dry-run", "calistirilamadi");
+		warnings++;
+	}
+
+	printSummary(pass, warnings, fail, strict, targetVersion);
+}
+
+function printSummary(pass, warnings, fail, strict, targetVersion) {
+	console.log("");
+	console.log(
+		`${chalk.bold("Sonuc:")} ${chalk.green(`${pass} OK`)} / ${chalk.yellow(`${warnings} UYARI`)} / ${chalk.red(`${fail} HATA`)}`,
+	);
+	if (targetVersion) {
+		console.log(chalk.dim(`  Hedef surum: ${targetVersion}`));
+	}
+	console.log("");
+
+	if (fail > 0) {
+		console.log(chalk.red("Publish'a hazir degil. Hatalari giderin."));
+		process.exit(1);
+	}
+	if (strict && warnings > 0) {
+		console.log(
+			chalk.yellow("--strict modu: uyarilar hata sayilir. Publish iptal."),
+		);
+		process.exit(1);
+	}
+	if (warnings > 0) {
+		console.log(
+			chalk.dim(
+				"Publish'a hazir (uyarilar var). --strict ile CI'da blok edilebilir.",
+			),
+		);
+	} else {
+		console.log(chalk.green("Publish'a hazir."));
+	}
+}
+
+function printHelp() {
+	console.log(chalk.bold("Release Komutlari:"));
+	console.log("");
+	console.log(
+		`  badi release check                ${chalk.dim("Publish-oncesi pre-flight kontroller")}`,
+	);
+	console.log("");
+	console.log(chalk.bold("Secenekler:"));
+	console.log(
+		`  --version <X.Y.Z>                 Hedef surum (CHANGELOG kontrolu icin)`,
+	);
+	console.log(
+		`  --bump <patch|minor|major>        package.json'dan otomatik bump hesapla`,
+	);
+	console.log(
+		`  --strict                          Uyariyi da hata say (CI'da kullanin)`,
+	);
+	console.log(
+		`  --skip-test                       Test asamasini atla (hizli check)`,
+	);
+	console.log("");
+	console.log(chalk.bold("Ornekler:"));
+	console.log(`  badi release check`);
+	console.log(`  badi release check --bump minor`);
+	console.log(`  badi release check --version 1.30.0 --strict`);
+	console.log(`  badi release check --skip-test`);
+}
+
+export async function runRelease(args = []) {
+	const sub = args[0];
+	if (!sub || sub === "--help" || sub === "-h") {
+		printHelp();
+		return;
+	}
+	if (sub === "check") {
+		return runReleaseCheck(args.slice(1));
+	}
+	console.error(chalk.red(`Bilinmeyen release komutu: ${sub}`));
+	printHelp();
+	process.exit(1);
+}

--- a/lib/data/plugin-manifest.js
+++ b/lib/data/plugin-manifest.js
@@ -1,0 +1,255 @@
+// Plugin manifest schema + apiVersion compat checker + dependency sort.
+//
+// Manifest format (badi-plugin.json):
+//
+//   {
+//     "name": "my-plugin",
+//     "version": "0.3.0",
+//     "description": "...",
+//     "badi": {                       // optional (v1.30+ field)
+//       "apiVersion": "1.x",          // semver-range basit form: X.x | X.Y.x | X.Y.Z | *
+//       "dependsOn": ["other@>=0.2"]  // diger plugin'lere bagimlilik (semver range)
+//     },
+//     "agents": [...],
+//     "commands": [...],
+//     "hooks": [...],
+//     "skills": { ... }
+//   }
+//
+// apiVersion eksikse: BADI_DEFAULT_API_VERSION uygulanir (1.x). Bu, eski
+// plugin'ler icin geri-uyumluluk saglar.
+
+export const BADI_DEFAULT_API_VERSION = "1.x";
+
+/**
+ * Parse a simple range string into a matcher fn(version) -> bool.
+ * Supported forms:
+ *   "*"          any
+ *   "1.x"        major 1 (any minor/patch)
+ *   "1.30.x"    major 1, minor 30 (any patch)
+ *   "1.30.5"     exact (major.minor.patch)
+ *   ">=1.0"      gte (major.minor)
+ *   ">=1.30.0"   gte (major.minor.patch)
+ */
+export function parseRange(range) {
+	if (!range || range === "*") return () => true;
+	const trimmed = String(range).trim();
+
+	// >=X.Y[.Z]
+	const gte = trimmed.match(/^>=\s*(\d+)\.(\d+)(?:\.(\d+))?$/);
+	if (gte) {
+		const M = Number(gte[1]);
+		const m = Number(gte[2]);
+		const p = gte[3] != null ? Number(gte[3]) : 0;
+		return (version) => {
+			const parts = parseVersion(version);
+			if (!parts) return false;
+			if (parts.major !== M) return parts.major > M;
+			if (parts.minor !== m) return parts.minor > m;
+			return parts.patch >= p;
+		};
+	}
+
+	// X.Y.x
+	const minorWildcard = trimmed.match(/^(\d+)\.(\d+)\.x$/);
+	if (minorWildcard) {
+		const M = Number(minorWildcard[1]);
+		const m = Number(minorWildcard[2]);
+		return (version) => {
+			const parts = parseVersion(version);
+			return !!parts && parts.major === M && parts.minor === m;
+		};
+	}
+
+	// X.x
+	const majorWildcard = trimmed.match(/^(\d+)\.x$/);
+	if (majorWildcard) {
+		const M = Number(majorWildcard[1]);
+		return (version) => {
+			const parts = parseVersion(version);
+			return !!parts && parts.major === M;
+		};
+	}
+
+	// X.Y.Z (exact)
+	const exact = trimmed.match(/^(\d+)\.(\d+)\.(\d+)$/);
+	if (exact) {
+		return (version) => version === trimmed;
+	}
+
+	// Unrecognized — be permissive (warn at call site)
+	return () => true;
+}
+
+export function parseVersion(version) {
+	if (!version || typeof version !== "string") return null;
+	const m = version.match(/^(\d+)\.(\d+)\.(\d+)/);
+	if (!m) return null;
+	return {
+		major: Number(m[1]),
+		minor: Number(m[2]),
+		patch: Number(m[3]),
+	};
+}
+
+/**
+ * Manifest validate. Returns {valid, errors[], warnings[]}.
+ * Hard errors prevent install/load. Warnings are surfaced but allowed.
+ */
+export function validateManifest(manifest) {
+	const errors = [];
+	const warnings = [];
+
+	if (!manifest || typeof manifest !== "object") {
+		errors.push("Manifest gecersiz veya bos");
+		return { valid: false, errors, warnings };
+	}
+
+	if (!manifest.name || typeof manifest.name !== "string") {
+		errors.push("'name' alani zorunlu (string)");
+	}
+	if (manifest.version && !parseVersion(manifest.version)) {
+		warnings.push(`'version' semver formatinda degil: ${manifest.version}`);
+	}
+
+	const badiField = manifest.badi || {};
+	if (badiField.apiVersion !== undefined) {
+		if (typeof badiField.apiVersion !== "string") {
+			errors.push("'badi.apiVersion' string olmali");
+		}
+	}
+	if (badiField.dependsOn !== undefined) {
+		if (!Array.isArray(badiField.dependsOn)) {
+			errors.push("'badi.dependsOn' array olmali");
+		} else {
+			for (const dep of badiField.dependsOn) {
+				if (typeof dep !== "string") {
+					errors.push(`'badi.dependsOn' her eleman string olmali: ${dep}`);
+				}
+			}
+		}
+	}
+
+	return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
+ * apiVersion karsilastir.
+ *  - manifest.badi.apiVersion belirtilmemisse: BADI_DEFAULT_API_VERSION (1.x)
+ *  - badiVersion (mevcut badi semver) range'i karsilamaliyse: ok
+ * Return: { ok, range, badiVersion, reason? }
+ */
+export function checkApiCompat(manifest, badiVersion) {
+	const range =
+		manifest?.badi?.apiVersion ||
+		manifest?.engines?.badi ||
+		BADI_DEFAULT_API_VERSION;
+	const matcher = parseRange(range);
+	const ok = matcher(badiVersion);
+	if (!ok) {
+		return {
+			ok: false,
+			range,
+			badiVersion,
+			reason: `Plugin apiVersion '${range}' ile Badi v${badiVersion} uyumlu degil`,
+		};
+	}
+	return { ok: true, range, badiVersion };
+}
+
+/**
+ * Parse "name@range" -> { name, range }. range null ise "*".
+ */
+export function parseDependency(spec) {
+	const at = spec.indexOf("@");
+	if (at < 0) return { name: spec, range: "*" };
+	return { name: spec.slice(0, at), range: spec.slice(at + 1) || "*" };
+}
+
+/**
+ * Topological sort plugin'leri bagimlilik sirasiyla. Plugins: array
+ * of { name, version, badi: { dependsOn } }. Cycle varsa hata firlatir.
+ * Tek-yon: a depends on b => b once load edilir.
+ */
+export function topoSort(plugins) {
+	const byName = new Map();
+	for (const p of plugins) {
+		byName.set(p.name, p);
+	}
+
+	const indeg = new Map();
+	const adj = new Map();
+	for (const p of plugins) {
+		indeg.set(p.name, 0);
+		adj.set(p.name, []);
+	}
+	for (const p of plugins) {
+		const deps = p.badi?.dependsOn || [];
+		for (const dep of deps) {
+			const { name } = parseDependency(dep);
+			if (!byName.has(name)) continue; // unresolved dep: warn caller
+			adj.get(name).push(p.name);
+			indeg.set(p.name, (indeg.get(p.name) || 0) + 1);
+		}
+	}
+
+	const queue = [];
+	for (const [name, deg] of indeg) {
+		if (deg === 0) queue.push(name);
+	}
+	const sorted = [];
+	while (queue.length) {
+		const name = queue.shift();
+		sorted.push(name);
+		for (const next of adj.get(name)) {
+			const d = indeg.get(next) - 1;
+			indeg.set(next, d);
+			if (d === 0) queue.push(next);
+		}
+	}
+	if (sorted.length !== plugins.length) {
+		throw new Error(
+			`Plugin dependency cycle algilandi (${plugins.length - sorted.length} plugin sort edilemedi)`,
+		);
+	}
+	return sorted.map((n) => byName.get(n));
+}
+
+/**
+ * Find missing/unsatisfied dependencies. Returns array of issues:
+ *   { plugin, dep, reason: "missing" | "version-mismatch", requested, installed }
+ */
+export function findUnsatisfied(plugins) {
+	const byName = new Map();
+	for (const p of plugins) byName.set(p.name, p);
+
+	const issues = [];
+	for (const p of plugins) {
+		const deps = p.badi?.dependsOn || [];
+		for (const dep of deps) {
+			const { name, range } = parseDependency(dep);
+			const installed = byName.get(name);
+			if (!installed) {
+				issues.push({
+					plugin: p.name,
+					dep: name,
+					reason: "missing",
+					requested: range,
+					installed: null,
+				});
+				continue;
+			}
+			const matcher = parseRange(range);
+			if (!matcher(installed.version || "0.0.0")) {
+				issues.push({
+					plugin: p.name,
+					dep: name,
+					reason: "version-mismatch",
+					requested: range,
+					installed: installed.version,
+				});
+			}
+		}
+	}
+	return issues;
+}

--- a/lib/harnesses/agents.js
+++ b/lib/harnesses/agents.js
@@ -1,0 +1,169 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { PKG_ROOT } from "../cli.js";
+
+/**
+ * Generic Agents adapter — compiles Badi's Claude-centric source into a single
+ * AGENTS.md file. AGENTS.md is the neutral fallback used by OpenAI Codex CLI,
+ * Aider, and other tools that look for a project-level agent context file.
+ *
+ * Target layout:
+ *   AGENTS.md                   # merged: CLAUDE.md + memory.md + knowledge-base.md
+ *
+ * Not supported (reported as skippedComponents):
+ *   hooks, skills, subagents, slash commands, mcp — AGENTS.md is purely prompt
+ *   context for any tool that reads it.
+ */
+
+function countSourceCommands(src) {
+	const dir = join(src, "commands");
+	if (!existsSync(dir)) return 0;
+	return readdirSync(dir).filter((f) => f.endsWith(".md")).length;
+}
+
+function countSourceHooks(src) {
+	const dir = join(src, "hooks");
+	if (!existsSync(dir)) return 0;
+	return readdirSync(dir).filter((f) => f.endsWith(".mjs") || f.endsWith(".sh"))
+		.length;
+}
+
+function countSourceSkills(src) {
+	const vault = join(src, "skills-vault");
+	const dir = existsSync(vault) ? vault : join(src, "skills");
+	if (!existsSync(dir)) return 0;
+	return readdirSync(dir, { withFileTypes: true }).filter((d) =>
+		d.isDirectory(),
+	).length;
+}
+
+function countSourceAgents(src) {
+	const dir = join(src, "agents");
+	if (!existsSync(dir)) return 0;
+	return readdirSync(dir).filter((f) => f.endsWith(".md")).length;
+}
+
+function buildAgentsMd(src) {
+	const sections = [];
+	const claudeMd = resolve(PKG_ROOT, "CLAUDE.md");
+	if (existsSync(claudeMd)) {
+		sections.push(readFileSync(claudeMd, "utf-8").trim());
+	}
+	const memoryMd = join(src, "memory.md");
+	if (existsSync(memoryMd)) {
+		sections.push(
+			`\n---\n\n# Proje Bellegi\n\n${readFileSync(memoryMd, "utf-8").trim()}`,
+		);
+	}
+	const kbMd = join(src, "knowledge-base.md");
+	if (existsSync(kbMd)) {
+		sections.push(
+			`\n---\n\n# Bilgi Tabani\n\n${readFileSync(kbMd, "utf-8").trim()}`,
+		);
+	}
+	return sections.length ? `${sections.join("\n\n")}\n` : null;
+}
+
+function compileAgentsMd(src, target, force, dryRun, result) {
+	const content = buildAgentsMd(src);
+	if (!content) return;
+	const dest = join(target, "AGENTS.md");
+	const existed = existsSync(dest);
+	if (existed && !force) {
+		result.skipped++;
+		return;
+	}
+	if (!dryRun) writeFileSync(dest, content);
+	result.copied++;
+	if (!existed) result.created++;
+}
+
+function buildSkippedReport(src) {
+	const skipped = [];
+	const hooks = countSourceHooks(src);
+	const skills = countSourceSkills(src);
+	const agents = countSourceAgents(src);
+	const commands = countSourceCommands(src);
+	if (hooks > 0)
+		skipped.push({
+			component: "hooks",
+			count: hooks,
+			reason: "Generic AGENTS.md sadece prompt context, runtime yok",
+		});
+	if (skills > 0)
+		skipped.push({
+			component: "skills",
+			count: skills,
+			reason: "AGENTS.md tek dosya, skill sistemi disinda",
+		});
+	if (agents > 0)
+		skipped.push({
+			component: "subagents",
+			count: agents,
+			reason: "AGENTS.md tek dosya, subagent yok",
+		});
+	if (commands > 0)
+		skipped.push({
+			component: "commands",
+			count: commands,
+			reason: "AGENTS.md sadece prompt context, slash komut yok",
+		});
+	return skipped;
+}
+
+function runInstall({ target, src, force = false, dryRun = false }) {
+	const result = { copied: 0, skipped: 0, created: 0 };
+	compileAgentsMd(src, target, force, dryRun, result);
+	result.skippedComponents = buildSkippedReport(src);
+	return result;
+}
+
+export default {
+	id: "agents",
+	name: "AGENTS.md (Generic)",
+	supports: {
+		rules: true,
+		commands: false,
+		mcp: false,
+		subagents: false,
+		hooks: false,
+		skills: false,
+	},
+
+	detect(target) {
+		return existsSync(join(target, "AGENTS.md"));
+	},
+
+	install(opts) {
+		return runInstall(opts);
+	},
+
+	update(opts) {
+		return runInstall({ ...opts, force: !!opts.force });
+	},
+
+	doctor({ target }) {
+		const checks = [];
+		let pass = 0;
+		let warn = 0;
+		let fail = 0;
+
+		const run = (label, fn) => {
+			try {
+				const r = fn();
+				const status = r === true ? "pass" : r === "warn" ? "warn" : "fail";
+				checks.push({ label, status });
+				if (status === "pass") pass++;
+				else if (status === "warn") warn++;
+				else fail++;
+			} catch (e) {
+				checks.push({ label: `${label} (${e.message})`, status: "fail" });
+				fail++;
+			}
+		};
+
+		run("AGENTS.md mevcut", () => existsSync(join(target, "AGENTS.md")));
+
+		return { pass, warn, fail, checks };
+	},
+};

--- a/lib/harnesses/index.js
+++ b/lib/harnesses/index.js
@@ -1,6 +1,8 @@
+import agents from "./agents.js";
 import claude from "./claude.js";
 import cursor from "./cursor.js";
 import gemini from "./gemini.js";
+import windsurf from "./windsurf.js";
 
 /**
  * Harness adapter contract:
@@ -20,7 +22,7 @@ import gemini from "./gemini.js";
  * src = absolute path to the canonical .claude/ source dir (TEMPLATE_DIR in cli.js).
  * target = the user project root (where .claude/ or .cursor/ etc. will be written).
  */
-export const HARNESSES = [claude, cursor, gemini];
+export const HARNESSES = [claude, cursor, gemini, windsurf, agents];
 
 export const HARNESS_IDS = HARNESSES.map((h) => h.id);
 

--- a/lib/harnesses/windsurf.js
+++ b/lib/harnesses/windsurf.js
@@ -1,0 +1,171 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { PKG_ROOT } from "../cli.js";
+
+/**
+ * Windsurf adapter — compiles Badi's Claude-centric source into a single
+ * .windsurfrules file (Windsurf IDE's per-project rules format).
+ *
+ * Target layout:
+ *   .windsurfrules              # merged: CLAUDE.md + memory.md + knowledge-base.md
+ *
+ * Not supported (reported as skippedComponents):
+ *   hooks, skills, subagents, slash commands, mcp — Windsurf's rule system is
+ *   prompt-only. We fall back to inlining guidance into .windsurfrules.
+ */
+
+function countSourceCommands(src) {
+	const dir = join(src, "commands");
+	if (!existsSync(dir)) return 0;
+	return readdirSync(dir).filter((f) => f.endsWith(".md")).length;
+}
+
+function countSourceHooks(src) {
+	const dir = join(src, "hooks");
+	if (!existsSync(dir)) return 0;
+	return readdirSync(dir).filter((f) => f.endsWith(".mjs") || f.endsWith(".sh"))
+		.length;
+}
+
+function countSourceSkills(src) {
+	const vault = join(src, "skills-vault");
+	const dir = existsSync(vault) ? vault : join(src, "skills");
+	if (!existsSync(dir)) return 0;
+	return readdirSync(dir, { withFileTypes: true }).filter((d) =>
+		d.isDirectory(),
+	).length;
+}
+
+function countSourceAgents(src) {
+	const dir = join(src, "agents");
+	if (!existsSync(dir)) return 0;
+	return readdirSync(dir).filter((f) => f.endsWith(".md")).length;
+}
+
+function buildWindsurfRules(src) {
+	const sections = [];
+	const claudeMd = resolve(PKG_ROOT, "CLAUDE.md");
+	if (existsSync(claudeMd)) {
+		sections.push(readFileSync(claudeMd, "utf-8").trim());
+	}
+	const memoryMd = join(src, "memory.md");
+	if (existsSync(memoryMd)) {
+		sections.push(
+			`\n---\n\n# Proje Bellegi\n\n${readFileSync(memoryMd, "utf-8").trim()}`,
+		);
+	}
+	const kbMd = join(src, "knowledge-base.md");
+	if (existsSync(kbMd)) {
+		sections.push(
+			`\n---\n\n# Bilgi Tabani\n\n${readFileSync(kbMd, "utf-8").trim()}`,
+		);
+	}
+	return sections.length ? `${sections.join("\n\n")}\n` : null;
+}
+
+function compileWindsurfRules(src, target, force, dryRun, result) {
+	const content = buildWindsurfRules(src);
+	if (!content) return;
+	const dest = join(target, ".windsurfrules");
+	const existed = existsSync(dest);
+	if (existed && !force) {
+		result.skipped++;
+		return;
+	}
+	if (!dryRun) writeFileSync(dest, content);
+	result.copied++;
+	if (!existed) result.created++;
+}
+
+function buildSkippedReport(src) {
+	const skipped = [];
+	const hooks = countSourceHooks(src);
+	const skills = countSourceSkills(src);
+	const agents = countSourceAgents(src);
+	const commands = countSourceCommands(src);
+	if (hooks > 0)
+		skipped.push({
+			component: "hooks",
+			count: hooks,
+			reason: "Windsurf'ta hook esdegeri yok",
+		});
+	if (skills > 0)
+		skipped.push({
+			component: "skills",
+			count: skills,
+			reason: "Windsurf'ta skill esdegeri yok",
+		});
+	if (agents > 0)
+		skipped.push({
+			component: "subagents",
+			count: agents,
+			reason: "Windsurf'ta subagent yok",
+		});
+	if (commands > 0)
+		skipped.push({
+			component: "commands",
+			count: commands,
+			reason:
+				"Windsurf'ta slash komut yok (.windsurfrules'a inline rehber gonderildi)",
+		});
+	return skipped;
+}
+
+function runInstall({ target, src, force = false, dryRun = false }) {
+	const result = { copied: 0, skipped: 0, created: 0 };
+	compileWindsurfRules(src, target, force, dryRun, result);
+	result.skippedComponents = buildSkippedReport(src);
+	return result;
+}
+
+export default {
+	id: "windsurf",
+	name: "Windsurf",
+	supports: {
+		rules: true,
+		commands: false,
+		mcp: false,
+		subagents: false,
+		hooks: false,
+		skills: false,
+	},
+
+	detect(target) {
+		return existsSync(join(target, ".windsurfrules"));
+	},
+
+	install(opts) {
+		return runInstall(opts);
+	},
+
+	update(opts) {
+		return runInstall({ ...opts, force: !!opts.force });
+	},
+
+	doctor({ target }) {
+		const checks = [];
+		let pass = 0;
+		let warn = 0;
+		let fail = 0;
+
+		const run = (label, fn) => {
+			try {
+				const r = fn();
+				const status = r === true ? "pass" : r === "warn" ? "warn" : "fail";
+				checks.push({ label, status });
+				if (status === "pass") pass++;
+				else if (status === "warn") warn++;
+				else fail++;
+			} catch (e) {
+				checks.push({ label: `${label} (${e.message})`, status: "fail" });
+				fail++;
+			}
+		};
+
+		run(".windsurfrules mevcut", () =>
+			existsSync(join(target, ".windsurfrules")),
+		);
+
+		return { pass, warn, fail, checks };
+	},
+};

--- a/lib/observability/event-emitter.js
+++ b/lib/observability/event-emitter.js
@@ -1,0 +1,170 @@
+// Badi typed event emission — self-telemetry.
+//
+// Privacy notu:
+//   - Tum kayitlar LOKAL: ~/.claude/projects/<project>/badi-events.jsonl
+//   - Hicbir veri dis sisteme gonderilmez (network call yok).
+//   - BADI_TELEMETRY=off ile tamamen devre disi (her cagri no-op).
+//   - Args/payload icinde token, secret, kullanici icerigi DEPOLANMAZ.
+//     Sadece cmd adi + duration_ms + exit_code + bilinen safe alanlar.
+//
+// Format: JSONL, her satir tek bir event.
+//   { ts, type, cmd?, duration_ms?, exit_code?, ... }
+
+import { appendFileSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+
+const TELEMETRY_OFF =
+	process.env.BADI_TELEMETRY === "off" ||
+	process.env.BADI_TELEMETRY === "0" ||
+	process.env.BADI_TELEMETRY === "false";
+
+// Allowed event types (whitelist; unknown types blocked).
+export const ALLOWED_TYPES = new Set([
+	"badi.command.started",
+	"badi.command.completed",
+	"badi.command.failed",
+	"badi.skill.installed",
+	"badi.skill.removed",
+	"badi.plugin.installed",
+	"badi.plugin.removed",
+	"badi.publish.started",
+	"badi.publish.completed",
+	"badi.publish.failed",
+	"badi.release.check",
+]);
+
+function projectSlug(cwd) {
+	// ~/.claude/projects/<slug>/ — Claude Code'in slug normalizasyonu ile
+	// uyumlu: tum yol separator'lari "-" yapilir, baslangic "-" eklenir.
+	// Ornek: /Volumes/Backup/cloud/git/badi -> -Volumes-Backup-cloud-git-badi
+	let s = cwd.replace(/[\\\/]/g, "-");
+	if (!s.startsWith("-")) s = `-${s}`;
+	return s;
+}
+
+function eventsLogPath(cwd) {
+	const slug = projectSlug(cwd || process.cwd());
+	const dir = join(homedir(), ".claude", "projects", slug);
+	if (!existsSync(dir)) {
+		try {
+			mkdirSync(dir, { recursive: true });
+		} catch {
+			return null;
+		}
+	}
+	return join(dir, "badi-events.jsonl");
+}
+
+/**
+ * Emit a single event. Pure best-effort; never throws to caller.
+ *   type: must be in ALLOWED_TYPES
+ *   data: shallow object; only safe primitives recommended
+ */
+export function emit(type, data = {}) {
+	if (TELEMETRY_OFF) return;
+	if (!ALLOWED_TYPES.has(type)) return; // unknown types silently dropped
+	try {
+		const event = {
+			ts: new Date().toISOString(),
+			type,
+			...sanitize(data),
+		};
+		const path = eventsLogPath(data.cwd || process.cwd());
+		if (!path) return;
+		appendFileSync(path, `${JSON.stringify(event)}\n`, "utf-8");
+	} catch {
+		// best-effort: never propagate telemetry errors
+	}
+}
+
+function sanitize(data) {
+	const out = {};
+	for (const [k, v] of Object.entries(data)) {
+		if (k === "cwd") continue; // cwd already used for path, not stored
+		if (typeof v === "string") {
+			// Truncate strings to 200 chars to prevent accidental leakage
+			out[k] = v.length > 200 ? `${v.slice(0, 200)}...` : v;
+		} else if (
+			typeof v === "number" ||
+			typeof v === "boolean" ||
+			v === null
+		) {
+			out[k] = v;
+		} else if (Array.isArray(v)) {
+			out[k] = v.slice(0, 50).map((x) =>
+				typeof x === "string" && x.length > 100 ? `${x.slice(0, 100)}...` : x,
+			);
+		}
+		// drop nested objects / undefined silently
+	}
+	return out;
+}
+
+/**
+ * Read all events from current project's JSONL. Best-effort.
+ * Returns array of parsed events, newest first.
+ */
+export async function readEvents(opts = {}) {
+	const path = eventsLogPath(opts.cwd || process.cwd());
+	if (!path || !existsSync(path)) return [];
+	const { readFileSync } = await import("node:fs");
+	const lines = readFileSync(path, "utf-8").split("\n").filter(Boolean);
+	const events = [];
+	for (const line of lines) {
+		try {
+			events.push(JSON.parse(line));
+		} catch {
+			// skip corrupted line
+		}
+	}
+	return events.reverse();
+}
+
+export function isEnabled() {
+	return !TELEMETRY_OFF;
+}
+
+export function getEventsPath(cwd) {
+	return eventsLogPath(cwd || process.cwd());
+}
+
+/**
+ * Helper: time a sync/async function with command emission.
+ * Returns the wrapped function's return value (or re-throws).
+ */
+export async function timeCommand(cmd, args, fn) {
+	const start = Date.now();
+	emit("badi.command.started", { cmd, args_count: args?.length || 0 });
+	try {
+		const result = await fn();
+		emit("badi.command.completed", {
+			cmd,
+			duration_ms: Date.now() - start,
+			exit_code: 0,
+		});
+		return result;
+	} catch (e) {
+		emit("badi.command.failed", {
+			cmd,
+			duration_ms: Date.now() - start,
+			error_message: e?.message || String(e),
+			exit_code: 1,
+		});
+		throw e;
+	}
+}
+
+// File size diagnostics (used by `badi events` to advise rotation).
+export function eventsFileSize(cwd) {
+	const p = eventsLogPath(cwd || process.cwd());
+	if (!p || !existsSync(p)) return 0;
+	try {
+		return statSync(p).size;
+	} catch {
+		return 0;
+	}
+}
+
+export const FILENAME = "badi-events.jsonl";
+export { basename };

--- a/tests/cli.events.test.js
+++ b/tests/cli.events.test.js
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const CLI = resolve(__dirname, "..", "bin", "badi.js");
+
+function run(args = [], env = {}) {
+	try {
+		return {
+			stdout: execFileSync("node", [CLI, ...args], {
+				encoding: "utf-8",
+				timeout: 10_000,
+				env: { ...process.env, ...env },
+			}),
+			code: 0,
+		};
+	} catch (e) {
+		return {
+			stdout: e.stdout?.toString() || "",
+			stderr: e.stderr?.toString() || "",
+			code: e.status ?? 1,
+		};
+	}
+}
+
+describe("badi events", () => {
+	it("--help subcommand listesi gosterir", () => {
+		const r = run(["events", "--help"]);
+		assert.equal(r.code, 0);
+		assert.match(r.stdout, /badi events list/);
+		assert.match(r.stdout, /badi events stats/);
+		assert.match(r.stdout, /BADI_TELEMETRY=off/);
+	});
+
+	it("status komutu telemetry on/off gosterir", () => {
+		const r = run(["events", "status"]);
+		assert.equal(r.code, 0);
+		assert.match(r.stdout, /Telemetry:/);
+		assert.match(r.stdout, /Log dosyasi:/);
+	});
+
+	it("BADI_TELEMETRY=off status'ta off gosterir", () => {
+		const r = run(["events", "status"], { BADI_TELEMETRY: "off" });
+		assert.equal(r.code, 0);
+		assert.match(r.stdout, /off/);
+	});
+
+	it("path komutu yolu yazar", () => {
+		const r = run(["events", "path"]);
+		assert.equal(r.code, 0);
+		assert.ok(r.stdout.includes("badi-events.jsonl"));
+	});
+
+	it("list komutu cagri yapilirsa olay gosterir", () => {
+		// Telemetry on (default), once bir komut cagiralim
+		run(["doctor", "--help"]);
+		const r = run(["events", "list", "--limit", "5"]);
+		assert.equal(r.code, 0);
+		// Pek cok kez emit olur — kontrol esnek
+		assert.ok(r.stdout.length > 0);
+	});
+
+	it("bilinmeyen subcommand exit 1", () => {
+		const r = run(["events", "bogus"]);
+		assert.equal(r.code, 1);
+	});
+});

--- a/tests/cli.release.test.js
+++ b/tests/cli.release.test.js
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const CLI = resolve(__dirname, "..", "bin", "badi.js");
+
+function run(args = []) {
+	try {
+		return {
+			stdout: execFileSync("node", [CLI, ...args], {
+				encoding: "utf-8",
+				timeout: 10_000,
+			}),
+			code: 0,
+		};
+	} catch (e) {
+		return {
+			stdout: e.stdout?.toString() || "",
+			stderr: e.stderr?.toString() || "",
+			code: e.status ?? 1,
+		};
+	}
+}
+
+describe("badi release", () => {
+	it("--help temel komutlari listeler", () => {
+		const r = run(["release", "--help"]);
+		assert.equal(r.code, 0);
+		assert.match(r.stdout, /badi release check/);
+		assert.match(r.stdout, /--bump/);
+		assert.match(r.stdout, /--strict/);
+	});
+
+	it("check --help bagimsiz calisir", () => {
+		const r = run(["release", "check", "--help"]);
+		assert.equal(r.code, 0);
+		assert.ok(r.stdout.length > 0);
+	});
+
+	it("bilinmeyen subcommand exit 1", () => {
+		const r = run(["release", "bogus"]);
+		assert.equal(r.code, 1);
+	});
+});

--- a/tests/event-emitter.test.js
+++ b/tests/event-emitter.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	ALLOWED_TYPES,
+	emit,
+	getEventsPath,
+	isEnabled,
+} from "../lib/observability/event-emitter.js";
+
+describe("event-emitter", () => {
+	it("ALLOWED_TYPES whitelist tanimli", () => {
+		assert.ok(ALLOWED_TYPES.has("badi.command.started"));
+		assert.ok(ALLOWED_TYPES.has("badi.command.completed"));
+		assert.ok(ALLOWED_TYPES.has("badi.command.failed"));
+		assert.ok(!ALLOWED_TYPES.has("bogus.type"));
+	});
+
+	it("BADI_TELEMETRY=off sirasinda isEnabled false", () => {
+		const prev = process.env.BADI_TELEMETRY;
+		// import zaten okudu — bu test sadece flagi sayar
+		assert.equal(typeof isEnabled(), "boolean");
+		if (prev !== undefined) process.env.BADI_TELEMETRY = prev;
+		else delete process.env.BADI_TELEMETRY;
+	});
+
+	it("emit bilinmeyen tip atilir (silently dropped)", () => {
+		// throw etmemeli; emit dropp eder
+		assert.doesNotThrow(() => emit("bogus.type", {}));
+	});
+
+	it("getEventsPath bir yol uretir", () => {
+		const p = getEventsPath();
+		assert.ok(p);
+		assert.match(p, /badi-events\.jsonl$/);
+	});
+});

--- a/tests/harness-extras.test.js
+++ b/tests/harness-extras.test.js
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const PKG_ROOT = resolve(__dirname, "..");
+const TEMPLATE_DIR = join(PKG_ROOT, ".claude");
+
+// Dynamic import (no top-level await issues across runners)
+const { default: windsurf } = await import("../lib/harnesses/windsurf.js");
+const { default: agents } = await import("../lib/harnesses/agents.js");
+const { HARNESSES, getHarness } = await import("../lib/harnesses/index.js");
+
+describe("HARNESSES registry", () => {
+	it("windsurf ve agents kayitli", () => {
+		const ids = HARNESSES.map((h) => h.id);
+		assert.ok(ids.includes("windsurf"));
+		assert.ok(ids.includes("agents"));
+	});
+
+	it("getHarness windsurf bulur", () => {
+		const h = getHarness("windsurf");
+		assert.ok(h);
+		assert.equal(h.id, "windsurf");
+	});
+
+	it("getHarness agents bulur", () => {
+		const h = getHarness("agents");
+		assert.ok(h);
+		assert.equal(h.id, "agents");
+	});
+});
+
+describe("windsurf harness", () => {
+	it("install .windsurfrules olusturur", () => {
+		const target = mkdtempSync(join(tmpdir(), "badi-ws-"));
+		try {
+			const result = windsurf.install({ target, src: TEMPLATE_DIR });
+			assert.equal(result.copied, 1);
+			assert.ok(existsSync(join(target, ".windsurfrules")));
+			const body = readFileSync(join(target, ".windsurfrules"), "utf-8");
+			assert.ok(body.length > 0);
+		} finally {
+			rmSync(target, { recursive: true, force: true });
+		}
+	});
+
+	it("detect existing .windsurfrules", () => {
+		const target = mkdtempSync(join(tmpdir(), "badi-ws-d-"));
+		try {
+			assert.ok(!windsurf.detect(target));
+			windsurf.install({ target, src: TEMPLATE_DIR });
+			assert.ok(windsurf.detect(target));
+		} finally {
+			rmSync(target, { recursive: true, force: true });
+		}
+	});
+
+	it("skippedComponents commands/hooks/skills'i raporlar", () => {
+		const target = mkdtempSync(join(tmpdir(), "badi-ws-s-"));
+		try {
+			const result = windsurf.install({ target, src: TEMPLATE_DIR });
+			const skipped = result.skippedComponents || [];
+			const types = skipped.map((s) => s.component);
+			// Source repo'da hooks/skills/commands olduguna gore en az biri raporlanmali
+			assert.ok(
+				types.length > 0,
+				"Source repo bilesenler iceriyor olmali (template tarafindan dolduruluyor)",
+			);
+		} finally {
+			rmSync(target, { recursive: true, force: true });
+		}
+	});
+
+	it("force=false olmadan tekrar install skip eder", () => {
+		const target = mkdtempSync(join(tmpdir(), "badi-ws-f-"));
+		try {
+			windsurf.install({ target, src: TEMPLATE_DIR });
+			const result = windsurf.install({ target, src: TEMPLATE_DIR });
+			assert.equal(result.copied, 0);
+			assert.equal(result.skipped, 1);
+		} finally {
+			rmSync(target, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("agents harness", () => {
+	it("install AGENTS.md olusturur", () => {
+		const target = mkdtempSync(join(tmpdir(), "badi-ag-"));
+		try {
+			const result = agents.install({ target, src: TEMPLATE_DIR });
+			assert.equal(result.copied, 1);
+			assert.ok(existsSync(join(target, "AGENTS.md")));
+		} finally {
+			rmSync(target, { recursive: true, force: true });
+		}
+	});
+
+	it("detect existing AGENTS.md", () => {
+		const target = mkdtempSync(join(tmpdir(), "badi-ag-d-"));
+		try {
+			assert.ok(!agents.detect(target));
+			agents.install({ target, src: TEMPLATE_DIR });
+			assert.ok(agents.detect(target));
+		} finally {
+			rmSync(target, { recursive: true, force: true });
+		}
+	});
+
+	it("doctor pass when AGENTS.md mevcut", () => {
+		const target = mkdtempSync(join(tmpdir(), "badi-ag-doc-"));
+		try {
+			agents.install({ target, src: TEMPLATE_DIR });
+			const r = agents.doctor({ target });
+			assert.equal(r.fail, 0);
+		} finally {
+			rmSync(target, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/harness.test.js
+++ b/tests/harness.test.js
@@ -44,8 +44,14 @@ function runCli(args, cwd, extraEnv = {}) {
 }
 
 describe("harness registry", () => {
-	it("3 harness kayitli: claude, cursor, gemini", () => {
-		assert.deepEqual(HARNESS_IDS.sort(), ["claude", "cursor", "gemini"]);
+	it("5 harness kayitli: claude, cursor, gemini, windsurf, agents", () => {
+		assert.deepEqual(HARNESS_IDS.sort(), [
+			"agents",
+			"claude",
+			"cursor",
+			"gemini",
+			"windsurf",
+		]);
 	});
 
 	it("getHarness id ile bulur", () => {
@@ -57,7 +63,7 @@ describe("harness registry", () => {
 
 	it("resolveHarnesses 'all' tum harness'lari verir", () => {
 		const r = resolveHarnesses("all");
-		assert.equal(r.length, 3);
+		assert.equal(r.length, 5);
 	});
 
 	it("resolveHarnesses virgul-ayrimli parse eder", () => {
@@ -85,7 +91,7 @@ describe("harness registry", () => {
 	it("resolveHarnesses case-insensitive calisir", () => {
 		assert.equal(resolveHarnesses("CURSOR")[0].id, "cursor");
 		assert.equal(resolveHarnesses("Gemini")[0].id, "gemini");
-		assert.equal(resolveHarnesses("ALL").length, 3);
+		assert.equal(resolveHarnesses("ALL").length, 5);
 		const mixed = resolveHarnesses("Claude,CURSOR");
 		assert.equal(mixed[0].id, "claude");
 		assert.equal(mixed[1].id, "cursor");

--- a/tests/hooks-failsafe.test.js
+++ b/tests/hooks-failsafe.test.js
@@ -32,8 +32,8 @@ function runHook(hookPath, stdin = "", env = {}) {
 describe("hooks fail-safe header (#162)", () => {
 	const hooks = listHooks();
 
-	it("13 .mjs hook bulunmali", () => {
-		assert.equal(hooks.length, 13, `Beklenen 13, bulunan ${hooks.length}`);
+	it("14 .mjs hook bulunmali", () => {
+		assert.equal(hooks.length, 14, `Beklenen 14, bulunan ${hooks.length}`);
 	});
 
 	for (const hookPath of hooks) {

--- a/tests/plugin-manifest.test.js
+++ b/tests/plugin-manifest.test.js
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	BADI_DEFAULT_API_VERSION,
+	checkApiCompat,
+	findUnsatisfied,
+	parseDependency,
+	parseRange,
+	parseVersion,
+	topoSort,
+	validateManifest,
+} from "../lib/data/plugin-manifest.js";
+
+describe("parseVersion", () => {
+	it("X.Y.Z parse eder", () => {
+		const v = parseVersion("1.30.0");
+		assert.deepEqual(v, { major: 1, minor: 30, patch: 0 });
+	});
+
+	it("invalid versions returns null", () => {
+		assert.equal(parseVersion(""), null);
+		assert.equal(parseVersion("abc"), null);
+		assert.equal(parseVersion(null), null);
+	});
+
+	it("X.Y formatinda patch yoksa null", () => {
+		assert.equal(parseVersion("1.30"), null);
+	});
+});
+
+describe("parseRange", () => {
+	it("'*' her zaman true", () => {
+		const m = parseRange("*");
+		assert.ok(m("1.0.0"));
+		assert.ok(m("99.99.99"));
+	});
+
+	it("'1.x' sadece major 1", () => {
+		const m = parseRange("1.x");
+		assert.ok(m("1.0.0"));
+		assert.ok(m("1.99.99"));
+		assert.ok(!m("2.0.0"));
+		assert.ok(!m("0.99.99"));
+	});
+
+	it("'1.30.x' major 1 minor 30", () => {
+		const m = parseRange("1.30.x");
+		assert.ok(m("1.30.0"));
+		assert.ok(m("1.30.99"));
+		assert.ok(!m("1.31.0"));
+	});
+
+	it("'1.30.5' exact", () => {
+		const m = parseRange("1.30.5");
+		assert.ok(m("1.30.5"));
+		assert.ok(!m("1.30.6"));
+	});
+
+	it("'>=1.30' gte basic", () => {
+		const m = parseRange(">=1.30");
+		assert.ok(m("1.30.0"));
+		assert.ok(m("1.30.5"));
+		assert.ok(m("2.0.0"));
+		assert.ok(!m("1.29.99"));
+	});
+
+	it("'>=1.30.5' gte patch", () => {
+		const m = parseRange(">=1.30.5");
+		assert.ok(m("1.30.5"));
+		assert.ok(m("1.30.6"));
+		assert.ok(m("1.31.0"));
+		assert.ok(!m("1.30.4"));
+	});
+
+	it("bilinmeyen format permissive (her seye true)", () => {
+		const m = parseRange("garbage");
+		assert.ok(m("1.0.0"));
+	});
+});
+
+describe("validateManifest", () => {
+	it("name yoksa invalid", () => {
+		const r = validateManifest({});
+		assert.ok(!r.valid);
+		assert.ok(r.errors.length > 0);
+	});
+
+	it("minimum valid manifest", () => {
+		const r = validateManifest({ name: "x" });
+		assert.ok(r.valid);
+	});
+
+	it("badi.apiVersion string degilse error", () => {
+		const r = validateManifest({
+			name: "x",
+			badi: { apiVersion: 1 },
+		});
+		assert.ok(!r.valid);
+	});
+
+	it("badi.dependsOn array degilse error", () => {
+		const r = validateManifest({
+			name: "x",
+			badi: { dependsOn: "foo" },
+		});
+		assert.ok(!r.valid);
+	});
+
+	it("badi.dependsOn icinde non-string error", () => {
+		const r = validateManifest({
+			name: "x",
+			badi: { dependsOn: ["foo", 123] },
+		});
+		assert.ok(!r.valid);
+	});
+});
+
+describe("checkApiCompat", () => {
+	it("apiVersion yok ise default 1.x", () => {
+		const r = checkApiCompat({ name: "x" }, "1.30.0");
+		assert.ok(r.ok);
+		assert.equal(r.range, BADI_DEFAULT_API_VERSION);
+	});
+
+	it("uyumsuz major reject", () => {
+		const r = checkApiCompat({ badi: { apiVersion: "2.x" } }, "1.30.0");
+		assert.ok(!r.ok);
+		assert.match(r.reason, /uyumlu degil/);
+	});
+
+	it("engines.badi de kabul edilir (fallback)", () => {
+		const r = checkApiCompat({ engines: { badi: "1.x" } }, "1.30.0");
+		assert.ok(r.ok);
+	});
+});
+
+describe("parseDependency", () => {
+	it("name@range parse eder", () => {
+		assert.deepEqual(parseDependency("foo@1.x"), { name: "foo", range: "1.x" });
+	});
+
+	it("range yoksa '*'", () => {
+		assert.deepEqual(parseDependency("foo"), { name: "foo", range: "*" });
+	});
+});
+
+describe("topoSort", () => {
+	it("bagimsiz plugins sirali kalir", () => {
+		const plugins = [{ name: "a", version: "1.0.0" }, { name: "b", version: "1.0.0" }];
+		const sorted = topoSort(plugins);
+		assert.equal(sorted.length, 2);
+	});
+
+	it("dependency once load edilir", () => {
+		const plugins = [
+			{ name: "a", version: "1.0.0", badi: { dependsOn: ["b"] } },
+			{ name: "b", version: "1.0.0" },
+		];
+		const sorted = topoSort(plugins);
+		assert.equal(sorted[0].name, "b");
+		assert.equal(sorted[1].name, "a");
+	});
+
+	it("cycle hata firlatir", () => {
+		const plugins = [
+			{ name: "a", version: "1.0.0", badi: { dependsOn: ["b"] } },
+			{ name: "b", version: "1.0.0", badi: { dependsOn: ["a"] } },
+		];
+		assert.throws(() => topoSort(plugins), /cycle/);
+	});
+
+	it("unresolved dep cycle yapmaz (gormezden gelir)", () => {
+		const plugins = [
+			{ name: "a", version: "1.0.0", badi: { dependsOn: ["does-not-exist"] } },
+		];
+		const sorted = topoSort(plugins);
+		assert.equal(sorted.length, 1);
+	});
+});
+
+describe("findUnsatisfied", () => {
+	it("missing dependency reports", () => {
+		const issues = findUnsatisfied([
+			{ name: "a", version: "1.0.0", badi: { dependsOn: ["missing@1.x"] } },
+		]);
+		assert.equal(issues.length, 1);
+		assert.equal(issues[0].reason, "missing");
+		assert.equal(issues[0].dep, "missing");
+	});
+
+	it("version mismatch reports", () => {
+		const issues = findUnsatisfied([
+			{ name: "a", version: "1.0.0", badi: { dependsOn: ["b@2.x"] } },
+			{ name: "b", version: "1.0.0" },
+		]);
+		assert.equal(issues.length, 1);
+		assert.equal(issues[0].reason, "version-mismatch");
+	});
+
+	it("satisfied dep returns empty", () => {
+		const issues = findUnsatisfied([
+			{ name: "a", version: "1.0.0", badi: { dependsOn: ["b@1.x"] } },
+			{ name: "b", version: "1.5.0" },
+		]);
+		assert.equal(issues.length, 0);
+	});
+});


### PR DESCRIPTION
## Summary

5 issue tek surume sigdirildi (v1.29.0 → v1.30.0 minor). 21 dosya, +2422 / -19 satir.

| # | Issue | Yeni dosya/komut | Test |
|---|-------|------------------|------|
| #177 | Multi-agent context export | windsurf + agents harnesses | 10 |
| #178 | `badi release check` | release.js | 3 |
| #179 | Plan injection hook | inject-active-plan.mjs | (manual smoke) |
| #180 | Plugin apiVersion + graph | plugin-manifest.js | 24 |
| #181 | Self-telemetry | event-emitter.js + events.js | 10 |

Toplam: 1021/1021 yesil (967 -> 1021, +54)

## #177 — Multi-agent context export

`badi init --harness all` artik 5 cikti uretir: Claude Code, Cursor, Gemini (varolanlar) + Windsurf + AGENTS.md (yeni).

- `lib/harnesses/windsurf.js` — `.windsurfrules` (Windsurf IDE)
- `lib/harnesses/agents.js` — `AGENTS.md` (OpenAI Codex CLI, Aider, jenerik fallback)

## #178 — `badi release check`

Publish-oncesi 9 kontrol — state degistirmez, commit etmez, bump etmez.

```
badi release check                       # tam kontrol
badi release check --bump minor          # paket.json'dan hedef hesapla
badi release check --version 1.30.0      # spesifik kontrol
badi release check --strict              # CI modu (warn → error)
badi release check --skip-test           # hizli kontrol
```

Publish-gec-feedback dongusunu (kirli tree / eksik CHANGELOG / kirik test) "badi publish sirasinda kesfedildi"den "publish-oncesi yakalandi"ya indirir. Bu seansda yasadigimiz pratik motivasyon.

## #179 — Plan injection hook

`.claude/hooks/inject-active-plan.mjs` — UserPromptSubmit hook.

- `.claude/plans/<slug>.approved` marker'lari tar
- Plan icerigini `<active-plan slug="X" state="approved">…</active-plan>` blok olarak Claude context'ine inject et
- Max 5 plan / 200KB injection / cap
- Pending veya denied planlar inject edilmez
- `BADI_HOOK_DEBUG=1` ile stderr trace

`badi plan approve`'u **aktif Claude memory**'ye baglar — plan sadece gate'lenmez, her prompt'ta hatirlatilir.

## #180 — Plugin apiVersion + dependency graph

`badi-plugin.json` icin yeni `badi` alani:

```json
{
  "name": "my-plugin",
  "version": "0.3.0",
  "badi": {
    "apiVersion": "1.x",
    "dependsOn": ["other-plugin@>=0.2"]
  }
}
```

Range syntax: `*`, `X.x`, `X.Y.x`, `X.Y.Z`, `>=X.Y[.Z]`. Default `1.x` (mevcut plugin'leri kapsar).

Iki yeni subcommand: `badi plugin doctor` (audit + exit 1), `badi plugin graph` (topo-sorted load order).

Icerik: `parseRange`, `validateManifest`, `checkApiCompat`, `topoSort` (cycle algilama), `findUnsatisfied`.

## #181 — Self-telemetry

`lib/observability/event-emitter.js` — Badi kendi typed event'lerini yayinlar.

`bin/badi.js` dispatcher'a baglandi; tum komutlar otomatik:
- `badi.command.started` (cmd, args_count)
- `badi.command.completed` (cmd, duration_ms, exit_code: 0)
- `badi.command.failed` (cmd, duration_ms, error_message, exit_code: 1)

Event'ler `~/.claude/projects/<slug>/badi-events.jsonl` (Badi'nin zaten okudugu dizin).

**Privacy:**
- Append-only JSONL, **sadece lokal** (network call yok)
- Whitelist event tipleri; bilinmeyen tipler droppe
- Arg DEGERLERI yazilmaz (sadece `args_count`) — secret leak yok
- String 200 char, array 50 elem cap
- `BADI_TELEMETRY=off` ile tamamen kapali

Yeni reader: `badi events list/stats/tail/path/status`.

## Test plan

- [x] `npm test` — 1021/1021 yesil
- [x] `badi doctor help` — 0 drift, 36 komut dosyasi temiz
- [x] `badi release check --help` smoke
- [x] `badi events status / list / path / stats` smoke
- [x] `badi plugin doctor / graph` (bos pluginler) smoke
- [x] Windsurf + agents harnesses tmp dir'de smoke
- [x] Plan injection hook real-plan smoke (additionalContext JSON verified)

## Davranis degisikligi

- **`badi init --harness all`**: 3 cikti → 5 cikti (windsurf + agents eklendi). `--harness windsurf` veya `--harness agents` ayri ayri da kullanilabilir.
- **Hook layer**: UserPromptSubmit hook'u **aktif** (settings.json'da kayitli). Onayli plan yoksa no-op. Devre disi birakmak isteyenler settings.json'dan satiri silebilir.
- **Telemetry**: Default **on**. Lokal-only. `export BADI_TELEMETRY=off` ile kapatilir.
- **Plugin manifest**: `apiVersion` belirtilmeyen plugin'ler `1.x` default'una dusurulur — mevcut plugin'ler kirilmaz.

Closes #177 #178 #179 #180 #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)