### PR TITLE
fix(v1.30.1): review hotfix — 9 findings closed

### DIFF
--- a/.github/workflows/dist-publish.yml
+++ b/.github/workflows/dist-publish.yml
@@ -8,6 +8,17 @@ name: Distribution mirror publish
 # Triggered manually after a successful `badi publish`. Auto-trigger on
 # `release: published` is also available (commented out below) but kept
 # opt-in to match Badi's "no auto-CI" policy.
+#
+# Runtime: ubuntu-latest. Implicit deps: python3 (ubuntu-latest default),
+# curl, sha256sum, git. No external actions besides actions/checkout@v4.
+#
+# Security notes (v1.30.1+ review K1, Y1, O2):
+#   - `${{ ... }}` user inputs interpolation HARDENED via env: pass-through
+#     (prevents shell injection from inputs.version).
+#   - Token transit via `http.extraHeader` Authorization Basic, NOT in URL
+#     (prevents token leak via git error logs).
+#   - Bot identity uses GitHub Actions standard suffix
+#     (41898282+github-actions[bot]@users.noreply.github.com).
 
 on:
   workflow_dispatch:
@@ -33,88 +44,126 @@ jobs:
 
       - name: Resolve target version
         id: ver
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$INPUT_VERSION" ]; then
+            # validate semver-shape to prevent garbage downstream (defense in depth)
+            if ! echo "$INPUT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9.-]+)?$'; then
+              echo "::error::INPUT_VERSION '$INPUT_VERSION' is not valid semver"
+              exit 1
+            fi
+            echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
           else
             v=$(curl -sf "https://registry.npmjs.org/-/package/@fatihkan/badi/dist-tags" | python3 -c "import json,sys; print(json.load(sys.stdin)['latest'])")
+            if ! echo "$v" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9.-]+)?$'; then
+              echo "::error::npm registry returned non-semver '$v'"
+              exit 1
+            fi
             echo "version=$v" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Compute npm tarball sha256
         id: hash
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          v="${{ steps.ver.outputs.version }}"
-          url="https://registry.npmjs.org/@fatihkan/badi/-/badi-${v}.tgz"
+          url="https://registry.npmjs.org/@fatihkan/badi/-/badi-${VERSION}.tgz"
           curl -sf "$url" -o /tmp/badi.tgz
           sha=$(sha256sum /tmp/badi.tgz | awk '{print $1}')
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
       - name: Render Homebrew formula
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          SHA: ${{ steps.hash.outputs.sha }}
         run: |
-          v="${{ steps.ver.outputs.version }}"
-          sha="${{ steps.hash.outputs.sha }}"
-          url="${{ steps.hash.outputs.url }}"
-          sed -e "s|REPLACE_AT_RELEASE_TIME|${sha}|" \
-              -e "s|badi-1.30.1.tgz|badi-${v}.tgz|" \
+          sed -e "s|REPLACE_AT_RELEASE_TIME|${SHA}|" \
+              -e "s|badi-1\.30\.1\.tgz|badi-${VERSION}.tgz|" \
               dist/homebrew/badi.rb > /tmp/badi.rb
           cat /tmp/badi.rb
 
       - name: Render Scoop manifest
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          SHA: ${{ steps.hash.outputs.sha }}
         run: |
-          v="${{ steps.ver.outputs.version }}"
-          sha="${{ steps.hash.outputs.sha }}"
-          python3 -c "
-          import json
+          python3 <<'PYEOF'
+          import json, os
+          v = os.environ['VERSION']
+          sha = os.environ['SHA']
           with open('dist/scoop/badi.json') as f:
               m = json.load(f)
-          m['version'] = '${v}'
-          m['hash'] = '${sha}'
-          m['url'] = 'https://registry.npmjs.org/@fatihkan/badi/-/badi-${v}.tgz'
+          m['version'] = v
+          m['hash'] = sha
+          m['url'] = f'https://registry.npmjs.org/@fatihkan/badi/-/badi-{v}.tgz'
           with open('/tmp/badi-scoop.json','w') as f:
               json.dump(m, f, indent='\t')
