### PR TITLE
feat(i18n): English-only Phase 2h — doctor, commit, stats CLI output

### DIFF
--- a/lib/commands/commit.js
+++ b/lib/commands/commit.js
@@ -3,16 +3,16 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { chalk, showBanner } from "../cli.js";
 
 const TYPES = [
-	{ type: "feat", desc: "Yeni ozellik", emoji: "+" },
-	{ type: "fix", desc: "Hata duzeltmesi", emoji: "x" },
-	{ type: "docs", desc: "Dokumantasyon", emoji: "d" },
+	{ type: "feat", desc: "New feature", emoji: "+" },
+	{ type: "fix", desc: "Bug fix", emoji: "x" },
+	{ type: "docs", desc: "Documentation", emoji: "d" },
 	{ type: "style", desc: "Format, whitespace", emoji: "s" },
-	{ type: "refactor", desc: "Yeniden duzenleme", emoji: "r" },
-	{ type: "perf", desc: "Performans", emoji: "p" },
-	{ type: "test", desc: "Test ekleme/guncelleme", emoji: "t" },
-	{ type: "chore", desc: "Bakim isleri", emoji: "c" },
-	{ type: "ci", desc: "CI/CD degisiklikleri", emoji: "ci" },
-	{ type: "build", desc: "Build sistemi", emoji: "b" },
+	{ type: "refactor", desc: "Refactor", emoji: "r" },
+	{ type: "perf", desc: "Performance", emoji: "p" },
+	{ type: "test", desc: "Add/update tests", emoji: "t" },
+	{ type: "chore", desc: "Chores", emoji: "c" },
+	{ type: "ci", desc: "CI/CD changes", emoji: "ci" },
+	{ type: "build", desc: "Build system", emoji: "b" },
 ];
 
 function git(args) {
@@ -22,7 +22,7 @@ function git(args) {
 			timeout: 10000,
 		}).trim();
 	} catch (e) {
-		throw new Error(`git ${args[0]} hatasi: ${e.message}`);
+		throw new Error(`git ${args[0]} error: ${e.message}`);
 	}
 }
 
