### PR TITLE
feat(icerik): basla + durum CLI output English (English-only phase 2b)

### DIFF
--- a/lib/commands/icerik/basla.js
+++ b/lib/commands/icerik/basla.js
@@ -7,33 +7,33 @@ export function runBasla() {
 	const workspaceBase = join(process.cwd(), ".claude", "workspace");
 	const today = getDateString();
 	const dayNames = [
-		"Pazar",
-		"Pazartesi",
-		"Sali",
-		"Carsamba",
-		"Persembe",
-		"Cuma",
-		"Cumartesi",
+		"Sunday",
+		"Monday",
+		"Tuesday",
+		"Wednesday",
+		"Thursday",
+		"Friday",
+		"Saturday",
 	];
 	const dayName = dayNames[new Date().getDay()];
 	const dayTheme = {
-		Pazartesi: "Motivasyon / Hafta basligi",
-		Sali: "Egitici / Ipucu",
-		Carsamba: "Perde arkasi / Topluluk",
-		Persembe: "Urun / Hizmet",
-		Cuma: "Eglence / Trend",
-		Cumartesi: "UGC / Sosyal kanit",
-		Pazar: "Ilham / Haftalik ozet",
+		Monday: "Motivation / Week kickoff",
+		Tuesday: "Educational / Tip",
+		Wednesday: "Behind the scenes / Community",
+		Thursday: "Product / Service",
+		Friday: "Fun / Trend",
+		Saturday: "UGC / Social proof",
+		Sunday: "Inspiration / Weekly recap",
 	}[dayName];
 
 	showBanner();
-	console.log(chalk.bold(`Icerik Seansi — ${today} (${dayName})`));
+	console.log(chalk.bold(`Content Session — ${today} (${dayName})`));
 	console.log("");
 
 	const markaPath = join(workspaceBase, "marka-sesi.md");
 	const markaVar = existsSync(markaPath);
 	console.log(
-		`Marka Sesi:  ${markaVar ? chalk.green("yuklendi") : chalk.yellow("eksik — badi icerik marka")}`,
+		`Brand Voice:  ${markaVar ? chalk.green("loaded") : chalk.yellow("missing — badi icerik marka")}`,
 	);
 
 	const takvimDir = join(workspaceBase, "takvim");
@@ -41,15 +41,15 @@ export function runBasla() {
 		? readdirSync(takvimDir).filter((f) => f.endsWith(".md")).length
 		: 0;
 	console.log(
-		`Takvim:      ${takvimSayisi > 0 ? chalk.green(`${takvimSayisi} dosya`) : chalk.yellow("yok — badi icerik takvim")}`,
+		`Calendar:     ${takvimSayisi > 0 ? chalk.green(`${takvimSayisi} files`) : chalk.yellow("none — badi icerik takvim")}`,
 	);
 
 	console.log("");
-	console.log(chalk.bold(`Bugunun Temasi (${dayName}):`));
+	console.log(chalk.bold(`Today's Theme (${dayName}):`));
 	console.log(`  ${chalk.cyan(dayTheme)}`);
 	console.log("");
 
-	console.log(chalk.bold("Bekleyen Taslaklar (son 7 gun):"));
+	console.log(chalk.bold("Pending Drafts (last 7 days):"));
 	const sevenDaysAgo = new Date();
 	sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 	const taslakDirs = [
@@ -81,21 +81,21 @@ export function runBasla() {
 		}
 	}
 	if (bekleyenSayisi === 0) {
-		console.log(chalk.dim("  (bekleyen taslak yok)"));
+		console.log(chalk.dim("  (no pending drafts)"));
 	}
 
 	console.log("");
-	console.log(chalk.bold("Bugun Odaklanabileceklerin:"));
+	console.log(chalk.bold("What You Can Focus On Today:"));
 	console.log(
-		`  1. Bugunun temasina uygun icerik: ${chalk.cyan(`badi icerik post "${dayTheme.toLowerCase()}"`)}`,
+		`  1. Content matching today's theme: ${chalk.cyan(`badi icerik post "${dayTheme.toLowerCase()}"`)}`,
 	);
 	if (bekleyenSayisi > 0) {
-		console.log(`  2. Bekleyen ${bekleyenSayisi} taslagi tamamla`);
+		console.log(`  2. Complete ${bekleyenSayisi} pending draft(s)`);
 	}
-	console.log(`  3. Fikir uret: ${chalk.cyan("badi icerik fikir")}`);
-	console.log(`  4. Durum gor: ${chalk.cyan("badi icerik durum")}`);
+	console.log(`  3. Generate ideas: ${chalk.cyan("badi icerik fikir")}`);
+	console.log(`  4. See status: ${chalk.cyan("badi icerik durum")}`);
 	console.log("");
 	console.log(
-		chalk.dim("Interaktif seans icin Claude Code'da /icerik-basla komutu."),
+		chalk.dim("For an interactive session, use /icerik-basla in Claude Code."),
 	);
 }

--- a/lib/commands/icerik/durum.js
+++ b/lib/commands/icerik/durum.js
@@ -7,13 +7,13 @@ export function runDurum() {
 	const workspaceBase = join(process.cwd(), ".claude", "workspace");
 	if (!existsSync(workspaceBase)) {
 		console.log(
-			chalk.dim("Henuz icerik olusturulmamis. Basla: badi icerik basla"),
+			chalk.dim("No content generated yet. Start: badi icerik basla"),
 		);
 		return;
 	}
 
 	showBanner();
-	console.log(chalk.bold("Icerik Uretim Durumu"));
+	console.log(chalk.bold("Content Production Status"));
 	console.log(
 		chalk.dim(
 			`${getDateString()} ${new Date().toTimeString().substring(0, 5)}`,
@@ -65,53 +65,51 @@ export function runDurum() {
 		}
 	}
 
-	console.log(chalk.bold("Envanter"));
-	console.log(`  Toplam:    ${chalk.cyan(envanter.total)}`);
-	console.log(`  Bugun:     ${chalk.cyan(envanter.bugun)}`);
-	console.log(`  Bu Hafta:  ${chalk.cyan(envanter.buHafta)}`);
-	console.log(`  Bu Ay:     ${chalk.cyan(envanter.buAy)}`);
-	console.log(`  Eski (30+): ${chalk.yellow(envanter.eski)}`);
+	console.log(chalk.bold("Inventory"));
+	console.log(`  Total:     ${chalk.cyan(envanter.total)}`);
+	console.log(`  Today:     ${chalk.cyan(envanter.bugun)}`);
+	console.log(`  This Week: ${chalk.cyan(envanter.buHafta)}`);
+	console.log(`  This Month:${chalk.cyan(envanter.buAy)}`);
+	console.log(`  Old (30+): ${chalk.yellow(envanter.eski)}`);
 	console.log("");
 
-	console.log(chalk.bold("Tamamlanmislik"));
+	console.log(chalk.bold("Completeness"));
 	const toplam =
 		tamamlanmislik.tamamlanan + tamamlanmislik.kismi + tamamlanmislik.taslak;
 	const orani =
 		toplam > 0 ? Math.round((tamamlanmislik.tamamlanan / toplam) * 100) : 0;
-	console.log(`  ${chalk.green("Tamamlanan:")} ${tamamlanmislik.tamamlanan}`);
-	console.log(`  ${chalk.yellow("Kismi:     ")} ${tamamlanmislik.kismi}`);
-	console.log(`  ${chalk.red("Taslak:    ")} ${tamamlanmislik.taslak}`);
-	console.log(`  Oran:      ${chalk.cyan(orani)}%`);
+	console.log(`  ${chalk.green("Complete:")} ${tamamlanmislik.tamamlanan}`);
+	console.log(`  ${chalk.yellow("Partial: ")} ${tamamlanmislik.kismi}`);
+	console.log(`  ${chalk.red("Draft:   ")} ${tamamlanmislik.taslak}`);
+	console.log(`  Rate:      ${chalk.cyan(orani)}%`);
 	console.log("");
 
 	const markaPath = join(workspaceBase, "marka-sesi.md");
-	console.log(chalk.bold("Durum"));
+	console.log(chalk.bold("Status"));
 	console.log(
-		`  Marka Sesi: ${existsSync(markaPath) ? chalk.green("VAR") : chalk.yellow("YOK")}`,
+		`  Brand Voice: ${existsSync(markaPath) ? chalk.green("YES") : chalk.yellow("NO")}`,
 	);
 	console.log("");
 
 	if (envanter.eski > 0) {
 		console.log(
 			chalk.yellow(
-				`UYARI: ${envanter.eski} eski (30+ gun) dosya var, gozden gecirin.`,
+				`WARNING: ${envanter.eski} old (30+ days) files, please review.`,
 			),
 		);
 	}
 	if (tamamlanmislik.taslak > tamamlanmislik.tamamlanan) {
 		console.log(
-			chalk.yellow(
-				"UYARI: Taslak sayisi tamamlanandan fazla, bitirmeye odaklan.",
-			),
+			chalk.yellow("WARNING: More drafts than completed, focus on finishing."),
 		);
 	}
 	if (envanter.bugun === 0) {
 		console.log(
-			chalk.dim("BILGI: Bugun henuz icerik uretilmemis. badi icerik basla"),
+			chalk.dim("INFO: No content generated today yet. badi icerik basla"),
 		);
 	}
 	console.log("");
 	console.log(
-		chalk.dim("Detayli durum icin Claude Code'da /icerik-durum komutu."),
+		chalk.dim("For detailed status, use /icerik-durum in Claude Code."),
 	);
 }

--- a/tests/cli.icerik.test.js
+++ b/tests/cli.icerik.test.js
@@ -196,16 +196,16 @@ describe("badi icerik", () => {
 	describe("oturum yonetimi", () => {
 		it("basla seansi baslatir", () => {
 			const output = run(["icerik", "basla"]);
-			assert.ok(output.includes("Icerik Seansi"));
-			assert.ok(output.includes("Bugunun Temasi"));
-			assert.ok(output.includes("Odaklanabileceklerin"));
+			assert.ok(output.includes("Content Session"));
+			assert.ok(output.includes("Today's Theme"));
+			assert.ok(output.includes("What You Can Focus On"));
 		});
 
 		it("durum envanter gosterir", () => {
 			const output = run(["icerik", "durum"]);
-			assert.ok(output.includes("Envanter"));
-			assert.ok(output.includes("Tamamlanmislik"));
-			assert.ok(output.includes("Toplam"));
+			assert.ok(output.includes("Inventory"));
+			assert.ok(output.includes("Completeness"));
+			assert.ok(output.includes("Total"));
 		});
 
 		it("fikir varsayilan tur icin calisir", () => {


### PR DESCRIPTION
## Ozet
English-only goc **Faz 2b** — `icerik` session komutlari (`basla`, `durum`) CLI ciktilari English'e cevrildi.

## Degisiklik
- `basla.js`: gun adlari (Pazartesi→Monday...), gun temalari (Motivasyon→Motivation...), session/draft/focus ciktilari English.
- `durum.js`: inventory/completeness/status bloklari + uyari/info mesajlari English.
- `cli.icerik.test.js`: basla + durum assertion'lari English.

## Kapsam
Cikti stringleri. Arayuz adlari (`basla`/`durum`/`badi icerik`), ic degisken adlari, workspace dir adlari → **atomik rename capstone**'a birakildi (kararlastirildigi gibi).

## Dogrulama
- `npm test` 1132/1132 · `npm run lint` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)