### PR TITLE
feat(icerik): help + template/release-notes leftovers English (phase 2f)

### DIFF
--- a/lib/commands/icerik/ara.js
+++ b/lib/commands/icerik/ara.js
@@ -50,7 +50,9 @@ export function runAra(args) {
 		console.log(
 			`  badi icerik ara [q] --tur post    ${chalk.dim("Type filter (post/karousel/video/gorsel)")}`,
 		);
-		console.log(`  badi icerik ara [q] --son 30      ${chalk.dim("Last N days")}`);
+		console.log(
+			`  badi icerik ara [q] --son 30      ${chalk.dim("Last N days")}`,
+		);
 		console.log(
 			`  badi icerik ara [q] --hashtag X   ${chalk.dim("Hashtag search")}`,
 		);

--- a/lib/commands/icerik/help.js
+++ b/lib/commands/icerik/help.js
@@ -2,97 +2,97 @@ import { chalk, showBanner } from "../../cli.js";
 
 export function runHelp() {
 	showBanner();
-	console.log(chalk.bold("Icerik Uretim Komutlari:"));
+	console.log(chalk.bold("Content Production Commands:"));
 	console.log("");
-	console.log(chalk.bold.cyan("Oturum Yonetimi:"));
+	console.log(chalk.bold.cyan("Session Management:"));
 	console.log(
-		`  ${chalk.cyan("badi icerik basla")}              Gunluk icerik seansini baslat`,
+		`  ${chalk.cyan("badi icerik basla")}              Start the daily content session`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik durum")}              Uretim durumu paneli`,
+		`  ${chalk.cyan("badi icerik durum")}              Production status panel`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik plan")}               Haftalik planlama seansi`,
+		`  ${chalk.cyan("badi icerik plan")}               Weekly planning session`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik kapat")}              Gunu kapat ve ozetle`,
+		`  ${chalk.cyan("badi icerik kapat")}              Close the day and summarize`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik fikir [tur]")}        Fikir uret (post/video/karousel)`,
+		`  ${chalk.cyan("badi icerik fikir [type]")}       Generate ideas (post/video/karousel)`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik ac [filtre]")}        En son icerik dosyasini ac`,
+		`  ${chalk.cyan("badi icerik ac [filter]")}        Open the latest content file`,
 	);
 	console.log("");
-	console.log(chalk.bold.cyan("Sablon Uretimi:"));
+	console.log(chalk.bold.cyan("Template Generation:"));
 	console.log(
-		`  ${chalk.cyan("badi icerik post [konu]")}        Sosyal medya post sablonu`,
+		`  ${chalk.cyan("badi icerik post [topic]")}       Social media post template`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik karousel [konu]")}    Karousel (coklu kare) sablonu`,
+		`  ${chalk.cyan("badi icerik karousel [topic]")}   Carousel (multi-slide) template`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik video [konu]")}       Video senaryo sablonu`,
+		`  ${chalk.cyan("badi icerik video [topic]")}      Video script template`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik gorsel [konu]")}      Gorsel brief sablonu`,
+		`  ${chalk.cyan("badi icerik gorsel [topic]")}     Visual brief template`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik takvim [donem]")}     Icerik takvimi sablonu`,
+		`  ${chalk.cyan("badi icerik takvim [period]")}    Content calendar template`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik marka")}              Marka sesi rehberi sablonu`,
+		`  ${chalk.cyan("badi icerik marka")}              Brand voice guide template`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik newsletter [konu]")} Haftalik bulten sablonu (v1.11+)`,
+		`  ${chalk.cyan("badi icerik newsletter [topic]")} Weekly newsletter template (v1.11+)`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik podcast [konu]")}    Podcast episode + show notes sablonu (v1.11+)`,
+		`  ${chalk.cyan("badi icerik podcast [topic]")}    Podcast episode + show notes template (v1.11+)`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik thread [konu]")}     X/LinkedIn 10-post thread (v1.11+)`,
+		`  ${chalk.cyan("badi icerik thread [topic]")}     X/LinkedIn 10-post thread (v1.11+)`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik case-study [konu]")} Musteri basari hikayesi (v1.11+)`,
+		`  ${chalk.cyan("badi icerik case-study [topic]")} Customer success story (v1.11+)`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik list")}               Uretilen icerikleri listele`,
+		`  ${chalk.cyan("badi icerik list")}               List generated content`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik perf [secenekler]")} Performans takibi`,
+		`  ${chalk.cyan("badi icerik perf [options]")}     Performance tracking`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik ara [sorgu]")}        Arsiv arama ve benzerlik tespiti`,
+		`  ${chalk.cyan("badi icerik ara [query]")}        Archive search and similarity detection`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi icerik sablon [komut]")}     Ozel sablon mirasi yonetimi`,
+		`  ${chalk.cyan("badi icerik sablon [command]")}   Custom template inheritance management`,
 	);
 	console.log(
 		`  ${chalk.cyan("badi icerik release-notes")}      App Store/Play Store release notes (--platform ios|android --version X.Y.Z)`,
 	);
 	console.log("");
-	console.log(chalk.bold("Gunluk Is Akisi:"));
+	console.log(chalk.bold("Daily Workflow:"));
 	console.log(
-		"  Sabah:  badi icerik basla         # Seansa basla, bugun ne var?",
+		"  Morning: badi icerik basla        # Start the session, what's on today?",
 	);
-	console.log('  Uretim: badi icerik post "konu"   # Sablon olustur');
-	console.log("  Kontrol: badi icerik durum        # Ne kadar ilerledim?");
+	console.log('  Create:  badi icerik post "topic" # Generate a template');
+	console.log("  Check:   badi icerik durum        # How far have I come?");
 	console.log(
-		"  Aksam:  badi icerik kapat         # Seansi kapat, yarini planla",
+		"  Evening: badi icerik kapat        # Close the session, plan tomorrow",
 	);
 	console.log("");
-	console.log(chalk.bold("Ornekler:"));
+	console.log(chalk.bold("Examples:"));
 	console.log("  badi icerik basla");
-	console.log('  badi icerik post "yeni urun lansman"');
+	console.log('  badi icerik post "new product launch"');
 	console.log("  badi icerik fikir post");
 	console.log("  badi icerik ac");
 	console.log("");
 	console.log(
-		chalk.dim("Not: Sablonlar .claude/workspace/ altina olusturulur."),
+		chalk.dim("Note: Templates are created under .claude/workspace/."),
 	);
 	console.log(
 		chalk.dim(
-			"Tam interaktif akis icin Claude Code'da /icerik-basla, /icerik-durum, /icerik-fikir slash komutlarini kullanin.",
+			"For the full interactive flow, use the /icerik-basla, /icerik-durum, /icerik-fikir slash commands in Claude Code.",
 		),
 	);
 }

--- a/lib/commands/icerik/release-notes.js
+++ b/lib/commands/icerik/release-notes.js
@@ -14,7 +14,7 @@ export function runReleaseNotes(args) {
 	}
 
 	if (!["ios", "android"].includes(platform)) {
-		console.error(chalk.red(`Gecersiz platform: ${platform} (ios|android)`));
+		console.error(chalk.red(`Invalid platform: ${platform} (ios|android)`));
 		process.exit(1);
 	}
 
@@ -24,7 +24,7 @@ export function runReleaseNotes(args) {
 	const filePath = join(workspaceBase, fileName);
 
 	if (existsSync(filePath)) {
-		console.log(chalk.yellow(`Atlaniyor (mevcut): ${fileName}`));
+		console.log(chalk.yellow(`Skipping (exists): ${fileName}`));
 		process.exit(1);
 	}
 
@@ -37,9 +37,9 @@ export function runReleaseNotes(args) {
 	writeFileSync(filePath, header + body + footer);
 
 	showBanner();
-	console.log(chalk.bold.green("Release notes sablonu olusturuldu!"));
+	console.log(chalk.bold.green("Release notes template created!"));
 	console.log(`Platform: ${chalk.cyan(platform)}`);
 	console.log(`Version:  ${chalk.cyan(version)}`);
 	console.log(`Limit:    ${chalk.cyan(`${limit} chars`)}`);
-	console.log(`  Dosya: ${chalk.cyan(relative(process.cwd(), filePath))}`);
+	console.log(`  File: ${chalk.cyan(relative(process.cwd(), filePath))}`);
 }

--- a/lib/commands/icerik/template.js
+++ b/lib/commands/icerik/template.js
@@ -45,7 +45,7 @@ export async function runTemplate(args) {
 			konuParts.push(langRemaining[i]);
 		}
 	}
-	const konu = konuParts.join(" ") || "yeni-icerik";
+	const konu = konuParts.join(" ") || "new-content";
 	const dateStr = getDateString();
 	const konuSlug = slugify(konu);
 
@@ -53,14 +53,14 @@ export async function runTemplate(args) {
 		const wsBase = join(process.cwd(), ".claude", "workspace");
 		const similar = checkDuplicates(konu, wsBase);
 		if (similar.length > 0) {
-			console.log(chalk.yellow("UYARI: Benzer icerik tespit edildi!"));
+			console.log(chalk.yellow("WARNING: Similar content detected!"));
 			for (const s of similar) {
 				console.log(
-					`  ${chalk.yellow("~")} ${s.dir}/${s.file} ${chalk.dim(`(%${s.similarity} benzerlik)`)}`,
+					`  ${chalk.yellow("~")} ${s.dir}/${s.file} ${chalk.dim(`(${s.similarity}% similar)`)}`,
 				);
 			}
 			console.log("");
-			console.log(chalk.dim("Devam etmek icin --force kullanin."));
+			console.log(chalk.dim("Use --force to continue."));
 			process.exit(2);
 		}
 	}
@@ -74,14 +74,14 @@ export async function runTemplate(args) {
 
 		const markaPath = join(workspaceBase, "marka-sesi.md");
 		if (existsSync(markaPath)) {
-			console.error(chalk.yellow("marka-sesi.md zaten mevcut."));
+			console.error(chalk.yellow("marka-sesi.md already exists."));
 			process.exit(1);
 		}
 		writeFileSync(markaPath, tmplSet.marka());
 
 		showBanner();
-		console.log(chalk.bold.green("Marka sesi rehberi olusturuldu!"));
-		console.log(`  Dosya: ${chalk.cyan(relative(process.cwd(), markaPath))}`);
+		console.log(chalk.bold.green("Brand voice guide created!"));
+		console.log(`  File: ${chalk.cyan(relative(process.cwd(), markaPath))}`);
 		return;
 	}
 
@@ -155,7 +155,7 @@ export async function runTemplate(args) {
 	if (existsSync(targetPath)) {
 		console.error(
 			chalk.yellow(
-				`Dosya zaten mevcut: ${relative(process.cwd(), targetPath)}`,
+				`File already exists: ${relative(process.cwd(), targetPath)}`,
 			),
 		);
 		process.exit(1);
@@ -173,18 +173,18 @@ export async function runTemplate(args) {
 
 	showBanner();
 	console.log(
-		chalk.bold.green(`${subcommand.toUpperCase()} sablonu olusturuldu!`),
+		chalk.bold.green(`${subcommand.toUpperCase()} template created!`),
 	);
-	console.log(`Konu: ${chalk.cyan(konu)}`);
-	if (sablonFlag) console.log(`Sablon: ${chalk.cyan(sablonFlag)}`);
-	console.log(`  Dosya: ${chalk.cyan(relative(process.cwd(), targetPath))}`);
+	console.log(`Topic: ${chalk.cyan(konu)}`);
+	if (sablonFlag) console.log(`Template: ${chalk.cyan(sablonFlag)}`);
+	console.log(`  File: ${chalk.cyan(relative(process.cwd(), targetPath))}`);
 	console.log("");
-	console.log(chalk.bold("Sonraki adimlar:"));
-	console.log("  1. Dosyayi ac ve placeholder'lari doldur");
+	console.log(chalk.bold("Next steps:"));
+	console.log("  1. Open the file and fill the placeholders");
 	console.log(
-		"  2. Marka sesi rehberini kontrol et: .claude/workspace/marka-sesi.md",
+		"  2. Check the brand voice guide: .claude/workspace/marka-sesi.md",
 	);
 	console.log(
-		`  3. Tam interaktif akis icin Claude Code'da ${chalk.cyan(`/${subcommand === "post" ? "icerik-uret" : subcommand === "video" ? "video-senaryo" : subcommand === "gorsel" ? "gorsel-brief" : subcommand === "takvim" ? "icerik-takvimi" : subcommand === "karousel" ? "karousel" : "icerik-uret"}`)}`,
+		`  3. For the full interactive flow, use ${chalk.cyan(`/${subcommand === "post" ? "icerik-uret" : subcommand === "video" ? "video-senaryo" : subcommand === "gorsel" ? "gorsel-brief" : subcommand === "takvim" ? "icerik-takvimi" : subcommand === "karousel" ? "karousel" : "icerik-uret"}`)} in Claude Code`,
 	);
 }

--- a/tests/cli.icerik-lang.test.js
+++ b/tests/cli.icerik-lang.test.js
@@ -36,7 +36,7 @@ describe("badi icerik (English-only)", () => {
 
 	it("post English icerik olusturur (lang suffix yok)", () => {
 		const output = run(["icerik", "post", "post-test"]);
-		assert.ok(output.includes("POST sablonu olusturuldu"));
+		assert.ok(output.includes("POST template created"));
 		const dir = join(TMP, ".claude", "workspace", "icerikler");
 		const files = existsSync(dir) ? readdirSync(dir) : [];
 		const f = files.find((x) => x.includes("post-test"));
@@ -61,7 +61,7 @@ describe("badi icerik (English-only)", () => {
 
 	it("marka sesi English marka-sesi.md olusturur", () => {
 		const output = run(["icerik", "marka"]);
-		assert.ok(output.includes("olusturuldu"));
+		assert.ok(output.includes("created"));
 		const p = join(TMP, ".claude", "workspace", "marka-sesi.md");
 		assert.ok(existsSync(p), "marka-sesi.md olusturulmali");
 		const content = readFileSync(p, "utf-8");
@@ -70,7 +70,7 @@ describe("badi icerik (English-only)", () => {
 
 	it("karousel English sablon olusturur", () => {
 		const output = run(["icerik", "karousel", "karo-test", "--force"]);
-		assert.ok(output.includes("KAROUSEL sablonu olusturuldu"));
+		assert.ok(output.includes("KAROUSEL template created"));
 		const dir = join(TMP, ".claude", "workspace", "icerikler");
 		const f = readdirSync(dir).find((x) => x.includes("karo-test"));
 		assert.ok(f, "karousel dosyasi olusturulmali");

--- a/tests/cli.icerik-sablon.test.js
+++ b/tests/cli.icerik-sablon.test.js
@@ -120,7 +120,7 @@ describe("badi icerik sablon", () => {
 			"test-sablon",
 			"--force",
 		]);
-		assert.ok(output.includes("POST sablonu olusturuldu"));
+		assert.ok(output.includes("POST template created"));
 		assert.ok(output.includes("test-sablon"));
 	});
 

--- a/tests/cli.icerik.test.js
+++ b/tests/cli.icerik.test.js
@@ -35,7 +35,7 @@ describe("badi icerik", () => {
 
 	it("--help yardim gosterir", () => {
 		const output = run(["icerik", "--help"]);
-		assert.ok(output.includes("Icerik Uretim Komutlari"));
+		assert.ok(output.includes("Content Production Commands"));
 		assert.ok(output.includes("post"));
 		assert.ok(output.includes("karousel"));
 		assert.ok(output.includes("video"));
@@ -46,33 +46,33 @@ describe("badi icerik", () => {
 
 	it("post sablonu olusturur", () => {
 		const output = run(["icerik", "post", "test konu"]);
-		assert.ok(output.includes("POST sablonu olusturuldu"));
+		assert.ok(output.includes("POST template created"));
 		const icerikDir = join(TMP, ".claude", "workspace", "icerikler");
 		assert.ok(existsSync(icerikDir));
 	});
 
 	it("karousel sablonu olusturur", () => {
 		const output = run(["icerik", "karousel", "5 ipucu"]);
-		assert.ok(output.includes("KAROUSEL sablonu olusturuldu"));
+		assert.ok(output.includes("KAROUSEL template created"));
 	});
 
 	it("video sablonu olusturur", () => {
 		const output = run(["icerik", "video", "30 saniye demo"]);
-		assert.ok(output.includes("VIDEO sablonu olusturuldu"));
+		assert.ok(output.includes("VIDEO template created"));
 		const videoDir = join(TMP, ".claude", "workspace", "senaryolar");
 		assert.ok(existsSync(videoDir));
 	});
 
 	it("gorsel brief sablonu olusturur", () => {
 		const output = run(["icerik", "gorsel", "banner"]);
-		assert.ok(output.includes("GORSEL sablonu olusturuldu"));
+		assert.ok(output.includes("GORSEL template created"));
 		const gorselDir = join(TMP, ".claude", "workspace", "gorseller");
 		assert.ok(existsSync(gorselDir));
 	});
 
 	it("takvim sablonu olusturur", () => {
 		const output = run(["icerik", "takvim", "2026-04"]);
-		assert.ok(output.includes("TAKVIM sablonu olusturuldu"));
+		assert.ok(output.includes("TAKVIM template created"));
 		const takvimDir = join(TMP, ".claude", "workspace", "takvim");
 		assert.ok(existsSync(takvimDir));
 	});
@@ -80,7 +80,7 @@ describe("badi icerik", () => {
 	// v1.11+ yeni icerik turleri
 	it("newsletter sablonu olusturur", () => {
 		const output = run(["icerik", "newsletter", "haftalik bulten"]);
-		assert.ok(output.includes("NEWSLETTER sablonu olusturuldu"));
+		assert.ok(output.includes("NEWSLETTER template created"));
 		const dir = join(TMP, ".claude", "workspace", "bultenler");
 		assert.ok(existsSync(dir));
 		const files = readdirSync(dir).filter((f) => f.endsWith(".md"));
@@ -91,7 +91,7 @@ describe("badi icerik", () => {
 
 	it("podcast sablonu olusturur", () => {
 		const output = run(["icerik", "podcast", "ep-01 giris"]);
-		assert.ok(output.includes("PODCAST sablonu olusturuldu"));
+		assert.ok(output.includes("PODCAST template created"));
 		const dir = join(TMP, ".claude", "workspace", "podcastler");
 		assert.ok(existsSync(dir));
 		const files = readdirSync(dir).filter((f) => f.endsWith(".md"));
@@ -102,7 +102,7 @@ describe("badi icerik", () => {
 
 	it("thread sablonu olusturur (icerikler/)", () => {
 		const output = run(["icerik", "thread", "10 ipucu"]);
-		assert.ok(output.includes("THREAD sablonu olusturuldu"));
+		assert.ok(output.includes("THREAD template created"));
 		const dir = join(TMP, ".claude", "workspace", "icerikler");
 		// UTC / yerel saat farki olmasin diye sadece "thread" icerigine bakiyoruz.
 		const files = readdirSync(dir).filter(
@@ -115,7 +115,7 @@ describe("badi icerik", () => {
 
 	it("case-study sablonu olusturur", () => {
 		const output = run(["icerik", "case-study", "acme"]);
-		assert.ok(output.includes("CASE-STUDY sablonu olusturuldu"));
+		assert.ok(output.includes("CASE-STUDY template created"));
 		const dir = join(TMP, ".claude", "workspace", "case-study");
 		assert.ok(existsSync(dir));
 		const files = readdirSync(dir).filter((f) => f.endsWith(".md"));
@@ -126,7 +126,7 @@ describe("badi icerik", () => {
 
 	it("newsletter English sablon olusturur (suffix yok)", () => {
 		const output = run(["icerik", "newsletter", "weekly update"]);
-		assert.ok(output.includes("NEWSLETTER sablonu olusturuldu"));
+		assert.ok(output.includes("NEWSLETTER template created"));
 		const dir = join(TMP, ".claude", "workspace", "bultenler");
 		const files = readdirSync(dir).filter(
 			(f) => f.includes("weekly-update") && f.endsWith(".md"),
@@ -150,7 +150,7 @@ describe("badi icerik", () => {
 
 	it("marka sesi sablonu olusturur", () => {
 		const output = run(["icerik", "marka"]);
-		assert.ok(output.includes("Marka sesi rehberi olusturuldu"));
+		assert.ok(output.includes("Brand voice guide created"));
 		const markaPath = join(TMP, ".claude", "workspace", "marka-sesi.md");
 		assert.ok(existsSync(markaPath));
 		const content = readFileSync(markaPath, "utf-8");


### PR DESCRIPTION
icerik `help` (full --help text) + `template`/`release-notes` leftover CLI strings English. icerik family output now English except `perf.js` (next batch). Test 1132/1132, lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)