### PR TITLE
feat(v1.31.0): Anthropic 2.1.126-147 uyum — security orchestration + /review parity + hook isolation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,7 +34,8 @@
 				"code-review"
 			],
 			"category": "productivity",
-			"strict": true
+			"strict": true,
+			"lastUpdated": "2026-05-19T11:18:19+03:00"
 		}
 	]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
 	"name": "badi",
-	"version": "1.30.0",
+	"version": "1.30.1",
 	"description": "Workflow management for Claude Code, Cursor, Gemini, Windsurf, AGENTS.md — 22 AI agents, 77 commands, 14 hooks, 62 opt-in skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
 	"author": {
 		"name": "Fatih Kan",
@@ -84,5 +84,6 @@
 				]
 			}
 		]
-	}
+	},
+	"lastUpdated": "2026-05-19T11:18:19+03:00"
 }

--- a/.claude/commands-vault/review.md
+++ b/.claude/commands-vault/review.md
@@ -20,6 +20,11 @@ Derin kod incelemesi komutu. Guvenlik, performans ve mimari boyutlariyla kapsaml
 
 ### Adim 0: Argument Parse + Effort & Mod Belirle (v1.31.0+)
 
+> **Not**: Bu komut Claude tarafindan **prompt baglaminda yorumlanir** — kod-bazli
+> argument parsing yok. Asagidaki argumanlar Claude'a "review high --comment"
+> formatinda gelir, Claude prosedurde belirtilen davranisi uygular.
+
+
 Komut argumanlari:
 - `effort` (positional): `low` | `medium` | `high`
   - `low`: yalniz KRITIK + YUKSEK bulgu; performans/mimari kanallarini hizli tara

--- a/.claude/commands-vault/review.md
+++ b/.claude/commands-vault/review.md
@@ -1,15 +1,36 @@
 Derin kod incelemesi komutu. Guvenlik, performans ve mimari boyutlariyla kapsamli kod analizi yapar.
 
+> **Argument formati (v1.31.0+)**: `/review [effort] [--comment] [--correctness-only]`
+> - `effort`: `low` | `medium` (default) | `high` — analiz derinligi
+> - `--comment`: bulgulari aktif PR'a inline yorum olarak post et (gh CLI gerekir)
+> - `--correctness-only`: yalniz correctness bug'larina odaklan (mimari/perf/guvenlik kanallarini atla)
+
+> **Anthropic native `/code-review` (Claude Code 2.1.147+) farki:**
+> - `/code-review`: correctness bug + effort tuning + `--comment` (native English render)
+> - `/review` (badi): yukaridakilerin **superset**'i — 3 kanal (guvenlik+perf+mimari) + TR rapor + classification
+> - Kombine kullanim: `/code-review high --comment` (logic) sonra `/review high --comment` (mimari/perf/guvenlik)
+
 # Gerekli Araclar
 - Read (kod okuma)
 - Grep (kalip arama)
 - Glob (dosya taramasi)
-- Bash (git diff, analiz araclari)
+- Bash (git diff, gh CLI inline PR comment, analiz araclari)
 
-# Prosedur (4 Adim)
+# Prosedur (4 Adim + opsiyonel PR Comment)
+
+### Adim 0: Argument Parse + Effort & Mod Belirle (v1.31.0+)
+
+Komut argumanlari:
+- `effort` (positional): `low` | `medium` | `high`
+  - `low`: yalniz KRITIK + YUKSEK bulgu; performans/mimari kanallarini hizli tara
+  - `medium` (default): mevcut davranis — KRITIK + YUKSEK + ORTA siniflari
+  - `high`: tum siniflar (KRITIK/YUKSEK/ORTA/DUSUK) + olumlu gozlemler + alternative cozumler
+- `--comment`: Adim 5'i etkinlestir (PR inline comment)
+- `--correctness-only`: Adim 3'te yalniz Kanal A guvenlik + correctness bug'larina odaklan, Kanal B (performans) + Kanal C (mimari) atla
 
 ### Adim 1: Kapsam Tanimla
 Incelenecek kodu belirle:
+- **Aktif PR (auto-detect)**: `gh pr view --json number,baseRefName,headRefName` ile mevcut branch'in PR'i tespit edilir. Varsa scope otomatik PR diff'i (`gh pr diff <num>`).
 - **PR/Commit:** `git diff` ciktisini al (branch veya commit hash ile)
 - **Dosya:** Belirli dosya veya dosyalar
 - **Modul:** Bir ozellik veya modul dizini
@@ -26,7 +47,7 @@ Kapsam bilgisini kaydet:
 - Ilgili test dosyalarini bul ve oku
 - Etkilenen API'leri veya arayuzleri kontrol et
 
-### Adim 3: Paralel Analiz (3 Kanal)
+### Adim 3: Paralel Analiz (3 Kanal — `--correctness-only` ile Kanal B+C atlanir)
 
 **Kanal A: Guvenlik Analizi**
 - Girdi dogrulama eksiklikleri
@@ -81,6 +102,32 @@ Her bulguyu su seviyelere ata:
 - Stil tercihleri
 - Dokumantasyon iyilestirmeleri
 - Gelecek refactoring firsatlari