-          " && cat /tmp/badi-scoop.json
+          PYEOF
+          cat /tmp/badi-scoop.json
 
       - name: Push to Homebrew tap
         if: env.DIST_PUBLISH_TOKEN != ''
         env:
           DIST_PUBLISH_TOKEN: ${{ secrets.DIST_PUBLISH_TOKEN }}
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          v="${{ steps.ver.outputs.version }}"
-          git clone "https://x-access-token:${DIST_PUBLISH_TOKEN}@github.com/fatihkan/homebrew-badi.git" /tmp/tap
+          # Y1 fix: Authorization header (extra-header) instead of URL-embedded token.
+          # Token never appears in git URL, error logs, or process listings.
+          auth=$(echo -n "x-access-token:${DIST_PUBLISH_TOKEN}" | base64 -w 0)
+          git -c http.https://github.com/.extraHeader="Authorization: Basic ${auth}" \
+              clone https://github.com/fatihkan/homebrew-badi.git /tmp/tap
           mkdir -p /tmp/tap/Formula
           cp /tmp/badi.rb /tmp/tap/Formula/badi.rb
           cd /tmp/tap
-          git config user.email "noreply@github.com"
-          git config user.name "badi-dist-bot"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name  "github-actions[bot]"
           git add Formula/badi.rb
-          git commit -m "badi v${v}" || echo "no changes"
-          git push origin HEAD
+          if git diff --cached --quiet; then
+            echo "::notice::Homebrew tap up to date, no commit needed"
+            exit 0
+          fi
+          git -c http.https://github.com/.extraHeader="Authorization: Basic ${auth}" \
+              commit -m "badi v${VERSION}"
+          git -c http.https://github.com/.extraHeader="Authorization: Basic ${auth}" \
+              push origin HEAD
 
       - name: Push to Scoop bucket
         if: env.DIST_PUBLISH_TOKEN != ''
         env:
           DIST_PUBLISH_TOKEN: ${{ secrets.DIST_PUBLISH_TOKEN }}
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          v="${{ steps.ver.outputs.version }}"
-          git clone "https://x-access-token:${DIST_PUBLISH_TOKEN}@github.com/fatihkan/scoop-bucket.git" /tmp/bucket
+          auth=$(echo -n "x-access-token:${DIST_PUBLISH_TOKEN}" | base64 -w 0)
+          git -c http.https://github.com/.extraHeader="Authorization: Basic ${auth}" \
+              clone https://github.com/fatihkan/scoop-bucket.git /tmp/bucket
           mkdir -p /tmp/bucket/bucket
           cp /tmp/badi-scoop.json /tmp/bucket/bucket/badi.json
           cd /tmp/bucket
-          git config user.email "noreply@github.com"
-          git config user.name "badi-dist-bot"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name  "github-actions[bot]"
           git add bucket/badi.json
-          git commit -m "badi v${v}" || echo "no changes"
-          git push origin HEAD
+          if git diff --cached --quiet; then
+            echo "::notice::Scoop bucket up to date, no commit needed"
+            exit 0
+          fi
+          git -c http.https://github.com/.extraHeader="Authorization: Basic ${auth}" \
+              commit -m "badi v${VERSION}"
+          git -c http.https://github.com/.extraHeader="Authorization: Basic ${auth}" \
+              push origin HEAD
 
       - name: Summary
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          SHA: ${{ steps.hash.outputs.sha }}
+          URL: ${{ steps.hash.outputs.url }}
         run: |
-          echo "## Dist publish v${{ steps.ver.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Dist publish v${VERSION}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- sha256: \`${{ steps.hash.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- tarball: ${{ steps.hash.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
-          if [ -z "$DIST_PUBLISH_TOKEN" ]; then
+          echo "- sha256: \`${SHA}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- tarball: ${URL}" >> "$GITHUB_STEP_SUMMARY"
+          if [ -z "${DIST_PUBLISH_TOKEN:-}" ]; then
             echo "- mirrors: skipped (no DIST_PUBLISH_TOKEN secret)" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- mirrors: pushed to homebrew-badi + scoop-bucket" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # Badi OS dosyalari
