### PR TITLE
chore(release): v1.31.0 manifest sync + wrap-up ogrenimleri

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
 			],
 			"category": "productivity",
 			"strict": true,
-			"lastUpdated": "2026-05-19T11:18:19+03:00"
+			"lastUpdated": "2026-05-22T09:07:50+03:00"
 		}
 	]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
 	"name": "badi",
-	"version": "1.30.1",
+	"version": "1.31.0",
 	"description": "Workflow management for Claude Code, Cursor, Gemini, Windsurf, AGENTS.md — 22 AI agents, 77 commands, 14 hooks, 62 opt-in skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
 	"author": {
 		"name": "Fatih Kan",
@@ -85,5 +85,5 @@
 			}
 		]
 	},
-	"lastUpdated": "2026-05-19T11:18:19+03:00"
+	"lastUpdated": "2026-05-22T09:07:50+03:00"
 }

--- a/.claude/knowledge-base.md
+++ b/.claude/knowledge-base.md
@@ -50,3 +50,64 @@ tum kategorileri aktive etmesini saglar.
 
 ## Bilinen Hata Kaliplari
 <!-- Daha once karsilasilan ve cozulen hatalar -->
+
+### GitHub squash merge "Closes" referansi her zaman calismaz
+PR body'sindeki `Closes #X #Y #Z` referanslari squash merge sirasinda GitHub
+tarafindan parse edilmedigi durumlar olur (3+ issue listesinde belirgin).
+Tespit edilen: v1.30.0 PR #182 (#178-181 acik kaldi), v1.31.0 PR #193
+(#189-191 acik kaldi — #188 ve #192 kapanmis, kararsiz davranis). Cozum:
+yayindan sonra `gh issue list --state open` kontrolu + manuel
+`gh issue close N` ile kapat. Wrap-up checklistine ekle.
+[Kaynak: 2026-05-22 v1.31.0 yayin pattern tekrari]
+
+### ESM module hem programatik hem CLI: import.meta.url tespiti
+`lib/commands/X.js` hem `export function runX()` ile programatik hem de
+`node lib/commands/X.js` ile CLI olarak calistirilmasi gerekiyorsa, dosya
+sonuna su deyimi ekle:
+```js
+if (import.meta.url.startsWith("file:") && process.argv[1] &&
+    import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  runX(process.argv.slice(2));
+}
+```
+Yalniz `node lib/commands/X.js` ile cagrildiginda calisir, `import`
+edildiginde no-op. v1.31.0 K1 hotfix bu pattern'i secret-scan'e uyguladi
+(badi security baseline'in calismasi icin gerekti).
+[Kaynak: 2026-05-22 v1.31.0 K1 hotfix]
+
+## Surec Kaliplari
+<!-- Calistigi denenmis ve dogrulanmis surecler -->
+
+### Internal /review hotfix BEFORE npm publish — 3 release tekrar
+Pattern v1.30.0 (PR #183 11 bulgu), v1.30.1 (PR #186 9 bulgu), v1.31.0
+(commit 6132e44 13 bulgu) ile **3 kez** ardarda calisti. Kanonik akis:
+1. Feature PR ac (issue'lardan ureilen scope)
+2. PR uzerine `/review` calistir (3 kanal: sec+perf+arch)
+3. Bulgulari ayni release branch'inde hotfix commit ile kapat
+4. Squash merge → main
+5. `badi publish --version <bump>` → npm yayin
+6. Release notes zenginlestir + memory marker chore PR
+
+Avantaj: tek release'de hem feature hem cleanup, npm latest "bug-free"
+versiyon olur. Dezavantaj: PR review yuku surekli ust uste binebilir.
+[Kaynak: 2026-05-22 v1.31.0 ile 3. tekrar — pattern olgunlasmis]
+
+### lastUpdated stale-check semantigi: per-commit DEGIL per-package.json
+Marketplace manifest'te `lastUpdated` field eklerken, "her commit'te
+degisir" yerine "package.json commit'inde degisir" davranisi tercih edilmeli
+(`git log -1 --format=%cI -- package.json`). Sebep: release sync-manifest
+calismadan onceki commit'lerde stale check noise olmaz; yalniz version
+bump sonrasi manifest stale olur. v1.31.0'da uygulandi.
+[Kaynak: 2026-05-22 marketplace-manifest.js lastPackageJsonCommitDate()]
+
+### Hook output protocol 3-kategorize audit kalibi
+Anthropic Claude Code 2.1.139 ile hook isolation gereksinimi geldi. Audit
+calistirilirken her hook su 3 kategoriden birine atanir:
+- Kategori 1: JSON output protocol (`writeDecision`, `writeContextInjection`)
+  veya log-only — guvenli
+- Kategori 2: Plain text stdout protokol ihlali — fix gerek (kayboluyor
+  ya da terminal'e dusuyor)
+- Kategori 3: ANSI escape / cursor manipulation — tehlikeli, derhal fix
+Audit raporu `docs/hooks/isolation-audit.md` formatinda tutulur, her hook
+icin tablo satir + fix kayit. v1.31.0'da 15 hook icin uygulandi.
+[Kaynak: 2026-05-22 docs/hooks/isolation-audit.md]


### PR DESCRIPTION
v1.31.0 wrap-up'ta tespit edilen plugin.json/marketplace.json v1.30.1 stale durumu manuel `badi release sync-manifest` ile duzeltildi.

Yeni issue acilacak: `badi publish` workflow'una sync-manifest adimi entegrasyonu (bu durum gelecek release'lerde tekrarlanmasin).

Ek olarak `.claude/knowledge-base.md`'ye 5 yeni ogrenim eklendi (Squash merge Closes bug, ESM CLI entry pattern, internal /review hotfix pattern, lastUpdated semantigi, hook isolation kalibi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)