### PR TITLE
feat(icerik): ara CLI output English (English-only phase 2a pilot)

### DIFF
--- a/lib/commands/icerik/ara.js
+++ b/lib/commands/icerik/ara.js
@@ -39,35 +39,33 @@ export function runAra(args) {
 	}
 
 	if (showAraHelp || !query) {
-		console.log(chalk.bold("Icerik Arsiv Arama:"));
+		console.log(chalk.bold("Content Archive Search:"));
 		console.log("");
 		console.log(
-			`  badi icerik ara [sorgu]           ${chalk.dim("Anahtar kelime arama")}`,
+			`  badi icerik ara [query]           ${chalk.dim("Keyword search")}`,
 		);
 		console.log(
-			`  badi icerik ara [s] --platform X  ${chalk.dim("Platform filtresi")}`,
+			`  badi icerik ara [q] --platform X  ${chalk.dim("Platform filter")}`,
 		);
 		console.log(
-			`  badi icerik ara [s] --tur post    ${chalk.dim("Tur filtresi (post/karousel/video/gorsel)")}`,
+			`  badi icerik ara [q] --tur post    ${chalk.dim("Type filter (post/karousel/video/gorsel)")}`,
+		);
+		console.log(`  badi icerik ara [q] --son 30      ${chalk.dim("Last N days")}`);
+		console.log(
+			`  badi icerik ara [q] --hashtag X   ${chalk.dim("Hashtag search")}`,
 		);
 		console.log(
-			`  badi icerik ara [s] --son 30      ${chalk.dim("Son N gun")}`,
-		);
-		console.log(
-			`  badi icerik ara [s] --hashtag X   ${chalk.dim("Hashtag arama")}`,
-		);
-		console.log(
-			`  badi icerik ara [s] --format json ${chalk.dim("JSON cikti")}`,
+			`  badi icerik ara [q] --format json ${chalk.dim("JSON output")}`,
 		);
 		if (!query && !showAraHelp) {
 			console.log("");
-			console.log(chalk.yellow("Arama sorgusu belirtin."));
+			console.log(chalk.yellow("Specify a search query."));
 		}
 		return;
 	}
 
 	if (!existsSync(workspaceBase)) {
-		console.log(chalk.yellow("Workspace bulunamadi. Once icerik uretin."));
+		console.log(chalk.yellow("Workspace not found. Generate content first."));
 		return;
 	}
 
@@ -79,23 +77,21 @@ export function runAra(args) {
 	}
 
 	if (results.length === 0) {
-		console.log(chalk.yellow(`"${query}" icin sonuc bulunamadi.`));
+		console.log(chalk.yellow(`No results for "${query}".`));
 		return;
 	}
 
 	console.log(
-		chalk.bold(`Arama Sonuclari: "${query}" (${results.length} sonuc)`),
+		chalk.bold(`Search Results: "${query}" (${results.length} results)`),
 	);
 	console.log("");
 
 	for (let i = 0; i < Math.min(results.length, 20); i++) {
 		const r = results[i];
 		console.log(
-			`  ${chalk.cyan(`${i + 1}.`)} [${chalk.bold(r.icon)}] ${r.file} ${chalk.dim(`(Skor: ${r.score})`)}`,
+			`  ${chalk.cyan(`${i + 1}.`)} [${chalk.bold(r.icon)}] ${r.file} ${chalk.dim(`(Score: ${r.score})`)}`,
 		);
-		console.log(
-			`     Tarih: ${chalk.dim(r.date)} | Dizin: ${chalk.dim(r.dir)}`,
-		);
+		console.log(`     Date: ${chalk.dim(r.date)} | Dir: ${chalk.dim(r.dir)}`);
 		if (r.snippet) console.log(`     ${chalk.dim(`"${r.snippet}"`)}`);
 		console.log("");
 	}