+.DS_Store
+Thumbs.db
 .claude/logs/
 .claude/agent-memory/
 .claude/backups/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,20 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [1.30.1] - 2026-05-19
 
+> Includes review-driven refinements (see `### Refinements (post-#185 internal review)` below) before npm publish. All 9 review findings closed in the same release.
+
 ### Added — Multi-channel distribution mirrors
 
-Badi is now installable from **4 channels** that all mirror the same npm tarball:
+Badi is now installable from **2 live channels + 2 in-progress channels** (skeletoned in `dist/`, awaiting tap/bucket repo creation):
 
 ```bash
-npm i -g @fatihkan/badi                                       # primary (canonical)
-/plugin install fatihkan/badi                                 # Claude Code marketplace
-brew tap fatihkan/badi && brew install badi                   # Homebrew (macOS/Linux)
-scoop bucket add badi <repo> && scoop install badi            # Scoop (Windows)
+npm i -g @fatihkan/badi                                       # primary (canonical) ✅ live
+/plugin install fatihkan/badi                                 # Claude Code marketplace ✅ live
+brew tap fatihkan/badi && brew install badi                   # Homebrew (macOS/Linux) ⏳ coming soon
+scoop bucket add badi <repo> && scoop install badi            # Scoop (Windows) ⏳ coming soon
 ```
+
+The Homebrew tap (`fatihkan/homebrew-badi`) and Scoop bucket (`fatihkan/scoop-bucket`) repos are **not yet published**; this release ships the manifest skeletons and CI workflow. Until those repos exist, use npm or the Claude Code marketplace.
 
 - **`.claude-plugin/plugin.json` + `marketplace.json`** brought up-to-date with v1.30.0 reality (was stale since v1.16.5 — 21 → 22 agents, .sh → .mjs hooks, added `skills` field pointing to `./.claude/skills-vault`, added UserPromptSubmit hook block for the new plan-inject hook).
 - **`dist/homebrew/badi.rb`** — npm-backed Homebrew formula skeleton. Sha256 is populated by the release workflow after npm publish.
@@ -48,10 +52,31 @@ Block-on-stale ensures every npm publish ships with marketplace metadata that ac
 - `lib/data/marketplace-manifest.js` — generator + staleness checker (`buildPluginManifest`, `buildMarketplaceManifest`, `collectAgents`, `countHooks`, `countCommands`, `countSkillCategories`, `isManifestStale`, `writeManifests`). Pure functions; deterministic output.
 - `lib/commands/release.js` — `checkMarketplaceManifest` added to `CHECKS` array; `runSyncManifest` added as a new subcommand.
 
+### Refinements (post-#185 internal review)
+
+Pre-publish hotfix closing 9 review findings:
+
+**Security**
+- **K1** — Workflow `${{ inputs.version }}` and `${{ steps.X.outputs.* }}` no longer flow directly into shell scripts. All user-controlled values pass through an explicit `env:` block, then are referenced as quoted `$VAR` inside the shell. Defends against shell injection from `workflow_dispatch` inputs even if a collaborator account is compromised. Additionally, the version field is semver-validated before being used downstream.
+- **Y1** — Git operations no longer embed `DIST_PUBLISH_TOKEN` in the clone URL (`https://x-access-token:$TOKEN@...`). Instead, an `http.https://github.com/.extraHeader` config injects `Authorization: Basic <base64(x-access-token:$TOKEN)>`. Token never appears in git URLs, error logs, or process listings.
+- **O2** — Bot commits now use the GitHub Actions standard identity `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>` (verified-bot-eligible) instead of the generic `noreply@github.com`.
+
+**Correctness**
+- **O3** — Marketplace manifest staleness check uses a recursive `deepEqualJson` instead of `JSON.stringify` comparison. Hand-edited or differently-formatted JSON files with the same semantic content are no longer reported as stale. Generator output remains deterministic; this only affects the false-positive case when users (or tooling) reorder keys.
+- **D2** — Scoop installer script now `throw`s on `npm install` failure (`$LASTEXITCODE -ne 0`) and on missing `badi` binary post-install. Previously `Write-Error` was used, which does not change the exit code — Scoop treated failed installs as successful.
+
+**Docs**
+- **Y2** — `README.md` install matrix gains a **Status** column. Homebrew and Scoop rows show `⏳ Coming soon (tap/bucket repo setup pending)` until the mirror repos (`fatihkan/homebrew-badi`, `fatihkan/scoop-bucket`) are created. CHANGELOG entry also notes the in-progress status.
+
+**Quality**
+- **O1** — Unused `statSync` import removed from `lib/data/marketplace-manifest.js`.
+- **D1** — `.gitignore` now covers `.DS_Store` (macOS) and `Thumbs.db` (Windows) at the project root. Prevents OS metadata from slipping into newly-tracked `dist/` directories.
+- **D3** — Workflow header now documents implicit `python3` runtime dependency (provided by `ubuntu-latest` default).
+
 ### Tests
 
