### PR TITLE
feat(i18n): English-only Phase 2i — aso, seo, market CLI output

### DIFF
--- a/lib/aso-helpers.js
+++ b/lib/aso-helpers.js
@@ -37,7 +37,7 @@ export async function lookupAppStore(appId, country = "us") {
 	const url = `https://itunes.apple.com/lookup?id=${encodeURIComponent(appId)}&country=${country}`;
 	const data = await fetchJson(url);
 	if (!data.results || data.results.length === 0) {
-		throw new Error(`App bulunamadi: ${appId} (country: ${country})`);
+		throw new Error(`App not found: ${appId} (country: ${country})`);
 	}
 	const r = data.results[0];
 	return {

--- a/lib/commands/aso.js
+++ b/lib/commands/aso.js
@@ -39,66 +39,66 @@ async function asoAudit(appIdOrAlias, country = "us") {
 		else console.log(`  ${chalk.yellow("!!")} ${label}`);
 	}
 
-	console.log(chalk.bold("App Bilgisi:"));
+	console.log(chalk.bold("App Info:"));
 	console.log(`  Name:    ${chalk.cyan(info.name)}`);
 	console.log(`  Seller:  ${chalk.cyan(info.seller)}`);
 	console.log(`  Version: ${chalk.cyan(info.version)}`);
 	console.log(`  Genre:   ${chalk.cyan(info.primaryGenre)}`);
 	console.log(
-		`  Rating:  ${chalk.cyan(info.averageRating?.toFixed(1) ?? "?")} (${info.ratingCount ?? 0} oy)`,
+		`  Rating:  ${chalk.cyan(info.averageRating?.toFixed(1) ?? "?")} (${info.ratingCount ?? 0} ratings)`,
 	);
 	console.log("");
 
-	console.log(chalk.bold("Metadata Kontrolleri:"));
+	console.log(chalk.bold("Metadata Checks:"));
 	const nameVal = validateMetadata("appstore", "title", info.name);
-	check(`Title uzunlugu (${nameVal.length}/${nameVal.limit})`, nameVal.ok, 2);
+	check(`Title length (${nameVal.length}/${nameVal.limit})`, nameVal.ok, 2);
 
 	if (info.subtitle) {
 		const subVal = validateMetadata("appstore", "subtitle", info.subtitle);
-		check(`Subtitle uzunlugu (${subVal.length}/${subVal.limit})`, subVal.ok);
+		check(`Subtitle length (${subVal.length}/${subVal.limit})`, subVal.ok);
 	} else {
 		console.log(
-			`  ${chalk.yellow("!!")} Subtitle tanimlanmamis (SEO firsati kacti)`,
+			`  ${chalk.yellow("!!")} Subtitle not defined (missed SEO opportunity)`,
 		);
 	}
 
 	const descLen = info.description.length;
-	check(`Description uzunlugu >= 500 karakter (${descLen})`, descLen >= 500);
-	check(`Description uzunlugu <= 4000 karakter (${descLen})`, descLen <= 4000);
+	check(`Description length >= 500 chars (${descLen})`, descLen >= 500);
+	check(`Description length <= 4000 chars (${descLen})`, descLen <= 4000);
 
 	console.log("");
-	console.log(chalk.bold("Gorseller:"));
+	console.log(chalk.bold("Visuals:"));
 	check(
-		`Screenshot sayisi >= 3 (${info.screenshotUrls.length})`,
+		`Screenshot count >= 3 (${info.screenshotUrls.length})`,
 		info.screenshotUrls.length >= 3,
 		2,
 	);
 	warn(
-		`Screenshot sayisi >= 6 (${info.screenshotUrls.length})`,
+		`Screenshot count >= 6 (${info.screenshotUrls.length})`,
 		info.screenshotUrls.length >= 6,
 	);
 
 	console.log("");
-	console.log(chalk.bold("Teknik:"));
-	check("iOS minimum surumu tanimli", !!info.minimumOsVersion);
+	console.log(chalk.bold("Technical:"));
+	check("iOS minimum version defined", !!info.minimumOsVersion);
 	warn(
-		`Desteklenen dil sayisi (${info.supportedLanguages.length})`,
+		`Supported language count (${info.supportedLanguages.length})`,
 		info.supportedLanguages.length >= 2,
 	);
 
 	console.log("");
-	console.log(chalk.bold("Sosyal Kanit:"));
+	console.log(chalk.bold("Social Proof:"));
 	check(
 		`Rating count >= 100 (${info.ratingCount ?? 0})`,
 		(info.ratingCount ?? 0) >= 100,
 		2,
 	);
 	warn(
-		`Ortalama rating >= 4.0 (${info.averageRating?.toFixed(1) ?? "?"})`,
+		`Average rating >= 4.0 (${info.averageRating?.toFixed(1) ?? "?"})`,
 		(info.averageRating ?? 0) >= 4.0,
 	);
 
-	// Keyword analizi
+	// Keyword analysis
 	console.log("");
 	console.log(chalk.bold("Top Keywords (description):"));
 	const kws = extractKeywords(info.description).slice(0, 10);
@@ -106,7 +106,7 @@ async function asoAudit(appIdOrAlias, country = "us") {
 		console.log(`  ${chalk.cyan(kw.padEnd(20))} ${chalk.dim(`${freq}x`)}`);
 	}
 
-	// Skor
+	// Score
 	console.log("");
 	console.log(chalk.bold("═".repeat(50)));
 	const pct = Math.round((score / maxScore) * 100);
@@ -116,11 +116,11 @@ async function asoAudit(appIdOrAlias, country = "us") {
 			: pct >= 60
 				? chalk.bold.yellow
 				: chalk.bold.red;
-	console.log(`  ASO Skoru: ${color(`${pct}/100`)} (${score}/${maxScore})`);
+	console.log(`  ASO Score: ${color(`${pct}/100`)} (${score}/${maxScore})`);
 
 	if (issues.length > 0) {
 		console.log("");
-		console.log(chalk.bold("Duzeltilmesi Gereken:"));
+		console.log(chalk.bold("Needs Fixing:"));
 		for (const i of issues) console.log(`  ${chalk.red("-")} ${i}`);
 	}
 }
@@ -129,7 +129,7 @@ async function asoAudit(appIdOrAlias, country = "us") {
 
 async function asoKeywords(appId, country = "us") {
 	showBanner();
-	console.log(chalk.bold(`Keyword Analizi: ${appId}`));
+	console.log(chalk.bold(`Keyword Analysis: ${appId}`));
 	console.log("");
 
 	const info = await lookupAppStore(appId, country);
@@ -162,48 +162,46 @@ async function asoKeywords(appId, country = "us") {
 function asoMetadata(platform = "appstore") {
 	if (!LIMITS[platform]) {
 		console.error(
-			chalk.red(`Gecersiz platform: ${platform} (appstore|playstore)`),
+			chalk.red(`Invalid platform: ${platform} (appstore|playstore)`),
 		);
 		process.exit(1);
 	}
 	showBanner();
-	console.log(chalk.bold(`Metadata Rehberi: ${platform}`));
+	console.log(chalk.bold(`Metadata Guide: ${platform}`));
 	console.log("");
 
-	console.log(chalk.bold("Karakter Limitleri:"));
+	console.log(chalk.bold("Character Limits:"));
 	const limits = LIMITS[platform];
 	for (const [k, v] of Object.entries(limits)) {
-		console.log(
-			`  ${chalk.cyan(k.padEnd(15))} ${chalk.yellow(`${v} karakter`)}`,
-		);
+		console.log(`  ${chalk.cyan(k.padEnd(15))} ${chalk.yellow(`${v} chars`)}`);
 	}
 
 	console.log("");
-	console.log(chalk.bold("TR/EN Sablon:"));
+	console.log(chalk.bold("Template:"));
 	if (platform === "appstore") {
-		console.log(chalk.dim("  Title (30):       [Marka] - [Ana Fayda]"));
+		console.log(chalk.dim("  Title (30):       [Brand] - [Main Benefit]"));
 		console.log(
-			chalk.dim("  Subtitle (30):    [Kullanici tipini cozen tek cumle]"),
+			chalk.dim("  Subtitle (30):    [One sentence solving the user's need]"),
 		);
 		console.log(
 			chalk.dim(
-				"  Keywords (100):   virgul,ayrimli,hic,bosluk,yok,100,karakter",
+				"  Keywords (100):   comma,separated,no,spaces,up,to,100,chars",
 			),
 		);
 		console.log(
 			chalk.dim(
-				"  Description:      Hook (ilk 3 satir) + Ozellikler + Sosyal kanit + CTA",
+				"  Description:      Hook (first 3 lines) + Features + Social proof + CTA",
 			),
 		);
 		console.log(
-			chalk.dim("  Promo Text (170): Yeni ozellik duyurusu / kampanya"),
+			chalk.dim("  Promo Text (170): New feature announcement / campaign"),
 		);
 	} else {
 		console.log(
-			chalk.dim("  Title (50):       [Marka] - [Ana Fayda ve Kategori]"),
+			chalk.dim("  Title (50):       [Brand] - [Main Benefit and Category]"),
 		);
 		console.log(
-			chalk.dim("  Short (80):       Appi tek cumlede aciklayan hook"),
+			chalk.dim("  Short (80):       Hook describing the app in one sentence"),
 		);
 		console.log(
 			chalk.dim(
@@ -213,18 +211,20 @@ function asoMetadata(platform = "appstore") {
 	}
 
 	console.log("");
-	console.log(chalk.bold("Ipuclari:"));
-	console.log("  - Title'a en guclu keyword'u yerlestir (ilk 30 karakter)");
-	console.log("  - Keywords alani: marka rakiplerini dahil etme (rejected)");
-	console.log("  - Description: ilk 3 satir hook, kalan detaylar");
-	console.log("  - Localizasyon: her dilde ayri keyword optimizasyonu");
+	console.log(chalk.bold("Tips:"));
+	console.log("  - Place your strongest keyword in the title (first 30 chars)");
+	console.log(
+		"  - Keywords field: do not include competitor brands (rejected)",
+	);
+	console.log("  - Description: first 3 lines hook, remaining details after");
+	console.log("  - Localization: optimize keywords separately per language");
 }
 
 // ─── compete ───
 
 async function asoCompete(myAppId, competitorId, country = "us") {
 	showBanner();
-	console.log(chalk.bold("Rakip Karsilastirma"));
+	console.log(chalk.bold("Competitor Comparison"));
 	console.log("");
 
 	const [me, they] = await Promise.all([
@@ -280,7 +280,7 @@ async function asoCompete(myAppId, competitorId, country = "us") {
 		);
 	}
 
-	// Ortak keywordler
+	// Shared keywords
 	const myKws = new Set(
 		extractKeywords(me.description)
 			.slice(0, 30)
@@ -295,13 +295,11 @@ async function asoCompete(myAppId, competitorId, country = "us") {
 	const onlyThem = [...theirKws].filter((k) => !myKws.has(k));
 
 	console.log("");
-	console.log(chalk.bold(`Ortak Keywordler (${shared.length}):`));
+	console.log(chalk.bold(`Shared Keywords (${shared.length}):`));
 	console.log(`  ${chalk.dim(shared.slice(0, 15).join(", "))}`);
 
 	console.log("");
-	console.log(
-		chalk.bold(`Rakibin Kullanip Sizin Kullanmadiginiz (${onlyThem.length}):`),
-	);
+	console.log(chalk.bold(`Competitor Uses, You Don't (${onlyThem.length}):`));
 	console.log(`  ${chalk.yellow(onlyThem.slice(0, 15).join(", "))}`);
 }
 
@@ -310,45 +308,45 @@ async function asoCompete(myAppId, competitorId, country = "us") {
 async function asoReview(appId, country = "us") {
 	showBanner();
 	const info = await lookupAppStore(appId, country);
-	console.log(chalk.bold(`Review Bilgileri: ${info.name}`));
+	console.log(chalk.bold(`Review Info: ${info.name}`));
 	console.log("");
 
-	console.log(chalk.bold("Mevcut Durum:"));
+	console.log(chalk.bold("Current Status:"));
 	console.log(
-		`  Ortalama Rating: ${chalk.cyan(info.averageRating?.toFixed(2) ?? "?")}`,
+		`  Average Rating: ${chalk.cyan(info.averageRating?.toFixed(2) ?? "?")}`,
 	);
-	console.log(`  Toplam Oy:       ${chalk.cyan(info.ratingCount ?? 0)}`);
+	console.log(`  Total Ratings:  ${chalk.cyan(info.ratingCount ?? 0)}`);
 	console.log(
-		`  Son Surum:       ${chalk.cyan(info.version)} (${info.updatedAt?.substring(0, 10)})`,
+		`  Latest Version: ${chalk.cyan(info.version)} (${info.updatedAt?.substring(0, 10)})`,
 	);
 	console.log("");
 
-	console.log(chalk.bold("Response Sablonlari:"));
+	console.log(chalk.bold("Response Templates:"));
 	console.log("");
-	console.log(chalk.cyan("Pozitif Review Yaniti:"));
+	console.log(chalk.cyan("Positive Review Reply:"));
 	console.log(
 		chalk.dim(
-			`  "[Kullanici adi], guzel yorumunuz icin tesekkurler! [Spesifik ozellik]'in size yardimci olmasina seviniyoruz. Yeni ozellikler icin bizi takip edin."`,
+			`  "[User name], thanks for your kind review! We're glad [specific feature] is helping you. Follow us for new features."`,
 		),
 	);
 	console.log("");
-	console.log(chalk.cyan("Negatif Review Yaniti (bug):"));
+	console.log(chalk.cyan("Negative Review Reply (bug):"));
 	console.log(
 		chalk.dim(
-			`  "[Kullanici adi], yasadiginiz sorun icin ozur dileriz. Lutfen destek@example.com'a [cihaz modeli + iOS surumu] ile ulasin. En kisa surede cozelim."`,
+			`  "[User name], we're sorry for the trouble. Please reach support@example.com with [device model + iOS version]. We'll resolve it as soon as possible."`,
 		),
 	);
 	console.log("");
-	console.log(chalk.cyan("Negatif Review Yaniti (feature):"));
+	console.log(chalk.cyan("Negative Review Reply (feature):"));
 	console.log(
 		chalk.dim(
-			`  "[Kullanici adi], geri bildiriminiz icin tesekkurler! [Istenen ozellik]'i roadmap'e aldik. Yeni surumde goreceksiniz."`,
+			`  "[User name], thanks for your feedback! We've added [requested feature] to the roadmap. You'll see it in an upcoming release."`,
 		),
 	);
 	console.log("");
 	console.log(
 		chalk.dim(
-			"Not: Detayli sentiment analizi icin Claude Code'da /aso-strategist ajanini cagirin.",
+			"Note: For detailed sentiment analysis, call the /aso-strategist agent in Claude Code.",
 		),
 	);
 }
@@ -357,40 +355,42 @@ async function asoReview(appId, country = "us") {
 
 function asoScreenshots() {
 	showBanner();
-	console.log(chalk.bold("App Store / Play Store Screenshot Rehberi"));
+	console.log(chalk.bold("App Store / Play Store Screenshot Guide"));
 	console.log("");
 
-	console.log(chalk.bold("iOS Boyutlari (zorunlu):"));
+	console.log(chalk.bold("iOS Sizes (required):"));
 	console.log(`  ${chalk.cyan('6.5" (iPhone 11 Pro Max)')} 1242 x 2688 px`);
 	console.log(`  ${chalk.cyan('5.5" (iPhone 8 Plus)')}    1242 x 2208 px`);
 	console.log(`  ${chalk.cyan('12.9" iPad Pro (3rd+)')}   2048 x 2732 px`);
 	console.log("");
-	console.log(chalk.bold("iOS Boyutlari (opsiyonel):"));
+	console.log(chalk.bold("iOS Sizes (optional):"));
 	console.log(`  ${chalk.dim('6.7" (iPhone 14 Pro Max)')} 1290 x 2796 px`);
 	console.log(`  ${chalk.dim('5.8" (iPhone 11 Pro)')}    1125 x 2436 px`);
 	console.log(`  ${chalk.dim('4.7" (iPhone 8)')}          750 x 1334 px`);
 
 	console.log("");
-	console.log(chalk.bold("Android Boyutlari:"));
+	console.log(chalk.bold("Android Sizes:"));
 	console.log(
-		`  ${chalk.cyan("Phone")}   1080 x 1920 px (min) - 2-8 screenshot`,
+		`  ${chalk.cyan("Phone")}   1080 x 1920 px (min) - 2-8 screenshots`,
 	);
 	console.log(`  ${chalk.cyan('7" Tablet')} 1200 x 1920 px`);
 	console.log(`  ${chalk.cyan('10" Tablet')} 1920 x 1200 px`);
-	console.log(`  ${chalk.cyan("Feature Graphic")} 1024 x 500 px (zorunlu)`);
+	console.log(`  ${chalk.cyan("Feature Graphic")} 1024 x 500 px (required)`);
 
 	console.log("");
-	console.log(chalk.bold("Tasarim Rehberi:"));
-	console.log("  1. Ilk screenshot en onemli — value proposition");
-	console.log("  2. Metin: max 5 kelime, buyuk punto (>= 40pt)");
-	console.log("  3. Device frame ekleyin (daha profesyonel)");
-	console.log("  4. Action/benefit gosterin, statik UI yerine");
-	console.log("  5. Brand rengi + sade arka plan");
-	console.log("  6. Carousel mantigi: hikaye anlatsin");
+	console.log(chalk.bold("Design Guide:"));
+	console.log("  1. First screenshot matters most — value proposition");
+	console.log("  2. Text: max 5 words, large font (>= 40pt)");
+	console.log("  3. Add a device frame (more professional)");
+	console.log("  4. Show action/benefit, not static UI");
+	console.log("  5. Brand color + clean background");
+	console.log("  6. Carousel logic: tell a story");
 
 	console.log("");
 	console.log(
-		chalk.dim('Detayli brief icin: badi icerik gorsel "app store screenshot"'),
+		chalk.dim(
+			'For a detailed brief: badi icerik gorsel "app store screenshot"',
+		),
 	);
 }
 
@@ -417,34 +417,30 @@ async function asoPlaystore(appIdOrPackage, country = "us", lang = "en") {
 		}
 	}
 
-	console.log(chalk.bold("App Bilgisi:"));
+	console.log(chalk.bold("App Info:"));
 	console.log(`  Name:   ${chalk.cyan(info.name || "?")}`);
 	console.log(
-		`  Rating: ${chalk.cyan(info.averageRating?.toFixed(1) ?? "?")} (${info.ratingCount ?? 0} oy)`,
+		`  Rating: ${chalk.cyan(info.averageRating?.toFixed(1) ?? "?")} (${info.ratingCount ?? 0} ratings)`,
 	);
 	console.log("");
 
-	console.log(chalk.bold("Metadata Kontrolleri:"));
+	console.log(chalk.bold("Metadata Checks:"));
 	const titleVal = validateMetadata("playstore", "title", info.name);
-	check(
-		`Title uzunlugu (${titleVal.length}/${titleVal.limit})`,
-		titleVal.ok,
-		2,
-	);
+	check(`Title length (${titleVal.length}/${titleVal.limit})`, titleVal.ok, 2);
 
 	const descLen = (info.description || "").length;
-	check(`Description >= 500 karakter (${descLen})`, descLen >= 500);
-	check(`Description <= 4000 karakter (${descLen})`, descLen <= 4000);
+	check(`Description >= 500 chars (${descLen})`, descLen >= 500);
+	check(`Description <= 4000 chars (${descLen})`, descLen <= 4000);
 
 	console.log("");
-	console.log(chalk.bold("Sosyal Kanit:"));
+	console.log(chalk.bold("Social Proof:"));
 	check(
 		`Rating count >= 100 (${info.ratingCount ?? 0})`,
 		(info.ratingCount ?? 0) >= 100,
 		2,
 	);
 	check(
-		`Ortalama rating >= 4.0 (${info.averageRating?.toFixed(1) ?? "?"})`,
+		`Average rating >= 4.0 (${info.averageRating?.toFixed(1) ?? "?"})`,
 		(info.averageRating ?? 0) >= 4.0,
 	);
 
@@ -467,19 +463,19 @@ async function asoPlaystore(appIdOrPackage, country = "us", lang = "en") {
 				? chalk.bold.yellow
 				: chalk.bold.red;
 	console.log(
-		`  ASO Skoru (Play Store): ${color(`${pct}/100`)} (${score}/${maxScore})`,
+		`  ASO Score (Play Store): ${color(`${pct}/100`)} (${score}/${maxScore})`,
 	);
 
 	if (issues.length > 0) {
 		console.log("");
-		console.log(chalk.bold("Duzeltilmesi Gereken:"));
+		console.log(chalk.bold("Needs Fixing:"));
 		for (const i of issues) console.log(`  ${chalk.red("-")} ${i}`);
 	}
 
 	console.log("");
 	console.log(
 		chalk.dim(
-			"Not: Play Store verileri sinirli (HTML scraping). Screenshot/short desc icin Console'a bakin.",
+			"Note: Play Store data is limited (HTML scraping). Check the Console for screenshots / short description.",
 		),
 	);
 }
@@ -488,7 +484,7 @@ async function asoPlaystore(appIdOrPackage, country = "us", lang = "en") {
 
 async function asoReviews(appId, country = "us", pages = 2) {
 	showBanner();
-	console.log(chalk.bold(`Review Analizi: ${appId} (${country})`));
+	console.log(chalk.bold(`Review Analysis: ${appId} (${country})`));
 	console.log("");
 
 	const all = [];
@@ -504,43 +500,48 @@ async function asoReviews(appId, country = "us", pages = 2) {
 	}
 
 	if (all.length === 0) {
-		console.log(chalk.yellow("Yorum bulunamadi."));
+		console.log(chalk.yellow("No reviews found."));
 		console.log(
-			chalk.dim("Not: Yeni uygulamalar RSS feed'de henuz gorunmuyor olabilir."),
+			chalk.dim("Note: New apps may not appear in the RSS feed yet."),
 		);
 		return;
 	}
 
 	const analysis = analyzeSentiment(all);
 
-	console.log(chalk.bold(`Cekilen Yorumlar: ${analysis.total}`));
+	console.log(chalk.bold(`Fetched Reviews: ${analysis.total}`));
 	console.log(
-		`Ortalama Rating: ${chalk.cyan(analysis.averageRating.toFixed(2))}`,
+		`Average Rating: ${chalk.cyan(analysis.averageRating.toFixed(2))}`,
 	);
 	console.log("");
 
-	console.log(chalk.bold("Kategori Dagilimi:"));
+	console.log(chalk.bold("Category Distribution:"));
 	const rows = [
 		[
-			"Pozitif",
+			"Positive",
 			analysis.counts.positive,
 			analysis.percentages.positive,
 			chalk.green,
 		],
 		[
-			"Negatif",
+			"Negative",
 			analysis.counts.negative,
 			analysis.percentages.negative,
 			chalk.red,
 		],
-		["Bug/Hata", analysis.counts.bug, analysis.percentages.bug, chalk.red],
+		["Bug/Error", analysis.counts.bug, analysis.percentages.bug, chalk.red],
 		[
-			"Feature Talep",
+			"Feature Request",
 			analysis.counts.feature_request,
 			analysis.percentages.feature_request,
 			chalk.yellow,
 		],
-		["Notr", analysis.counts.neutral, analysis.percentages.neutral, chalk.dim],
+		[
+			"Neutral",
+			analysis.counts.neutral,
+			analysis.percentages.neutral,
+			chalk.dim,
+		],
 	];
 	for (const [label, count, pct, color] of rows) {
 		const bar = "█".repeat(Math.max(0, Math.floor(pct / 3)));
@@ -549,7 +550,7 @@ async function asoReviews(appId, country = "us", pages = 2) {
 		);
 	}
 
-	// En kritik 5 review
+	// Top 5 critical reviews
 	const critical = analysis.categorized
 		.filter(
 			(r) => r.categories.includes("bug") || r.categories.includes("negative"),
@@ -558,7 +559,7 @@ async function asoReviews(appId, country = "us", pages = 2) {
 
 	if (critical.length > 0) {
 		console.log("");
-		console.log(chalk.bold("Kritik Yorumlar (ilk 5):"));
+		console.log(chalk.bold("Critical Reviews (top 5):"));
 		for (const r of critical) {
 			console.log(
 				`  ${chalk.red("★".repeat(r.rating))} ${chalk.cyan(r.author || "?")} (v${r.version || "?"})`,
@@ -567,18 +568,18 @@ async function asoReviews(appId, country = "us", pages = 2) {
 			console.log(
 				`    ${chalk.dim(r.content.substring(0, 120).replace(/\n/g, " "))}${r.content.length > 120 ? "..." : ""}`,
 			);
-			console.log(`    ${chalk.dim(`Kategori: ${r.categories.join(", ")}`)}`);
+			console.log(`    ${chalk.dim(`Category: ${r.categories.join(", ")}`)}`);
 			console.log("");
 		}
 	}
 
-	// Feature talepleri
+	// Feature requests
 	const features = analysis.categorized
 		.filter((r) => r.categories.includes("feature_request"))
 		.slice(0, 5);
 
 	if (features.length > 0) {
-		console.log(chalk.bold("Feature Talepleri (ilk 5):"));
+		console.log(chalk.bold("Feature Requests (top 5):"));
 		for (const r of features) {
 			console.log(
 				`  ${chalk.yellow("→")} ${chalk.bold(r.title)} — ${chalk.dim(r.author || "?")}`,
@@ -592,7 +593,7 @@ async function asoReviews(appId, country = "us", pages = 2) {
 
 	console.log(
 		chalk.dim(
-			"Basit anahtar kelime siniflandirma. Detay icin /aso-strategist ajanini cagirin.",
+			"Simple keyword classification. For details, call the /aso-strategist agent.",
 		),
 	);
 }
@@ -602,28 +603,28 @@ async function asoReviews(appId, country = "us", pages = 2) {
 async function asoScreenshotsFor(appId, country = "us") {
 	showBanner();
 	const info = await lookupAppStore(appId, country);
-	console.log(chalk.bold(`Screenshot Varliklari: ${info.name}`));
+	console.log(chalk.bold(`Screenshot Assets: ${info.name}`));
 	console.log("");
 
 	const shots = (info.screenshotUrls || []).map(parseScreenshotUrl);
 	if (shots.length === 0) {
-		console.log(chalk.yellow("Bu uygulamada screenshot URL'si yok."));
+		console.log(chalk.yellow("This app has no screenshot URLs."));
 		return;
 	}
 
-	console.log(chalk.bold(`Toplam: ${shots.length} adet`));
+	console.log(chalk.bold(`Total: ${shots.length}`));
 	console.log("");
 
-	// Orientation dagilimi
+	// Orientation distribution
 	const portrait = shots.filter((s) => s.orientation === "portrait").length;
 	const landscape = shots.filter((s) => s.orientation === "landscape").length;
-	console.log(chalk.bold("Yonelim:"));
+	console.log(chalk.bold("Orientation:"));
 	console.log(`  Portrait:  ${chalk.cyan(portrait)}`);
 	console.log(`  Landscape: ${chalk.cyan(landscape)}`);
 	console.log("");
 
-	// Cozunurluk dagilimi
-	console.log(chalk.bold("Cozunurlukler:"));
+	// Resolution distribution
+	console.log(chalk.bold("Resolutions:"));
 	const byRes = {};
 	for (const s of shots) {
 		if (s.width && s.height) {
@@ -634,14 +635,12 @@ async function asoScreenshotsFor(appId, country = "us") {
 	for (const [res, count] of Object.entries(byRes).sort(
 		(a, b) => b[1] - a[1],
 	)) {
-		console.log(
-			`  ${chalk.cyan(res.padEnd(12))} ${chalk.dim(`${count} adet`)}`,
-		);
+		console.log(`  ${chalk.cyan(res.padEnd(12))} ${chalk.dim(`${count}`)}`);
 	}
 	console.log("");
 
-	// URL'ler (ilk 10)
-	console.log(chalk.bold("URL Ornekleri (ilk 5):"));
+	// URLs (first 10)
+	console.log(chalk.bold("URL Examples (first 5):"));
 	for (const s of shots.slice(0, 5)) {
 		console.log(
 			`  ${chalk.dim(s.url.substring(0, 80))}${s.url.length > 80 ? "..." : ""}`,
@@ -649,28 +648,28 @@ async function asoScreenshotsFor(appId, country = "us") {
 	}
 
 	console.log("");
-	console.log(chalk.bold("Oneriler:"));
+	console.log(chalk.bold("Recommendations:"));
 	if (shots.length < 3)
 		console.log(
-			`  ${chalk.yellow("!!")} Screenshot < 3 (minimum 3, ideal 6-10)`,
+			`  ${chalk.yellow("!!")} Screenshots < 3 (minimum 3, ideal 6-10)`,
 		);
 	if (shots.length >= 3 && shots.length < 6)
-		console.log(`  ${chalk.yellow("!!")} 6+ screenshot conversion'i arttirir`);
+		console.log(`  ${chalk.yellow("!!")} 6+ screenshots increase conversion`);
 	if (shots.length >= 6)
-		console.log(`  ${chalk.green("OK")} Screenshot sayisi yeterli`);
+		console.log(`  ${chalk.green("OK")} Screenshot count is sufficient`);
 	if (landscape > portrait)
 		console.log(
-			`  ${chalk.yellow("!!")} Landscape agirlikli — mobil uygulamalarda genelde portrait tercih edilir`,
+			`  ${chalk.yellow("!!")} Landscape-heavy — portrait is usually preferred for mobile apps`,
 		);
 	console.log("");
 	console.log(
 		chalk.dim(
-			"Gorsel tasarim analizi icin app-store-screenshots skill'ini Claude Code'da tetikleyin.",
+			"To analyze visual design, trigger the app-store-screenshots skill in Claude Code.",
 		),
 	);
 }
 
-// ─── Ana komut ───
+// ─── Main command ───
 
 export async function runAso(args) {
 	const sub = args[0];
@@ -680,39 +679,39 @@ export async function runAso(args) {
 		console.log(chalk.bold("ASO — App Store Optimization:"));
 		console.log("");
 		console.log(
-			`  ${chalk.cyan("badi aso audit")} [app-id]          App listing denetimi (iOS)`,
+			`  ${chalk.cyan("badi aso audit")} [app-id]          App listing audit (iOS)`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi aso playstore")} [app-id]     Play Store listing denetimi (v1.11+)`,
+			`  ${chalk.cyan("badi aso playstore")} [app-id]     Play Store listing audit (v1.11+)`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi aso keywords")} [app-id]       Keyword analizi`,
+			`  ${chalk.cyan("badi aso keywords")} [app-id]       Keyword analysis`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi aso metadata")} [platform]     Metadata limit rehberi`,
+			`  ${chalk.cyan("badi aso metadata")} [platform]     Metadata limit guide`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi aso review")} [app-id]         Review response sablonlari`,
+			`  ${chalk.cyan("badi aso review")} [app-id]         Review response templates`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi aso reviews")} [app-id]        Gercek yorumlari cek + sentiment analiz (v1.11+)`,
+			`  ${chalk.cyan("badi aso reviews")} [app-id]        Fetch real reviews + sentiment analysis (v1.11+)`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi aso compete")} [id1] [id2]     Iki app karsilastirma`,
+			`  ${chalk.cyan("badi aso compete")} [id1] [id2]     Compare two apps`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi aso screenshots")} [app-id?]   Rehber + app-spesifik varlik dokumunu (v1.11+)`,
+			`  ${chalk.cyan("badi aso screenshots")} [app-id?]   Guide + app-specific asset dump (v1.11+)`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi aso search")} [sorgu]          App Store arama`,
+			`  ${chalk.cyan("badi aso search")} [query]          App Store search`,
 		);
 		console.log("");
-		console.log(chalk.bold("Ornekler:"));
+		console.log(chalk.bold("Examples:"));
 		console.log("  badi aso audit 284882215        # Facebook iOS");
 		console.log("  badi aso playstore com.facebook.katana  # Facebook Android");
 		console.log("  badi aso reviews 284882215 --country us");
 		console.log(
-			"  badi aso screenshots 284882215  # Uygulamaya ait screenshot varlik analizi",
+			"  badi aso screenshots 284882215  # App-specific screenshot asset analysis",
 		);
 		console.log("  badi aso keywords 284882215");
 		console.log("  badi aso metadata appstore");
@@ -721,7 +720,7 @@ export async function runAso(args) {
 		console.log("");
 		console.log(
 			chalk.dim(
-				"Not: Detayli strateji icin Claude Code'da /aso-master cagirin.",
+				"Note: For detailed strategy, call /aso-master in Claude Code.",
 			),
 		);
 		return;
@@ -738,14 +737,14 @@ export async function runAso(args) {
 		switch (sub) {
 			case "audit":
 				if (!args[1]) {
-					console.error(chalk.red("App ID gerekli"));
+					console.error(chalk.red("App ID required"));
 					process.exit(1);
 				}
 				await asoAudit(args[1], country);
 				break;
 			case "keywords":
 				if (!args[1]) {
-					console.error(chalk.red("App ID gerekli"));
+					console.error(chalk.red("App ID required"));
 					process.exit(1);
 				}
 				await asoKeywords(args[1], country);
@@ -755,7 +754,7 @@ export async function runAso(args) {
 				break;
 			case "review":
 				if (!args[1]) {
-					console.error(chalk.red("App ID gerekli"));
+					console.error(chalk.red("App ID required"));
 					process.exit(1);
 				}
 				await asoReview(args[1], country);
@@ -763,7 +762,7 @@ export async function runAso(args) {
 			case "compete":
 				if (!args[1] || !args[2]) {
 					console.error(
-						chalk.red("Iki App ID gerekli: badi aso compete [id1] [id2]"),
+						chalk.red("Two App IDs required: badi aso compete [id1] [id2]"),
 					);
 					process.exit(1);
 				}
@@ -775,27 +774,27 @@ export async function runAso(args) {
 				break;
 			case "playstore":
 				if (!args[1]) {
-					console.error(chalk.red("App ID / package gerekli"));
+					console.error(chalk.red("App ID / package required"));
 					process.exit(1);
 				}
 				await asoPlaystore(args[1], country);
 				break;
 			case "reviews":
 				if (!args[1]) {
-					console.error(chalk.red("App ID gerekli"));
+					console.error(chalk.red("App ID required"));
 					process.exit(1);
 				}
 				await asoReviews(args[1], country);
 				break;
 			case "search": {
 				if (!args[1]) {
-					console.error(chalk.red("Sorgu gerekli"));
+					console.error(chalk.red("Query required"));
 					process.exit(1);
 				}
 				const results = await searchAppStore(args[1], country, 10);
 				showBanner();
 				console.log(
-					chalk.bold(`Arama Sonuclari: "${args[1]}" (${results.length})`),
+					chalk.bold(`Search Results: "${args[1]}" (${results.length})`),
 				);
 				console.log("");
 				for (const r of results) {
@@ -807,14 +806,14 @@ export async function runAso(args) {
 				break;
 			}
 			default:
-				console.error(chalk.red(`Bilinmeyen aso komutu: ${sub}`));
+				console.error(chalk.red(`Unknown aso command: ${sub}`));
 				console.log(
-					"Kullanim: badi aso [audit|playstore|keywords|metadata|review|reviews|compete|screenshots|search]",
+					"Usage: badi aso [audit|playstore|keywords|metadata|review|reviews|compete|screenshots|search]",
 				);
 				process.exit(1);
 		}
 	} catch (e) {
-		console.error(chalk.red(`Hata: ${e.message}`));
+		console.error(chalk.red(`Error: ${e.message}`));
 		process.exit(1);
 	}
 }

--- a/lib/commands/market.js
+++ b/lib/commands/market.js
@@ -57,43 +57,39 @@ function parseFlags(args) {
 
 function showHelp() {
 	showBanner();
-	console.log(chalk.bold("Badi Market — App Store Pazar Arastirmasi"));
+	console.log(chalk.bold("Badi Market — App Store Market Research"));
 	console.log("");
-	console.log(chalk.bold("Kullanim:"));
+	console.log(chalk.bold("Usage:"));
 	console.log(
-		`  ${chalk.cyan("badi market <appId>")}                 Tam rapor`,
+		`  ${chalk.cyan("badi market <appId>")}                 Full report`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi market discover <appId>")}        Sadece rakip kesfi`,
+		`  ${chalk.cyan("badi market discover <appId>")}        Competitor discovery only`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi market reviews <appId>")}         Coklu bolge yorum aggregation`,
+		`  ${chalk.cyan("badi market reviews <appId>")}         Multi-region review aggregation`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi market difficulty <appId>")}      Sadece zorluk skoru`,
+		`  ${chalk.cyan("badi market difficulty <appId>")}      Difficulty score only`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi market wishlist <kategori>")}     Demand × supply matrix (Reddit + App Store)`,
+		`  ${chalk.cyan("badi market wishlist <category>")}     Demand × supply matrix (Reddit + App Store)`,
 	);
 	console.log(
 		`  ${chalk.cyan("badi market gaps <appId>")}            Opportunity gaps (difficulty × complaints × demand)`,
 	);
 	console.log("");
-	console.log(chalk.bold("Secenekler:"));
-	console.log("  --country <c1,c2,..>    Bolgeler (varsayilan: us)");
+	console.log(chalk.bold("Options:"));
+	console.log("  --country <c1,c2,..>    Regions (default: us)");
+	console.log("  --pages <N>             Review page count (1-10, default: 3)");
+	console.log("  --limit <N>             Competitor app count (default: 10)");
 	console.log(
-		"  --pages <N>             Inceleme sayfa sayisi (1-10, varsayilan: 3)",
+		"  --days <N>              wishlist/Reddit demand window in days (default: 30)",
 	);
-	console.log(
-		"  --limit <N>             Rakip uygulama sayisi (varsayilan: 10)",
-	);
-	console.log(
-		"  --days <N>              wishlist/Reddit talep penceresi gun olarak (varsayilan: 30)",
-	);
-	console.log("  --query <q>             gaps icin alternatif arama sorgusu");
-	console.log("  --json                  Cikti JSON olarak (program-icin)");
+	console.log("  --query <q>             alternative search query for gaps");
+	console.log("  --json                  Output as JSON (for piping)");
 	console.log("");
-	console.log(chalk.bold("Ornekler:"));
+	console.log(chalk.bold("Examples:"));
 	console.log("  badi market 284882215");
 	console.log("  badi market 284882215 --country us,gb,de --pages 5");
 	console.log("  badi market discover 284882215 --limit 15");
@@ -106,15 +102,15 @@ function showHelp() {
 	console.log("");
 	console.log(
 		chalk.dim(
-			"App ID = numerik id (284882215) veya tam URL (https://apps.apple.com/us/app/id284882215)",
+			"App ID = numeric id (284882215) or full URL (https://apps.apple.com/us/app/id284882215)",
 		),
 	);
 	console.log(
-		chalk.dim("Kaynak: iTunes Lookup, iTunes Search, Apple RSS Reviews"),
+		chalk.dim("Source: iTunes Lookup, iTunes Search, Apple RSS Reviews"),
 	);
 	console.log(
 		chalk.dim(
-			"API anahtari gerekmez. SensorTower revenue ve gap report v1.15.x'te.",
+			"No API key required. SensorTower revenue and gap report in v1.15.x.",
 		),
 	);
 }
@@ -130,8 +126,8 @@ function parseAppId(input) {
 
 async function subWishlist(query, flags) {
 	if (!query) {
-		console.error(chalk.red("Kategori/anahtar kelime gerekli"));
-		console.log(chalk.dim('Ornek: badi market wishlist "habit tracker"'));
+		console.error(chalk.red("Category/keyword required"));
+		console.log(chalk.dim('Example: badi market wishlist "habit tracker"'));
 		process.exit(1);
 	}
 
@@ -139,10 +135,10 @@ async function subWishlist(query, flags) {
 		showBanner();
 		console.log(chalk.bold(`Wishlist Matrix: ${query}`));
 		console.log(
-			chalk.dim(`Demand: Reddit (son ${flags.days} gun) | Supply: App Store`),
+			chalk.dim(`Demand: Reddit (last ${flags.days} days) | Supply: App Store`),
 		);
 		console.log("");
-		console.log(chalk.dim("[1/2] Reddit talep sinyali toplaniyor..."));
+		console.log(chalk.dim("[1/2] Collecting Reddit demand signal..."));
 	}
 
 	const demand = await fetchRedditDemand(query, {
@@ -151,7 +147,7 @@ async function subWishlist(query, flags) {
 	});
 
 	if (!flags.json) {
-		console.log(chalk.dim(`[2/2] App Store rakip arz hacmi olculuyor...`));
+		console.log(chalk.dim(`[2/2] Measuring App Store competitor supply...`));
 	}
 
 	let supply = 0;
@@ -167,7 +163,7 @@ async function subWishlist(query, flags) {
 		}));
 	} catch (e) {
 		if (!flags.json) {
-			console.log(chalk.yellow(`  Arz olcumu basarisiz: ${e.message}`));
+			console.log(chalk.yellow(`  Supply measurement failed: ${e.message}`));
 		}
 	}
 
@@ -207,44 +203,44 @@ async function subWishlist(query, flags) {
 					? chalk.cyan
 					: chalk.red;
 
-	console.log(chalk.bold("Sonuc:"));
+	console.log(chalk.bold("Result:"));
 	console.log(`  ${verdictColor(chalk.bold(matrix.quadrant))}`);
 	console.log("");
 	console.log(chalk.bold("Demand (Reddit):"));
-	console.log(`  ${demand.mentions} mention son ${flags.days} gunde`);
+	console.log(`  ${demand.mentions} mentions in the last ${flags.days} days`);
 	if (demand.error) {
-		console.log(chalk.yellow(`  Uyari: ${demand.error}`));
+		console.log(chalk.yellow(`  Warning: ${demand.error}`));
 	}
 	const topSubs = Object.entries(demand.subreddits)
 		.sort((a, b) => b[1] - a[1])
 		.slice(0, 5);
 	if (topSubs.length > 0) {
-		console.log(chalk.bold("  Top subreddit'ler:"));
+		console.log(chalk.bold("  Top subreddits:"));
 		for (const [sub, c] of topSubs) {
 			console.log(`    r/${sub.padEnd(25)} ${c}`);
 		}
 	}
 	console.log("");
 	console.log(chalk.bold("Supply (App Store):"));
-	console.log(`  ${supply} app bulundu (ilk sayfa)`);
+	console.log(`  ${supply} apps found (first page)`);
 	for (const s of supplySample) {
 		console.log(
 			`    ${(s.name || "").substring(0, 38).padEnd(40)} ${chalk.dim(`★${s.rating || "-"} (${s.ratingCount || 0})`)}`,
 		);
 	}
 	console.log("");
-	console.log(chalk.bold("Quadrant rehberi:"));
+	console.log(chalk.bold("Quadrant guide:"));
 	console.log(
-		`${chalk.green("  BLUE_OCEAN")}    yuksek talep, dusuk arz  -> firsat`,
+		`${chalk.green("  BLUE_OCEAN")}    high demand, low supply   -> opportunity`,
 	);
 	console.log(
-		`${chalk.yellow("  COMPETITIVE")}  yuksek talep, yuksek arz -> farklilas`,
+		`${chalk.yellow("  COMPETITIVE")}  high demand, high supply  -> differentiate`,
 	);
 	console.log(
-		`${chalk.cyan("  NICHE")}        dusuk talep, dusuk arz   -> ozel kitle`,
+		`${chalk.cyan("  NICHE")}        low demand, low supply    -> niche audience`,
 	);
 	console.log(
-		`${chalk.red("  SATURATED")}    dusuk talep, yuksek arz  -> kacin`,
+		`${chalk.red("  SATURATED")}    low demand, high supply   -> avoid`,
 	);
 }
 
@@ -254,23 +250,25 @@ async function subGaps(appId, flags) {
 		console.log(chalk.bold(`Opportunity Gaps: app ${appId}`));
 		console.log(
 			chalk.dim(
-				"Difficulty + cross-rakip sikayetler + (opsiyonel) Reddit demand",
+				"Difficulty + cross-competitor complaints + (optional) Reddit demand",
 			),
 		);
 		console.log("");
-		console.log(chalk.dim("[1/5] Hedef profili..."));
+		console.log(chalk.dim("[1/5] Target profile..."));
 	}
 	const target = await lookupAppStore(appId, flags.countries[0]);
 
 	if (!flags.json)
-		console.log(chalk.dim(`[2/5] Rakip kesfi (${flags.limit} app)...`));
+		console.log(
+			chalk.dim(`[2/5] Competitor discovery (${flags.limit} apps)...`),
+		);
 	const competitors = await discoverCompetitors(target, {
 		country: flags.countries[0],
 		limit: flags.limit,
 	});
 
 	if (!flags.json)
-		console.log(chalk.dim(`[3/5] Rakip yorumlari toplaniyor...`));
+		console.log(chalk.dim(`[3/5] Collecting competitor reviews...`));
 	const competitorSummaries = [];
 	for (const c of competitors) {
 		try {
@@ -304,10 +302,12 @@ async function subGaps(appId, flags) {
 			// non-fatal
 		}
 	} else if (!flags.json) {
-		console.log(chalk.dim("[4/5] Reddit demand atlandi (--query verilmedi)"));
+		console.log(
+			chalk.dim("[4/5] Reddit demand skipped (--query not provided)"),
+		);
 	}
 
-	if (!flags.json) console.log(chalk.dim("[5/5] Gap skoru hesaplaniyor..."));
+	if (!flags.json) console.log(chalk.dim("[5/5] Computing gap score..."));
 	const gaps = findOpportunityGaps({
 		crossComplaints,
 		competitorCount: competitorSummaries.length,
@@ -338,35 +338,37 @@ async function subGaps(appId, flags) {
 	}
 
 	console.log("");
-	console.log(chalk.bold(`Hedef: ${target.name}`));
+	console.log(chalk.bold(`Target: ${target.name}`));
 	console.log(
 		chalk.dim(
-			`Tur: ${target.primaryGenre} | Zorluk: ${difficulty.score}/100 (${difficulty.verdict})`,
+			`Genre: ${target.primaryGenre} | Difficulty: ${difficulty.score}/100 (${difficulty.verdict})`,
 		),
 	);
 	console.log(
 		chalk.dim(
-			`Rakip: ${competitorSummaries.length} | Sikayet kategorisi: ${crossComplaints.length}`,
+			`Competitors: ${competitorSummaries.length} | Complaint categories: ${crossComplaints.length}`,
 		),
 	);
 	if (demandMeta) {
 		console.log(
 			chalk.dim(
-				`Demand: "${flags.query}" → ${demandMeta.mentions} mention/${flags.days} gun`,
+				`Demand: "${flags.query}" → ${demandMeta.mentions} mentions/${flags.days} days`,
 			),
 		);
 	}
 	console.log("");
 
 	if (gaps.length === 0) {
-		console.log(chalk.dim("(yetersiz veri — daha fazla rakip yorumu gerekli)"));
+		console.log(
+			chalk.dim("(insufficient data — more competitor reviews needed)"),
+		);
 		return;
 	}
 
 	console.log(chalk.bold("Top Opportunity Gaps:"));
 	console.log(
 		chalk.dim(
-			`  ${"Kod".padEnd(18)} ${"Sev".padEnd(8)} ${"Score".padEnd(8)} Aciklama`,
+			`  ${"Code".padEnd(18)} ${"Sev".padEnd(8)} ${"Score".padEnd(8)} Description`,
 		),
 	);
 	for (const g of gaps.slice(0, 8)) {
@@ -382,12 +384,10 @@ async function subGaps(appId, flags) {
 	}
 	console.log("");
 	console.log(
-		chalk.dim("Yuksek skor + HIGH severity = pazara giris icin guclu sinyal"),
+		chalk.dim("High score + HIGH severity = strong signal for market entry"),
 	);
 	console.log(
-		chalk.dim(
-			"--query <kategori> ile Reddit demand ekleyerek skoru zenginlestir",
-		),
+		chalk.dim("Add Reddit demand with --query <category> to enrich the score"),
 	);
 }
 
@@ -399,14 +399,14 @@ async function subDiscover(appId, flags) {
 	});
 
 	showBanner();
-	console.log(chalk.bold(`Hedef: ${target.name}`));
+	console.log(chalk.bold(`Target: ${target.name}`));
 	console.log(
 		chalk.dim(
-			`Tur: ${target.primaryGenre} | Rating: ${target.averageRating} | Yorum: ${target.ratingCount}`,
+			`Genre: ${target.primaryGenre} | Rating: ${target.averageRating} | Reviews: ${target.ratingCount}`,
 		),
 	);
 	console.log("");
-	console.log(chalk.bold(`${competitors.length} Rakip Bulundu:`));
+	console.log(chalk.bold(`${competitors.length} Competitors Found:`));
 	for (const c of competitors) {
 		console.log(
 			`  ${chalk.cyan(c.id.toString().padEnd(12))} ${(c.name || "").substring(0, 35).padEnd(36)} ${chalk.dim(`★${c.rating || "-"} (${c.ratingCount || 0})`)}`,
@@ -423,14 +423,14 @@ async function subReviews(appId, flags) {
 	const summary = summarizeReviews(reviews);
 
 	showBanner();
-	console.log(chalk.bold(`Yorum Aggregation: ${target.name}`));
+	console.log(chalk.bold(`Review Aggregation: ${target.name}`));
 	console.log(
 		chalk.dim(
-			`Bolgeler: ${flags.countries.join(", ")} | Sayfa: ${flags.pages} | Toplam: ${summary.total}`,
+			`Regions: ${flags.countries.join(", ")} | Pages: ${flags.pages} | Total: ${summary.total}`,
 		),
 	);
 	console.log("");
-	console.log(chalk.bold("Rating Dagilimi:"));
+	console.log(chalk.bold("Rating Distribution:"));
 	for (const star of [5, 4, 3, 2, 1]) {
 		const c = summary.byRating[star];
 		const pct = summary.total > 0 ? Math.round((c / summary.total) * 100) : 0;
@@ -440,7 +440,7 @@ async function subReviews(appId, flags) {
 		);
 	}
 	console.log("");
-	console.log(chalk.bold("Sikayet Kategorileri (1-3 ★):"));
+	console.log(chalk.bold("Complaint Categories (1-3 ★):"));
 	const ranked = Object.entries(summary.issueCounts)
 		.filter(([, n]) => n > 0)
 		.sort((a, b) => b[1] - a[1]);
@@ -461,7 +461,7 @@ async function subDifficulty(appId, flags) {
 	const diff = calculateDifficulty(target, competitors);
 
 	showBanner();
-	console.log(chalk.bold(`Zorluk Analizi: ${target.name}`));
+	console.log(chalk.bold(`Difficulty Analysis: ${target.name}`));
 	console.log("");
 
 	const verdictColor =
@@ -472,30 +472,30 @@ async function subDifficulty(appId, flags) {
 				: diff.verdict === "HARD"
 					? chalk.red
 					: chalk.bold.red;
-	console.log(`  Skor:    ${chalk.bold(diff.score)}/100`);
+	console.log(`  Score:   ${chalk.bold(diff.score)}/100`);
 	console.log(`  Verdict: ${verdictColor(diff.verdict)}`);
 	console.log("");
-	console.log(chalk.bold("Bilesenler:"));
+	console.log(chalk.bold("Components:"));
 	console.log(
-		`  Rakip baskisi:        ${diff.components.competitorPressure}/100`,
+		`  Competitor pressure:  ${diff.components.competitorPressure}/100`,
 	);
 	console.log(
-		`  Rating tavani:        ${diff.components.ratingFloor}/30 (avg: ${diff.components.avgRating})`,
+		`  Rating floor:         ${diff.components.ratingFloor}/30 (avg: ${diff.components.avgRating})`,
 	);
 	console.log(
-		`  Sahip olunmus alan:   ${diff.components.incumbentEntrenchment}/30 (median ratings: ${diff.components.medianRatingCount})`,
+		`  Incumbent ownership:  ${diff.components.incumbentEntrenchment}/30 (median ratings: ${diff.components.medianRatingCount})`,
 	);
 }
 
 async function subFull(appId, flags) {
 	const target = await lookupAppStore(appId, flags.countries[0]);
-	console.log(chalk.dim(`[1/5] Hedef: ${target.name}`));
+	console.log(chalk.dim(`[1/5] Target: ${target.name}`));
 
 	const competitors = await discoverCompetitors(target, {
 		country: flags.countries[0],
 		limit: flags.limit,
 	});
-	console.log(chalk.dim(`[2/5] ${competitors.length} rakip bulundu`));
+	console.log(chalk.dim(`[2/5] ${competitors.length} competitors found`));
 
 	const targetReviews = await aggregateReviewsMultiRegion(appId, {
 		countries: flags.countries,
@@ -503,7 +503,7 @@ async function subFull(appId, flags) {
 	});
 	const targetSummary = summarizeReviews(targetReviews);
 	console.log(
-		chalk.dim(`[3/5] Hedef icin ${targetSummary.total} yorum toplandi`),
+		chalk.dim(`[3/5] Collected ${targetSummary.total} reviews for the target`),
 	);
 
 	const competitorSummaries = [];
@@ -524,21 +524,21 @@ async function subFull(appId, flags) {
 	}
 	console.log(
 		chalk.dim(
-			`[4/5] ${competitorSummaries.length} rakip icin yorum analizi tamamlandi`,
+			`[4/5] Review analysis done for ${competitorSummaries.length} competitors`,
 		),
 	);
 
 	const diff = calculateDifficulty(target, competitors);
 	const crossComplaints = findCrossCompetitorComplaints(competitorSummaries);
-	console.log(chalk.dim(`[5/5] Cross-rakip kesim analizi tamamlandi`));
+	console.log(chalk.dim(`[5/5] Cross-competitor intersection analysis done`));
 	console.log("");
 
 	// Report
 	showBanner();
-	console.log(chalk.bold(`Pazar Arastirma Raporu: ${target.name}`));
+	console.log(chalk.bold(`Market Research Report: ${target.name}`));
 	console.log(
 		chalk.dim(
-			`Tur: ${target.primaryGenre} | Bolgeler: ${flags.countries.join(", ")}`,
+			`Genre: ${target.primaryGenre} | Regions: ${flags.countries.join(", ")}`,
 		),
 	);
 	console.log("");
@@ -549,12 +549,12 @@ async function subFull(appId, flags) {
 			: diff.verdict === "COMPETITIVE"
 				? chalk.yellow
 				: chalk.red;
-	console.log(chalk.bold("Zorluk:"));
+	console.log(chalk.bold("Difficulty:"));
 	console.log(`  ${chalk.bold(diff.score)}/100  ${verdictColor(diff.verdict)}`);
 	console.log("");
 
 	console.log(
-		chalk.bold(`Hedef Rating Dagilimi (${targetSummary.total} yorum):`),
+		chalk.bold(`Target Rating Distribution (${targetSummary.total} reviews):`),
 	);
 	for (const star of [5, 4, 3, 2, 1]) {
 		const c = targetSummary.byRating[star];
@@ -562,12 +562,12 @@ async function subFull(appId, flags) {
 	}
 	console.log("");
 
-	console.log(chalk.bold("Hedefin Sikayet Kategorileri (1-3 ★):"));
+	console.log(chalk.bold("Target Complaint Categories (1-3 ★):"));
 	const targetRanked = Object.entries(targetSummary.issueCounts)
 		.filter(([, n]) => n > 0)
 		.sort((a, b) => b[1] - a[1]);
 	if (targetRanked.length === 0) {
-		console.log(chalk.dim("  (yok)"));
+		console.log(chalk.dim("  (none)"));
 	} else {
 		for (const [code, count] of targetRanked.slice(0, 6)) {
 			console.log(`  ${chalk.yellow(code.padEnd(20))} ${count}`);
@@ -575,34 +575,40 @@ async function subFull(appId, flags) {
 	}
 	console.log("");
 
-	console.log(chalk.bold("Cross-Rakip Sik Sikayetler (pazar firsati):"));
+	console.log(
+		chalk.bold("Cross-Competitor Common Complaints (market opportunity):"),
+	);
 	if (crossComplaints.length === 0) {
-		console.log(chalk.dim("  (yetersiz veri)"));
+		console.log(chalk.dim("  (insufficient data)"));
 	} else {
-		console.log(chalk.dim(`  ${"Kod".padEnd(20)} Toplam  Etkilenen rakip`));
+		console.log(
+			chalk.dim(`  ${"Code".padEnd(20)} Total   Affected competitors`),
+		);
 		for (const c of crossComplaints.slice(0, 8)) {
 			const apps = Object.keys(c.perApp).length;
 			console.log(
-				`  ${chalk.red(c.code.padEnd(20))} ${String(c.total).padStart(5)}   ${apps} rakip`,
+				`  ${chalk.red(c.code.padEnd(20))} ${String(c.total).padStart(5)}   ${apps} competitors`,
 			);
 		}
 		console.log("");
 		console.log(
 			chalk.dim(
-				"  Bircok rakip icin geri donen sikayetler = pazar bosligu sinyali",
+				"  Complaints recurring across many competitors = market gap signal",
 			),
 		);
 	}
 	console.log("");
 
-	console.log(chalk.bold("Rakip Listesi:"));
+	console.log(chalk.bold("Competitor List:"));
 	for (const c of competitors.slice(0, 8)) {
 		console.log(
 			`  ${chalk.cyan(c.id.toString().padEnd(12))} ${(c.name || "").substring(0, 35).padEnd(36)} ${chalk.dim(`★${c.rating || "-"} (${c.ratingCount || 0})`)}`,
 		);
 	}
 	if (competitors.length > 8) {
-		console.log(chalk.dim(`  ... ve ${competitors.length - 8} rakip daha`));
+		console.log(
+			chalk.dim(`  ... and ${competitors.length - 8} more competitors`),
+		);
 	}
 	console.log("");
 	console.log(
@@ -625,7 +631,7 @@ export async function runMarket(args) {
 		try {
 			return await subWishlist(query, flags);
 		} catch (e) {
-			console.error(chalk.red(`Hata: ${e.message}`));
+			console.error(chalk.red(`Error: ${e.message}`));
 			process.exit(1);
 		}
 	}
@@ -640,9 +646,9 @@ export async function runMarket(args) {
 	const appId = parseAppId(appIdInput);
 	if (!appId) {
 		console.error(
-			chalk.red(`Gecersiz app ID veya URL: ${appIdInput || "(yok)"}`),
+			chalk.red(`Invalid app ID or URL: ${appIdInput || "(none)"}`),
 		);
-		console.log(chalk.dim("Ornek: badi market 284882215"));
+		console.log(chalk.dim("Example: badi market 284882215"));
 		console.log(
 			chalk.dim("       badi market https://apps.apple.com/us/app/id284882215"),
 		);
@@ -658,7 +664,7 @@ export async function runMarket(args) {
 		if (sub === "gaps") return await subGaps(appId, flags);
 		return await subFull(appId, flags);
 	} catch (e) {
-		console.error(chalk.red(`Hata: ${e.message}`));
+		console.error(chalk.red(`Error: ${e.message}`));
 		process.exit(1);
 	}
 }

--- a/lib/commands/seo.js
+++ b/lib/commands/seo.js
@@ -4,7 +4,7 @@ import { fetchWithTimeout } from "../helpers.js";
 
 const SEO_UA = "Badi-SEO/1.11 (+https://github.com/fatihkan/badi)";
 
-// ─── HTML Parse Yardimcilari ───
+// ─── HTML Parse Helpers ───
 
 function extractTag(html, tag) {
 	const regex = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, "i");
@@ -13,14 +13,14 @@ function extractTag(html, tag) {
 }
 
 function extractMeta(html, name) {
-	// name veya property attribute'u
+	// name or property attribute
 	const regex = new RegExp(
 		`<meta[^>]*(?:name|property)=["']${name}["'][^>]*content=["']([^"']*)["']`,
 		"i",
 	);
 	const match = html.match(regex);
 	if (match) return match[1];
-	// ters siralama (content once)
+	// reverse order (content first)
 	const regex2 = new RegExp(
 		`<meta[^>]*content=["']([^"']*)["'][^>]*(?:name|property)=["']${name}["']`,
 		"i",
@@ -41,9 +41,9 @@ function extractAllMeta(html) {
 	return metas;
 }
 
-// Iceri-icine tag yerlestirme (orn. `<scr<script>ipt>`) tek-gecisli
-// strip'te calismaz: ic tag silinince dis tag tamamlanir. Recursive
-// olarak, hicbir degisiklik kalmayana kadar replace et.
+// Nested tag injection (e.g. `<scr<script>ipt>`) is not handled by a
+// single-pass strip: removing the inner tag completes the outer one.
+// Replace recursively until no further change remains.
 function stripTags(text) {
 	let prev;
 	let out = text;
@@ -107,12 +107,12 @@ function extractLinks(html, baseUrl) {
 }
 
 function countWords(html) {
-	// HTML parser ile script/style icerigini guvenli sekilde cikar. Regex
-	// bazli sanitization CodeQL tarafindan bypass-prone goruluyor (icine
-	// yerlestirme, attribute'lu closing tag, vb.) — DOM tree uzerinden
-	// dolasarak cok daha saglam. `structuredText` blok elementleri arasina
-	// newline koyar, boylelikle "<p>One</p><p>Two</p>" "OneTwo" yerine
-	// "One\nTwo" olur (kelime sayisi dogru).
+	// Strip script/style content safely via the HTML parser. Regex-based
+	// sanitization is considered bypass-prone by CodeQL (nested injection,
+	// closing tags with attributes, etc.) — walking the DOM tree is far more
+	// robust. `structuredText` inserts newlines between block elements, so
+	// "<p>One</p><p>Two</p>" becomes "One\nTwo" instead of "OneTwo" (correct
+	// word count).
 	const root = parseHtml(html, { lowerCaseTagName: true });
 	for (const node of root.querySelectorAll("script, style")) {
 		node.remove();
@@ -121,7 +121,7 @@ function countWords(html) {
 	return text.split(" ").filter(Boolean).length;
 }
 
-// ─── Fetch Yardimcisi ───
+// ─── Fetch Helper ───
 
 async function fetchPage(url) {
 	try {
@@ -133,7 +133,7 @@ async function fetchPage(url) {
 		const html = await res.text();
 		return { html, status: res.status, headers: res.headers, url: res.url };
 	} catch (e) {
-		throw new Error(`Sayfa yuklenemedi: ${e.message}`);
+		throw new Error(`Failed to load page: ${e.message}`);
 	}
 }
 
@@ -141,7 +141,7 @@ async function fetchPage(url) {
 
 async function seoAudit(url) {
 	showBanner();
-	console.log(chalk.bold(`SEO Denetimi: ${url}`));
+	console.log(chalk.bold(`SEO Audit: ${url}`));
 	console.log("");
 
 	const { html, status } = await fetchPage(url);
@@ -170,132 +170,126 @@ async function seoAudit(url) {
 	}
 
 	// Status code
-	check(`HTTP durum kodu: ${status}`, status === 200, 2);
+	check(`HTTP status code: ${status}`, status === 200, 2);
 
 	// Title
 	const title = extractTag(html, "title");
 	console.log("");
-	console.log(chalk.bold("Meta Bilgileri:"));
-	check(
-		`Title tagi mevcut${title ? ` (${title.length} karakter)` : ""}`,
-		!!title,
-	);
+	console.log(chalk.bold("Meta Info:"));
+	check(`Title tag present${title ? ` (${title.length} chars)` : ""}`, !!title);
 	if (title) {
-		check(
-			"Title uzunlugu 30-60 karakter",
-			title.length >= 30 && title.length <= 60,
-		);
+		check("Title length 30-60 chars", title.length >= 30 && title.length <= 60);
 	}
 
 	// Description
 	const description = extractMeta(html, "description");
 	check(
-		`Meta description mevcut${description ? ` (${description.length} karakter)` : ""}`,
+		`Meta description present${description ? ` (${description.length} chars)` : ""}`,
 		!!description,
 	);
 	if (description) {
 		check(
-			"Description uzunlugu 120-160 karakter",
+			"Description length 120-160 chars",
 			description.length >= 120 && description.length <= 160,
 		);
 	}
 
 	// Open Graph
 	console.log("");
-	console.log(chalk.bold("Sosyal Medya:"));
+	console.log(chalk.bold("Social Media:"));
 	const ogTitle = extractMeta(html, "og:title");
 	const ogDesc = extractMeta(html, "og:description");
 	const ogImage = extractMeta(html, "og:image");
-	check("og:title mevcut", !!ogTitle);
-	check("og:description mevcut", !!ogDesc);
-	check("og:image mevcut", !!ogImage);
+	check("og:title present", !!ogTitle);
+	check("og:description present", !!ogDesc);
+	check("og:image present", !!ogImage);
 
 	// Twitter Card
 	const twCard = extractMeta(html, "twitter:card");
-	warn("twitter:card mevcut", !!twCard);
+	warn("twitter:card present", !!twCard);
 
 	// Headings
 	console.log("");
-	console.log(chalk.bold("Baslik Yapisi:"));
+	console.log(chalk.bold("Heading Structure:"));
 	const headings = extractHeadings(html);
 	const h1s = headings.filter((h) => h.level === 1);
-	check(`H1 tagi mevcut (${h1s.length} adet)`, h1s.length === 1, 2);
+	check(`H1 tag present (${h1s.length})`, h1s.length === 1, 2);
 	if (h1s.length > 1) {
 		console.log(
 			chalk.yellow(
-				`       Birden fazla H1: ${h1s.map((h) => h.text.substring(0, 40)).join(", ")}`,
+				`       Multiple H1: ${h1s.map((h) => h.text.substring(0, 40)).join(", ")}`,
 			),
 		);
 	}
 	const h2s = headings.filter((h) => h.level === 2);
-	warn(`H2 taglari mevcut (${h2s.length} adet)`, h2s.length > 0);
+	warn(`H2 tags present (${h2s.length})`, h2s.length > 0);
 
 	// Images
 	console.log("");
-	console.log(chalk.bold("Gorseller:"));
+	console.log(chalk.bold("Visuals:"));
 	const images = extractImages(html);
 	const noAlt = images.filter((img) => !img.hasAlt || !img.alt);
 	check(
-		`Tum gorsellerde alt tagi var (${images.length} gorsel)`,
+		`All images have alt text (${images.length} images)`,
 		noAlt.length === 0,
 	);
 	if (noAlt.length > 0) {
 		for (const img of noAlt.slice(0, 5)) {
-			console.log(chalk.dim(`       Eksik alt: ${img.src}`));
+			console.log(chalk.dim(`       Missing alt: ${img.src}`));
 		}
 	}
 
 	// Links
 	console.log("");
-	console.log(chalk.bold("Linkler:"));
+	console.log(chalk.bold("Links:"));
 	const links = extractLinks(html, url);
 	console.log(
-		`  ${chalk.dim("Ic linkler:")} ${links.internal}  ${chalk.dim("Dis linkler:")} ${links.external}  ${chalk.dim("Nofollow:")} ${links.nofollow}`,
+		`  ${chalk.dim("Internal links:")} ${links.internal}  ${chalk.dim("External links:")} ${links.external}  ${chalk.dim("Nofollow:")} ${links.nofollow}`,
 	);
 
 	// Content
 	console.log("");
-	console.log(chalk.bold("Icerik:"));
+	console.log(chalk.bold("Content:"));
 	const wordCount = countWords(html);
-	check(`Kelime sayisi yeterli (${wordCount} kelime)`, wordCount >= 300);
+	check(`Word count sufficient (${wordCount} words)`, wordCount >= 300);
 
 	// Canonical
 	console.log("");
-	console.log(chalk.bold("Teknik:"));
+	console.log(chalk.bold("Technical:"));
 	const canonical = html.match(
 		/<link[^>]*rel=["']canonical["'][^>]*href=["']([^"']*)["']/i,
 	)?.[1];
-	check("Canonical URL tanimli", !!canonical);
+	check("Canonical URL defined", !!canonical);
 	if (canonical) console.log(chalk.dim(`       ${canonical}`));
 
 	// Viewport
 	const viewport = extractMeta(html, "viewport");
-	check("Viewport meta tanimli (mobil uyumluluk)", !!viewport);
+	check("Viewport meta defined (mobile-friendly)", !!viewport);
 
 	// Language
 	const lang = html.match(/<html[^>]*lang=["']([^"']*)["']/i)?.[1];
-	check("HTML lang attribute tanimli", !!lang);
+	check("HTML lang attribute defined", !!lang);
 	if (lang) console.log(chalk.dim(`       lang="${lang}"`));
 
 	// Charset
 	const charset = html.match(/<meta[^>]*charset=["']?([^"'\s>]*)["']?/i)?.[1];
-	check("Charset tanimli", !!charset);
+	check("Charset defined", !!charset);
 
 	// HTTPS
-	check("HTTPS kullaniliyor", url.startsWith("https://"), 2);
+	check("HTTPS in use", url.startsWith("https://"), 2);
 
 	// Schema.org
 	const hasSchema =
 		html.includes("application/ld+json") || html.includes("itemscope");
-	warn("Schema.org structured data mevcut", hasSchema);
+	warn("Schema.org structured data present", hasSchema);
 
 	// robots
 	const robotsMeta = extractMeta(html, "robots");
 	if (robotsMeta) {
-		check("robots meta noindex icermiyor", !robotsMeta.includes("noindex"));
+		check("robots meta has no noindex", !robotsMeta.includes("noindex"));
 	}
 
-	// Sonuc
+	// Result
 	console.log("");
 	console.log(chalk.bold("═".repeat(50)));
 	const pct = Math.round((score / maxScore) * 100);
@@ -306,23 +300,23 @@ async function seoAudit(url) {
 				? chalk.bold.yellow
 				: chalk.bold.red;
 	console.log(
-		`  SEO Skoru: ${color(`${pct}/100`)} (${score}/${maxScore} kontrol gecti)`,
+		`  SEO Score: ${color(`${pct}/100`)} (${score}/${maxScore} checks passed)`,
 	);
 
 	if (issues.length > 0) {
 		console.log("");
-		console.log(chalk.bold("Duzeltilmesi Gereken:"));
+		console.log(chalk.bold("Needs Fixing:"));
 		for (const issue of issues) {
 			console.log(`  ${chalk.red("-")} ${issue}`);
 		}
 	}
 }
 
-// ─── SEO Meta Analiz ───
+// ─── SEO Meta Analysis ───
 
 async function seoMeta(url) {
 	showBanner();
-	console.log(chalk.bold(`Meta Tag Analizi: ${url}`));
+	console.log(chalk.bold(`Meta Tag Analysis: ${url}`));
 	console.log("");
 
 	const { html } = await fetchPage(url);
@@ -334,15 +328,15 @@ async function seoMeta(url) {
 		console.log(`  ${chalk.cyan(title)}`);
 		console.log(
 			chalk.dim(
-				`  ${title.length} karakter ${title.length >= 30 && title.length <= 60 ? chalk.green("(uygun)") : chalk.yellow("(30-60 onerilir)")}`,
+				`  ${title.length} chars ${title.length >= 30 && title.length <= 60 ? chalk.green("(good)") : chalk.yellow("(30-60 recommended)")}`,
 			),
 		);
 		console.log("");
 	}
 
-	// Kategorize et
+	// Categorize
 	const _categories = {
-		Temel: [
+		Basic: [
 			"description",
 			"keywords",
 			"author",
@@ -356,10 +350,10 @@ async function seoMeta(url) {
 		Twitter: metas
 			.filter((m) => m.name.startsWith("twitter:"))
 			.map((m) => m.name),
-		Diger: [],
+		Other: [],
 	};
 
-	console.log(chalk.bold("Meta Taglari:"));
+	console.log(chalk.bold("Meta Tags:"));
 	for (const m of metas) {
 		const isOg = m.name.startsWith("og:");
 		const isTw = m.name.startsWith("twitter:");
@@ -370,12 +364,12 @@ async function seoMeta(url) {
 	}
 
 	if (metas.length === 0) {
-		console.log(chalk.yellow("  Meta tag bulunamadi!"));
+		console.log(chalk.yellow("  No meta tags found!"));
 	}
 
-	// Eksik onemli meta taglari
+	// Missing important meta tags
 	console.log("");
-	console.log(chalk.bold("Eksik Onemli Meta Taglari:"));
+	console.log(chalk.bold("Missing Important Meta Tags:"));
 	const important = [
 		"description",
 		"og:title",
@@ -391,19 +385,19 @@ async function seoMeta(url) {
 		}
 	}
 	if (missingCount === 0) {
-		console.log(chalk.green("  Tum onemli meta taglar mevcut!"));
+		console.log(chalk.green("  All important meta tags present!"));
 	}
 }
 
-// ─── Sitemap Kontrol ───
+// ─── Sitemap Check ───
 
 async function seoSitemap(url) {
 	showBanner();
 	const baseUrl = url.replace(/\/$/, "");
-	console.log(chalk.bold(`Sitemap Kontrolu: ${baseUrl}`));
+	console.log(chalk.bold(`Sitemap Check: ${baseUrl}`));
 	console.log("");
 
-	// robots.txt kontrol
+	// robots.txt check
 	console.log(chalk.bold("robots.txt:"));
 	try {
 		const { html: robotsTxt, status } = await fetchPage(
@@ -411,13 +405,13 @@ async function seoSitemap(url) {
 		);
 		if (status === 200) {
 			console.log(
-				`  ${chalk.green("OK")} robots.txt mevcut (${robotsTxt.length} byte)`,
+				`  ${chalk.green("OK")} robots.txt present (${robotsTxt.length} bytes)`,
 			);
 			const sitemapLines = robotsTxt
 				.split("\n")
 				.filter((l) => l.toLowerCase().startsWith("sitemap:"));
 			if (sitemapLines.length > 0) {
-				console.log(`  ${chalk.green("OK")} Sitemap referansi mevcut:`);
+				console.log(`  ${chalk.green("OK")} Sitemap reference present:`);
 				for (const l of sitemapLines) {
 					console.log(
 						`       ${chalk.cyan(l.split(":").slice(1).join(":").trim())}`,
@@ -425,26 +419,24 @@ async function seoSitemap(url) {
 				}
 			} else {
 				console.log(
-					`  ${chalk.yellow("!!")} robots.txt'de Sitemap referansi yok`,
+					`  ${chalk.yellow("!!")} No Sitemap reference in robots.txt`,
 				);
 			}
-			// Disallow kontrol
+			// Disallow check
 			const disallowLines = robotsTxt
 				.split("\n")
 				.filter((l) => l.startsWith("Disallow:"));
 			if (disallowLines.length > 0) {
-				console.log(
-					`  ${chalk.dim(`${disallowLines.length} Disallow kurali`)}`,
-				);
+				console.log(`  ${chalk.dim(`${disallowLines.length} Disallow rules`)}`);
 			}
 		} else {
-			console.log(`  ${chalk.red("XX")} robots.txt bulunamadi (${status})`);
+			console.log(`  ${chalk.red("XX")} robots.txt not found (${status})`);
 		}
 	} catch (e) {
-		console.log(`  ${chalk.red("XX")} robots.txt erisilemedi: ${e.message}`);
+		console.log(`  ${chalk.red("XX")} robots.txt unreachable: ${e.message}`);
 	}
 
-	// Sitemap kontrol
+	// Sitemap check
 	console.log("");
 	console.log(chalk.bold("Sitemap:"));
 	const sitemapUrls = [
@@ -462,54 +454,54 @@ async function seoSitemap(url) {
 			) {
 				console.log(`  ${chalk.green("OK")} ${smUrl.replace(baseUrl, "")}`);
 
-				// URL sayisi
+				// URL count
 				const urlCount = (smContent.match(/<url>/gi) || []).length;
 				const sitemapCount = (smContent.match(/<sitemap>/gi) || []).length;
 
 				if (urlCount > 0) {
-					console.log(`       ${chalk.cyan(urlCount)} URL iceriyor`);
+					console.log(`       ${chalk.cyan(urlCount)} URLs`);
 				}
 				if (sitemapCount > 0) {
 					console.log(
-						`       ${chalk.cyan(sitemapCount)} alt sitemap iceriyor (index)`,
+						`       ${chalk.cyan(sitemapCount)} sub-sitemaps (index)`,
 					);
 				}
 
-				// lastmod kontrol
+				// lastmod check
 				const hasLastmod = smContent.includes("<lastmod>");
 				if (hasLastmod) {
-					console.log(`       ${chalk.green("OK")} lastmod tarihleri mevcut`);
+					console.log(`       ${chalk.green("OK")} lastmod dates present`);
 				} else {
-					console.log(`       ${chalk.yellow("!!")} lastmod tarihleri eksik`);
+					console.log(`       ${chalk.yellow("!!")} lastmod dates missing`);
 				}
 			}
 		} catch {
-			/* erisilemedi */
+			/* unreachable */
 		}
 	}
 }
 
-// ─── Hiz Testi ───
+// ─── Speed Test ───
 
 async function seoSpeed(url) {
 	showBanner();
-	console.log(chalk.bold(`Sayfa Hizi: ${url}`));
+	console.log(chalk.bold(`Page Speed: ${url}`));
 	console.log("");
 
 	const start = Date.now();
 	const { html, headers } = await fetchPage(url);
 	const loadTime = Date.now() - start;
 
-	console.log(chalk.bold("Yukleme Suresi:"));
+	console.log(chalk.bold("Load Time:"));
 	const timeColor =
 		loadTime < 1000 ? chalk.green : loadTime < 3000 ? chalk.yellow : chalk.red;
-	console.log(`  TTFB + icerik: ${timeColor(`${loadTime}ms`)}`);
+	console.log(`  TTFB + content: ${timeColor(`${loadTime}ms`)}`);
 	console.log("");
 
-	// Boyut analizi
+	// Size analysis
 	const htmlSize = new Blob([html]).size;
-	console.log(chalk.bold("Boyut Analizi:"));
-	console.log(`  HTML boyutu: ${chalk.cyan(formatBytes(htmlSize))}`);
+	console.log(chalk.bold("Size Analysis:"));
+	console.log(`  HTML size: ${chalk.cyan(formatBytes(htmlSize))}`);
 
 	// Resource count
 	const scripts = (html.match(/<script[^>]*src=/gi) || []).length;
@@ -518,37 +510,37 @@ async function seoSpeed(url) {
 	const iframes = (html.match(/<iframe/gi) || []).length;
 
 	console.log("");
-	console.log(chalk.bold("Kaynak Sayilari:"));
+	console.log(chalk.bold("Resource Counts:"));
 	console.log(
 		`  Script:  ${scripts > 10 ? chalk.yellow(scripts) : chalk.green(scripts)}`,
 	);
 	console.log(
 		`  CSS:     ${styles > 5 ? chalk.yellow(styles) : chalk.green(styles)}`,
 	);
-	console.log(`  Gorsel:  ${chalk.cyan(images)}`);
+	console.log(`  Images:  ${chalk.cyan(images)}`);
 	if (iframes > 0) console.log(`  iframe:  ${chalk.yellow(iframes)}`);
 
-	// Inline resource analizi
+	// Inline resource analysis
 	const inlineScripts = (html.match(/<script(?!.*src)[^>]*>/gi) || []).length;
 	const inlineStyles = (html.match(/<style/gi) || []).length;
 	if (inlineScripts > 3 || inlineStyles > 2) {
 		console.log("");
 		console.log(
 			chalk.yellow(
-				`UYARI: ${inlineScripts} inline script, ${inlineStyles} inline style — bundle etmeyi dusunun`,
+				`WARNING: ${inlineScripts} inline scripts, ${inlineStyles} inline styles — consider bundling`,
 			),
 		);
 	}
 
 	// Compression
 	console.log("");
-	console.log(chalk.bold("Sunucu:"));
+	console.log(chalk.bold("Server:"));
 	const encoding = headers.get("content-encoding");
 	if (encoding) {
 		console.log(`  ${chalk.green("OK")} Compression: ${encoding}`);
 	} else {
 		console.log(
-			`  ${chalk.yellow("!!")} Compression yok (gzip/brotli onerisi)`,
+			`  ${chalk.yellow("!!")} No compression (gzip/brotli recommended)`,
 		);
 	}
 
@@ -558,10 +550,10 @@ async function seoSpeed(url) {
 			`  ${chalk.green("OK")} Cache-Control: ${chalk.dim(cacheControl)}`,
 		);
 	} else {
-		console.log(`  ${chalk.yellow("!!")} Cache-Control header eksik`);
+		console.log(`  ${chalk.yellow("!!")} Cache-Control header missing`);
 	}
 
-	// Performans skoru
+	// Performance score
 	console.log("");
 	let perfScore = 0;
 	if (loadTime < 1000) perfScore += 3;
@@ -580,7 +572,7 @@ async function seoSpeed(url) {
 			: pctPerf >= 50
 				? chalk.bold.yellow
 				: chalk.bold.red;
-	console.log(`  Hiz Skoru: ${perfColor(`${pctPerf}/100`)}`);
+	console.log(`  Speed Score: ${perfColor(`${pctPerf}/100`)}`);
 }
 
 function formatBytes(bytes) {
@@ -589,10 +581,10 @@ function formatBytes(bytes) {
 	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-// ─── SEO Backlinks (best-effort, ucretsiz) ───
+// ─── SEO Backlinks (best-effort, free) ───
 
 async function fetchDDG(query, timeoutMs = 15000) {
-	// DDG HTML endpoint GET'te shell sayfa donduruyor — POST + browser UA sart.
+	// The DDG HTML endpoint returns a shell page on GET — POST + browser UA required.
 	const res = await fetchWithTimeout("https://html.duckduckgo.com/html/", {
 		timeoutMs,
 		method: "POST",
@@ -605,8 +597,8 @@ async function fetchDDG(query, timeoutMs = 15000) {
 	return await res.text();
 }
 
-// Pure fonksiyon: DDG HTML'inden sonuc listesini cikarir.
-// Test edilebilir (network gerekmez). Dondurulen URL host+position+raw bilgisi.
+// Pure function: extracts the result list from DDG HTML.
+// Testable (no network needed). Returns URL host+position+raw info.
 export function parseDDGResults(html, max = 30) {
 	const regex =
 		/<a[^>]*class=["'][^"']*result__url[^"']*["'][^>]*href=["']([^"']+)["']/gi;
@@ -619,7 +611,7 @@ export function parseDDGResults(html, max = 30) {
 			const host = new URL(decoded).hostname.replace(/^www\./, "");
 			results.push({ position: results.length + 1, host, url: decoded });
 		} catch {
-			/* gecersiz URL, atla */
+			/* invalid URL, skip */
 		}
 	}
 	return results;
@@ -628,16 +620,16 @@ export function parseDDGResults(html, max = 30) {
 async function seoBacklinks(domain) {
 	showBanner();
 	const clean = domain.replace(/^https?:\/\//, "").replace(/\/.*/, "");
-	console.log(chalk.bold(`Backlink Tarama: ${clean}`));
+	console.log(chalk.bold(`Backlink Scan: ${clean}`));
 	console.log("");
 	console.log(
 		chalk.dim(
-			"Not: Ahrefs/Moz API yerine DuckDuckGo + Wayback kullanilir. Sonuclar ornek niteliginde.",
+			"Note: Uses DuckDuckGo + Wayback instead of Ahrefs/Moz API. Results are indicative.",
 		),
 	);
 	console.log("");
 
-	// 1) DuckDuckGo: domain'den bahseden ama domain'de olmayan sayfalar
+	// 1) DuckDuckGo: pages that mention the domain but are not on the domain
 	const ddgQuery = `"${clean}" -site:${clean}`;
 	const referring = new Map();
 	try {
@@ -648,18 +640,16 @@ async function seoBacklinks(domain) {
 			}
 		}
 	} catch (e) {
-		console.log(
-			`  ${chalk.yellow("!!")} DuckDuckGo tarama basarisiz: ${e.message}`,
-		);
+		console.log(`  ${chalk.yellow("!!")} DuckDuckGo scan failed: ${e.message}`);
 	}
 
 	console.log(
 		chalk.bold(
-			`DuckDuckGo mention sonuclari (${referring.size} benzersiz domain):`,
+			`DuckDuckGo mention results (${referring.size} unique domains):`,
 		),
 	);
 	if (referring.size === 0) {
-		console.log(chalk.yellow("  Bahseden domain bulunamadi."));
+		console.log(chalk.yellow("  No referring domains found."));
 	} else {
 		const sorted = [...referring.entries()].sort((a, b) => b[1] - a[1]);
 		for (const [host, count] of sorted.slice(0, 15)) {
@@ -667,9 +657,9 @@ async function seoBacklinks(domain) {
 		}
 	}
 
-	// 2) Wayback Machine CDX: domain snapshot sayisi (erisim + aktiflik proxy'si)
+	// 2) Wayback Machine CDX: domain snapshot count (proxy for reach + activity)
 	console.log("");
-	console.log(chalk.bold("Wayback Machine Varligi:"));
+	console.log(chalk.bold("Wayback Machine Presence:"));
 	try {
 		const cdxUrl = `https://web.archive.org/cdx/search/cdx?url=${encodeURIComponent(clean)}&matchType=prefix&fl=timestamp&collapse=timestamp:6&limit=1000&output=json`;
 		const res = await fetchWithTimeout(cdxUrl, {
@@ -678,37 +668,37 @@ async function seoBacklinks(domain) {
 		});
 		if (res.ok) {
 			const data = await res.json();
-			const rows = data.slice(1); // ilk satir header
+			const rows = data.slice(1); // first row is the header
 			console.log(
-				`  ${chalk.green("OK")} ${rows.length} aylik snapshot mevcut`,
+				`  ${chalk.green("OK")} ${rows.length} monthly snapshots present`,
 			);
 			if (rows.length > 0) {
 				const first = rows[0][0];
 				const last = rows[rows.length - 1][0];
 				console.log(
-					`       Ilk snapshot:  ${chalk.cyan(first.substring(0, 4))}-${first.substring(4, 6)}`,
+					`       First snapshot: ${chalk.cyan(first.substring(0, 4))}-${first.substring(4, 6)}`,
 				);
 				console.log(
-					`       Son snapshot:  ${chalk.cyan(last.substring(0, 4))}-${last.substring(4, 6)}`,
+					`       Last snapshot:  ${chalk.cyan(last.substring(0, 4))}-${last.substring(4, 6)}`,
 				);
 			}
 		} else {
 			console.log(
-				`  ${chalk.yellow("!!")} Wayback erisilemedi (${res.status})`,
+				`  ${chalk.yellow("!!")} Wayback unreachable (${res.status})`,
 			);
 		}
 	} catch (e) {
-		console.log(`  ${chalk.yellow("!!")} Wayback hatasi: ${e.message}`);
+		console.log(`  ${chalk.yellow("!!")} Wayback error: ${e.message}`);
 	}
 
 	console.log("");
-	console.log(chalk.bold("Daha Derin Analiz:"));
+	console.log(chalk.bold("Deeper Analysis:"));
 	console.log(
-		chalk.dim("  - Ahrefs Webmaster Tools (site sahibiyseniz) — ucretsiz"),
+		chalk.dim("  - Ahrefs Webmaster Tools (if you own the site) — free"),
 	);
-	console.log(chalk.dim("  - Google Search Console -> Links raporu"));
+	console.log(chalk.dim("  - Google Search Console -> Links report"));
 	console.log(chalk.dim("  - Bing Webmaster Tools -> Backlinks"));
-	console.log(chalk.dim("  - Common Crawl (toplu veri analizi)"));
+	console.log(chalk.dim("  - Common Crawl (bulk data analysis)"));
 }
 
 // ─── SEO Rank Tracker (DuckDuckGo) ───
@@ -716,11 +706,11 @@ async function seoBacklinks(domain) {
 async function seoRank(domain, keyword) {
 	showBanner();
 	const clean = domain.replace(/^https?:\/\//, "").replace(/\/.*/, "");
-	console.log(chalk.bold(`Rank Kontrolu: "${keyword}" → ${clean}`));
+	console.log(chalk.bold(`Rank Check: "${keyword}" → ${clean}`));
 	console.log("");
 	console.log(
 		chalk.dim(
-			"Not: Google yerine DuckDuckGo kullanilir (hizli + botlara dostane). Google ranki icin Search Console.",
+			"Note: Uses DuckDuckGo instead of Google (fast + bot-friendly). For Google rank, use Search Console.",
 		),
 	);
 	console.log("");
@@ -730,12 +720,14 @@ async function seoRank(domain, keyword) {
 
 	if (results.length === 0) {
 		console.log(
-			chalk.yellow("Sonuc cikarilamadi (HTML yapisi degismis olabilir)."),
+			chalk.yellow(
+				"Could not extract results (HTML structure may have changed).",
+			),
 		);
 		return;
 	}
 
-	console.log(chalk.bold(`Top ${results.length} sonuc:`));
+	console.log(chalk.bold(`Top ${results.length} results:`));
 	let found = false;
 	for (const r of results) {
 		const match = r.host === clean || r.host.endsWith(`.${clean}`);
@@ -752,17 +744,17 @@ async function seoRank(domain, keyword) {
 		const pos = results.find(
 			(r) => r.host === clean || r.host.endsWith(`.${clean}`),
 		).position;
-		console.log(chalk.bold.green(`Bulundu: ${clean} → #${pos} pozisyon`));
-		if (pos <= 3) console.log(chalk.green("  Top 3 — mukemmel!"));
-		else if (pos <= 10) console.log(chalk.green("  Top 10 — iyi"));
-		else console.log(chalk.yellow("  Top 10 disi — optimizasyon gerekli"));
+		console.log(chalk.bold.green(`Found: ${clean} → position #${pos}`));
+		if (pos <= 3) console.log(chalk.green("  Top 3 — excellent!"));
+		else if (pos <= 10) console.log(chalk.green("  Top 10 — good"));
+		else console.log(chalk.yellow("  Outside Top 10 — optimization needed"));
 	} else {
 		console.log(
-			chalk.red(`Bulunamadi: ${clean} ilk ${results.length} sonuca girmiyor`),
+			chalk.red(
+				`Not found: ${clean} is not in the first ${results.length} results`,
+			),
 		);
-		console.log(
-			chalk.dim(`  Optimizasyon icin: badi seo audit https://${clean}`),
-		);
+		console.log(chalk.dim(`  To optimize: badi seo audit https://${clean}`));
 	}
 }
 
@@ -770,7 +762,7 @@ async function seoRank(domain, keyword) {
 
 async function seoCompare(url1, url2) {
 	showBanner();
-	console.log(chalk.bold(`SEO Karsilastirma`));
+	console.log(chalk.bold(`SEO Comparison`));
 	console.log(`  A: ${chalk.cyan(url1)}`);
 	console.log(`  B: ${chalk.cyan(url2)}`);
 	console.log("");
@@ -856,12 +848,7 @@ async function seoCompare(url1, url2) {
 		B.status,
 		winner((a, b) => (a === 200 ? 1 : 0) - (b === 200 ? 1 : 0)),
 	);
-	row(
-		"HTTPS",
-		A.https ? "evet" : "hayir",
-		B.https ? "evet" : "hayir",
-		winner(boolCmp),
-	);
+	row("HTTPS", A.https ? "yes" : "no", B.https ? "yes" : "no", winner(boolCmp));
 	row("Lang attribute", A.lang, B.lang);
 	row("Title", A.title.substring(0, 26), B.title.substring(0, 26));
 	row(
@@ -889,14 +876,14 @@ async function seoCompare(url1, url2) {
 	);
 	row(
 		"Twitter Card",
-		A.twCard ? "evet" : "hayir",
-		B.twCard ? "evet" : "hayir",
+		A.twCard ? "yes" : "no",
+		B.twCard ? "yes" : "no",
 		winner(boolCmp),
 	);
 	row(
 		"Canonical",
-		A.canonical ? "evet" : "hayir",
-		B.canonical ? "evet" : "hayir",
+		A.canonical ? "yes" : "no",
+		B.canonical ? "yes" : "no",
 		winner(boolCmp),
 	);
 	row(
@@ -916,8 +903,8 @@ async function seoCompare(url1, url2) {
 	row("Word count", A.wordCount, B.wordCount, winner(numCmp));
 	row(
 		"Schema.org",
-		A.schema ? "evet" : "hayir",
-		B.schema ? "evet" : "hayir",
+		A.schema ? "yes" : "no",
+		B.schema ? "yes" : "no",
 		winner(boolCmp),
 	);
 	row(
@@ -934,67 +921,71 @@ async function seoCompare(url1, url2) {
 	);
 	row(
 		"Compression",
-		A.compression ? "evet" : "hayir",
-		B.compression ? "evet" : "hayir",
+		A.compression ? "yes" : "no",
+		B.compression ? "yes" : "no",
 		winner(boolCmp),
 	);
 
 	console.log("");
 	console.log(
-		chalk.dim("Yesil = o satirda o taraf daha iyi. Nötr metrikler renksiz."),
+		chalk.dim(
+			"Green = that side is better on that row. Neutral metrics are uncolored.",
+		),
 	);
 }
 
-// ─── Ana Komut ───
+// ─── Main Command ───
 
 export async function runSeo(args) {
 	const sub = args[0];
 
 	if (!sub || sub === "--help" || sub === "-h") {
 		showBanner();
-		console.log(chalk.bold("SEO Analiz ve Denetim:"));
+		console.log(chalk.bold("SEO Analysis and Audit:"));
 		console.log("");
-		console.log(chalk.bold.cyan("Denetim:"));
+		console.log(chalk.bold.cyan("Audit:"));
 		console.log(
-			`  ${chalk.cyan("badi seo audit")} [url]           Kapsamli SEO denetimi (20+ kontrol)`,
+			`  ${chalk.cyan("badi seo audit")} [url]           Comprehensive SEO audit (20+ checks)`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi seo meta")} [url]            Meta tag analizi`,
+			`  ${chalk.cyan("badi seo meta")} [url]            Meta tag analysis`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi seo sitemap")} [url]         Sitemap ve robots.txt kontrolu`,
+			`  ${chalk.cyan("badi seo sitemap")} [url]         Sitemap and robots.txt check`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi seo speed")} [url]           Sayfa hizi ve kaynak analizi`,
-		);
-		console.log("");
-		console.log(chalk.bold.cyan("Genisletme (v1.11+):"));
-		console.log(
-			`  ${chalk.cyan("badi seo backlinks")} [domain]    DuckDuckGo + Wayback mention/snapshot taramasi`,
-		);
-		console.log(
-			`  ${chalk.cyan("badi seo rank")} [domain] [kw]   DuckDuckGo organic rank kontrolu`,
-		);
-		console.log(
-			`  ${chalk.cyan("badi seo compare")} [url1] [url2] Iki URL yan yana karsilastirma`,
+			`  ${chalk.cyan("badi seo speed")} [url]           Page speed and resource analysis`,
 		);
 		console.log("");
-		console.log(chalk.bold("Ornekler:"));
+		console.log(chalk.bold.cyan("Extended (v1.11+):"));
+		console.log(
+			`  ${chalk.cyan("badi seo backlinks")} [domain]    DuckDuckGo + Wayback mention/snapshot scan`,
+		);
+		console.log(
+			`  ${chalk.cyan("badi seo rank")} [domain] [kw]   DuckDuckGo organic rank check`,
+		);
+		console.log(
+			`  ${chalk.cyan("badi seo compare")} [url1] [url2] Compare two URLs side by side`,
+		);
+		console.log("");
+		console.log(chalk.bold("Examples:"));
 		console.log("  badi seo audit https://example.com");
 		console.log("  badi seo meta https://blog.example.com/post-1");
 		console.log("  badi seo sitemap https://example.com");
 		console.log("  badi seo speed https://example.com");
 		console.log("  badi seo backlinks example.com");
-		console.log('  badi seo rank example.com "anahtar kelime"');
-		console.log("  badi seo compare https://example.com https://rakip.com");
+		console.log('  badi seo rank example.com "keyword"');
+		console.log(
+			"  badi seo compare https://example.com https://competitor.com",
+		);
 		console.log("");
-		console.log(chalk.bold("Kontrol Edilen Alanlar:"));
+		console.log(chalk.bold("Checked Areas:"));
 		console.log("  Title, Description, OG tags, Twitter Card");
-		console.log("  Baslik yapisi (H1-H6), Gorsel alt taglari");
+		console.log("  Heading structure (H1-H6), Image alt tags");
 		console.log("  Canonical URL, Viewport, Lang, Charset");
 		console.log("  HTTPS, Schema.org, robots meta");
 		console.log("  Sitemap.xml, robots.txt, lastmod");
-		console.log("  TTFB, HTML boyutu, kaynak sayilari");
+		console.log("  TTFB, HTML size, resource counts");
 		console.log("  Compression, Cache-Control");
 		return;
 	}
@@ -1002,7 +993,7 @@ export async function runSeo(args) {
 	const url = args[1];
 	if (!url) {
 		console.error(
-			chalk.red(`URL/domain belirtin: badi seo ${sub} [url|domain]`),
+			chalk.red(`Specify a URL/domain: badi seo ${sub} [url|domain]`),
 		);
 		process.exit(1);
 	}
@@ -1034,9 +1025,7 @@ export async function runSeo(args) {
 				const keyword = args.slice(2).join(" ");
 				if (!keyword) {
 					console.error(
-						chalk.red(
-							"Anahtar kelime gerekli: badi seo rank [domain] [keyword]",
-						),
+						chalk.red("Keyword required: badi seo rank [domain] [keyword]"),
 					);
 					process.exit(1);
 				}
@@ -1047,7 +1036,7 @@ export async function runSeo(args) {
 				const url2 = args[2];
 				if (!url2) {
 					console.error(
-						chalk.red("Iki URL gerekli: badi seo compare [url1] [url2]"),
+						chalk.red("Two URLs required: badi seo compare [url1] [url2]"),
 					);
 					process.exit(1);
 				}
@@ -1058,14 +1047,14 @@ export async function runSeo(args) {
 				break;
 			}
 			default:
-				console.error(chalk.red(`Bilinmeyen seo komutu: ${sub}`));
+				console.error(chalk.red(`Unknown seo command: ${sub}`));
 				console.log(
-					"Kullanim: badi seo [audit|meta|sitemap|speed|backlinks|rank|compare]",
+					"Usage: badi seo [audit|meta|sitemap|speed|backlinks|rank|compare]",
 				);
 				process.exit(1);
 		}
 	} catch (e) {
-		console.error(chalk.red(`Hata: ${e.message}`));
+		console.error(chalk.red(`Error: ${e.message}`));
 		process.exit(1);
 	}
 }

--- a/lib/market-helpers.js
+++ b/lib/market-helpers.js
@@ -263,7 +263,7 @@ export function findOpportunityGaps(input) {
 		else severity = "LOW";
 
 		const coveragePct = Math.round(coverage * 100);
-		const rationale = `${affected}/${competitorCount} rakip (${coveragePct}%) bu sorundan etkileniyor; ${volume} negatif yorum; pazar zorlugu ${difficulty.score}/100`;
+		const rationale = `${affected}/${competitorCount} competitors (${coveragePct}%) affected by this issue; ${volume} negative reviews; market difficulty ${difficulty.score}/100`;
 
 		return {
 			code: c.code,

--- a/tests/cli.aso.test.js
+++ b/tests/cli.aso.test.js
@@ -34,15 +34,15 @@ describe("badi aso", () => {
 	it("metadata appstore limitleri gosterir", () => {
 		const out = run("aso", "metadata", "appstore");
 		assert.ok(
-			out.includes("30 karakter") ||
-				out.includes("100 karakter") ||
-				out.includes("4000 karakter"),
+			out.includes("30 chars") ||
+				out.includes("100 chars") ||
+				out.includes("4000 chars"),
 		);
 	});
 
 	it("metadata playstore limitleri gosterir", () => {
 		const out = run("aso", "metadata", "playstore");
-		assert.ok(out.includes("50 karakter") || out.includes("80 karakter"));
+		assert.ok(out.includes("50 chars") || out.includes("80 chars"));
 	});
 
 	it("screenshots rehberi gosterir", () => {

--- a/tests/cli.market.test.js
+++ b/tests/cli.market.test.js
@@ -200,7 +200,7 @@ describe("market: CLI smoke", () => {
 			encoding: "utf-8",
 			timeout: 10000,
 		});
-		assert.match(out, /Pazar Arastirmasi/);
+		assert.match(out, /Market Research/);
 		assert.match(out, /discover/);
 		assert.match(out, /reviews/);
 		assert.match(out, /difficulty/);
@@ -211,7 +211,7 @@ describe("market: CLI smoke", () => {
 			encoding: "utf-8",
 			timeout: 10000,
 		});
-		assert.match(out, /Pazar Arastirmasi/);
+		assert.match(out, /Market Research/);
 	});
 
 	it("gecersiz appId hata verir", () => {
@@ -221,7 +221,7 @@ describe("market: CLI smoke", () => {
 				timeout: 10000,
 				stdio: "pipe",
 			});
-		}, /Gecersiz app ID/);
+		}, /Invalid app ID/);
 	});
 
 	it("URL'den appId cikarir (parse smoke)", () => {
@@ -392,8 +392,8 @@ describe("market: findOpportunityGaps", () => {
 			competitorCount: 5,
 			difficulty: { score: 40 },
 		});
-		assert.match(gaps[0].rationale, /rakip/);
-		assert.match(gaps[0].rationale, /negatif yorum/);
-		assert.match(gaps[0].rationale, /pazar zorlugu/);
+		assert.match(gaps[0].rationale, /competitors/);
+		assert.match(gaps[0].rationale, /negative reviews/);
+		assert.match(gaps[0].rationale, /market difficulty/);
 	});
 });

--- a/tests/cli.seo.test.js
+++ b/tests/cli.seo.test.js
@@ -14,7 +14,7 @@ const run = (...args) =>
 describe("badi seo", () => {
 	it("yardim gosterir", () => {
 		const out = run("seo", "--help");
-		assert.ok(out.includes("SEO Analiz ve Denetim"));
+		assert.ok(out.includes("SEO Analysis and Audit"));
 		assert.ok(out.includes("badi seo audit"));
 		assert.ok(out.includes("badi seo meta"));
 		assert.ok(out.includes("badi seo sitemap"));
@@ -23,7 +23,7 @@ describe("badi seo", () => {
 
 	it("argumansiz yardim gosterir", () => {
 		const out = run("seo");
-		assert.ok(out.includes("SEO Analiz ve Denetim"));
+		assert.ok(out.includes("SEO Analysis and Audit"));
 	});
 
 	it("url olmadan hata verir", () => {


### PR DESCRIPTION
## Phase 2i — English-only migration (#207)

Translates all user-facing CLI output to English across the **app-marketing command cluster** (aso + seo + market), plus the two output strings their helpers emit. Subcommand names and flags stay stable — no interface renames in this batch.

### Changed
- **aso.js** — audit / keywords / metadata / compete / review / reviews / screenshots / playstore / search output, help text, error messages
- **seo.js** — audit / meta / sitemap / speed / backlinks / rank / compare output, code comments, help text, error messages
- **market.js** — full / discover / reviews / difficulty / gaps / wishlist report labels, help text, quadrant guide, error messages
- **market-helpers.js** — opportunity-gap `rationale` string (printed by `market gaps`)
- **aso-helpers.js** — `App not found` lookup error

### Kept intentionally
The `broken-feature` detector regex in `market-helpers.js` still matches Turkish words (`calismi`/`bozuk`/`hata`). Those match Turkish-language **review text written by app users**, not Badi's own output — removing them would break complaint categorization for Turkish-market apps. This is input-matching, not interface content.

### Tests
Updated in lockstep: `cli.aso.test.js` (chars assertions), `cli.seo.test.js` (help title), `cli.market.test.js` (help title, error, rationale assertions). Turkish `it()` descriptions and test-fixture data left for a later phase, consistent with prior batches.

### Verification
- `npm run lint` — clean (201 files; 3 files auto-formatted after translation)
- `npm test` — **1132/1132 pass**
- Guard grep — no Turkish console strings remain in the 3 modules or 2 helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)