--- a/tests/cli.icerik-ara.test.js
+++ b/tests/cli.icerik-ara.test.js
@@ -50,30 +50,30 @@ describe("badi icerik ara", () => {
 
 	it("ara --help yardim gosterir", () => {
 		const output = run(["icerik", "ara", "--help"]);
-		assert.ok(output.includes("Arsiv Arama"));
+		assert.ok(output.includes("Archive Search"));
 	});
 
 	it("sorgu belirtilmeden yardim gosterir", () => {
 		const output = run(["icerik", "ara"]);
 		assert.ok(
-			output.includes("Arama sorgusu") || output.includes("Arsiv Arama"),
+			output.includes("search query") || output.includes("Archive Search"),
 		);
 	});
 
 	it("arama sonuc bulur", () => {
 		const output = run(["icerik", "ara", "uretkenlik"]);
-		assert.ok(output.includes("Arama Sonuclari"));
+		assert.ok(output.includes("Search Results"));
 		assert.ok(output.includes("uretkenlik"));
 	});
 
 	it("bos sonuc mesaji gosterir", () => {
 		const output = run(["icerik", "ara", "zzzyokboyle"]);
-		assert.ok(output.includes("bulunamadi"));
+		assert.ok(output.includes("No results"));
 	});
 
 	it("--platform filtresi calisiyor", () => {
 		const output = run(["icerik", "ara", "urun", "--platform", "LinkedIn"]);
-		assert.ok(output.includes("lansman") || output.includes("Arama Sonuclari"));
+		assert.ok(output.includes("lansman") || output.includes("Search Results"));
 	});
 
 	it("--format json cikti uretir", () => {
@@ -88,16 +88,16 @@ describe("badi icerik ara", () => {
 	it("--hashtag filtresi calisiyor", () => {
 		const output = run(["icerik", "ara", "rutin", "--hashtag", "sabahrutini"]);
 		assert.ok(
-			output.includes("sabah-rutini") || output.includes("Arama Sonuclari"),
+			output.includes("sabah-rutini") || output.includes("Search Results"),
 		);
 	});
 
 	it("birden fazla sonuc skor sirasinda", () => {
 		const output = run(["icerik", "ara", "uretkenlik"]);
-		const lines = output.split("\n").filter((l) => l.includes("Skor:"));
+		const lines = output.split("\n").filter((l) => l.includes("Score:"));
 		if (lines.length >= 2) {
 			const scores = lines.map((l) => {
-				const m = l.match(/Skor: ([\d.]+)/);
+				const m = l.match(/Score: ([\d.]+)/);
 				return m ? Number.parseFloat(m[1]) : 0;
 			});
 			assert.ok(scores[0] >= scores[1], "Sonuclar skora gore siralanmali");


### PR DESCRIPTION
## Ozet
English-only goc **Faz 2** (CLI runtime string cevirisi) **pilot batch**'i. `badi icerik ara` komutunun kullaniciya gosterilen tum console ciktilari English'e cevrildi; pattern'i (output string → English + test assertion guncelle) kurar.

## Degisiklik
- `lib/commands/icerik/ara.js`: arsiv-arama header, 6 filtre aciklamasi, sonuc/skor satirlari, bos-sonuc + "specify query" mesajlari → English.
- `tests/cli.icerik-ara.test.js`: assertion'lar English string'lere (Archive Search, Search Results, No results, Score:, search query).

## Kapsam notlari
- **Arayuz adlari korundu** (komut `ara`, flag `--tur`/`--son`). Rename ayri/breaking bir eksen — PR aciklamasinda ve mesajda kullaniciya soruluyor.
- Test **fixture** verisi (Turkce ornek icerik) dil-bagimsiz olduğu icin degistirilmedi.

## Dogrulama
- ara testi 8/8 · `npm test` 1132/1132 · `npm run lint` 0

## Faz 2 gercegi
Tum lib'de **~2950 console cagrisi** var (icerik ailesi ~311). Bu, cok sayida batch/PR gerektiren buyuk bir is. Bu pilot pattern'i kurar; kalan pacing + arayuz-rename karari kullaniciya birakildi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)