-1054 → **1068** (+14):
-- `tests/marketplace-manifest.test.js` — generator unit + on-disk stale detection + dist skeleton existence
+1054 → **1074** (+20):
+- `tests/marketplace-manifest.test.js` — generator unit (11) + on-disk stale detection (1) + dist skeleton + hardened workflow regex assertions + `deepEqualJson` (6)
 
 ### Distribution channels NOT in this release
 

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -8,16 +8,20 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [1.30.1] - 2026-05-19
 
+> npm yayini oncesi review-tabanli iyilestirmeler dahildir (asagida `### Iyilestirmeler (PR #185 sonrasi ic review)` bolumune bakin). 9 review bulgusu ayni surumde kapali.
+
 ### Eklendi — Coklu kanal dagitim mirror'lari
 
-Badi artik ayni npm tarball'i mirror'layan **4 kanaldan** yuklenebilir:
+Badi artik **2 canli kanal + 2 hazirlik asamasinda kanal** (`dist/` icinde iskelet, tap/bucket repo'lari beklemede):
 
 ```bash
-npm i -g @fatihkan/badi                                       # birincil (canonical)
-/plugin install fatihkan/badi                                 # Claude Code marketplace
-brew tap fatihkan/badi && brew install badi                   # Homebrew (macOS/Linux)
-scoop bucket add badi <repo> && scoop install badi            # Scoop (Windows)
+npm i -g @fatihkan/badi                                       # birincil (canonical) ✅ canli
+/plugin install fatihkan/badi                                 # Claude Code marketplace ✅ canli
+brew tap fatihkan/badi && brew install badi                   # Homebrew (macOS/Linux) ⏳ yakinda
+scoop bucket add badi <repo> && scoop install badi            # Scoop (Windows) ⏳ yakinda
 ```
+
+Homebrew tap (`fatihkan/homebrew-badi`) ve Scoop bucket (`fatihkan/scoop-bucket`) repo'lari **henuz acilmadi**; bu surum manifest iskeletlerini ve CI workflow'unu icerir. O repo'lar olusturulana kadar npm veya Claude Code marketplace kullanin.
 
 - **`.claude-plugin/plugin.json` + `marketplace.json`** v1.30.0 gercegine senkronlandi (v1.16.5'ten beri stale — 21 → 22 ajan, .sh → .mjs hook'lar, `./.claude/skills-vault` isaret eden `skills` alani eklendi, yeni plan-inject hook icin UserPromptSubmit hook bloku eklendi).
 - **`dist/homebrew/badi.rb`** — npm-backed Homebrew formula iskeleti. Sha256 npm publish sonrasi release workflow tarafindan doldurulur.
@@ -48,10 +52,31 @@ Stale-bloku sayesinde her npm publish, package ile gercekten eslesen marketplace
 - `lib/data/marketplace-manifest.js` — generator + staleness checker (`buildPluginManifest`, `buildMarketplaceManifest`, `collectAgents`, `countHooks`, `countCommands`, `countSkillCategories`, `isManifestStale`, `writeManifests`). Pure functions; deterministic output.
 - `lib/commands/release.js` — `checkMarketplaceManifest` `CHECKS` array'ine eklendi; `runSyncManifest` yeni subcommand olarak eklendi.
 
+### Iyilestirmeler (PR #185 sonrasi ic review)
+
+Yayin oncesi hotfix — 9 review bulgu kapali:
+
+**Guvenlik**
+- **K1** — Workflow'da `${{ inputs.version }}` ve `${{ steps.X.outputs.* }}` artik shell script'lerine direkt akmiyor. Tum kullanici-kontrolu degerler `env:` blogu uzerinden gecirilip shell icinde `$VAR` olarak quoted referansla kullaniliyor. `workflow_dispatch` inputs uzerinden shell injection'a karsi koruma (collaborator hesabi compromise olsa bile). Ayrica version semver dogrulamasindan geciyor.
+- **Y1** — Git operasyonlari `DIST_PUBLISH_TOKEN`'i clone URL'ine gomerken (`https://x-access-token:$TOKEN@...`) artik `http.https://github.com/.extraHeader` ile `Authorization: Basic <base64(x-access-token:$TOKEN)>` header'i injekte ediyor. Token git URL'lerinde, hata log'larinda, process listing'lerde gozukmuyor.
+- **O2** — Bot commit'leri artik GitHub Actions standart kimligini kullaniyor (`github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>` — verified-bot uygun) eskiden `noreply@github.com` jenerikti.
+
+**Dogruluk**
+- **O3** — Marketplace manifest staleness kontrolu artik `JSON.stringify` yerine recursive `deepEqualJson` kullaniyor. Elle duzenlenmis veya farkli formatlanmis JSON dosyalari ayni semantic icerige sahipse "stale" raporlanmiyor. Generator ciktisi hala deterministik; bu sadece kullanici-kaynakli key sirasi degisikliklerinde olusan false-positive'i temizliyor.
+- **D2** — Scoop installer script'i `npm install` basarisizliginda (`$LASTEXITCODE -ne 0`) ve install sonrasi `badi` binary'si bulunamadiginda `throw` ediyor. Eskiden `Write-Error` kullanilyordu — exit kodunu degistirmiyordu, Scoop basarili olarak gosteriyordu.
+
+**Dokuman**
+- **Y2** — `README.md` install matrix'ine **Status** kolonu eklendi. Homebrew ve Scoop satirlari mirror repo'lari (`fatihkan/homebrew-badi`, `fatihkan/scoop-bucket`) olusturulana kadar `⏳ Coming soon (tap/bucket repo setup pending)` gosteriyor. CHANGELOG girdisi de in-progress durumunu notlandiriyor.
+
+**Kalite**
+- **O1** — `lib/data/marketplace-manifest.js`'den kullanilmayan `statSync` import'u kaldirildi.
+- **D1** — `.gitignore` artik proje kokunde `.DS_Store` (macOS) ve `Thumbs.db` (Windows) kapsiyor. Yeni track edilen `dist/` dizinlerine OS metadata sizinmasi engellenir.
+- **D3** — Workflow header'i implicit `python3` runtime bagimliligini dokumante ediyor (`ubuntu-latest` default'undan gelir).
+
 ### Test
 