+
+### Adim 5 (opsiyonel): PR Inline Comment (`--comment`)
+
+`--comment` flag ile birlikte calistirildiginda, bulgular aktif PR'a inline yorum olarak post edilir. gh CLI gerekir.
+
+**On kontroller:**
+1. `gh` PATH'te mi: `which gh`
+2. Aktif branch'in PR'i var mi: `gh pr view --json number,headRefName` (yoksa hata: "PR bulunamadi. /review --comment yalniz PR icindeyken calisir")
+3. Yetki kontrolu: `gh auth status`
+
+**Yorum yazimi (her KRITIK + YUKSEK bulgu icin):**
+```bash
+gh api repos/:owner/:repo/pulls/<num>/comments \
+  --method POST \
+  --field body="<bulgu_aciklamasi>" \
+  --field path="<dosya_yolu>" \
+  --field line=<satir_no> \
+  --field side="RIGHT"
+```
+
+**Ozet yorum (PR description'a):**
+```bash
+gh pr comment <num> --body "$(badi review --format markdown-summary)"
+```
+
+Cikti: KRITIK N | YUKSEK N | ORTA N | DUSUK N + onerilen action (merge OK / revize / red).
 
 # Cikti Formati
 ```

--- a/.claude/commands-vault/secret-scan.md
+++ b/.claude/commands-vault/secret-scan.md
@@ -1,5 +1,7 @@
 Proje genelinde sir/credential taramasi komutu. AWS/GCP/GitHub/npm/Stripe/OpenAI/Anthropic anahtarlari, JWT, database URI'leri, private key'ler.
 
+> **Daha genis kapsam icin**: `badi security baseline` (secret-scan + npm audit), `/security-review` (Anthropic native AI semantic — Claude Code 2.1.140+).
+
 # Gerekli Araclar
 - Bash (badi secret-scan komutu cagirisi)
 

--- a/.claude/commands-vault/security-scan.md
+++ b/.claude/commands-vault/security-scan.md
@@ -1,5 +1,13 @@
 Guvenlik taramasi. Kod tabani ve bagimliliklarda guvenlik aciklari arar ve ciddiyet siralmasili rapor olusturur.
 
+> **Native komut (v1.31.0+)**: Claude Code 2.1.140+ ile `/security-review` artik **native** komut (built-in slash). Bu komut onun yaninda **deterministic baseline** (`badi security baseline`) + **post-scan triage** (`badi security triage`) saglar.
+>
+> **Onerilen akis**:
+> 1. `badi security baseline` — sirlar + bagimliliklar (deterministic)
+> 2. `/security-review` — AI semantic vulnerability hunt (Anthropic native)
+> 3. `badi security triage` — rapor severity filtreleme
+> 4. CI: `badi security init --ci` — PR'larda otomatik review
+
 ## Badi CLI Komutlari (v1.6+)
 Bu komut ilk olarak su CLI araclarini cagirir:
 - `badi secret-scan` — 17 pattern sir/credential taramasi (AWS, GCP, GitHub, OpenAI, Stripe, DB URI'leri, private keys)

--- a/.claude/hooks/dependency-audit.mjs
+++ b/.claude/hooks/dependency-audit.mjs
@@ -62,9 +62,13 @@ try {
 }
 
 // Cache kontrolu (24 saat + lock dosyasi hash)
+// v1.31.0+ D1 hotfix: cache'e lastInjectedAt eklendi — audit cache'i taze ama
+// inject mesaji 1 saatten yeni ise tekrar inject etme (Claude context noise azalt).
+let cachedInjectAt = 0;
 if (existsSync(cacheFile)) {
 	try {
 		const cache = JSON.parse(readFileSync(cacheFile, "utf-8"));
+		cachedInjectAt = cache.lastInjectedAt || 0;
 		if (cache.lastCheck && cache.lockHash === lockHash) {
 			const cachedEpoch = new Date(cache.lastCheck).getTime();
 			const diff = Date.now() - cachedEpoch;
@@ -113,7 +117,11 @@ try {
 	/* audit basarisiz, sayilari 0 birak */
 }
 
-// Cache kaydet
+// D1 hotfix: inject mesaji 1 saatten genc ise context noise olusturmamak icin skip
+const shouldInject = Date.now() - cachedInjectAt > 3600 * 1000;
+const nowMs = Date.now();
+
+// Cache kaydet (lastInjectedAt yalniz inject ettigimizde guncellenir)
 writeFileSync(
 	cacheFile,
 	`${JSON.stringify({
@@ -122,6 +130,8 @@ writeFileSync(
 		critical,
 		high,
 		manager,
+		lastInjectedAt:
+			shouldInject && (critical > 0 || high > 0) ? nowMs : cachedInjectAt,
 	})}\n`,
 	"utf-8",
 );
@@ -135,6 +145,7 @@ appendLog(
 // Bulgu sayilari icin Claude'a additionalContext inject et
 // (v1.31.0 fix: Anthropic 2.1.139 hook terminal-isolation uyumu —
 //  eski plain text stdout context'e girmiyordu, terminal'e yaziyordu).
+// D1 hotfix: 1 saatten yeni mesaj varsa tekrar inject etme.
 if (critical > 0) {
 	appendLog(
 		logPath("incident-log.md"),
@@ -144,10 +155,12 @@ if (critical > 0) {
 			`${critical} kritik guvenlik acigi`,
 		),
 	);
-	writeContextInjection(
-		`[badi:dependency-audit] UYARI: ${critical} kritik guvenlik acigi tespit edildi. Duzeltmek icin: \`${manager} audit fix\``,
-	);
-} else if (high > 0) {
+	if (shouldInject) {
+		writeContextInjection(
+			`[badi:dependency-audit] UYARI: ${critical} kritik guvenlik acigi tespit edildi. Duzeltmek icin: \`${manager} audit fix\``,
+		);
+	}
+} else if (high > 0 && shouldInject) {
 	writeContextInjection(
 		`[badi:dependency-audit] Bilgi: ${high} yuksek oncelikli guvenlik acigi. Detay: \`${manager} audit\``,
 	);

--- a/.claude/hooks/dependency-audit.mjs
+++ b/.claude/hooks/dependency-audit.mjs
@@ -26,6 +26,7 @@ import {
 	logPath,
 	projectRoot,
 	timestamp,
+	writeContextInjection,
 } from "./_util.mjs";
 
 const root = projectRoot();
@@ -131,10 +132,10 @@ appendLog(
 	`- \`${ts}\` | ${manager} | Kritik: ${critical} | Yuksek: ${high}`,
 );
 
+// Bulgu sayilari icin Claude'a additionalContext inject et
+// (v1.31.0 fix: Anthropic 2.1.139 hook terminal-isolation uyumu —
+//  eski plain text stdout context'e girmiyordu, terminal'e yaziyordu).
 if (critical > 0) {
-	process.stdout.write(
-		`UYARI: ${critical} kritik guvenlik acigi! Duzelt: ${manager} audit fix\n`,
-	);
 	appendLog(
 		logPath("incident-log.md"),
 		incidentLine(
@@ -143,9 +144,12 @@ if (critical > 0) {
 			`${critical} kritik guvenlik acigi`,
 		),
 	);
+	writeContextInjection(
+		`[badi:dependency-audit] UYARI: ${critical} kritik guvenlik acigi tespit edildi. Duzeltmek icin: \`${manager} audit fix\``,
+	);
 } else if (high > 0) {
-	process.stdout.write(
-		`Bilgi: ${high} yuksek oncelikli guvenlik acigi. Detay: ${manager} audit\n`,
+	writeContextInjection(
+		`[badi:dependency-audit] Bilgi: ${high} yuksek oncelikli guvenlik acigi. Detay: \`${manager} audit\``,
 	);
 }
 

--- a/.claude/hooks/post-compact-resume.mjs
+++ b/.claude/hooks/post-compact-resume.mjs
@@ -16,7 +16,7 @@ process.on("unhandledRejection", _badiFailSafe);
 
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { projectRoot } from "./_util.mjs";
+import { projectRoot, writeContextInjection } from "./_util.mjs";
 
 const root = projectRoot();
 const marker = join(root, ".claude", ".compaction-occurred");
@@ -45,13 +45,15 @@ for (const f of [
 	}
 }
 
-process.stdout.write(`Sikistirma sonrasi devam (${compactTime}).
-
-Baglami yeniden yuklemek icin:
-1. .claude/memory.md dosyasini oku
-2. En son Gunluk Notu oku
-3. Devam eden gorev uzerinde calismaya devam et
-
-Oncelik: Yarida kalan islemleri tamamla.
-`);
+// v1.31.0 fix: Anthropic 2.1.139 hook terminal-isolation uyumu.
+// Eski plain text stdout SessionStart context'e girmiyordu; additionalContext
+// JSON protocol ile inject edilir.
+writeContextInjection(
+	`[badi:post-compact-resume] Sikistirma sonrasi devam (${compactTime}).\n\n` +
+		"Baglami yeniden yuklemek icin:\n" +
+		"1. .claude/memory.md dosyasini oku\n" +
+		"2. En son Gunluk Notu oku\n" +
+		"3. Devam eden gorev uzerinde calismaya devam et\n\n" +
+		"Oncelik: Yarida kalan islemleri tamamla.",
+);
 process.exit(0);

--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -3,6 +3,9 @@
 ## Mevcut Durum
 - Proje: Badi - Claude Code Is Akisi Yonetim Sistemi
 - npm: @fatihkan/badi v1.30.1 (yayinda) — 19.05.2026 marketplace sync + multi-channel dist + 9 hotfix bulgu
+- **Aktif gelistirme**: v1.31.0 (Anthropic 2.1.126-2.1.147 uyum) — feat/v1.31.0-anthropic-2.1-compat branch'i
+  - Issue'lar: #188 (/security-review entegrasyon), #189 (/review parity), #190 (manifest lastUpdated), #191 (CI scaffold), #192 (hook isolation audit)
+  - v1.30.2 install UX rafa kaldirildi (kullanici karari, 22.05.2026)
 - Tests: 1074 (Linux+macOS yesil; Windows non-blocking)
 - Marketplace: .claude-plugin/{plugin,marketplace}.json v1.30.1 ile senkron (badi release sync-manifest komutu ile)
 - Dagitim kanallari: npm (✅) + Claude Code marketplace (✅) + Homebrew (⏳ tap repo pending) + Scoop (⏳ bucket repo pending)

--- a/.claude/skills-vault/security-check/SKILL.md
+++ b/.claude/skills-vault/security-check/SKILL.md
@@ -17,6 +17,12 @@ metadata:
 
 > Your AI Becomes a Security Team. Every Language. Every Layer. Zero Tools.
 
+> **Entry points (v1.31.0+)**:
+> - `/security-review` — Anthropic native komut (Claude Code 2.1.140+, AI semantic)
+> - `badi security baseline` — deterministic baseline (secret-scan + audit)
+> - `badi security triage` — /security-review rapor severity filtreleme
+> - Bu skill: `sc-orchestrator` 4-fazli pipeline (Recon → Hunt → Verify → Report)
+
 ## What This Skill Does
 
 security-check transforms your AI coding assistant into a comprehensive security scanning team.

--- a/.claude/workspace/TaskBoard.md
+++ b/.claude/workspace/TaskBoard.md
@@ -19,4 +19,8 @@
 - [ ] #9 (P3) feat(ui): badi serve - lokal web dashboard
 
 ## Tamamlanan
-- (henuz yok)
+- 22.05.2026 (Cuma): #192 hook isolation audit (15 hook, 2 fix) — PR #193
+- 22.05.2026: #188 /security-review entegrasyon + badi security CLI — PR #193
+- 22.05.2026: #189 /review effort + --comment + --correctness-only parity — PR #193
+- 22.05.2026: #190 marketplace manifest lastUpdated (2.1.144+ uyumu) — PR #193
+- 22.05.2026: #191 CI scaffold (anthropics/claude-code-security-review wrap) — PR #193

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ dist/*
 !dist/homebrew
 !dist/scoop
 !dist/README.md
+# v1.31.0+ GitHub Actions templates (security-review scaffold)
+!dist/github-actions
 build/
 *.tgz
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,98 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [1.31.0] - 2026-05-22
+
+> Anthropic Claude Code 2.1.126-2.1.147 (May 1-22, 2026) compatibility release. Adds `/security-review` (built-in slash command in 2.1.140+) bridge, `/code-review` (2.1.147+) feature-parity, hook terminal-isolation audit (2.1.139+), marketplace manifest `lastUpdated` field (2.1.144+), and a GitHub Action scaffold wrapping Anthropic's official `claude-code-security-review`.
+
+### Added — Security orchestration (`badi security`)
+
+New CLI command bridging Anthropic's native `/security-review` (built-in in Claude Code 2.1.140+) with badi's deterministic baseline + CI scaffold:
+
+```bash
+badi security baseline [--json]      # secret-scan + npm audit deterministic taban
+badi security triage [report]        # /security-review raporu severity'ye gore filtrele
+badi security init --ci [--force]    # GitHub Action scaffold (.github/workflows/security-review.yml)
+```
+
+Badi yapmaz: AI semantic vulnerability hunt — bu Anthropic native `/security-review` tarafindan yapilir. Badi koprusu: deterministic baseline + post-scan triage + CI orkestrasyon.
+
+Skill/slash cross-ref'leri eklendi: `security-scan.md`, `secret-scan.md`, `security-check/SKILL.md` artik `/security-review` native komutunu entry point olarak gosteriyor.
+
+### Added — `/review` feature parity (Anthropic `/code-review` 2.1.147+)
+
+`.claude/commands-vault/review.md` argument formati genisletildi:
+
+- `effort`: `low` | `medium` (default) | `high` — analiz derinligi
+- `--comment`: aktif PR'a inline yorum olarak post et (gh CLI uzerinden)
+- `--correctness-only`: yalniz correctness bug'larina odaklan (Kanal B+C atla)
+- Auto PR context: `gh pr view` ile aktif branch'in PR'i tespit edilir
+
+Badi `/review` Anthropic `/code-review`'un **superset**'i — 3 kanal (guvenlik+performans+mimari) + TR rapor + KRITIK/YUKSEK/ORTA/DUSUK classification + effort tuning + `--comment` + `--correctness-only`.
+
+### Added — Plugin marketplace `lastUpdated` (Anthropic 2.1.144+)
+
+`lib/data/marketplace-manifest.js`:
+- `lastPackageJsonCommitDate()` — `git log -1 --format=%cI -- package.json` ile son version bump tarihi (ISO 8601)
+- `buildPluginManifest()` ve `buildMarketplaceManifest()` `lastUpdated` field uretir
+- Anthropic Claude Code 2.1.144+ `/plugin` Browse pane'inde plugin son guncelleme zamani gozukur
+
+`badi release sync-manifest` otomatik gunceller; bos string ise field eklenmez (CI clone'larda git yoksa stale-check uyumu).
+
+### Added — GitHub Action scaffold (`dist/github-actions/security-review.yml`)
+
+Opt-in workflow template:
+- Anthropic resmi `anthropics/claude-code-security-review` action wrap
+- `permissions: pull-requests: write, contents: read`
+- `ANTHROPIC_API_KEY` secret ref (input degil)
+- Badi-spesifik default exclude'lar: `node_modules, coverage, dist, _bootstrap, .claude/skills-vault, .claude/commands-vault`
+- `pull_request` (head SHA) — `pull_request_target` DEGIL (prompt injection hardening)
+- Custom prompt + FP filter opsiyonel
+
+Kurulum: `badi security init --ci` proje root'una scaffold eder.
+
+### Fixed — Hook terminal-isolation (Anthropic 2.1.139+)
+
+Anthropic Claude Code 2.1.139 (11 May 2026) hook'lari terminal access olmadan calistirmaya basladi. Badi'nin 15 hook'u (14 + `_util.mjs`) audit edildi:
+
+- **Kategori 1 (JSON output protocol / log-only)**: 13 hook — guvenli, degisiklik yok
+- **Kategori 2 (plain text stdout protokol ihlali)**: 2 hook — **FIX uygulandi**
+  - `dependency-audit.mjs`: `process.stdout.write(plain)` → `writeContextInjection()`
+  - `post-compact-resume.mjs`: `process.stdout.write(plain)` → `writeContextInjection()`
+- **Kategori 3 (terminal manipulation / ANSI)**: 0 hook — temiz
+
+Bu fix v1.31.0 oncesinde de teknik olarak yanlisi: Kategori 2 ciktilar Claude'un contextine girmiyor, terminal'e dusuyor veya kayboluyordu. Artik gercekten `additionalContext` JSON protocol ile inject ediliyor.
+
+Audit raporu: `docs/hooks/isolation-audit.md`.
+
+### Added — Documentation
+
+- **`docs/enterprise.md`** — Anthropic managed-settings uyum rehberi (`forceLoginOrgUUID`, `allowManagedDomainsOnly`, `parentSettingsBehavior`, hook isolation, plugin marketplace, telemetri, SSO, audit log)
+- **`docs/hooks/isolation-audit.md`** — 15 hook kategorize raporu + Kategori 2 fix dokumantasyonu
+- **README** "Security Notes (v1.31.0+)" bolumu:
+  - `--dangerously-skip-permissions` Claude Code 2.1.126+ scope extension uyari
+  - Hook isolation crossref
+  - Enterprise managed-settings crossref
+
+### Added — Tests
+
+54 yeni test:
+- `tests/hooks-isolation.test.js` (45 test) — her hook icin JSON-only stdout + ANSI escape yok + stderr bos
+- `tests/security.test.js` (6 test) — `badi security baseline/triage/init --ci` subcommand'lari
+- `tests/marketplace-manifest.test.js` (+3) — `lastUpdated` field + dist/github-actions scaffold dogrulama
+
+Test sayisi: 1074 → 1128.
+
+### Changed
+
+- `bin/badi.js` — `security` komutu dispatcher'a eklendi, help text'inde "Guvenlik orkestrasyonu (v1.31+)" bolumu
+- `.gitignore` — `!dist/github-actions` exception (tracked workflow template)
+- `dist/README.md` — "GitHub Action templates (v1.31.0+)" bolumu
+
+### Closes
+
+#188 (security-review entegrasyon), #189 (/review parity), #190 (marketplace lastUpdated), #191 (CI scaffold), #192 (hook isolation audit).
+
 ## [1.30.1] - 2026-05-19
 
 > Includes review-driven refinements (see `### Refinements (post-#185 internal review)` below) before npm publish. All 9 review findings closed in the same release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,26 @@ Badi `/review` Anthropic `/code-review`'un **superset**'i — 3 kanal (guvenlik+
 - `buildPluginManifest()` ve `buildMarketplaceManifest()` `lastUpdated` field uretir
 - Anthropic Claude Code 2.1.144+ `/plugin` Browse pane'inde plugin son guncelleme zamani gozukur
 
+**Stale-check semantigi**: `lastUpdated` `package.json` commit'ine bagli, her commit'te degismez — yalniz version bump'i sonrasi. Bu, `badi release check`'in "noisy stale" raporlamamasini saglar. `badi publish --version <bump>` package.json bump'i sonrasi `release sync-manifest`'i otomatik calistirir.
+
 `badi release sync-manifest` otomatik gunceller; bos string ise field eklenmez (CI clone'larda git yoksa stale-check uyumu).
+
+### Fixed — v1.31.0 internal review hotfix (13 finding)
+
+PR #193 internal `/review` 13 bulgu tespit etti, ayni release'de tum bulgular kapatildi:
+
+- **K1**: `badi security baseline` secret-scan'i calistirmiyordu (module CLI entry eksikti) — `secret-scan.js`'e CLI entry point eklendi; baseline integration testi yazildi (O1)
+- **K2**: `runTriage` regex'leri word-boundary'siz — "below/follow/yellow" gibi kelimeleri sayiyordu; `\b(...)\b` + markdown heading-first parsing
+- **Y1**: `dist/github-actions/security-review.yml` `@main` floating ref — supply chain riski; SHA-pinned (`0c6a49f...`, periyodik update)
+- **Y2**: `runBaseline` line 105 dead ternary (her iki dal ayniydi) — sadelestirildi
+- **Y3**: `runBaseline`/`runTriage` cwd-relative path — `projectRoot()` helper'i eklendi, subdirectory'den cagrida kullanim duzeldi
+- **O2**: secret-scan/npm-audit parse hatasi silent catch — kullaniciya `console.error` ile warning
+- **O3**: `tests/hooks-isolation.test.js` skill-router fixture early-exit only — tam-akis test prompt'una guncellendi
+- **O4**: `.claude/commands-vault/review.md` argument parse dokumantasyon notu — Claude'un prompt interpretation ettigini netlestir
+- **D1**: `dependency-audit.mjs` inject rate limit yok — cache'e `lastInjectedAt` eklendi, 1 saatten genc inject etmiyor (context noise azalt)
+- **D2**: `docs/enterprise.md` dead outbound link — `code.claude.com/docs/en/server-managed-settings` ile guncellendi
+- **D3**: TaskBoard 5 issue (#188-192) Tamamlanan'a tasindi
+- **D4**: Bu CHANGELOG entry — internal review hotfix kayit gecmisi
 
 ### Added — GitHub Action scaffold (`dist/github-actions/security-review.yml`)
 

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -40,7 +40,24 @@ Badi `/review` Anthropic `/code-review`'un **superset**'i: 3 kanal + TR + classi
 - `lastPackageJsonCommitDate()` — son version bump tarihi (ISO 8601)
 - Anthropic Claude Code 2.1.144+ `/plugin` Browse pane'inde son guncelleme tarihi gozukur
 
+**Stale-check semantigi**: `lastUpdated` `package.json` commit'ine bagli, her commit'te degismez — yalniz version bump sonrasi. `release check` noisy stale uretmez.
+
 `badi release sync-manifest` otomatik gunceller.
+
+### Duzeltilen — v1.31.0 internal review hotfix (13 bulgu)
+
+PR #193 internal `/review` 13 bulgu tespit etti, ayni release'de hepsi kapatildi:
+
+- **K1**: `badi security baseline` secret-scan'i calistirmiyordu — `secret-scan.js`'e CLI entry point eklendi
+- **K2**: `runTriage` regex word-boundary yok — `\b(...)\b` + markdown heading parsing
+- **Y1**: action `@main` floating ref — SHA-pinned (supply chain hardening)
+- **Y2**: `runBaseline` dead ternary kaldirildi
+- **Y3**: cwd-relative path — `projectRoot()` helper'i
+- **O1-O4**: baseline integration testi, parse warning, full-flow fixture, slash command Claude-interprets notu
+- **D1**: dependency-audit inject rate limit (1 saat)
+- **D2**: `docs/enterprise.md` dead link → `server-managed-settings`
+- **D3**: TaskBoard 5 issue tasindi
+- **D4**: Bu changelog entry
 
 ### Eklenen — GitHub Action scaffold (`dist/github-actions/security-review.yml`)
 

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,78 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+## [1.31.0] - 2026-05-22
+
+> Anthropic Claude Code 2.1.126-2.1.147 (1-22 Mayis 2026) uyum surumu. `/security-review` (2.1.140+ built-in slash) koprusu, `/code-review` (2.1.147+) feature-parity, hook terminal-isolation audit (2.1.139+), marketplace manifest `lastUpdated` (2.1.144+) ve Anthropic'in resmi `claude-code-security-review` action'ini wrap eden GitHub Action sablonu eklendi.
+
+### Eklenen — Guvenlik orkestrasyonu (`badi security`)
+
+Yeni CLI komut, Anthropic native `/security-review` (Claude Code 2.1.140+ built-in) ile badi'nin deterministic baseline + CI scaffold'unu koprular:
+
+```bash
+badi security baseline [--json]      # secret-scan + npm audit deterministic taban
+badi security triage [report]        # /security-review raporu severity'ye gore filtrele
+badi security init --ci [--force]    # GitHub Action scaffold
+```
+
+Badi yapmaz: AI semantic vulnerability hunt — bunu Anthropic native `/security-review` yapar. Badi koprusu: deterministic baseline + post-scan triage + CI orkestrasyon.
+
+Skill/slash cross-ref: `security-scan.md`, `secret-scan.md`, `security-check/SKILL.md` artik `/security-review` native komutunu entry point gosteriyor.
+
+### Eklenen — `/review` parity (Anthropic `/code-review` 2.1.147+)
+
+`.claude/commands-vault/review.md` argument formati:
+- `effort`: `low | medium (default) | high`
+- `--comment`: aktif PR'a inline yorum (gh CLI)
+- `--correctness-only`: yalniz correctness bug'larina odaklan
+- Auto PR context: `gh pr view` ile tespit
+
+Badi `/review` Anthropic `/code-review`'un **superset**'i: 3 kanal + TR + classification + effort + --comment + --correctness-only.
+
+### Eklenen — Plugin marketplace `lastUpdated` (Anthropic 2.1.144+)
+
+`lib/data/marketplace-manifest.js`:
+- `lastPackageJsonCommitDate()` — son version bump tarihi (ISO 8601)
+- Anthropic Claude Code 2.1.144+ `/plugin` Browse pane'inde son guncelleme tarihi gozukur
+
+`badi release sync-manifest` otomatik gunceller.
+
+### Eklenen — GitHub Action scaffold (`dist/github-actions/security-review.yml`)
+
+- Anthropic resmi `anthropics/claude-code-security-review` action wrap
+- `permissions: pull-requests: write, contents: read`
+- `ANTHROPIC_API_KEY` secret ref
+- Default exclude: `node_modules, coverage, dist, _bootstrap, .claude/skills-vault, .claude/commands-vault`
+- `pull_request` head SHA (prompt injection hardening)
+
+Kurulum: `badi security init --ci`.
+
+### Duzeltilen — Hook terminal-isolation (Anthropic 2.1.139+)
+
+Claude Code 2.1.139 hook'lari terminal access olmadan calistirmaya basladi. Badi'nin 15 hook'u audit edildi:
+- Kategori 1 (JSON protocol / log-only): 13 hook — guvenli
+- Kategori 2 (plain text stdout): 2 hook — **FIX** (`dependency-audit.mjs`, `post-compact-resume.mjs` → `writeContextInjection()`)
+- Kategori 3 (terminal manipulation): 0 hook
+
+Bu fix v1.31.0 oncesinde de teknik olarak yanlisi: Kategori 2 ciktilar Claude'un contextine girmiyor, terminal'e dusuyordu. Artik gercekten inject ediliyor.
+
+### Eklenen — Dokumantasyon
+
+- `docs/enterprise.md` — Anthropic managed-settings uyum rehberi
+- `docs/hooks/isolation-audit.md` — 15 hook kategorize raporu
+- README "Security Notes (v1.31.0+)" — `--dangerously-skip-permissions` uyari + crossref'ler
+
+### Eklenen — Testler
+
+54 yeni test (1074 → 1128):
+- `tests/hooks-isolation.test.js` (45): her hook JSON-only stdout + ANSI escape yok + stderr bos
+- `tests/security.test.js` (6): `badi security baseline/triage/init`
+- `tests/marketplace-manifest.test.js` (+3): `lastUpdated` + scaffold
+
+### Kapatilan
+
+#188 (security-review entegrasyon), #189 (/review parity), #190 (marketplace lastUpdated), #191 (CI scaffold), #192 (hook isolation audit).
+
 ## [1.30.1] - 2026-05-19
 
 > npm yayini oncesi review-tabanli iyilestirmeler dahildir (asagida `### Iyilestirmeler (PR #185 sonrasi ic review)` bolumune bakin). 9 review bulgusu ayni surumde kapali.

--- a/README.md
+++ b/README.md
@@ -435,6 +435,21 @@ Comprehensive scanning with 48 security skills:
 
 4-phase pipeline: **Discover** → **Scan** → **Verify** → **Report**
 
+### Security Notes (v1.31.0+)
+
+> ⚠️ **`--dangerously-skip-permissions`**: Claude Code 2.1.126+ (May 2026) bu flag'in
+> scope'unu genisletti — artik `.claude/`, `.git/`, `.vscode/` ve shell config
+> dosyalarini da bypass eder. Badi `init`/`update`/CI script'lerinde bu flag'i
+> KULLANMAYIN. Yalnizca manuel debugging icin.
+
+> 🔒 **Hook isolation (Claude Code 2.1.139+)**: Badi'nin 14 hook'unun tamami
+> JSON output protocol veya log-only kategorisinde. Terminal manipulation yok.
+> Audit raporu: [docs/hooks/isolation-audit.md](./docs/hooks/isolation-audit.md).
+
+> 🏢 **Enterprise managed-settings uyumu**: `forceLoginOrgUUID`,
+> `allowManagedDomainsOnly`, `allowManagedReadPathsOnly` Anthropic managed-settings
+> ile uyumlu. Detay: [docs/enterprise.md](./docs/enterprise.md).
+
 ## Performance
 
 | Metric | Before | After |

--- a/bin/badi.js
+++ b/bin/badi.js
@@ -85,6 +85,7 @@ function showHelp() {
 	);
 	console.log(
 		`  ${chalk.cyan("events")}    Badi self-telemetry (komut sayaclari, durations) — v1.30+`,
+		`  ${chalk.cyan("security")}  Guvenlik orkestrasyonu (baseline/triage/init --ci) — v1.31+`,
 	);
 	console.log("");
 	console.log(chalk.bold("Domain & Altyapi:"));
@@ -204,6 +205,11 @@ function showHelp() {
 	console.log("  badi events list                Son N olay (--limit, --since/--until)");
 	console.log("  badi events stats               Komut bazli sayim + ortalama sure");
 	console.log("  badi events path / status       Log dosyasi yolu / telemetry durumu");
+	console.log("");
+	console.log(chalk.bold("Guvenlik orkestrasyonu (v1.31+):"));
+	console.log("  badi security baseline          Deterministic baseline (secret-scan + audit)");
+	console.log("  badi security triage [report]   /security-review raporunu severity'ye gore filtrele");
+	console.log("  badi security init --ci         GitHub Action scaffold (Anthropic resmi action)");
 	console.log(chalk.dim("    Kapatma: export BADI_TELEMETRY=off"));
 	console.log("");
 	console.log(chalk.bold("Icerik Alt Komutlari:"));
@@ -359,6 +365,8 @@ const commands = {
 	release: () => import("../lib/commands/release.js").then((m) => m.runRelease),
 	events: () =>
 		import("../lib/commands/events.js").then((m) => m.runEvents),
+	security: () =>
+		import("../lib/commands/security.js").then((m) => m.runSecurity),
 };
 
 // ─── Ana Giris Noktasi ───

--- a/dist/README.md
+++ b/dist/README.md
@@ -8,6 +8,7 @@ Badi is published to **npm** (primary) and mirrored to additional package manage
 | **Claude Code marketplace** | `.claude-plugin/{plugin,marketplace}.json` | (in-repo) | `/plugin install fatihkan/badi` |
 | **Homebrew** (macOS/Linux) | `dist/homebrew/badi.rb` | `fatihkan/homebrew-badi` | `brew tap fatihkan/badi && brew install badi` |
 | **Scoop** (Windows) | `dist/scoop/badi.json` | `fatihkan/scoop-bucket` | `scoop bucket add badi <repo> && scoop install badi` |
+| **GitHub Action templates** | `dist/github-actions/` | (in-repo) | `badi security init --ci` (v1.31+) |
 
 ## How the mirrors work
 
@@ -51,6 +52,20 @@ cd scoop-bucket && git add -A && git commit -m "init bucket" && git push
 ```
 
 After the tap/bucket exist, the release workflow auto-updates them on every npm publish.
+
+## GitHub Action templates (v1.31.0+)
+
+`dist/github-actions/` icinde Badi'nin scaffold ettigi opt-in workflow sablonlari:
+
+- `security-review.yml` — Anthropic resmi [`anthropics/claude-code-security-review`](https://github.com/anthropics/claude-code-security-review) action'ini wrap eder, PR'larda otomatik AI semantic security review yapar.
+
+Kurulum:
+```bash
+badi security init --ci   # .github/workflows/security-review.yml olusturur
+# Sonra: Repo Settings → Secrets → ANTHROPIC_API_KEY ekle
+```
+
+Workflow'lar `pull_request` (head SHA) ile tetiklenir, **`pull_request_target` DEGIL** — prompt injection hardening icin.
 
 ## Channels NOT supported
 

--- a/dist/github-actions/security-review.yml
+++ b/dist/github-actions/security-review.yml
@@ -1,0 +1,41 @@
+# Badi v1.31.0+ — Security Review GitHub Action sablonu
+#
+# Anthropic'in resmi action'i ile PR'larda otomatik AI semantic security review.
+# Scaffold: `badi security init --ci` proje root'una kopyalar.
+#
+# Onkosul: Repo Settings → Secrets → ANTHROPIC_API_KEY ekle.
+#
+# Opt-in: bu workflow head SHA'da calisir (prompt injection hardening).
+
+name: Security Review (AI)
+
+permissions:
+  pull-requests: write
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 2
+
+      - name: AI Security Review
+        uses: anthropics/claude-code-security-review@main
+        with:
+          claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          comment-pr: true
+          upload-results: true
+          # Badi-spesifik exclude'lar (skill bundle, bootstrap, generated dist)
+          exclude-directories: "node_modules,coverage,dist,_bootstrap,.claude/skills-vault,.claude/commands-vault"
+          # Opsiyonel custom prompt (badi init --ci ile birlikte scaffold):
+          # custom-security-scan-instructions: ".claude/security-review-instructions.md"
+          # false-positive-filtering-instructions: ".claude/security-review-fp-filter.md"

--- a/dist/github-actions/security-review.yml
+++ b/dist/github-actions/security-review.yml
@@ -28,8 +28,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
 
+      # v1.31.0+ Y1 hotfix: third-party action SHA-pinned (supply chain hardening).
+      # Floating @main yerine immutable commit ref — Anthropic ana branch'inda
+      # kotu amacli commit olursa bizim sablonu kullananlar etkilenmez.
+      # SHA periyodik guncellenmeli (release check'te uyari verebilir).
       - name: AI Security Review
-        uses: anthropics/claude-code-security-review@main
+        uses: anthropics/claude-code-security-review@0c6a49f1fa56a1d472575da86a94dbc1edb78eda  # main HEAD 2026-05-22
         with:
           claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           comment-pr: true

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -1,0 +1,84 @@
+# Badi for Enterprise
+
+Badi, Anthropic Claude Code'un **enterprise managed-settings** ozellikleri ile uyumludur. Bu sayfa, kurumsal ortamlarda Badi'yi yapilandirma rehberidir.
+
+## Anthropic Managed-Settings ile Uyum
+
+Claude Code (2.1.126+) admin-tier managed settings sunar. Badi runtime'inda bu ayarlara dokunmaz — sadece pass-through davranir.
+
+### `forceLoginOrgUUID` / `forceLoginMethod` (2.1.143)
+
+Claude Code 2.1.143'te bu enforcement'in 3rd-party provider ve API-key session'larinda atlandi bug'i kapatildi.
+
+**Badi etki**: Yok. Badi kendi auth tutmaz; `claude` binary'sinin auth state'ini kullanir. Bir kullanici `forceLoginMethod=sso` ile zorlanmissa, Badi calismadan once Claude Code login surec uygulanir.
+
+### `allowManagedDomainsOnly` / `allowManagedReadPathsOnly` (2.1.126)
+
+Sandbox-block eksik managed-settings source'lari icin enforcement'i bypass eden bug 2.1.126'da kapatildi.
+
+**Badi etki**: Yok. Badi `dist/` (Homebrew/Scoop manifest'leri) ve `_bootstrap/badi-skills/` (skill bundle) altinda statik dosyalar uretir; uzak domain erisimi gerektirmez. Managed-settings policy badi'nin filesystem yazimini kisitlamiyor.
+
+### `parentSettingsBehavior` (2.1.133)
+
+Admin-tier yeni key: `'first-wins' | 'merge'`. SDK `managedSettings` parent tier policy merge'e opt-in olabilir.
+
+**Badi etki**: Badi `.claude/settings.json` proje dosyalarini yazar (CLAUDE.md, hooks registration). Admin managed-settings ile cakisma riski: `first-wins` modunda admin policy badi'nin lokal `permissions:` rule'larini override edebilir. Onerim: kurumsal ortamlarda `badi init --no-settings-write` (v1.31+) flag'i ile sadece komut/agent/hook dosyalari yazsin, settings.json'a dokunmasin.
+
+## `--dangerously-skip-permissions` Uyari
+
+Claude Code 2.1.126'da bu flag'in scope'u genisletildi:
+
+> Now bypasses prompts for writes to `.claude/`, `.git/`, `.vscode/`, shell config files, and other previously-protected paths (catastrophic removal commands still prompt as a safety net)
+
+**Kurumsal ortamda KULLANMAYIN**. Badi'nin tum komutlari (`init`, `update`, `doctor`, `publish`) bu flag olmadan calisir. Yalniz manuel debugging icin.
+
+## Hook Isolation (2.1.139)
+
+Claude Code 2.1.139'da hook'lar artik terminal access olmadan calistirilir (terminal corruption fix). Badi'nin 14 hook'u (`tests/hooks-isolation.test.js` ile dogrulanmis) Anthropic'in yeni izolasyon kurallarina **tam uyumlu**:
+
+- 13 hook: JSON output protocol veya log-only
+- 1 hook (`dependency-audit.mjs`): v1.31.0'da `writeContextInjection()` JSON protocol'e refactor edildi
+- 1 hook (`post-compact-resume.mjs`): v1.31.0'da `writeContextInjection()`'e refactor edildi
+- 0 hook: ANSI escape veya terminal manipulation
+
+Audit raporu: [docs/hooks/isolation-audit.md](./hooks/isolation-audit.md).
+
+## Plugin Marketplace (2.1.143-145)
+
+- **2.1.143**: `claude plugin disable` bagimli plugin varsa reddediyor (runtime enforcement)
+- **2.1.144**: Browse pane plugin son guncelleme zamani gosteriyor
+- **2.1.145**: Browse pane install **oncesinde** plugin'in commands/agents/skills/hooks/MCP/LSP listesini gosteriyor
+
+**Badi uyum**:
+- `badi plugin doctor` + `badi plugin graph` (v1.30.0+) — pre-flight + planlama (Anthropic'in runtime enforcement'ini tamamlar)
+- `badi release sync-manifest` (v1.30.1+) — `.claude-plugin/{plugin,marketplace}.json` otomatik senkron
+- `lastUpdated` field (v1.31.0+) — Anthropic Browse pane'de gozukur
+
+## Telemetri ve Veri Akisi
+
+Badi telemetrisi (`badi events`, v1.30+) **tamamen lokal**:
+- `~/.claude/projects/<slug>/badi-events.jsonl`
+- Whitelist: `badi.*` closed list + `plugin.<owner>.<event>` regex namespace
+- Disa veri gondermez. `BADI_TELEMETRY=off` ile tamamen kapali.
+
+Kurumsal compliance icin: bu dizinleri backup/audit policy'sine eklemek opsiyonel.
+
+## SSO / SAML Entegrasyonu
+
+Badi kendi auth'unu yapmaz. Claude Code'un Anthropic SSO/SAML konfigurasyonunu kullanir. Detay icin [Anthropic Enterprise docs](https://docs.claude.com/en/docs/claude-code/enterprise).
+
+## Audit Log
+
+Badi audit izleri:
+- `.claude/logs/audit-trail.md` — tum dosya degisiklikleri (PostToolUse)
+- `.claude/logs/incident-log.md` — guvenlik olaylari, branch-guard engelleri, dependency audit kritik bulgular
+- `.claude/logs/usage.jsonl` — komut kullanim log
+- `~/.claude/projects/<slug>/badi-events.jsonl` — telemetri event'leri
+
+Tum log'lar lokal dosya sistemi; harici servise gonderim yok.
+
+## Referans
+
+- [Claude Code Changelog](https://code.claude.com/docs/en/changelog)
+- [Anthropic Enterprise Documentation](https://docs.claude.com/en/docs/claude-code/enterprise)
+- Badi hook audit: [docs/hooks/isolation-audit.md](./hooks/isolation-audit.md)

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -65,7 +65,7 @@ Kurumsal compliance icin: bu dizinleri backup/audit policy'sine eklemek opsiyone
 
 ## SSO / SAML Entegrasyonu
 
-Badi kendi auth'unu yapmaz. Claude Code'un Anthropic SSO/SAML konfigurasyonunu kullanir. Detay icin [Anthropic Enterprise docs](https://docs.claude.com/en/docs/claude-code/enterprise).
+Badi kendi auth'unu yapmaz. Claude Code'un Anthropic SSO/SAML konfigurasyonunu kullanir. Detay icin [Claude Code server-managed settings](https://code.claude.com/docs/en/server-managed-settings).
 
 ## Audit Log
 
@@ -80,5 +80,5 @@ Tum log'lar lokal dosya sistemi; harici servise gonderim yok.
 ## Referans
 
 - [Claude Code Changelog](https://code.claude.com/docs/en/changelog)
-- [Anthropic Enterprise Documentation](https://docs.claude.com/en/docs/claude-code/enterprise)
+- [Claude Code Server-Managed Settings](https://code.claude.com/docs/en/server-managed-settings)
 - Badi hook audit: [docs/hooks/isolation-audit.md](./hooks/isolation-audit.md)

--- a/docs/hooks/isolation-audit.md
+++ b/docs/hooks/isolation-audit.md
@@ -1,0 +1,79 @@
+# Hook Isolation Audit (v1.31.0)
+
+Anthropic Claude Code **2.1.139** (11 May 2026) ile hook'lar **terminal access olmadan** calistirilmaya basladi. Bu degisiklik, hook'lardan terminal'e plain text yazimi ile interactive prompt corruption sorununu cozmek icin yapildi.
+
+Bu audit, badi'nin 15 hook'unu (14 hook + `_util.mjs` shared) Anthropic'in yeni izolasyon kurallarina uyumluluk acisindan kategorize eder.
+
+## Kategoriler
+
+| Kategori | Aciklama | Etki |
+|----------|----------|------|
+| **1 — JSON Protocol** | stdout'a yalnizca Claude Code hook protokolune uygun JSON tek-satir yazimi. `writeDecision()` veya `writeContextInjection()`. | ✅ Guvenli |
+| **2 — Plain Text Stdout** | stdout'a plain text yazimi. Eski Claude Code'da terminal'e gozukurdu, 2.1.139+ kayboluyor. | ⚠️ Protokol ihlali — fix gerek |
+| **3 — Terminal Manipulation** | ANSI escape, cursor move, raw bytes. Terminal corruption riski. | ❌ TEHLIKE — derhal fix |
+| **Log-only** | Yalnizca `.claude/logs/` dosyalarina yazim. stdout/stderr kullanim yok (defensive fail-safe haricinde). | ✅ Guvenli |
+
+## Sonuc (v1.31.0 oncesi vs sonrasi)
+
+### v1.31.0 ONCESI (snapshot)
+
+| Hook | Kategori | Detay |
+|------|----------|-------|
+| `_util.mjs` | Helper | Hook degil, utility |
+| `backup-before-write.mjs` | Log-only | Filesystem + log |
+| `branch-guard.mjs` | 1 | `writeDecision()` |
+| `completeness-gate.mjs` | 1 | `writeDecision()` |
+| `dependency-audit.mjs` | **2** | `process.stdout.write("UYARI:...")` plain text |
+| `guard-bash.mjs` | 1 | `writeDecision()` + log |
+| `inject-active-plan.mjs` | 1 | `writeContextInjection()` |
+| `log-changes.mjs` | Log-only | `appendLog()` |
+| `log-failures.mjs` | Log-only | `appendLog()` |
+| `log-stop-verdict.mjs` | Log-only | `appendLog()` |
+| `post-compact-resume.mjs` | **2** | `process.stdout.write()` multi-line plain text |
+| `pre-compact-handoff.mjs` | Log-only | Filesystem + log |
+| `session-reset.mjs` | Log-only | Filesystem + log |
+| `skill-router.mjs` | 1 | `writeContextInjection()` |
+| `track-usage.mjs` | Log-only | `appendLog()` JSONL |
+
+**Toplam Kategori 2**: 2 hook → **fix uygulandi**.
+
+### v1.31.0 SONRASI (target state)
+
+Kategori 2 hook'lari refactor edildi:
+
+#### `dependency-audit.mjs`
+- **Eski**: SessionStart'ta bulgu varsa `process.stdout.write("UYARI: ...")` plain text yazim.
+- **Yeni**: `writeContextInjection()` JSON protocol ile Claude'a additionalContext olarak inject.
+- **Sonuc**: Eskiden Claude'un contextine girmiyordu (kayboluyor veya terminal'e dusuyor); simdi gercekten gozukur.
+
+#### `post-compact-resume.mjs`
+- **Eski**: SessionStart-resumed'da compact mesaji `process.stdout.write()` multi-line plain text.
+- **Yeni**: `writeContextInjection()` ile additionalContext.
+- **Sonuc**: Compact sonrasi devam mesaji artik gercekten Claude'a iletilir.
+
+## Stderr Kullanimi
+
+Tum hook'lar `BADI_HOOK_DEBUG` env var ile **opt-in stderr** kullanir (defensive fail-safe):
+```javascript
+const _badiFailSafe = (e) => {
+  if (process.env.BADI_HOOK_DEBUG) {
+    try { process.stderr.write(`[badi-hook] ${e?.message || e}\n`); } catch {}
+  }
+  process.exit(0);
+};
+```
+
+Bu **guvenli** — sadece debug modunda stderr'e yazar, Claude Code default'ta `BADI_HOOK_DEBUG` set etmedigi icin sessiz kalir. Stderr Claude'un terminal corruption riski tasimaz (Claude Code stderr'i loglar veya yutar, terminal'e bypass etmez).
+
+## Test Stratejisi
+
+`tests/hooks-isolation.test.js` (yeni, v1.31.0):
+- Her hook icin: SIMULATE stdin → stdout cikti format kontrolu
+- stdout cikti varsa → valid JSON one-line olmali (parse + assertion)
+- Stderr default'ta bos (BADI_HOOK_DEBUG yok) olmali
+- ANSI escape sequence yokluk kontrolu (regex)
+
+## Referanslar
+- [Claude Code Changelog 2.1.139 (11 May 2026)](https://code.claude.com/docs/en/changelog) — hook terminal-isolation
+- [Hook output protocol](https://docs.claude.com/en/docs/claude-code/hooks)
+- Mevcut testler: `tests/hooks-failsafe.test.js`, `tests/cli.hooks-node.test.js`

--- a/lib/commands/secret-scan.js
+++ b/lib/commands/secret-scan.js
@@ -559,3 +559,14 @@ export {
 	scanGitHistory,
 	walkDir,
 };
+
+// v1.31.0+ K1 hotfix: doğrudan `node lib/commands/secret-scan.js ...` cagrildiginda
+// runSecretScan'i tetikle. `badi security baseline` bu yolu kullanir.
+// Test/import path'i etkilenmez — yalniz process.argv[1] bu dosya ise calisir.
+if (
+	import.meta.url.startsWith("file:") &&
+	process.argv[1] &&
+	import.meta.url === new URL(`file://${process.argv[1]}`).href
+) {
+	runSecretScan(process.argv.slice(2));
+}

--- a/lib/commands/security.js
+++ b/lib/commands/security.js
@@ -1,0 +1,252 @@
+import { spawnSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chalk } from "../cli.js";
+
+// `badi security` — Anthropic /security-review native komutuna kopru.
+//
+// v1.31.0+ — Anthropic 2.1.140 ile /security-review native slash command olarak
+// Claude Code'a gomulu. Bu modul AI cagirisi yapmaz; baseline (deterministic) +
+// triage (rapor okuma) + init (CI scaffold) ile kopru/orkestrasyon saglar.
+//
+// Subkomutlar:
+//   badi security baseline           — secret-scan + npm audit deterministic baseline
+//   badi security triage [report]    — son /security-review raporunu severity'ye gore filtrele
+//   badi security init [--ci]        — GitHub Action scaffold (anthropics/claude-code-security-review wrap)
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export function runSecurity(args) {
+	const sub = args[0];
+	if (!sub || sub === "--help" || sub === "-h") {
+		return showHelp();
+	}
+	switch (sub) {
+		case "baseline":
+			return runBaseline(args.slice(1));
+		case "triage":
+			return runTriage(args.slice(1));
+		case "init":
+			return runInit(args.slice(1));
+		default:
+			console.error(chalk.red(`Bilinmeyen security subkomut: ${sub}`));
+			showHelp();
+			process.exit(1);
+	}
+}
+
+function showHelp() {
+	console.log(`
+${chalk.bold("badi security")} — Guvenlik orkestrasyonu (Anthropic /security-review kopru)
+
+${chalk.bold("Subkomutlar:")}
+  ${chalk.cyan("baseline [--json]")}     Deterministic baseline scan (secret-scan + npm audit)
+  ${chalk.cyan("triage [report]")}       Son /security-review raporunu filtrele/ozetle
+  ${chalk.cyan("init --ci [--force]")}   GitHub Action scaffold (Anthropic resmi action wrap)
+
+${chalk.bold("Onerilen akis:")}
+  1. ${chalk.cyan("badi security baseline")}     # deterministic taban (sirlar + bagimliliklar)
+  2. Claude Code icinde ${chalk.cyan("/security-review")} (native, semantic AI)
+  3. ${chalk.cyan("badi security triage")}      # rapor varsa severity'ye gore filtrele
+  4. CI: ${chalk.cyan("badi security init --ci")} (PR'larda otomatik review)
+
+${chalk.bold("Cross-ref:")}
+  /security-review  → Anthropic native (Claude Code 2.1.140+)
+  /security-scan    → Badi slash (sc-orchestrator skill)
+  badi secret-scan  → Deterministic regex (17 pattern)
+
+Detay: ${chalk.cyan("docs/enterprise.md")} ve ${chalk.cyan("badi security <subkomut> --help")}
+`);
+}
+
+// ─── baseline ───
+
+function runBaseline(args) {
+	const jsonOut = args.includes("--format=json") || args.includes("--json");
+	const sections = [];
+
+	console.log(chalk.bold("\n🔒 Baseline (deterministic) — sirlar + bagimliliklar\n"));
+
+	// 1) secret-scan
+	const ss = spawnSync(
+		process.execPath,
+		[resolve(__dirname, "secret-scan.js"), "--format", "json"],
+		{ encoding: "utf-8", timeout: 60_000 },
+	);
+	let secretFindings = { count: 0, items: [] };
+	try {
+		const parsed = JSON.parse(ss.stdout || "{}");
+		secretFindings = {
+			count:
+				parsed.summary?.total ??
+				(Array.isArray(parsed.findings) ? parsed.findings.length : 0),
+			items: parsed.findings || [],
+		};
+	} catch {
+		// secret-scan tek dosya cagrisi degil — fallback: stdout yok say
+	}
+	const secretLine =
+		secretFindings.count > 0
+			? chalk.red(`  ✗ ${secretFindings.count} sir bulgu`)
+			: chalk.green("  ✓ Sir bulgu yok");
+	console.log(`${chalk.cyan("[1/2]")} secret-scan`);
+	console.log(secretLine);
+	sections.push({ check: "secret-scan", findings: secretFindings.count });
+
+	// 2) npm audit (varsa)
+	if (existsSync("package-lock.json") || existsSync("yarn.lock")) {
+		const manager = existsSync("yarn.lock") ? "yarn" : "npm";
+		const auditArgs = manager === "yarn" ? ["audit", "--json"] : ["audit", "--json"];
+		const audit = spawnSync(manager, auditArgs, {
+			encoding: "utf-8",
+			timeout: 60_000,
+		});
+		let critical = 0;
+		let high = 0;
+		try {
+			if (manager === "npm") {
+				const p = JSON.parse(audit.stdout || "{}");
+				critical = p.metadata?.vulnerabilities?.critical || 0;
+				high = p.metadata?.vulnerabilities?.high || 0;
+			} else {
+				const lines = (audit.stdout || "").split("\n").filter(Boolean);
+				const last = JSON.parse(lines[lines.length - 1] || "{}");
+				critical = last.data?.vulnerabilities?.critical || 0;
+				high = last.data?.vulnerabilities?.high || 0;
+			}
+		} catch {
+			// audit parse hatasi - 0 birak
+		}
+		console.log(`${chalk.cyan("[2/2]")} ${manager} audit`);
+		if (critical > 0)
+			console.log(chalk.red(`  ✗ ${critical} kritik bagimlilik acigi`));
+		if (high > 0)
+			console.log(chalk.yellow(`  ⚠ ${high} yuksek bagimlilik acigi`));
+		if (critical === 0 && high === 0)
+			console.log(chalk.green("  ✓ Kritik/yuksek bagimlilik acigi yok"));
+		sections.push({ check: `${manager} audit`, critical, high });
+	} else {
+		console.log(`${chalk.cyan("[2/2]")} npm audit ${chalk.gray("(atlandi — lock dosyasi yok)")}`);
+	}
+
+	console.log(
+		chalk.dim("\nSemantic AI review icin: Claude Code icinde /security-review"),
+	);
+
+	if (jsonOut) {
+		console.log(JSON.stringify({ baseline: sections }, null, 2));
+	}
+
+	const hasFindings = sections.some(
+		(s) => s.findings > 0 || s.critical > 0 || s.high > 0,
+	);
+	process.exit(hasFindings ? 1 : 0);
+}
+
+// ─── triage ───
+
+function runTriage(args) {
+	const reportPath =
+		args[0] || join(process.cwd(), "security-report", "SECURITY-REPORT.md");
+	if (!existsSync(reportPath)) {
+		console.error(chalk.red(`Rapor yok: ${reportPath}`));
+		console.error(
+			chalk.dim(
+				"\n/security-review calistirildiktan sonra security-report/ dizini olusur.",
+			),
+		);
+		process.exit(1);
+	}
+
+	const body = readFileSync(reportPath, "utf-8");
+	// Basit severity sayim — rapor formati genelde markdown heading + severity tag
+	const counts = {
+		critical: countMatches(body, /(?:critical|kritik|KRITIK)/gi),
+		high: countMatches(body, /(?:high|yuksek|YUKSEK)/gi),
+		medium: countMatches(body, /(?:medium|orta|ORTA)/gi),
+		low: countMatches(body, /(?:low|dusuk|DUSUK)/gi),
+	};
+
+	console.log(chalk.bold("\n📋 Security Report Triage\n"));
+	console.log(`  Kaynak: ${chalk.cyan(reportPath)}`);
+	console.log(`  ${chalk.red("Kritik")}: ${counts.critical}`);
+	console.log(`  ${chalk.yellow("Yuksek")}: ${counts.high}`);
+	console.log(`  ${chalk.blue("Orta")}:  ${counts.medium}`);
+	console.log(`  ${chalk.gray("Dusuk")}:  ${counts.low}`);
+
+	// Onerilen action
+	if (counts.critical > 0) {
+		console.log(
+			chalk.red("\n  ➜ KRITIK bulgular merge'i bloklamali. Once cozun."),
+		);
+		process.exit(1);
+	}
+	if (counts.high > 0) {
+		console.log(chalk.yellow("\n  ➜ Yuksek bulgular merge oncesi gozden gecirilmeli."));
+	}
+	process.exit(0);
+}
+
+function countMatches(text, re) {
+	const m = text.match(re);
+	return m ? m.length : 0;
+}
+
+// ─── init --ci ───
+
+function runInit(args) {
+	const ci = args.includes("--ci");
+	if (!ci) {
+		console.log(
+			chalk.yellow("Su an yalniz --ci destekleniyor. Calistir: badi security init --ci"),
+		);
+		process.exit(1);
+	}
+
+	const wfDir = join(process.cwd(), ".github", "workflows");
+	const wfPath = join(wfDir, "security-review.yml");
+	const distTemplate = resolve(
+		__dirname,
+		"..",
+		"..",
+		"dist",
+		"github-actions",
+		"security-review.yml",
+	);
+
+	if (!existsSync(distTemplate)) {
+		console.error(
+			chalk.red(`Sablon bulunamadi: ${distTemplate}`),
+		);
+		console.error(chalk.dim("Badi kurulumu eksik olabilir. badi doctor calistir."));
+		process.exit(1);
+	}
+
+	if (existsSync(wfPath) && !args.includes("--force")) {
+		console.error(
+			chalk.yellow(`Var olan dosyayi yazmaz: ${wfPath}`),
+		);
+		console.error(chalk.dim("Uzerine yazmak icin --force flag'i kullan."));
+		process.exit(1);
+	}
+
+	mkdirSync(wfDir, { recursive: true });
+	writeFileSync(wfPath, readFileSync(distTemplate, "utf-8"), "utf-8");
+
+	console.log(chalk.green(`✓ ${wfPath} olusturuldu`));
+	console.log(chalk.bold("\nSonraki adimlar:"));
+	console.log(
+		`  1. Repo Settings → Secrets → ${chalk.cyan("ANTHROPIC_API_KEY")} ekle`,
+	);
+	console.log(`  2. PR ac — workflow otomatik calisir`);
+	console.log(
+		`  3. Custom prompt (opsiyonel): ${chalk.cyan(".claude/security-review-instructions.md")}`,
+	);
+	process.exit(0);
+}

--- a/lib/commands/security.js
+++ b/lib/commands/security.js
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import {
 	existsSync,
 	mkdirSync,
@@ -21,6 +21,19 @@ import { chalk } from "../cli.js";
 //   badi security init [--ci]        — GitHub Action scaffold (anthropics/claude-code-security-review wrap)
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// v1.31.0+ Y3 hotfix: git proje koku tespiti — cwd-relative dosya kontrollerinden
+// daha guvenli (subdirectory'den cagrildiginda lock dosyalari bulunamaz hatasi).
+function projectRoot() {
+	try {
+		return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim();
+	} catch {
+		return process.cwd();
+	}
+}
 
 export function runSecurity(args) {
 	const sub = args[0];
@@ -69,43 +82,55 @@ Detay: ${chalk.cyan("docs/enterprise.md")} ve ${chalk.cyan("badi security <subko
 
 function runBaseline(args) {
 	const jsonOut = args.includes("--format=json") || args.includes("--json");
+	const root = projectRoot(); // Y3 hotfix: cwd yerine git root
 	const sections = [];
 
 	console.log(chalk.bold("\n🔒 Baseline (deterministic) — sirlar + bagimliliklar\n"));
 
-	// 1) secret-scan
+	// 1) secret-scan — K1 hotfix: secret-scan.js artik CLI entry point'e sahip
+	// (v1.31.0 hotfix), bu cagri gercekten taramayi tetikler.
 	const ss = spawnSync(
 		process.execPath,
 		[resolve(__dirname, "secret-scan.js"), "--format", "json"],
-		{ encoding: "utf-8", timeout: 60_000 },
+		{ encoding: "utf-8", timeout: 60_000, cwd: root },
 	);
-	let secretFindings = { count: 0, items: [] };
+	let secretCount = 0;
+	let secretParsed = false;
 	try {
 		const parsed = JSON.parse(ss.stdout || "{}");
-		secretFindings = {
-			count:
-				parsed.summary?.total ??
-				(Array.isArray(parsed.findings) ? parsed.findings.length : 0),
-			items: parsed.findings || [],
-		};
-	} catch {
-		// secret-scan tek dosya cagrisi degil — fallback: stdout yok say
+		secretCount = Array.isArray(parsed.findings) ? parsed.findings.length : 0;
+		secretParsed = true;
+	} catch (e) {
+		// O2 hotfix: silent fail yerine kullaniciya bildir
+		console.error(
+			chalk.yellow(`  ⚠ secret-scan ciktisi parse edilemedi: ${e.message}`),
+		);
+		console.error(chalk.dim(`    stderr: ${(ss.stderr || "").slice(0, 200)}`));
 	}
 	const secretLine =
-		secretFindings.count > 0
-			? chalk.red(`  ✗ ${secretFindings.count} sir bulgu`)
-			: chalk.green("  ✓ Sir bulgu yok");
+		!secretParsed
+			? chalk.yellow("  ⚠ secret-scan calistirilamadi")
+			: secretCount > 0
+				? chalk.red(`  ✗ ${secretCount} sir bulgu`)
+				: chalk.green("  ✓ Sir bulgu yok");
 	console.log(`${chalk.cyan("[1/2]")} secret-scan`);
 	console.log(secretLine);
-	sections.push({ check: "secret-scan", findings: secretFindings.count });
+	sections.push({
+		check: "secret-scan",
+		findings: secretCount,
+		parsed: secretParsed,
+	});
 
-	// 2) npm audit (varsa)
-	if (existsSync("package-lock.json") || existsSync("yarn.lock")) {
-		const manager = existsSync("yarn.lock") ? "yarn" : "npm";
-		const auditArgs = manager === "yarn" ? ["audit", "--json"] : ["audit", "--json"];
-		const audit = spawnSync(manager, auditArgs, {
+	// 2) npm audit (Y3 hotfix: root-relative lock dosyasi kontrolu)
+	const npmLock = join(root, "package-lock.json");
+	const yarnLock = join(root, "yarn.lock");
+	if (existsSync(npmLock) || existsSync(yarnLock)) {
+		const manager = existsSync(yarnLock) ? "yarn" : "npm";
+		// Y2 hotfix: dead code (identical ternary) kaldirildi
+		const audit = spawnSync(manager, ["audit", "--json"], {
 			encoding: "utf-8",
 			timeout: 60_000,
+			cwd: root,
 		});
 		let critical = 0;
 		let high = 0;
@@ -120,8 +145,10 @@ function runBaseline(args) {
 				critical = last.data?.vulnerabilities?.critical || 0;
 				high = last.data?.vulnerabilities?.high || 0;
 			}
-		} catch {
-			// audit parse hatasi - 0 birak
+		} catch (e) {
+			console.error(
+				chalk.yellow(`  ⚠ ${manager} audit ciktisi parse edilemedi: ${e.message}`),
+			);
 		}
 		console.log(`${chalk.cyan("[2/2]")} ${manager} audit`);
 		if (critical > 0)
@@ -132,7 +159,9 @@ function runBaseline(args) {
 			console.log(chalk.green("  ✓ Kritik/yuksek bagimlilik acigi yok"));
 		sections.push({ check: `${manager} audit`, critical, high });
 	} else {
-		console.log(`${chalk.cyan("[2/2]")} npm audit ${chalk.gray("(atlandi — lock dosyasi yok)")}`);
+		console.log(
+			`${chalk.cyan("[2/2]")} npm audit ${chalk.gray("(atlandi — lock dosyasi yok)")}`,
+		);
 	}
 
 	console.log(
@@ -150,10 +179,34 @@ function runBaseline(args) {
 }
 
 // ─── triage ───
+//
+// K2 hotfix: regex'ler word-boundary ile + markdown heading'lere oncelik veriyor.
+// Eski versiyon "/low/gi" ile "below", "follow", "yellow" kelimelerini sayardi.
+
+const SEVERITY_PATTERNS = {
+	critical: /\b(critical|kritik|KRITIK)\b/gi,
+	high: /\b(high|yuksek|YUKSEK)\b/gi,
+	medium: /\b(medium|orta|ORTA)\b/gi,
+	low: /\b(low|dusuk|DUSUK)\b/gi,
+};
+
+// Markdown heading-based count: `##? KRITIK SQLi` gibi yapilarda en guvenilir
+// sayim. /security-review default raporu bu formati kullanir.
+const HEADING_PATTERNS = {
+	critical: /^#{1,4}\s+(?:critical|kritik|KRITIK)\b/gim,
+	high: /^#{1,4}\s+(?:high|yuksek|YUKSEK)\b/gim,
+	medium: /^#{1,4}\s+(?:medium|orta|ORTA)\b/gim,
+	low: /^#{1,4}\s+(?:low|dusuk|DUSUK)\b/gim,
+};
+
+function countMatches(text, re) {
+	const m = text.match(re);
+	return m ? m.length : 0;
+}
 
 function runTriage(args) {
-	const reportPath =
-		args[0] || join(process.cwd(), "security-report", "SECURITY-REPORT.md");
+	const root = projectRoot(); // Y3: cwd-relative degil
+	const reportPath = args[0] || join(root, "security-report", "SECURITY-REPORT.md");
 	if (!existsSync(reportPath)) {
 		console.error(chalk.red(`Rapor yok: ${reportPath}`));
 		console.error(
@@ -165,22 +218,36 @@ function runTriage(args) {
 	}
 
 	const body = readFileSync(reportPath, "utf-8");
-	// Basit severity sayim — rapor formati genelde markdown heading + severity tag
-	const counts = {
-		critical: countMatches(body, /(?:critical|kritik|KRITIK)/gi),
-		high: countMatches(body, /(?:high|yuksek|YUKSEK)/gi),
-		medium: countMatches(body, /(?:medium|orta|ORTA)/gi),
-		low: countMatches(body, /(?:low|dusuk|DUSUK)/gi),
+
+	// Once markdown heading'leri dene (en guvenilir); 0 ise word-boundary
+	// regex'e dus (heading-less rapor formatlari icin).
+	const headingCounts = {
+		critical: countMatches(body, HEADING_PATTERNS.critical),
+		high: countMatches(body, HEADING_PATTERNS.high),
+		medium: countMatches(body, HEADING_PATTERNS.medium),
+		low: countMatches(body, HEADING_PATTERNS.low),
 	};
+	const headingTotal = Object.values(headingCounts).reduce((a, b) => a + b, 0);
+	const counts =
+		headingTotal > 0
+			? headingCounts
+			: {
+					critical: countMatches(body, SEVERITY_PATTERNS.critical),
+					high: countMatches(body, SEVERITY_PATTERNS.high),
+					medium: countMatches(body, SEVERITY_PATTERNS.medium),
+					low: countMatches(body, SEVERITY_PATTERNS.low),
+				};
 
 	console.log(chalk.bold("\n📋 Security Report Triage\n"));
 	console.log(`  Kaynak: ${chalk.cyan(reportPath)}`);
+	console.log(
+		`  Sayim yontemi: ${headingTotal > 0 ? "markdown heading" : "word-boundary regex"}`,
+	);
 	console.log(`  ${chalk.red("Kritik")}: ${counts.critical}`);
 	console.log(`  ${chalk.yellow("Yuksek")}: ${counts.high}`);
 	console.log(`  ${chalk.blue("Orta")}:  ${counts.medium}`);
 	console.log(`  ${chalk.gray("Dusuk")}:  ${counts.low}`);
 
-	// Onerilen action
 	if (counts.critical > 0) {
 		console.log(
 			chalk.red("\n  ➜ KRITIK bulgular merge'i bloklamali. Once cozun."),
@@ -188,14 +255,11 @@ function runTriage(args) {
 		process.exit(1);
 	}
 	if (counts.high > 0) {
-		console.log(chalk.yellow("\n  ➜ Yuksek bulgular merge oncesi gozden gecirilmeli."));
+		console.log(
+			chalk.yellow("\n  ➜ Yuksek bulgular merge oncesi gozden gecirilmeli."),
+		);
 	}
 	process.exit(0);
-}
-
-function countMatches(text, re) {
-	const m = text.match(re);
-	return m ? m.length : 0;
 }
 
 // ─── init --ci ───
@@ -204,7 +268,9 @@ function runInit(args) {
 	const ci = args.includes("--ci");
 	if (!ci) {
 		console.log(
-			chalk.yellow("Su an yalniz --ci destekleniyor. Calistir: badi security init --ci"),
+			chalk.yellow(
+				"Su an yalniz --ci destekleniyor. Calistir: badi security init --ci",
+			),
 		);
 		process.exit(1);
 	}
@@ -221,17 +287,13 @@ function runInit(args) {
 	);
 
 	if (!existsSync(distTemplate)) {
-		console.error(
-			chalk.red(`Sablon bulunamadi: ${distTemplate}`),
-		);
+		console.error(chalk.red(`Sablon bulunamadi: ${distTemplate}`));
 		console.error(chalk.dim("Badi kurulumu eksik olabilir. badi doctor calistir."));
 		process.exit(1);
 	}
 
 	if (existsSync(wfPath) && !args.includes("--force")) {
-		console.error(
-			chalk.yellow(`Var olan dosyayi yazmaz: ${wfPath}`),
-		);
+		console.error(chalk.yellow(`Var olan dosyayi yazmaz: ${wfPath}`));
 		console.error(chalk.dim("Uzerine yazmak icin --force flag'i kullan."));
 		process.exit(1);
 	}

--- a/lib/data/marketplace-manifest.js
+++ b/lib/data/marketplace-manifest.js
@@ -9,6 +9,7 @@
 //   - Stabil hash: agent listesi alfabetik sirali; manifest icerigi
 //     sirayla aynidir, gereksiz git diff'i olmaz.
 
+import { execFileSync } from "node:child_process";
 import {
 	existsSync,
 	readdirSync,
@@ -16,6 +17,34 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { join, relative } from "node:path";
+
+/**
+ * package.json'in son git commit tarihi (ISO 8601).
+ * v1.31.0+ — Claude Code 2.1.144+ marketplace Browse pane'inde gozukur.
+ *
+ * Kaynak: `git log -1 --format=%cI -- package.json`. Bu, version bump
+ * commit'inin tarihine denk gelir (release ile senkron).
+ *
+ * Fallback: bos string (manifest stale-check icin null gibi davranir).
+ * Git yoksa veya repo disindaysak silent skip.
+ */
+export function lastPackageJsonCommitDate(cwd = process.cwd()) {
+	try {
+		const out = execFileSync(
+			"git",
+			["log", "-1", "--format=%cI", "--", "package.json"],
+			{
+				encoding: "utf-8",
+				cwd,
+				stdio: ["ignore", "pipe", "ignore"],
+				timeout: 5000,
+			},
+		).trim();
+		return out || "";
+	} catch {
+		return "";
+	}
+}
 
 /**
  * .claude/agents/*.md dosyalarini topla (alfabetik).
@@ -105,7 +134,7 @@ function defaultHooksBlock() {
  * plugin.json icerigini generate eder. version + ozet bilgileri package.json'dan,
  * agent listesi + sayilar dosya sisteminden.
  */
-export function buildPluginManifest({ pkg, claudeDir }) {
+export function buildPluginManifest({ pkg, claudeDir, lastUpdated }) {
 	const agentCount = collectAgents(claudeDir).length;
 	const commandCount = countCommands(claudeDir);
 	const hookCount = countHooks(claudeDir);
@@ -116,7 +145,7 @@ export function buildPluginManifest({ pkg, claudeDir }) {
 		`— ${agentCount} AI agents, ${commandCount} commands, ${hookCount} hooks, ${skillCount} opt-in skill categories. ` +
 		`Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.`;
 
-	return {
+	const manifest = {
 		$schema: "https://json.schemastore.org/claude-code-plugin-manifest.json",
 		name: pkg.name?.replace(/^@.*\//, "") || "badi",
 		version: pkg.version || "0.0.0",
@@ -151,15 +180,53 @@ export function buildPluginManifest({ pkg, claudeDir }) {
 		skills: "./.claude/skills-vault",
 		hooks: defaultHooksBlock(),
 	};
+	// v1.31.0+ Claude Code 2.1.144 marketplace Browse pane uyumu.
+	// lastUpdated bos string ise field eklenmez (CI clone'larda git yoksa
+	// stale-check ile uyumlu kalmasi icin).
+	const lu = lastUpdated ?? lastPackageJsonCommitDate();
+	if (lu) manifest.lastUpdated = lu;
+	return manifest;
 }
 
 /**
  * marketplace.json icerigini generate eder.
  */
-export function buildMarketplaceManifest({ pkg, claudeDir }) {
+export function buildMarketplaceManifest({ pkg, claudeDir, lastUpdated }) {
 	const agentCount = collectAgents(claudeDir).length;
 	const commandCount = countCommands(claudeDir);
 	const skillCount = countSkillCategories(claudeDir);
+	const lu = lastUpdated ?? lastPackageJsonCommitDate();
+
+	const plugin = {
+		name: pkg.name?.replace(/^@.*\//, "") || "badi",
+		source: "./",
+		description:
+			`Workflow management for Claude Code — ${agentCount} AI agents, ${commandCount} commands, ${skillCount} skill categories. ` +
+			`Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.`,
+		author: {
+			name: "Fatih Kan",
+			url: "https://github.com/fatihkan",
+		},
+		homepage: "https://github.com/fatihkan/badi",
+		repository: "https://github.com/fatihkan/badi",
+		license: pkg.license || "MIT",
+		keywords: [
+			"claude",
+			"claude-code",
+			"claude-opus",
+			"claude-sonnet",
+			"anthropic",
+			"ai-agents",
+			"subagents",
+			"workflow",
+			"observability",
+			"owasp",
+			"code-review",
+		],
+		category: "productivity",
+		strict: true,
+	};
+	if (lu) plugin.lastUpdated = lu;
 
 	return {
 		$schema: "https://json.schemastore.org/claude-code-marketplace.json",
@@ -172,37 +239,7 @@ export function buildMarketplaceManifest({ pkg, claudeDir }) {
 			name: "Fatih Kan",
 			url: "https://github.com/fatihkan",
 		},
-		plugins: [
-			{
-				name: pkg.name?.replace(/^@.*\//, "") || "badi",
-				source: "./",
-				description:
-					`Workflow management for Claude Code — ${agentCount} AI agents, ${commandCount} commands, ${skillCount} skill categories. ` +
-					`Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.`,
-				author: {
-					name: "Fatih Kan",
-					url: "https://github.com/fatihkan",
-				},
-				homepage: "https://github.com/fatihkan/badi",
-				repository: "https://github.com/fatihkan/badi",
-				license: pkg.license || "MIT",
-				keywords: [
-					"claude",
-					"claude-code",
-					"claude-opus",
-					"claude-sonnet",
-					"anthropic",
-					"ai-agents",
-					"subagents",
-					"workflow",
-					"observability",
-					"owasp",
-					"code-review",
-				],
-				category: "productivity",
-				strict: true,
-			},
-		],
+		plugins: [plugin],
 	};
 }
 

--- a/tests/hooks-isolation.test.js
+++ b/tests/hooks-isolation.test.js
@@ -1,0 +1,163 @@
+// Hook terminal-isolation testleri (v1.31.0).
+//
+// Anthropic Claude Code 2.1.139 (11 May 2026) hook'lari terminal access
+// olmadan calistirmaya basladi. Bu test:
+//  1. Hook stdout'a sadece JSON one-line yaziyorsa (veya bos kaliyorsa) gecer.
+//  2. Plain text (non-JSON) stdout = protokol ihlali = fail.
+//  3. ANSI escape sequence yokluk kontrolu (terminal manipulation tehlikesi).
+//  4. Stderr default'ta bos olmali (BADI_HOOK_DEBUG opt-in).
+//
+// docs/hooks/isolation-audit.md ile birlikte tutulur.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HOOKS_DIR = resolve(__dirname, "../.claude/hooks");
+
+// Hook event tipine gore minimal valid stdin JSON
+const STDIN_FIXTURES = {
+	"backup-before-write.mjs": JSON.stringify({
+		tool_name: "Write",
+		tool_input: { file_path: "/tmp/__badi_test_nonexistent.md" },
+	}),
+	"branch-guard.mjs": JSON.stringify({
+		tool_name: "Bash",
+		tool_input: { command: "echo test" },
+	}),
+	"completeness-gate.mjs": JSON.stringify({
+		tool_name: "Write",
+		tool_input: { file_path: "/tmp/__badi_test.md", content: "OK" },
+	}),
+	"dependency-audit.mjs": "{}",
+	"guard-bash.mjs": JSON.stringify({
+		tool_name: "Bash",
+		tool_input: { command: "echo safe" },
+	}),
+	"inject-active-plan.mjs": JSON.stringify({ prompt: "test" }),
+	"log-changes.mjs": JSON.stringify({
+		tool_name: "Read",
+		tool_input: { file_path: "/tmp/__badi_test.md" },
+	}),
+	"log-failures.mjs": JSON.stringify({ tool_name: "Bash", error: "ENOENT" }),
+	"log-stop-verdict.mjs": JSON.stringify({
+		decision: "allow",
+		reason: "test",
+	}),
+	"post-compact-resume.mjs": "{}",
+	"pre-compact-handoff.mjs": "{}",
+	"session-reset.mjs": "{}",
+	"skill-router.mjs": JSON.stringify({ prompt: "kisa" }), // wordCount<3 → exit early
+	"track-usage.mjs": JSON.stringify({ tool_name: "Bash" }),
+};
+
+function listHooks() {
+	return readdirSync(HOOKS_DIR)
+		.filter((f) => f.endsWith(".mjs") && f !== "_util.mjs")
+		.sort();
+}
+
+function runHook(hookName, stdin) {
+	return spawnSync(process.execPath, [join(HOOKS_DIR, hookName)], {
+		input: stdin,
+		encoding: "utf-8",
+		timeout: 5000,
+	});
+}
+
+// ANSI escape: ESC[, ESC], cursor moves, color codes
+const ANSI_RE = /\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07/;
+
+describe("hooks terminal-isolation (Anthropic 2.1.139 uyum)", () => {
+	const hooks = listHooks();
+
+	it("14 hook fixture'i tanimli", () => {
+		for (const h of hooks) {
+			assert.ok(STDIN_FIXTURES[h], `${h} icin STDIN_FIXTURES eksik`);
+		}
+	});
+
+	for (const hookName of hooks) {
+		it(`${hookName} stdout JSON-only veya bos`, () => {
+			const r = runHook(hookName, STDIN_FIXTURES[hookName]);
+			assert.equal(r.status, 0, `${hookName} exit ${r.status}`);
+
+			const stdout = (r.stdout || "").trim();
+			if (stdout === "") return; // bos OK
+
+			// Satir satir kontrol — her satir valid JSON olmali
+			for (const line of stdout.split("\n")) {
+				const trimmed = line.trim();
+				if (trimmed === "") continue;
+				assert.doesNotThrow(
+					() => JSON.parse(trimmed),
+					`${hookName} non-JSON stdout: "${trimmed.slice(0, 80)}"`,
+				);
+			}
+		});
+
+		it(`${hookName} stdout ANSI escape icermez`, () => {
+			const r = runHook(hookName, STDIN_FIXTURES[hookName]);
+			const stdout = r.stdout || "";
+			assert.ok(
+				!ANSI_RE.test(stdout),
+				`${hookName} stdout'unda ANSI escape: ${JSON.stringify(stdout.slice(0, 100))}`,
+			);
+		});
+
+		it(`${hookName} stderr default'ta bos (BADI_HOOK_DEBUG yok)`, () => {
+			const r = runHook(hookName, STDIN_FIXTURES[hookName]);
+			const stderr = (r.stderr || "").trim();
+			// Module yukleme uyarilari (ExperimentalWarning, vs.) tolere edilir
+			const lines = stderr
+				.split("\n")
+				.filter((l) => l.trim() && !/Warning|deprecated/i.test(l));
+			assert.equal(
+				lines.length,
+				0,
+				`${hookName} default'ta stderr yazmamali: ${stderr.slice(0, 200)}`,
+			);
+		});
+	}
+});
+
+describe("hooks isolation regression — Kategori 2 fix dogrulamasi", () => {
+	it("dependency-audit.mjs writeContextInjection kullaniyor (plain stdout yok)", () => {
+		const r = runHook("dependency-audit.mjs", "{}");
+		assert.equal(r.status, 0);
+		const stdout = (r.stdout || "").trim();
+		if (stdout !== "") {
+			// Eger cikti varsa JSON ve hookSpecificOutput icermeli
+			for (const line of stdout.split("\n").filter((l) => l.trim())) {
+				const parsed = JSON.parse(line);
+				assert.ok(
+					parsed.hookSpecificOutput ||
+						parsed.decision ||
+						parsed.continue !== undefined,
+					"dependency-audit output JSON ama beklenen format yok",
+				);
+			}
+		}
+	});
+
+	it("post-compact-resume.mjs writeContextInjection kullaniyor", () => {
+		// .compaction-occurred marker yoksa exit early — cikti bos olmali
+		const r = runHook("post-compact-resume.mjs", "{}");
+		assert.equal(r.status, 0);
+		// Marker yok → silent exit beklenir
+		const stdout = (r.stdout || "").trim();
+		// Eger stdout varsa JSON olmali (plain "Sikistirma sonrasi..." asla)
+		if (stdout !== "") {
+			for (const line of stdout.split("\n").filter((l) => l.trim())) {
+				assert.doesNotThrow(
+					() => JSON.parse(line),
+					"post-compact-resume non-JSON cikti: regresyon!",
+				);
+			}
+		}
+	});
+});

--- a/tests/hooks-isolation.test.js
+++ b/tests/hooks-isolation.test.js
@@ -51,7 +51,9 @@ const STDIN_FIXTURES = {
 	"post-compact-resume.mjs": "{}",
 	"pre-compact-handoff.mjs": "{}",
 	"session-reset.mjs": "{}",
-	"skill-router.mjs": JSON.stringify({ prompt: "kisa" }), // wordCount<3 → exit early
+	"skill-router.mjs": JSON.stringify({
+		prompt: "uzun test prompt cumlesi route et",
+	}),
 	"track-usage.mjs": JSON.stringify({ tool_name: "Bash" }),
 };
 

--- a/tests/marketplace-manifest.test.js
+++ b/tests/marketplace-manifest.test.js
@@ -210,6 +210,45 @@ describe("dist/ multi-package skeletons exist", () => {
 		assert.match(scriptText, /\$LASTEXITCODE/);
 	});
 
+	it("v1.31.0+ lastUpdated field plugin.json'da", () => {
+		const p = readFileSync(
+			join(PKG_ROOT, ".claude-plugin", "plugin.json"),
+			"utf-8",
+		);
+		const parsed = JSON.parse(p);
+		assert.ok(
+			parsed.lastUpdated,
+			"plugin.json lastUpdated yok (Claude Code 2.1.144+ Browse uyumu)",
+		);
+		assert.match(
+			parsed.lastUpdated,
+			/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+			"lastUpdated ISO 8601 olmali",
+		);
+	});
+
+	it("v1.31.0+ lastUpdated field marketplace.json plugin entry'sinde", () => {
+		const p = readFileSync(
+			join(PKG_ROOT, ".claude-plugin", "marketplace.json"),
+			"utf-8",
+		);
+		const parsed = JSON.parse(p);
+		assert.ok(parsed.plugins?.[0]?.lastUpdated, "marketplace.json lastUpdated yok");
+	});
+
+	it("v1.31.0+ dist/github-actions/security-review.yml mevcut", () => {
+		const p = join(PKG_ROOT, "dist", "github-actions", "security-review.yml");
+		assert.ok(existsSync(p), "security-review.yml scaffold eksik");
+		const body = readFileSync(p, "utf-8");
+		assert.match(body, /permissions:/);
+		assert.match(body, /pull-requests: write/);
+		assert.match(body, /anthropics\/claude-code-security-review/);
+		assert.match(body, /ANTHROPIC_API_KEY/);
+		// pull_request (head SHA), NOT pull_request_target (prompt injection hardening)
+		assert.match(body, /on:\s*\n\s+pull_request:/);
+		assert.doesNotMatch(body, /pull_request_target/);
+	});
+
 	it("dist publish workflow mevcut + hardened", () => {
 		const p = join(PKG_ROOT, ".github", "workflows", "dist-publish.yml");
 		assert.ok(existsSync(p));

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -85,6 +85,57 @@ describe("badi security command", () => {
 		}
 	});
 
+	// v1.31.0+ O1 hotfix: K1 bug'inin tekrar gelmemesi icin baseline integration testi.
+	it("badi security baseline secret-scan'i gercekten calistirir (K1 regression)", () => {
+		// Clean repo'da baseline calistir — secret-scan satirini, npm audit satirini
+		// ve "Sir bulgu yok" mesajini ister.
+		const tmp = mkdtempSync(join(tmpdir(), "badi-sec-baseline-"));
+		try {
+			// Minimal proje: package.json olmadan secret-scan calisir; audit skip eder
+			writeFileSync(join(tmp, "README.md"), "# test\n");
+			// Git init — projectRoot tespiti icin
+			spawnSync("git", ["init"], { cwd: tmp, encoding: "utf-8" });
+
+			const r = runBadi(["security", "baseline"], { cwd: tmp });
+			// secret-scan calismali, audit lock yoksa skip etmeli
+			assert.match(
+				r.stdout,
+				/\[1\/2\].*secret-scan/,
+				`secret-scan satiri yok. stdout: ${r.stdout.slice(0, 300)}`,
+			);
+			assert.match(r.stdout, /Sir bulgu yok|sir bulgu/);
+			assert.match(r.stdout, /atlandi.*lock dosyasi yok/);
+			// K1 regression check: secret-scan ciktisi parse edilemedi yazmamali
+			assert.doesNotMatch(
+				r.stderr,
+				/secret-scan ciktisi parse edilemedi/,
+				"K1 hotfix gerileme: secret-scan parse hatasi tekrar dondu",
+			);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	// v1.31.0+ K2 hotfix regression: word-boundary regex over-counting
+	it("badi security triage 'below'/'follow'/'yellow' false positive uretmemeli", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-sec-k2-"));
+		try {
+			const reportDir = join(tmp, "security-report");
+			mkdirSync(reportDir, { recursive: true });
+			// Tek "DUSUK" word olmali ama "follow", "yellow", "below" trapleri var
+			writeFileSync(
+				join(reportDir, "SECURITY-REPORT.md"),
+				"# Report\n\nThe following code is below threshold, yellow flag.\n\n## DUSUK style\n",
+			);
+
+			const r = runBadi(["security", "triage"], { cwd: tmp });
+			// Heading-based count: tam 1 DUSUK olmali, asla 4+ degil
+			assert.match(r.stdout, /Dusuk.*1\b/, `K2 regression. stdout: ${r.stdout}`);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
 	it("badi security triage rapor varsa severity sayim", () => {
 		const tmp = mkdtempSync(join(tmpdir(), "badi-sec-triage2-"));
 		try {

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -1,0 +1,107 @@
+// `badi security` komutu testleri (v1.31.0+).
+//
+// 3 subkomut: baseline / triage / init --ci
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BADI = resolve(__dirname, "..", "bin", "badi.js");
+
+function runBadi(args, opts = {}) {
+	return spawnSync(process.execPath, [BADI, ...args], {
+		encoding: "utf-8",
+		timeout: 30_000,
+		...opts,
+	});
+}
+
+describe("badi security command", () => {
+	it("badi security --help calisir, 3 subkomut listeler", () => {
+		const r = runBadi(["security", "--help"]);
+		assert.equal(r.status, 0);
+		assert.match(r.stdout, /baseline/);
+		assert.match(r.stdout, /triage/);
+		assert.match(r.stdout, /init/);
+		assert.match(r.stdout, /security-review/);
+	});
+
+	it("badi security bilinmeyen subkomut exit 1", () => {
+		const r = runBadi(["security", "foobar"]);
+		assert.equal(r.status, 1);
+	});
+
+	it("badi security init --ci scaffold workflow yazar", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-sec-init-"));
+		try {
+			const r = runBadi(["security", "init", "--ci"], { cwd: tmp });
+			assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+			const wf = join(tmp, ".github", "workflows", "security-review.yml");
+			assert.ok(existsSync(wf), "scaffold dosyasi olusturulmadi");
+			// Workflow icerigi dogrula
+			const body = readFileSync(wf, "utf-8");
+			assert.match(body, /permissions:/);
+			assert.match(body, /anthropics\/claude-code-security-review/);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("badi security init --ci uzerinde varsa hata", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-sec-init2-"));
+		try {
+			const wfDir = join(tmp, ".github", "workflows");
+			mkdirSync(wfDir, { recursive: true });
+			writeFileSync(join(wfDir, "security-review.yml"), "# placeholder\n");
+
+			const r = runBadi(["security", "init", "--ci"], { cwd: tmp });
+			assert.equal(r.status, 1);
+			assert.match(r.stderr, /Var olan dosyayi yazmaz/);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("badi security triage rapor yoksa exit 1", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-sec-triage-"));
+		try {
+			const r = runBadi(["security", "triage"], { cwd: tmp });
+			assert.equal(r.status, 1);
+			assert.match(r.stderr, /Rapor yok/);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("badi security triage rapor varsa severity sayim", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-sec-triage2-"));
+		try {
+			const reportDir = join(tmp, "security-report");
+			mkdirSync(reportDir, { recursive: true });
+			writeFileSync(
+				join(reportDir, "SECURITY-REPORT.md"),
+				"# Report\n\n## KRITIK SQLi\n## YUKSEK XSS\n## ORTA CSRF\n## DUSUK style\n",
+			);
+
+			const r = runBadi(["security", "triage"], { cwd: tmp });
+			// Kritik bulgu varsa exit 1 — beklenir
+			assert.equal(r.status, 1);
+			assert.match(r.stdout, /Kritik.*1/);
+			assert.match(r.stdout, /Yuksek.*1/);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Ozet

Anthropic Claude Code **2.1.126-2.1.147** (1-22 Mayis 2026) surumlerine uyum saglar. 5 issue tek release'de kapanir.

| # | Konu | Durum |
|---|------|-------|
| #188 | `/security-review` native komut entegrasyonu + `badi security` CLI | ✅ |
| #189 | `/review` effort + `--comment` + `--correctness-only` parity | ✅ |
| #190 | Marketplace manifest `lastUpdated` field (2.1.144+ Browse uyumu) | ✅ |
| #191 | GitHub Action scaffold (Anthropic resmi action wrap) | ✅ |
| #192 | Hook terminal-isolation audit + 2 Kategori 2 fix (2.1.139+) | ✅ |

## Anthropic surum referansi

| Surum | Tarih | Ozellik | Badi etki |
|-------|-------|---------|-----------|
| 2.1.126 | 1 May | `--dangerously-skip-permissions` scope extension | README uyari |
| 2.1.139 | 11 May | Hook'lar terminal access olmadan calisir | **15 hook audit + 2 fix** |
| 2.1.140 | 12 May | Built-in slash command discovery (`/security-review` discoverable) | Skill + slash kopru |
| 2.1.142 | 14 May | Root-level `SKILL.md` destegi | Test (uyumlu) |
| 2.1.143 | 15 May | Plugin dependency enforcement | `plugin doctor` crossref |
| 2.1.144 | 19 May | Browse pane plugin son guncelleme tarihi | **`lastUpdated` field** |
| 2.1.145 | 20 May | Browse pane install oncesi component listesi | Manifest counts (zaten var) |
| 2.1.147 | 21 May | `/code-review` komutu (effort + --comment) | **`/review` parity** |

## Yeni komutlar

```bash
badi security baseline [--json]       # secret-scan + npm audit deterministic taban
badi security triage [report]         # /security-review raporu severity'ye gore filtrele
badi security init --ci [--force]     # GitHub Action scaffold yaz
```

`/review` slash komutu argumanlar:
```
/review [low|medium|high] [--comment] [--correctness-only]
```

## Hook isolation audit sonucu (#192)

15 hook (14 + `_util.mjs`) audit edildi:

| Kategori | Sayi | Aciklama |
|----------|------|----------|
| 1 (JSON protocol / log-only) | 13 | Guvenli — degisiklik yok |
| 2 (Plain text stdout protokol ihlali) | **2** | **FIX uygulandi** |
| 3 (Terminal manipulation / ANSI) | 0 | Temiz |

Kategori 2 fix'leri:
- `dependency-audit.mjs`: `process.stdout.write(plain)` → `writeContextInjection()`
- `post-compact-resume.mjs`: `process.stdout.write(plain)` → `writeContextInjection()`

**Onemli**: Bu fix v1.31.0 oncesinde de teknik olarak yanlisi — Kategori 2 ciktilar Claude'un contextine girmiyor, terminal'e dusuyor veya kayboluyordu. Artik gercekten `additionalContext` JSON protocol ile inject ediliyor.

Detay: `docs/hooks/isolation-audit.md`.

## /review ↔ /code-review farki (kapatildi)

| Boyut | badi `/review` (v1.31+) | Anthropic `/code-review` (2.1.147+) |
|-------|--------------------------|-------------------------------------|
| Kapsam | 3 kanal (sec+perf+arch) + correctness | Sadece correctness |
| Effort | low/med/high | low/med/high |
| `--comment` | ✅ (gh CLI inline PR) | ✅ |
| `--correctness-only` | ✅ (opt-in) | ✅ (default davranis) |
| Classification | KRITIK/YUKSEK/ORTA/DUSUK | Effort-tunable |
| Dil | Turkce + EN | Native English |

Badi `/review` artik Anthropic'in **superset**'i.

## Dokuman

- `docs/enterprise.md` (yeni) — Anthropic managed-settings + hook isolation + plugin marketplace + telemetri + SSO rehberi
- `docs/hooks/isolation-audit.md` (yeni) — 15 hook kategorize raporu
- README "Security Notes (v1.31.0+)" — `--dangerously-skip-permissions` uyari + crossref'ler
- CHANGELOG.md + CHANGELOG.tr.md [1.31.0] entry

## Testler

1074 → **1128** (+54):
- `tests/hooks-isolation.test.js` (45): her hook icin JSON-only stdout + ANSI escape yok + stderr bos
- `tests/security.test.js` (6): `badi security baseline/triage/init --ci` subcommand'lari
- `tests/marketplace-manifest.test.js` (+3): `lastUpdated` field + scaffold dogrulama

## Test Plan

- [x] `npm test` — 1128/1128 pass
- [x] `node bin/badi.js security --help` — yardim metni dogru
- [x] `node bin/badi.js security init --ci` (tmp dizinde) — workflow yazar
- [x] `node bin/badi.js security triage` (rapor yoksa) — exit 1 + hata mesaji
- [x] `node bin/badi.js release sync-manifest` — `lastUpdated` field iceren manifest uretir
- [x] Hook isolation: `dependency-audit.mjs` ve `post-compact-resume.mjs` JSON output protocol
- [x] CHANGELOG.md + CHANGELOG.tr.md [1.31.0] entry
- [ ] Manual: PR'a `--comment` flag ile `/review high --comment` test (gh CLI lazim)
- [ ] Manual: `badi security init --ci` + `ANTHROPIC_API_KEY` secret + PR open → workflow trigger dogrulama

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #188 #189 #190 #191 #192
