### PR TITLE
feat(icerik): ac + list CLI output English (English-only phase 2d)

### DIFF
--- a/lib/commands/icerik/ac.js
+++ b/lib/commands/icerik/ac.js
@@ -8,7 +8,9 @@ export function runAc(args) {
 	const workspaceBase = join(process.cwd(), ".claude", "workspace");
 	if (!existsSync(workspaceBase)) {
 		console.log(
-			chalk.dim('Workspace yok. Once icerik uret: badi icerik post "konu"'),
+			chalk.dim(
+				'No workspace. Generate content first: badi icerik post "topic"',
+			),
 		);
 		return;
 	}
@@ -44,11 +46,9 @@ export function runAc(args) {
 
 	if (allFiles.length === 0) {
 		console.log(
-			chalk.yellow(
-				`Filtreye uyan dosya bulunamadi${filtre ? ` ("${filtre}")` : ""}.`,
-			),
+			chalk.yellow(`No matching files${filtre ? ` ("${filtre}")` : ""}.`),
 		);
-		console.log(chalk.dim("Dosya listesi icin: badi icerik list"));
+		console.log(chalk.dim("For the file list: badi icerik list"));
 		return;
 	}
 
@@ -56,11 +56,11 @@ export function runAc(args) {
 	const latest = allFiles[0];
 	const relPath = relative(process.cwd(), latest.path);
 
-	console.log(chalk.bold("En son icerik dosyasi:"));
+	console.log(chalk.bold("Latest content file:"));
 	console.log(`  ${chalk.cyan(relPath)}`);
 	console.log(
 		chalk.dim(
-			`  Son degisiklik: ${latest.mtime.toISOString().substring(0, 16).replace("T", " ")}`,
+			`  Last modified: ${latest.mtime.toISOString().substring(0, 16).replace("T", " ")}`,
 		),
 	);
 	console.log("");
@@ -71,13 +71,13 @@ export function runAc(args) {
 			try {
 				execFileSync(editor, [latest.path], { stdio: "inherit" });
 			} catch {
-				console.log(chalk.dim(`Acmak icin: ${editor} ${relPath}`));
+				console.log(chalk.dim(`To open: ${editor} ${relPath}`));
 			}
 		} else {
 			const { cmd, args: openerArgs } = getOpener();
 			try {
 				execFileSync(cmd, [...openerArgs, latest.path], { stdio: "ignore" });
-				console.log(chalk.green(`Dosya acildi: ${relPath}`));
+				console.log(chalk.green(`File opened: ${relPath}`));
 			} catch {
 				console.log(chalk.dim(`  open ${relPath}     # macOS`));
 				console.log(chalk.dim(`  start ${relPath}    # Windows`));
@@ -85,12 +85,12 @@ export function runAc(args) {
 			}
 		}
 	} else {
-		console.log(chalk.dim(`Editorde acmak icin: badi icerik ac --open`));
+		console.log(chalk.dim("To open in editor: badi icerik ac --open"));
 	}
 
 	if (args.includes("--cat") || args.includes("-c")) {
 		console.log("");
-		console.log(chalk.bold("Icerik:"));
+		console.log(chalk.bold("Content:"));
 		console.log(chalk.dim("─".repeat(50)));
 		console.log(readFileSync(latest.path, "utf-8"));
 		console.log(chalk.dim("─".repeat(50)));

--- a/lib/commands/icerik/list.js
+++ b/lib/commands/icerik/list.js
@@ -5,26 +5,26 @@ import { chalk, showBanner } from "../../cli.js";
 export function runList() {
 	const workspaceBase = join(process.cwd(), ".claude", "workspace");
 	if (!existsSync(workspaceBase)) {
-		console.log(chalk.dim("Henuz icerik olusturulmamis."));
-		console.log(chalk.dim('Basla: badi icerik post "konu"'));
+		console.log(chalk.dim("No content generated yet."));
+		console.log(chalk.dim('Start: badi icerik post "topic"'));
 		return;
 	}
 
 	showBanner();
-	console.log(chalk.bold("Uretilen Icerikler:"));
+	console.log(chalk.bold("Generated Content:"));
 	console.log("");
 
 	const subdirs = [
 		{
 			dir: "icerikler",
-			label: "Postlar, Karouseller ve Thread'ler",
+			label: "Posts, Carousels & Threads",
 			icon: "P",
 		},
-		{ dir: "senaryolar", label: "Video Senaryolari", icon: "V" },
-		{ dir: "gorseller", label: "Gorsel Brifler", icon: "G" },
-		{ dir: "takvim", label: "Icerik Takvimleri", icon: "T" },
-		{ dir: "bultenler", label: "Bultenler (Newsletter)", icon: "N" },
-		{ dir: "podcastler", label: "Podcast Episode'lari", icon: "Pd" },
+		{ dir: "senaryolar", label: "Video Scripts", icon: "V" },
+		{ dir: "gorseller", label: "Visual Briefs", icon: "G" },
+		{ dir: "takvim", label: "Content Calendars", icon: "T" },
+		{ dir: "bultenler", label: "Newsletters", icon: "N" },
+		{ dir: "podcastler", label: "Podcast Episodes", icon: "Pd" },
 		{ dir: "case-study", label: "Case Studies", icon: "C" },
 	];
 
@@ -45,16 +45,16 @@ export function runList() {
 
 	const markaPath = join(workspaceBase, "marka-sesi.md");
 	if (existsSync(markaPath)) {
-		console.log(chalk.bold("Marka Sesi:"));
+		console.log(chalk.bold("Brand Voice:"));
 		console.log(`  ${chalk.magenta("M")} marka-sesi.md`);
 		console.log("");
 		totalFiles++;
 	}
 
 	if (totalFiles === 0) {
-		console.log(chalk.dim("Henuz icerik olusturulmamis."));
-		console.log(chalk.dim('Basla: badi icerik post "konu"'));
+		console.log(chalk.dim("No content generated yet."));
+		console.log(chalk.dim('Start: badi icerik post "topic"'));
 	} else {
-		console.log(chalk.dim(`Toplam: ${totalFiles} dosya`));
+		console.log(chalk.dim(`Total: ${totalFiles} files`));
 	}
 }

--- a/tests/cli.icerik.test.js
+++ b/tests/cli.icerik.test.js
@@ -159,8 +159,8 @@ describe("badi icerik", () => {
 
 	it("list uretilen icerikleri listeler", () => {
 		const output = run(["icerik", "list"]);
-		assert.ok(output.includes("Uretilen Icerikler"));
-		assert.ok(output.includes("Toplam"));
+		assert.ok(output.includes("Generated Content"));
+		assert.ok(output.includes("Total"));
 	});
 
 	it("marka sesi ikinci kez olusturulmaz", () => {
@@ -241,14 +241,16 @@ describe("badi icerik", () => {
 		it("ac en son dosyayi gosterir", () => {
 			const output = run(["icerik", "ac"]);
 			assert.ok(
-				output.includes("En son icerik dosyasi") ||
-					output.includes("bulunamadi"),
+				output.includes("Latest content file") ||
+					output.includes("No matching files"),
 			);
 		});
 
 		it("ac filtre ile calisir", () => {
 			const output = run(["icerik", "ac", "marka"]);
-			assert.ok(output.includes("marka") || output.includes("bulunamadi"));
+			assert.ok(
+				output.includes("marka") || output.includes("No matching files"),
+			);
 		});
 	});
 });


### PR DESCRIPTION
icerik `ac` (latest/open/cat) + `list` (generated content listing + subdir labels) CLI ciktilari English. Test 1132/1132, lint 0. Arayuz/dir adlari capstone rename'e birakildi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)