-1054 → **1068** (+14):
-- `tests/marketplace-manifest.test.js` — generator unit + disk stale tespiti + dist skeleton mevcudiyeti
+1054 → **1074** (+20):
+- `tests/marketplace-manifest.test.js` — generator unit (11) + disk stale tespiti (1) + dist skeleton + hardened workflow regex assertion'lari + `deepEqualJson` (6)
 
 ### Bu surumde olmayan dagitim kanallari
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@
 
 ## Install Options (v1.30.1+)
 
-| Channel | Command | Notes |
-|---------|---------|-------|
-| **npm** (primary) | `npm i -g @fatihkan/badi` | All features; canonical |
-| **Claude Code marketplace** | `/plugin install fatihkan/badi` | Drops in agents/commands/hooks/skills without npm |
-| **Homebrew** (macOS / Linux) | `brew tap fatihkan/badi && brew install badi` | Wraps the npm tarball |
-| **Scoop** (Windows) | `scoop bucket add badi https://github.com/fatihkan/scoop-bucket && scoop install badi` | Wraps the npm tarball |
+| Channel | Command | Status |
+|---------|---------|--------|
+| **npm** (primary) | `npm i -g @fatihkan/badi` | ✅ Live |
+| **Claude Code marketplace** | `/plugin install fatihkan/badi` | ✅ Live (manifest in repo) |
+| **Homebrew** (macOS / Linux) | `brew tap fatihkan/badi && brew install badi` | ⏳ Coming soon (tap repo setup pending) |
+| **Scoop** (Windows) | `scoop bucket add badi https://github.com/fatihkan/scoop-bucket && scoop install badi` | ⏳ Coming soon (bucket repo setup pending) |
 
