### PR TITLE
feat(release): release check'e biome lint gate ekle (denetim O1)

### DIFF
--- a/.claude/workspace/TaskBoard.md
+++ b/.claude/workspace/TaskBoard.md
@@ -20,12 +20,12 @@
 
 ## Denetim Bulgulari (T3 — 29.05.2026)
 
-- [ ] (O1/P2) release CHECKS'e biome lint gate ekle — lint/format rot'unu kaynagindan keser
 - [ ] (O2/P3) en.js/tr.js locale parite testi — 171 satir drift, en.js eksik olabilir
 - [ ] (O3/P3) buyuk komut dosyalarini split (mobile.js 1226 once) — icerik/plugin pattern'i
 - [ ] (D1/P4) seo.js stripTags'i node-html-parser'a tasi — regex-HTML kural tutarliligi
 
 ## Tamamlanan
+- 29.05.2026 (Cuma): #202 oturum sync · #197 publish auto-sync + isManifestStale kok fix · O1 release check lint gate (denetim bulgusu kapandi)
 - 29.05.2026 (Cuma): Bakim turu (test/lint/drift/changelog) PR #199 · manifest re-sync PR #200 · T3 denetim (KB+taskboard) PR #201
 - 22.05.2026 (Cuma): #192 hook isolation audit (15 hook, 2 fix) — PR #193
 - 22.05.2026: #188 /security-review entegrasyon + badi security CLI — PR #193

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Added — `badi release check` lint gate (audit O1)
+
+`badi release check` artik `biome check` (lint) asamasi calistirir — lint hatasi publish'i **bloklar** (level: fail), `--skip-lint` ile atlanabilir. Sebep: lint/format CI-release'de gate edilmiyordu ve rot birikiyordu (bakim turunda 19 birikmis hata bundan cikti). Yeni `checkLint` `CHECKS` array'ine eklendi; `--skip-lint` help + parser'da belgeli (help-doctor temiz).
+
 ### Fixed — `badi publish` workflow auto-sync manifest (#196)
 
 `badi publish --version <bump>` artik package.json bump sonrasi `.claude-plugin/{plugin,marketplace}.json` dosyalarini otomatik regenerate edip ayni commit'e ekler. v1.30.1 ve v1.31.0 publish'lerinde manifest stale kaliyordu, manuel `badi release sync-manifest` gerekiyordu — bu doneme kapanir.

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,10 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+### Eklenen — `badi release check` lint gate (denetim O1)
+
+`badi release check` artik `biome check` (lint) asamasi calistirir — lint hatasi publish'i **bloklar** (level: fail), `--skip-lint` ile atlanabilir. Sebep: lint/format CI-release'de gate edilmiyordu ve rot birikiyordu (bakim turunda 19 birikmis hata bundan cikti). Yeni `checkLint` `CHECKS` array'ine eklendi; `--skip-lint` help + parser'da belgeli (help-doctor temiz).
+
 ### Duzeltilen — `badi publish` workflow otomatik manifest sync (#196)
 
 `badi publish --version <bump>` artik package.json bump sonrasi `.claude-plugin/{plugin,marketplace}.json` dosyalarini otomatik yeniden uretip ayni commit'e ekler. v1.30.1 ve v1.31.0 publish'lerinde manifest stale kaliyordu, manuel `badi release sync-manifest` gerekiyordu — bu donem kapaniyor.

--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -75,6 +75,21 @@ function runNpmTest() {
 	};
 }
 