@@ -41,37 +41,37 @@ function showStagedChanges() {
 export async function runCommit(args) {
 	if (args[0] === "--help" || args[0] === "-h") {
 		showBanner();
-		console.log(chalk.bold("Conventional Commit Yardimi:"));
+		console.log(chalk.bold("Conventional Commit Help:"));
 		console.log("");
 		console.log(
-			`  ${chalk.cyan("badi commit")}                        Tip + mesaj onerileri goster`,
+			`  ${chalk.cyan("badi commit")}                        Show type + message suggestions`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi commit --check")}                Son commit lint kontrolu`,
+			`  ${chalk.cyan("badi commit --check")}                Lint-check the last commit`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi commit --message 'feat: X'")}    Conventional kontrol + git commit`,
+			`  ${chalk.cyan("badi commit --message 'feat: X'")}    Conventional check + git commit`,
 		);
 		console.log("");
-		console.log(chalk.bold("Tipler:"));
+		console.log(chalk.bold("Types:"));
 		for (const t of TYPES) {
 			console.log(`  ${chalk.cyan(t.type.padEnd(10))} ${chalk.dim(t.desc)}`);
 		}
 		console.log("");
 		console.log(chalk.bold("Format:"));
-		console.log(chalk.dim("  <tip>(<kapsam>): <kisa aciklama>"));
+		console.log(chalk.dim("  <type>(<scope>): <short description>"));
 		console.log(chalk.dim("  "));
-		console.log(chalk.dim("  <govde — ne/neden>"));
+		console.log(chalk.dim("  <body — what/why>"));
 		console.log(chalk.dim("  "));
-		console.log(chalk.dim("  BREAKING CHANGE: <aciklama>"));
+		console.log(chalk.dim("  BREAKING CHANGE: <description>"));
 		return;
 	}
 
-	// --check: son commit'in conventional olup olmadigini kontrol et
+	// --check: verify whether the last commit is conventional
 	if (args.includes("--check")) {
 		showBanner();
 		const lastMsg = git(["log", "-1", "--pretty=%B"]);
-		console.log(chalk.bold("Son Commit:"));
+		console.log(chalk.bold("Last Commit:"));
 		console.log(chalk.dim(lastMsg.substring(0, 200)));
 		console.log("");
 
@@ -79,29 +79,27 @@ export async function runCommit(args) {
 		const convRegex =
 			/^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(\([a-z0-9-]+\))?!?:\s.{1,100}$/;
 		if (convRegex.test(firstLine)) {
-			console.log(chalk.bold.green("Conventional commit formati uygun!"));
+			console.log(chalk.bold.green("Conventional commit format OK!"));
 			return;
 		}
 
-		console.log(chalk.bold.red("Conventional commit formati UYGUN DEGIL"));
+		console.log(chalk.bold.red("Conventional commit format INVALID"));
 		console.log("");
-		console.log(chalk.bold("Beklenen format:"));
-		console.log(chalk.dim("  tip(kapsam): kisa aciklama"));
+		console.log(chalk.bold("Expected format:"));
+		console.log(chalk.dim("  type(scope): short description"));
 		console.log("");
-		console.log(chalk.bold("Ornek:"));
-		console.log(
-			chalk.dim("  feat(auth): JWT token refresh mekanizmasi eklendi"),
-		);
-		console.log(chalk.dim("  fix(api): 500 hatasi yayinlanamazdi"));
+		console.log(chalk.bold("Example:"));
+		console.log(chalk.dim("  feat(auth): add JWT token refresh"));
+		console.log(chalk.dim("  fix(api): handle 500 error on publish"));
 		process.exit(1);
 	}
 
-	// --message ile gercek commit
+	// real commit via --message
 	const msgIdx = args.indexOf("--message");
 	if (msgIdx >= 0) {
 		const message = args[msgIdx + 1];
 		if (!message) {
-			console.error(chalk.red("Mesaj bos"));
+			console.error(chalk.red("Message empty"));
 			process.exit(1);
 		}
 
@@ -109,48 +107,50 @@ export async function runCommit(args) {
 		const convRegex =
 			/^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(\([a-z0-9-]+\))?!?:\s.{1,100}$/;
 		if (!convRegex.test(firstLine)) {
-			console.error(chalk.red("Conventional format UYMUYOR"));
-			console.log(chalk.dim(`  Alinan: ${firstLine}`));
-			console.log(chalk.dim("  Beklenen: tip(kapsam): aciklama"));
+			console.error(chalk.red("Conventional format MISMATCH"));
+			console.log(chalk.dim(`  Got: ${firstLine}`));
+			console.log(chalk.dim("  Expected: type(scope): description"));
 			process.exit(1);
 		}
 
 		try {
 			execFileSync("git", ["commit", "-m", message], { stdio: "inherit" });
 		} catch (e) {
-			console.error(chalk.red(`Commit hatasi: ${e.message}`));
+			console.error(chalk.red(`Commit error: ${e.message}`));
 			process.exit(1);
 		}
 		return;
 	}
 
-	// Varsayilan: interaktif rehberlik
+	// Default: interactive guidance
 	showBanner();
-	console.log(chalk.bold("Conventional Commit Olustur:"));
+	console.log(chalk.bold("Create Conventional Commit:"));
 	console.log("");
 
 	const staged = showStagedChanges();
 	if (staged) {
-		console.log(chalk.bold("Staged Dosyalar:"));
+		console.log(chalk.bold("Staged Files:"));
 		console.log(chalk.dim(staged));
 		console.log("");
 	} else {
-		console.log(chalk.yellow("Staged dosya yok. Once git add ..."));
+		console.log(chalk.yellow("No staged files. Run git add ... first."));
 		return;
 	}
 
-	console.log(chalk.bold("Onerilen Tipler:"));
+	console.log(chalk.bold("Suggested Types:"));
 	for (const t of TYPES) {
 		console.log(`  ${chalk.cyan(t.type.padEnd(10))} ${chalk.dim(t.desc)}`);
 	}
 
 	console.log("");
-	console.log(chalk.bold("Commit icin:"));
-	console.log(chalk.dim('  badi commit --message "feat(area): kisa aciklama"'));
-	console.log(chalk.dim('  git commit -m "feat(area): kisa aciklama"'));
+	console.log(chalk.bold("To commit:"));
+	console.log(
+		chalk.dim('  badi commit --message "feat(area): short description"'),
+	);
+	console.log(chalk.dim('  git commit -m "feat(area): short description"'));
 	console.log("");
-	console.log(chalk.bold("Kontrol icin:"));
-	console.log(chalk.dim("  badi commit --check    # Son commit'i dogrula"));
+	console.log(chalk.bold("To check:"));
+	console.log(chalk.dim("  badi commit --check    # Verify the last commit"));
 }
 
 // ─── changelog ───
@@ -170,16 +170,16 @@ function parseCommits(range) {
 
 function groupCommits(commits) {
 	const groups = {
-		feat: { label: "Eklenen", emoji: "+" },
-		fix: { label: "Duzeltilen", emoji: "x" },
-		perf: { label: "Performans", emoji: "p" },
-		refactor: { label: "Yeniden Duzenlenen", emoji: "r" },
-		docs: { label: "Dokumantasyon", emoji: "d" },
+		feat: { label: "Added", emoji: "+" },
+		fix: { label: "Fixed", emoji: "x" },
+		perf: { label: "Performance", emoji: "p" },
+		refactor: { label: "Refactored", emoji: "r" },
+		docs: { label: "Documentation", emoji: "d" },
 		test: { label: "Test", emoji: "t" },
 		build: { label: "Build", emoji: "b" },
 		ci: { label: "CI/CD", emoji: "ci" },
-		chore: { label: "Bakim", emoji: "c" },
-		other: { label: "Diger", emoji: "?" },
+		chore: { label: "Chores", emoji: "c" },
+		other: { label: "Other", emoji: "?" },
 	};
 	const result = {};
 	for (const c of commits) {
@@ -199,26 +199,26 @@ export async function runChangelog(args) {
 		console.log(chalk.bold("Changelog Generator:"));
 		console.log("");
 		console.log(
-			`  ${chalk.cyan("badi changelog")}                    Son tag'den HEAD'e`,
+			`  ${chalk.cyan("badi changelog")}                    From last tag to HEAD`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi changelog --from v1.0.0")}      Belirli tag'den beri`,
+			`  ${chalk.cyan("badi changelog --from v1.0.0")}      Since a specific tag`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi changelog --to v2.0.0")}        Belirli tag'e kadar`,
+			`  ${chalk.cyan("badi changelog --to v2.0.0")}        Up to a specific tag`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi changelog --version 1.5.0")}    Yeni CHANGELOG.md bolumu uret`,
+			`  ${chalk.cyan("badi changelog --version 1.5.0")}    Generate a new CHANGELOG.md section`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi changelog --write")}            CHANGELOG.md dosyasina ekle`,
+			`  ${chalk.cyan("badi changelog --write")}            Append to CHANGELOG.md`,
 		);
 		console.log("");
-		console.log(chalk.dim("Conventional commit tipleriyle gruplama yapar."));
+		console.log(chalk.dim("Groups by conventional commit types."));
 		return;
 	}
 
-	// Parametreler
+	// Parameters
 	let fromRef = null;
 	let toRef = "HEAD";
 	let version = null;
@@ -229,12 +229,12 @@ export async function runChangelog(args) {
 		else if (args[i] === "--version") version = args[++i];
 	}
 
-	// fromRef belirtilmemisse en son tag'i bul
+	// If fromRef is not given, find the latest tag
 	if (!fromRef) {
 		try {
 			fromRef = git(["describe", "--tags", "--abbrev=0"]);
 		} catch {
-			// Tag yok - ilk commit'ten baslat
+			// No tag — start from the first commit
 			fromRef = git(["rev-list", "--max-parents=0", "HEAD"]).split("\n")[0];
 		}
 	}
@@ -246,14 +246,14 @@ export async function runChangelog(args) {
 
 	const commits = parseCommits(range);
 	if (commits.length === 0) {
-		console.log(chalk.dim("Bu aralikta commit yok."));
+		console.log(chalk.dim("No commits in this range."));
 		return;
 	}
 
 	const { groups, result } = groupCommits(commits);
 	const today = new Date().toISOString().substring(0, 10);
 
-	// Markdown cikti
+	// Markdown output
 	const lines = [];
 	if (version) lines.push(`## [${version}] - ${today}`);
 	else lines.push(`## [${toRef}] - ${today}`);
@@ -272,12 +272,12 @@ export async function runChangelog(args) {
 
 	if (write) {
 		if (!existsSync("CHANGELOG.md")) {
-			writeFileSync("CHANGELOG.md", `# Degisiklik Gunlugu\n\n${content}\n`);
-			console.log(chalk.green("CHANGELOG.md olusturuldu"));
+			writeFileSync("CHANGELOG.md", `# Changelog\n\n${content}\n`);
+			console.log(chalk.green("CHANGELOG.md created"));
 			return;
 		}
 		const current = readFileSync("CHANGELOG.md", "utf-8");
-		// Ilk ## satirindan sonra ekle (veya en basa)
+		// Insert after the first ## line (or at the top)
 		const firstVersionIdx = current.search(/^## /m);
 		if (firstVersionIdx >= 0) {
 			const updated =
@@ -290,14 +290,14 @@ export async function runChangelog(args) {
 			writeFileSync("CHANGELOG.md", `${current}\n${content}\n`);
 		}
 		console.log(
-			chalk.green(`CHANGELOG.md guncellendi (${commits.length} commit)`),
+			chalk.green(`CHANGELOG.md updated (${commits.length} commits)`),
 		);
 	} else {
 		console.log(content);
 		console.log("");
-		console.log(chalk.dim(`Toplam: ${commits.length} commit`));
+		console.log(chalk.dim(`Total: ${commits.length} commits`));
 		console.log(
-			chalk.dim("Dosyaya yazmak icin: badi changelog --write --version X.Y.Z"),
+			chalk.dim("To write to file: badi changelog --write --version X.Y.Z"),
 		);
 	}
 }

--- a/lib/commands/doctor.js
+++ b/lib/commands/doctor.js
@@ -24,7 +24,7 @@ function printReport(harness, report) {
 	}
 	console.log("");
 	console.log(
-		`  ${chalk.green(`${report.pass} basarili`)}  ${chalk.yellow(`${report.warn} uyari`)}  ${chalk.red(`${report.fail} basarisiz`)}`,
+		`  ${chalk.green(`${report.pass} passed`)}  ${chalk.yellow(`${report.warn} warnings`)}  ${chalk.red(`${report.fail} failed`)}`,
 	);
 	console.log("");
 }
@@ -47,9 +47,9 @@ function runHelpDoctor(args) {
 			.filter((f) => f.endsWith(".js"))
 			.map((f) => join(commandsDir, f));
 	} catch {
-		console.error(chalk.red(`lib/commands/ bulunamadi: ${commandsDir}`));
+		console.error(chalk.red(`lib/commands/ not found: ${commandsDir}`));
 		console.error(
-			chalk.dim("badi doctor help yalniz Badi repo kokunden calistirilir."),
+			chalk.dim("badi doctor help only runs from the Badi repo root."),
 		);
 		process.exit(1);
 	}
@@ -74,38 +74,40 @@ function runHelpDoctor(args) {
 
 	showBanner();
 	console.log(chalk.bold("Help-Doctor"));
-	console.log(chalk.dim(`Hedef: ${commandsDir}`));
+	console.log(chalk.dim(`Target: ${commandsDir}`));
 	console.log(chalk.dim(`Allowlist: ${allowlistPath}`));
 	console.log("");
 
 	if (drift.length === 0) {
 		console.log(
-			chalk.bold.green(`Tum ${files.length} komut dosyasi drift-free.`),
+			chalk.bold.green(`All ${files.length} command files drift-free.`),
 		);
 		return;
 	}
 
 	console.log(
-		chalk.bold.red(`Drift tespit edildi (${drift.length}/${files.length}):`),
+		chalk.bold.red(`Drift detected (${drift.length}/${files.length}):`),
 	);
 	console.log("");
 	for (const d of drift) {
 		console.log(chalk.cyan(`  ${d.file}`));
 		if (d.missingSubs.length) {
-			console.log(chalk.yellow(`    subs eksik: ${d.missingSubs.join(", ")}`));
+			console.log(
+				chalk.yellow(`    missing subs: ${d.missingSubs.join(", ")}`),
+			);
 		}
 		if (d.missingFlags.length) {
 			console.log(
-				chalk.yellow(`    flags eksik: ${d.missingFlags.join(", ")}`),
+				chalk.yellow(`    missing flags: ${d.missingFlags.join(", ")}`),
 			);
 		}
 	}
 	console.log("");
-	console.log(chalk.dim("Cozum:"));
-	console.log(chalk.dim("  1. Help text'i guncelle (showHelp veya inline)"));
+	console.log(chalk.dim("Fix:"));
+	console.log(chalk.dim("  1. Update the help text (showHelp or inline)"));
 	console.log(
 		chalk.dim(
-			"  2. Mesru false-positive ise .claude/help-doctor.allow.json'a ekle",
+			"  2. If a legitimate false-positive, add to .claude/help-doctor.allow.json",
 		),
 	);
 	process.exit(1);
@@ -141,19 +143,19 @@ export function runDoctor(args, { showHelp }) {
 	}
 
 	showBanner();
-	console.log(chalk.bold("Badi Kurulum Dogrulamasi"));
-	console.log(`${chalk.bold("Hedef:")} ${target}`);
+	console.log(chalk.bold("Badi Installation Verification"));
+	console.log(`${chalk.bold("Target:")} ${target}`);
 	console.log(`${chalk.bold("OS:")}    ${osSummary()}`);
 	console.log(
-		`${chalk.bold("Bash:")}  ${bashAvailable() ? chalk.green("var") : chalk.red("yok")} (hooks bash gerektirir)`,
+		`${chalk.bold("Bash:")}  ${bashAvailable() ? chalk.green("yes") : chalk.red("no")} (hooks require bash)`,
 	);
-	console.log(`${chalk.bold("Sched:")} ${getSchedulerKind() || "yok"}`);
+	console.log(`${chalk.bold("Sched:")} ${getSchedulerKind() || "none"}`);
 	const hint = utf8Hint();
 	if (hint) console.log(chalk.yellow(`!! ${hint}`));
 	if (isWindows && !bashAvailable()) {
 		console.log(
 			chalk.yellow(
-				"!! Windows'ta bash bulunamadi — hooks calismayabilir. Git for Windows veya WSL2 kurun.",
+				"!! bash not found on Windows — hooks may not work. Install Git for Windows or WSL2.",
 			),
 		);
 	}
@@ -184,31 +186,31 @@ export function runDoctor(args, { showHelp }) {
 		totalFail += report.fail;
 	}
 
-	console.log(chalk.bold("Toplam:"));
+	console.log(chalk.bold("Total:"));
 	console.log(
-		`  ${chalk.green(`${totalPass} basarili`)}  ${chalk.yellow(`${totalWarn} uyari`)}  ${chalk.red(`${totalFail} basarisiz`)}`,
+		`  ${chalk.green(`${totalPass} passed`)}  ${chalk.yellow(`${totalWarn} warnings`)}  ${chalk.red(`${totalFail} failed`)}`,
 	);
 
 	if (totalFail === 0 && totalWarn === 0) {
 		console.log("");
-		console.log(chalk.bold.green("Badi kurulumu saglikli!"));
+		console.log(chalk.bold.green("Badi installation is healthy!"));
 	} else if (totalFail === 0) {
 		console.log("");
 		console.log(
 			chalk.bold.yellow(
-				"Badi kurulumunda kucuk sorunlar var. Detaylari inceleyin.",
+				"Badi installation has minor issues. Review the details.",
 			),
 		);
 	} else {
 		console.log("");
-		console.log(chalk.bold.red("Badi kurulumunda sorunlar tespit edildi."));
+		console.log(chalk.bold.red("Badi installation has problems."));
 		console.log("");
-		console.log(chalk.bold("Cozum onerileri:"));
+		console.log(chalk.bold("Suggested fixes:"));
 		console.log(
-			`  ${chalk.cyan("badi update")}         # Eksik dosyalari ekler, ozel dosyalari korur`,
+			`  ${chalk.cyan("badi update")}         # Adds missing files, preserves custom files`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi init --force")}   # Her seyi zorla yeniden kurar`,
+			`  ${chalk.cyan("badi init --force")}   # Force-reinstalls everything`,
 		);
 	}
 

--- a/lib/commands/stats.js
+++ b/lib/commands/stats.js
@@ -18,7 +18,7 @@ export function parseUsageLog(cwd) {
 		try {
 			entries.push(JSON.parse(line));
 		} catch {
-			// Bozuk satiri atla
+			// Skip corrupt line
 		}
 	}
 	return entries;
@@ -82,13 +82,13 @@ export function renderDailyTrend(dailyCounts) {
 export function renderHabitStreaks(dailyCounts) {
 	const days = Object.keys(dailyCounts).sort();
 	if (days.length === 0) {
-		console.log(chalk.dim("  Henuz veri yok"));
+		console.log(chalk.dim("  No data yet"));
 		return;
 	}
 
 	const today = new Date();
 
-	// Mevcut seri: bugunden geriye, kirilana kadar say
+	// Current streak: count back from today until a gap
 	let currentStreak = 0;
 	for (let i = 0; i < 365; i++) {
 		const d = new Date(today);
@@ -98,7 +98,7 @@ export function renderHabitStreaks(dailyCounts) {
 		else break;
 	}
 
-	// En uzun seri: tum gecmisi tara
+	// Longest streak: scan all history
 	let longestStreak = 0;
 	let streak = 0;
 	for (let i = 0; i < 365; i++) {
@@ -113,7 +113,7 @@ export function renderHabitStreaks(dailyCounts) {
 		}
 	}
 
-	// Bu hafta aktif gun
+	// Active days this week
 	const weekStart = new Date(today);
 	weekStart.setDate(weekStart.getDate() - weekStart.getDay());
 	let weekActive = 0;
@@ -124,15 +124,15 @@ export function renderHabitStreaks(dailyCounts) {
 		if (dailyCounts[key]) weekActive++;
 	}
 
-	console.log(`  Mevcut seri:   ${chalk.bold.green(currentStreak)} gun`);
-	console.log(`  En uzun seri:  ${chalk.bold(longestStreak)} gun`);
-	console.log(`  Bu hafta:      ${chalk.bold(weekActive)}/7 gun aktif`);
+	console.log(`  Current streak: ${chalk.bold.green(currentStreak)} days`);
+	console.log(`  Longest streak: ${chalk.bold(longestStreak)} days`);
+	console.log(`  This week:      ${chalk.bold(weekActive)}/7 days active`);
 }
 
-// v1.29+ Claude Code transcript bazli session istatistikleri.
-// Mevcut "tool usage from .claude/logs/usage.jsonl" akisi degismeden korunur;
-// yeni flag'lar (--session, --models, --cost, --since, --until, --branch) ise
-// ~/.claude/projects/*.jsonl transcript'lerini okur.
+// v1.29+ Claude Code transcript-based session statistics.
+// The existing "tool usage from .claude/logs/usage.jsonl" flow is preserved;
+// new flags (--session, --models, --cost, --since, --until, --branch) read
+// ~/.claude/projects/*.jsonl transcripts.
 function loadFilteredSessions(opts) {
 	const files = listTranscriptFiles();
 	const sessions = [];
@@ -155,7 +155,7 @@ function renderSessionList(sessions, limit) {
 		)
 		.slice(0, limit);
 	if (sorted.length === 0) {
-		console.log(chalk.dim("  Filtreye uyan session yok."));
+		console.log(chalk.dim("  No sessions match the filter."));
 		return;
 	}
 	const header = [
@@ -218,7 +218,7 @@ function renderModelStats(sessions) {
 		(a, b) => b[1].sessions - a[1].sessions,
 	);
 	if (rows.length === 0) {
-		console.log(chalk.dim("  Model verisi yok."));
+		console.log(chalk.dim("  No model data."));
 		return;
 	}
 	const maxLabel = Math.max(...rows.map(([k]) => k.length));
@@ -248,10 +248,10 @@ function renderCostBreakdown(sessions) {
 		byBranch[b] = (byBranch[b] || 0) + s.costUsd;
 	}
 	console.log(
-		`  ${chalk.bold("Toplam")}: ${chalk.green(`$${total.toFixed(2)}`)}  ${chalk.dim(`(${sessions.length} session)`)}`,
+		`  ${chalk.bold("Total")}: ${chalk.green(`$${total.toFixed(2)}`)}  ${chalk.dim(`(${sessions.length} session)`)}`,
 	);
 	console.log("");
-	console.log(chalk.bold("  Proje bazli:"));
+	console.log(chalk.bold("  By project:"));
 	const projs = Object.entries(byProj)
 		.sort((a, b) => b[1] - a[1])
 		.slice(0, 10);
@@ -327,48 +327,46 @@ export function runStats(args) {
 	}
 
 	if (showHelp) {
-		console.log(chalk.bold("Kullanim Istatistikleri:"));
+		console.log(chalk.bold("Usage Statistics:"));
 		console.log("");
 		console.log(
-			`  badi stats              ${chalk.dim("Haftalik ozet (varsayilan)")}`,
+			`  badi stats              ${chalk.dim("Weekly summary (default)")}`,
 		);
 		console.log(
-			`  badi stats --week       ${chalk.dim("Haftalik ozet (explicit)")}`,
+			`  badi stats --week       ${chalk.dim("Weekly summary (explicit)")}`,
 		);
-		console.log(`  badi stats --month      ${chalk.dim("Aylik ozet")}`);
-		console.log(`  badi stats --all        ${chalk.dim("Tum zamanlar")}`);
-		console.log(`  badi stats --command X  ${chalk.dim("Arac bazli filtre")}`);
+		console.log(`  badi stats --month      ${chalk.dim("Monthly summary")}`);
+		console.log(`  badi stats --all        ${chalk.dim("All time")}`);
+		console.log(`  badi stats --command X  ${chalk.dim("Filter by tool")}`);
 		console.log(
-			`  badi stats --habits     ${chalk.dim("Aliskanlik serisi analizi")}`,
+			`  badi stats --habits     ${chalk.dim("Habit streak analysis")}`,
 		);
-		console.log(
-			`  badi stats --export csv ${chalk.dim("CSV olarak disa aktar")}`,
-		);
+		console.log(`  badi stats --export csv ${chalk.dim("Export as CSV")}`);
 		console.log("");
-		console.log(chalk.bold("  Claude Code transcript analizi (v1.29+):"));
+		console.log(chalk.bold("  Claude Code transcript analysis (v1.29+):"));
 		console.log(
-			`  badi stats --session    ${chalk.dim("Son N session listesi (--limit ile sayi)")}`,
+			`  badi stats --session    ${chalk.dim("List last N sessions (count via --limit)")}`,
 		);
 		console.log(
-			`  badi stats --models     ${chalk.dim("Model dagilimi + cache hit rate")}`,
+			`  badi stats --models     ${chalk.dim("Model distribution + cache hit rate")}`,
 		);
 		console.log(
-			`  badi stats --cost       ${chalk.dim("Token bazli USD maliyet (proje breakdown)")}`,
+			`  badi stats --cost       ${chalk.dim("Token-based USD cost (project breakdown)")}`,
 		);
 		console.log(
-			`  badi stats --since DATE ${chalk.dim("Tarih araligi basi (ISO veya YYYY-MM-DD)")}`,
+			`  badi stats --since DATE ${chalk.dim("Date range start (ISO or YYYY-MM-DD)")}`,
 		);
-		console.log(`  badi stats --until DATE ${chalk.dim("Tarih araligi sonu")}`);
+		console.log(`  badi stats --until DATE ${chalk.dim("Date range end")}`);
 		console.log(
-			`  badi stats --branch X   ${chalk.dim("Git branch filtre (transcript modlari icin)")}`,
+			`  badi stats --branch X   ${chalk.dim("Git branch filter (for transcript modes)")}`,
 		);
 		console.log(
-			`  badi stats --limit N    ${chalk.dim("--session icin satir sayisi (default 20)")}`,
+			`  badi stats --limit N    ${chalk.dim("Row count for --session (default 20)")}`,
 		);
 		return;
 	}
 
-	// Yeni transcript-bazli akis (--session/--models/--cost)
+	// New transcript-based flow (--session/--models/--cost)
 	if (showSession || showModels || showCost) {
 		const sessions = loadFilteredSessions({
 			since,
@@ -376,28 +374,28 @@ export function runStats(args) {
 			branch: branchFilter,
 		});
 		showBanner();
-		console.log(chalk.bold("Claude Code Session Analitik"));
+		console.log(chalk.bold("Claude Code Session Analytics"));
 		const filterParts = [];
 		if (since) filterParts.push(`since=${since}`);
 		if (until) filterParts.push(`until=${until}`);
 		if (branchFilter) filterParts.push(`branch=${branchFilter}`);
 		if (filterParts.length)
-			console.log(chalk.dim(`Filtre: ${filterParts.join(" ")}`));
-		console.log(chalk.dim(`Bulunan: ${sessions.length} session`));
+			console.log(chalk.dim(`Filter: ${filterParts.join(" ")}`));
+		console.log(chalk.dim(`Found: ${sessions.length} sessions`));
 		console.log("");
 
 		if (showSession) {
-			console.log(chalk.bold(`Son ${limit} Session:`));
+			console.log(chalk.bold(`Last ${limit} Sessions:`));
 			renderSessionList(sessions, limit);
 			console.log("");
 		}
 		if (showModels) {
-			console.log(chalk.bold("Model Dagilimi:"));
+			console.log(chalk.bold("Model Distribution:"));
 			renderModelStats(sessions);
 			console.log("");
 		}
 		if (showCost) {
-			console.log(chalk.bold("Maliyet Ozeti:"));
+			console.log(chalk.bold("Cost Summary:"));
 			renderCostBreakdown(sessions);
 			console.log("");
 		}
@@ -437,41 +435,41 @@ export function runStats(args) {
 	}
 
 	if (entries.length === 0) {
-		console.log(chalk.yellow("Henuz kullanim verisi yok."));
-		console.log(chalk.dim("Badi kullandikca veriler otomatik toplanir."));
+		console.log(chalk.yellow("No usage data yet."));
+		console.log(chalk.dim("Data is collected automatically as you use Badi."));
 		return;
 	}
 
 	const periodLabels = {
-		week: "Son 7 gun",
-		month: "Son 30 gun",
-		all: "Tum zamanlar",
+		week: "Last 7 days",
+		month: "Last 30 days",
+		all: "All time",
 	};
 	const stats = buildStats(entries);
 
 	showBanner();
-	console.log(chalk.bold("Kullanim Istatistikleri"));
-	console.log(`Donem: ${chalk.cyan(periodLabels[period])}`);
-	if (commandFilter) console.log(`Filtre: ${chalk.cyan(commandFilter)}`);
+	console.log(chalk.bold("Usage Statistics"));
+	console.log(`Period: ${chalk.cyan(periodLabels[period])}`);
+	if (commandFilter) console.log(`Filter: ${chalk.cyan(commandFilter)}`);
 	console.log("");
 
 	if (showHabits) {
-		console.log(chalk.bold("Aliskanlik Serisi:"));
+		console.log(chalk.bold("Habit Streak:"));
 		renderHabitStreaks(stats.dailyCounts);
 		console.log("");
 		return;
 	}
 
-	console.log(chalk.bold("En Cok Kullanilan Araclar:"));
+	console.log(chalk.bold("Most Used Tools:"));
 	renderBarChart(stats.toolCounts);
 	console.log("");
 
-	console.log(chalk.bold("Gunluk Aktivite:"));
+	console.log(chalk.bold("Daily Activity:"));
 	renderDailyTrend(stats.dailyCounts);
 	console.log("");
 
 	if (Object.keys(stats.commandCounts).length > 0) {
-		console.log(chalk.bold("Badi Komutlari:"));
+		console.log(chalk.bold("Badi Commands:"));
 		renderBarChart(stats.commandCounts);
 		console.log("");
 	}
@@ -479,6 +477,6 @@ export function runStats(args) {
 	const totalTools = entries.length;
 	const totalBadi = entries.filter((e) => e.command === "badi").length;
 	console.log(
-		chalk.dim(`Toplam: ${totalTools} arac kullanimi, ${totalBadi} badi komutu`),
+		chalk.dim(`Total: ${totalTools} tool uses, ${totalBadi} badi commands`),
 	);
 }

--- a/tests/cli.doctor.test.js
+++ b/tests/cli.doctor.test.js
@@ -30,7 +30,7 @@ describe("badi doctor", () => {
 
 	it("saglikli kurulumda basarili sonuc doner", () => {
 		const output = run(["doctor", "--target", TMP]);
-		assert.ok(output.includes("basarili"));
+		assert.ok(output.includes("passed"));
 	});
 
 	it("settings.json kontrolu yapar", () => {

--- a/tests/cli.observability.test.js
+++ b/tests/cli.observability.test.js
@@ -43,19 +43,19 @@ describe("stats v1.29+ flag'lari", () => {
 	it("stats --session calisir (transcript yoksa bile)", () => {
 		const r = run(["stats", "--session", "--limit", "1"]);
 		assert.equal(r.code, 0);
-		assert.ok(r.stdout.includes("Session Analitik"));
+		assert.ok(r.stdout.includes("Session Analytics"));
 	});
 
 	it("stats --models calisir", () => {
 		const r = run(["stats", "--models"]);
 		assert.equal(r.code, 0);
-		assert.ok(r.stdout.includes("Model Dagilimi"));
+		assert.ok(r.stdout.includes("Model Distribution"));
 	});
 
 	it("stats --cost calisir", () => {
 		const r = run(["stats", "--cost"]);
 		assert.equal(r.code, 0);
-		assert.ok(r.stdout.includes("Maliyet"));
+		assert.ok(r.stdout.includes("Cost"));
 	});
 });
 

--- a/tests/cli.stats.test.js
+++ b/tests/cli.stats.test.js
@@ -36,7 +36,7 @@ describe("badi stats", () => {
 
 	it("--help yardim gosterir", () => {
 		const output = run(["stats", "--help"]);
-		assert.ok(output.includes("Kullanim Istatistikleri"));
+		assert.ok(output.includes("Usage Statistics"));
 		assert.ok(output.includes("month"));
 		assert.ok(output.includes("habits"));
 		assert.ok(output.includes("export"));
@@ -44,7 +44,7 @@ describe("badi stats", () => {
 
 	it("bos veri ile mesaj gosterir", () => {
 		const output = run(["stats"]);
-		assert.ok(output.includes("Henuz kullanim verisi yok"));
+		assert.ok(output.includes("No usage data yet"));
 	});
 
 	it("haftalik ozet gosterir", () => {
@@ -71,25 +71,25 @@ describe("badi stats", () => {
 		createUsageLog(entries);
 
 		const output = run(["stats", "--week"]);
-		assert.ok(output.includes("Kullanim Istatistikleri"));
-		assert.ok(output.includes("Son 7 gun"));
+		assert.ok(output.includes("Usage Statistics"));
+		assert.ok(output.includes("Last 7 days"));
 		assert.ok(output.includes("Bash"));
 	});
 
 	it("aylik ozet gosterir", () => {
 		const output = run(["stats", "--month"]);
-		assert.ok(output.includes("Son 30 gun"));
+		assert.ok(output.includes("Last 30 days"));
 	});
 
 	it("--command filtresi calisiyor", () => {
 		const output = run(["stats", "--command", "Bash"]);
 		assert.ok(output.includes("Bash"));
-		assert.ok(output.includes("Filtre"));
+		assert.ok(output.includes("Filter"));
 	});
 
 	it("--habits seri analizi gosterir", () => {
 		const output = run(["stats", "--habits"]);
-		assert.ok(output.includes("seri") || output.includes("gun"));
+		assert.ok(output.includes("streak") || output.includes("days"));
 	});
 
 	it("--export csv ciktisi uretir", () => {


### PR DESCRIPTION
## Phase 2h — English-only migration (#207)

Translates all user-facing CLI output to English for three command modules. Conventional commit type names (`feat`/`fix`/...) and CLI flags stay stable — no interface renames in this batch.

### Changed
- **doctor.js** — report labels (passed/warnings/failed), totals, health/issue messages, suggested fixes, help-doctor drift output
- **commit.js** — type descriptions, conventional-commit help, `--check`/`--message` messages, changelog group labels (Added/Fixed/Performance/...), "Changelog" heading
- **stats.js** — habit streaks, session/model/cost summaries, period labels, transcript-mode analytics headers, help text

### Tests
Updated in lockstep: `cli.doctor.test.js`, `cli.stats.test.js`, `cli.observability.test.js` (v1.29+ transcript-mode assertions → English).

### Verification
- `npm run lint` — clean (201 files)
- `npm test` — **1132/1132 pass**
- Guard grep — no Turkish console strings remain in the 3 modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)