-Source of truth: npm. Other channels mirror the same `@fatihkan/badi-<version>.tgz`. Sha256/hashes are populated by the release workflow (`.github/workflows/dist-publish.yml`). See [`dist/README.md`](dist/README.md) for tap/bucket setup details.
+Source of truth: npm. Other channels mirror the same `@fatihkan/badi-<version>.tgz`. Sha256/hashes are populated by the release workflow (`.github/workflows/dist-publish.yml`). Homebrew and Scoop channels are skeletoned in [`dist/`](dist/README.md) but the **tap/bucket mirror repos (`fatihkan/homebrew-badi`, `fatihkan/scoop-bucket`) are not yet created** — until then, use npm or the Claude Code marketplace.
 
 ## One-Command Install
 

--- a/dist/scoop/badi.json
+++ b/dist/scoop/badi.json
@@ -10,10 +10,12 @@
 	"hash": "REPLACE_AT_RELEASE_TIME",
 	"extract_dir": "package",
 	"installer": {
+		"_comment_": "v1.30.1+ D2 fix: throw on npm install failure or missing binary (Write-Error did not change exit code).",
 		"script": [
 			"npm install --location=global \"$dir\"",
+			"if ($LASTEXITCODE -ne 0) { throw 'npm install failed (exit ' + $LASTEXITCODE + ')' }",
 			"$badiCmd = (Get-Command badi -ErrorAction SilentlyContinue).Source",
-			"if (-not $badiCmd) { Write-Error 'badi binary not found after npm install' }"
+			"if (-not $badiCmd) { throw 'badi binary not found in PATH after npm install' }"
 		]
 	},
 	"uninstaller": {

--- a/lib/data/marketplace-manifest.js
+++ b/lib/data/marketplace-manifest.js
@@ -13,7 +13,6 @@ import {
 	existsSync,
 	readdirSync,
 	readFileSync,
-	statSync,
 	writeFileSync,
 } from "node:fs";
 import { join, relative } from "node:path";
@@ -208,6 +207,34 @@ export function buildMarketplaceManifest({ pkg, claudeDir }) {
 }
 
 /**
+ * Iki JSON-saf objeyi sirali kiyaslar (key-order'a duyarsiz, recursive).
+ * v1.30.1 review O3 fix: stale-check eskiden JSON.stringify ile karsilastiriyordu;
+ * kullanici editor JSON formatlamasi key sirasini bozdugunda yanlis "stale"
+ * raporluyordu. Bu deep-equal calistirmasi icerigi semantically kiyaslar.
+ */
+export function deepEqualJson(a, b) {
+	if (a === b) return true;
+	if (a === null || b === null) return a === b;
+	if (typeof a !== "object" || typeof b !== "object") return false;
+	if (Array.isArray(a) !== Array.isArray(b)) return false;
+	if (Array.isArray(a)) {
+		if (a.length !== b.length) return false;
+		for (let i = 0; i < a.length; i++) {
+			if (!deepEqualJson(a[i], b[i])) return false;
+		}
+		return true;
+	}
+	const ka = Object.keys(a).sort();
+	const kb = Object.keys(b).sort();
+	if (ka.length !== kb.length) return false;
+	for (let i = 0; i < ka.length; i++) {
+		if (ka[i] !== kb[i]) return false;
+		if (!deepEqualJson(a[ka[i]], b[ka[i]])) return false;
+	}
+	return true;
+}
+
+/**
  * Stale check — disk'teki manifest, generator ciktisi ile esit mi?
  * Returns { stale: bool, missing: bool, reason?: string }
  */
@@ -220,12 +247,12 @@ export function isManifestStale({ pluginDir, generated }) {
 	} catch (e) {
 		return { stale: true, missing: false, reason: `parse: ${e.message}` };
 	}
-	const a = JSON.stringify(current);
-	const b = JSON.stringify(generated);
+	// O3 fix: deep-equal (key-order bagimsiz) JSON.stringify yerine.
+	const equal = deepEqualJson(current, generated);
 	return {
-		stale: a !== b,
+		stale: !equal,
 		missing: false,
-		reason: a === b ? null : "icerik farkli",
+		reason: equal ? null : "icerik farkli",
 	};
 }
 