+function runLint() {
+	const r = spawnSync("npm", ["run", "lint", "--silent"], {
+		encoding: "utf-8",
+		timeout: 60_000,
+	});
+	const out = `${r.stdout || ""}${r.stderr || ""}`;
+	// biome "Found N errors" satirini yakala (info/hint icin).
+	const errMatch = out.match(/Found\s+(\d+)\s+error/i);
+	return {
+		exitCode: r.status,
+		out,
+		errors: errMatch ? Number(errMatch[1]) : null,
+	};
+}
+
 function npmPackDryRun() {
 	const r = spawnSync("npm", ["pack", "--dry-run", "--json"], {
 		encoding: "utf-8",
@@ -201,6 +216,30 @@ function checkNpmTest(ctx) {
 	};
 }
 
+function checkLint(ctx) {
+	if (ctx.skipLint) {
+		return {
+			name: "lint",
+			label: "Lint atlandi (--skip-lint)",
+			pass: true,
+			level: "warn",
+			hint: null,
+		};
+	}
+	const r = runLint();
+	const ok = r.exitCode === 0;
+	return {
+		name: "lint",
+		label: "Lint (biome check)",
+		pass: ok,
+		level: ok ? "ok" : "fail",
+		info: ok ? "temiz" : null,
+		hint: ok
+			? null
+			: `${r.errors != null ? `${r.errors} hata` : "lint hatasi"} — npm run lint:fix`,
+	};
+}
+
 function checkGhCli() {
 	const ok = hasCommand("gh");
 	return {
@@ -279,6 +318,7 @@ export const CHECKS = [
 	checkChangelogEn,
 	checkChangelogTr,
 	checkMarketplaceManifest,
+	checkLint,
 	checkNpmTest,
 	checkGhCli,
 	checkNpmPack,
@@ -348,12 +388,14 @@ export function runReleaseCheck(args = []) {
 	let strict = false;
 	let versionFlag = null;
 	let skipTest = false;
+	let skipLint = false;
 	let nextVersionType = null;
 
 	for (let i = 0; i < args.length; i++) {
 		const a = args[i];
 		if (a === "--strict") strict = true;
 		else if (a === "--skip-test") skipTest = true;
+		else if (a === "--skip-lint") skipLint = true;
 		else if (a === "--version") {
 			versionFlag = args[++i] ?? null;
 		} else if (a === "--bump") {
@@ -375,7 +417,7 @@ export function runReleaseCheck(args = []) {
 	}
 	if (!targetVersion && pkg?.version) targetVersion = pkg.version;
 
-	const ctx = { pkg, targetVersion, skipTest };
+	const ctx = { pkg, targetVersion, skipTest, skipLint };
 	const results = runChecks(ctx);
 
 	// Note: bazi check'ler uzun surer (npm test). Inline'da "calisiyor" mesaji
@@ -415,6 +457,9 @@ function printHelp() {
 	);
 	console.log(
 		`  --skip-test                       Test asamasini atla (hizli check)`,
+	);
+	console.log(
+		`  --skip-lint                       Lint (biome) asamasini atla`,
 	);
 	console.log("");
 	console.log(chalk.bold("'sync-manifest' Secenekleri:"));
@@ -499,6 +544,7 @@ export {
 	checkChangelogTr,
 	checkGhCli,
 	checkGitClean,
+	checkLint,
 	checkNpmPack,
 	checkNpmTest,
 	checkPackageJson,

--- a/tests/release-checks.test.js
+++ b/tests/release-checks.test.js
@@ -5,6 +5,7 @@ import {
 	CHECKS,
 	checkBranch,
 	checkGhCli,
+	checkLint,
 	checkPackageJson,
 	runChecks,
 } from "../lib/commands/release.js";
@@ -50,8 +51,22 @@ describe("release checks (post C2 refactor)", () => {
 		assert.ok(["ok", "warn", "fail"].includes(r.level));
 	});
 
+	it("checkLint --skip-lint atlar (warn, pass)", () => {
+		const r = checkLint({ skipLint: true });
+		assert.equal(r.name, "lint");
+		assert.equal(r.pass, true);
+		assert.equal(r.level, "warn");
+	});
+
+	it("checkLint gercek calistirma gecerli level doner", () => {
+		// biome calistirir (hizli); repo durumuna gore ok/fail — yapiyi dogrula.
+		const r = checkLint({});
+		assert.equal(r.name, "lint");
+		assert.ok(["ok", "fail"].includes(r.level));
+	});
+
 	it("runChecks calls all", () => {
-		const results = runChecks({ pkg: null, skipTest: true });
+		const results = runChecks({ pkg: null, skipTest: true, skipLint: true });
 		assert.ok(results.length >= 4);
 		for (const r of results) {
 			assert.ok(typeof r.label === "string");


### PR DESCRIPTION
## Ozet
T3 denetiminin en yuksek-degerli bulgusu (**O1**): lint/format `npm test` disinda gate edilmiyordu, rot birikiyordu (bakim turunda 19 birikmis hata tam da bundan cikmisti). `badi release check` artik bir **lint gate** icerir.

## Degisiklik
- **`lib/commands/release.js`**: `runLint()` (`npm run lint` = biome) + `checkLint()` CHECKS array'ine eklendi (testten once). Lint hatasi → `level: fail` → publish bloklanir. `--skip-lint` escape hatch (mevcut `--skip-test` pattern'i). Help + parser'da belgeli (help-doctor temiz). `checkLint` export edildi.
- **`tests/release-checks.test.js`**: `--skip-lint` skip testi + gercek-calistirma (biome) yapi testi (+2). `runChecks` cagrisina `skipLint: true`.
- **CHANGELOG md/tr** `[Unreleased]` Added entry; **TaskBoard** O1 kapandi.

## Davranis
`badi release check` ciktisina yeni satir: `OK  Lint (biome check)  (temiz)`. Lint hatasinda `XX  Lint (biome check)  (N hata — npm run lint:fix)` ve `Sonuc`'ta HATA → exit 1 (publish bloklanir). `--skip-lint` ile atlanir.

## Dogrulama
- `npm test` → **1134/1134** (+2 lint testi)
- `npm run lint` → 0
- Canli: `badi release check --skip-test` → `OK  Lint (biome check)  (temiz)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)