--- a/tests/marketplace-manifest.test.js
+++ b/tests/marketplace-manifest.test.js
@@ -17,9 +17,47 @@ const {
 	countCommands,
 	countHooks,
 	countSkillCategories,
+	deepEqualJson,
 	isManifestStale,
 	writeManifests,
 } = await import("../lib/data/marketplace-manifest.js");
+
+describe("deepEqualJson (key-order insensitive)", () => {
+	it("identical primitives", () => {
+		assert.ok(deepEqualJson(1, 1));
+		assert.ok(deepEqualJson("x", "x"));
+		assert.ok(deepEqualJson(null, null));
+		assert.ok(!deepEqualJson(null, undefined));
+		assert.ok(!deepEqualJson(1, "1"));
+	});
+
+	it("arrays element-wise", () => {
+		assert.ok(deepEqualJson([1, 2, 3], [1, 2, 3]));
+		assert.ok(!deepEqualJson([1, 2], [1, 2, 3]));
+		assert.ok(!deepEqualJson([1, 2, 3], [3, 2, 1])); // order matters in arrays
+	});
+
+	it("objects key-order insensitive (O3 fix kernel)", () => {
+		const a = { x: 1, y: 2, z: 3 };
+		const b = { z: 3, x: 1, y: 2 };
+		assert.ok(deepEqualJson(a, b));
+	});
+
+	it("nested object key-order insensitive", () => {
+		const a = { outer: { x: 1, y: 2 }, list: [{ p: 1, q: 2 }] };
+		const b = { list: [{ q: 2, p: 1 }], outer: { y: 2, x: 1 } };
+		assert.ok(deepEqualJson(a, b));
+	});
+
+	it("differing values fail", () => {
+		assert.ok(!deepEqualJson({ x: 1 }, { x: 2 }));
+		assert.ok(!deepEqualJson({ x: 1 }, { y: 1 }));
+	});
+
+	it("array vs object reject", () => {
+		assert.ok(!deepEqualJson([], {}));
+	});
+});
 
 describe("marketplace-manifest generator", () => {
 	it("collectAgents alfabetik dizi doner", () => {
@@ -166,13 +204,28 @@ describe("dist/ multi-package skeletons exist", () => {
 		assert.ok(m.version);
 		assert.equal(m.license, "MIT");
 		assert.equal(m.bin, "badi");
+		// v1.30.1+ D2 fix: installer script `throw` ile hard-fail eder
+		const scriptText = (m.installer?.script || []).join(" ");
+		assert.match(scriptText, /throw/);
+		assert.match(scriptText, /\$LASTEXITCODE/);
 	});
 
-	it("dist publish workflow mevcut", () => {
+	it("dist publish workflow mevcut + hardened", () => {
 		const p = join(PKG_ROOT, ".github", "workflows", "dist-publish.yml");
 		assert.ok(existsSync(p));
 		const body = readFileSync(p, "utf-8");
 		assert.match(body, /workflow_dispatch/);
 		assert.match(body, /permissions:/);
+		// v1.30.1+ K1 fix: env: pattern (no direct ${{ }} -> shell)
+		assert.match(body, /env:\s*\n\s+INPUT_VERSION:/);
+		assert.match(body, /env:\s*\n\s+VERSION:/);
+		// v1.30.1+ Y1 fix: Authorization header, NOT URL-embedded token
+		assert.match(body, /http\.https:\/\/github\.com\/\.extraHeader/);
+		assert.doesNotMatch(
+			body,
+			/https:\/\/x-access-token:\$\{DIST_PUBLISH_TOKEN\}@github\.com/,
+		);
+		// v1.30.1+ O2 fix: GitHub Actions bot suffix
+		assert.match(body, /github-actions\[bot\]@users\.noreply\.github\.com/);
 	});
 });


### PR DESCRIPTION
## Summary

PR #185 sonrasi internal `/review` 9 bulgu tespit etti. npm yayini oncesi hepsi ayni v1.30.1 surumunde kapatildi. **Davranis degisikligi yok** (sadece security/correctness/doc); kullanicilar etkilenmez.

| Sev | Code | Konu | Cozum |
|-----|------|------|-------|
| **KRITIK** | K1 | Workflow shell injection (`${{ inputs.* }}` → shell) | `env:` blok pass-through + quoted `$VAR` + semver validation |
| YUKSEK | Y1 | git token URL'e gomulu | `http.extraHeader` Authorization Basic |
| YUKSEK | Y2 | README var olmayan tap/bucket reklam ediyordu | "⏳ Coming soon" status sutunu |
| ORTA | O1 | unused statSync import | sildim |
| ORTA | O2 | Generic noreply@github.com bot email | `41898282+github-actions[bot]@users.noreply.github.com` |
| ORTA | O3 | isManifestStale JSON.stringify key-order bagimli | deepEqualJson (recursive, sorted-keys) |
| DUSUK | D1 | `.DS_Store`/`Thumbs.db` dist/ exception'larina sizar | `.gitignore` global ignore |
| DUSUK | D2 | Scoop Write-Error exit code degistirmez | `throw` + `$LASTEXITCODE` check |
| DUSUK | D3 | python3 implicit dep dokumante degil | workflow header notu |

## K1 detayi (en kritik)

Eski (vulnerable): `${{ steps.ver.outputs.version }}` YAML parse-time inline ediliyordu. `inputs.version = "1.30.1$(rm -rf $HOME)"` runner'da arbitrary code execution.

Yeni (hardened): `env: VERSION:` pass-through + shell icinde quoted `"$VERSION"`. Ekstra defense-in-depth: input semver regex validation.

## Y1 detayi (token leak fix)

Eski: `git clone https://x-access-token:${TOKEN}@github.com/...` → token git error log, `set -x`, crash dump'inda sizabilir.

Yeni: `git -c http.https://github.com/.extraHeader="Authorization: Basic <base64>" clone https://...` — token config'te kalir, URL/log'a girmez.

## Test plan

- [x] `npm test` — 1068 → 1074 (+6 deepEqualJson tests)
- [x] `badi doctor help` — 0 drift
- [x] `badi release sync-manifest` smoke (regenerate manifest)
- [x] `badi release check` smoke (plugin.json guncel OK + new fail-on-stale)
- [x] Workflow YAML manuel review (workflow_dispatch only, opt-in)

## Notlar

- v1.30.1 etiketi korunuyor (yayinlanmadi, ic-review trade-off v1.30 ile ayni pattern)
- CHANGELOG: `### Refinements (post-#185 internal review)` alt-section eklendi (EN+TR)
- Workflow K1+Y1+O2+D3'u tek pass'te yeniden yazdim; daha az diff noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)
