### PR TITLE
feat(i18n): English-only Phase 2j — mobile, dev, publish CLI output

### DIFF
--- a/lib/commands/dev.js
+++ b/lib/commands/dev.js
@@ -15,16 +15,16 @@ function detectManager() {
 
 function devDeps(args) {
 	showBanner();
-	console.log(chalk.bold("Bagimlilik Guncelleme Analizi"));
+	console.log(chalk.bold("Dependency Update Analysis"));
 	console.log("");
 
 	const mgr = detectManager();
 	if (!mgr) {
-		console.error(chalk.red("Paket yoneticisi bulunamadi (npm/yarn/pnpm)"));
+		console.error(chalk.red("Package manager not found (npm/yarn/pnpm)"));
 		process.exit(1);
 	}
 
-	console.log(chalk.dim(`Paket yoneticisi: ${mgr}`));
+	console.log(chalk.dim(`Package manager: ${mgr}`));
 	console.log("");
 
 	// npm outdated
@@ -36,7 +36,7 @@ function devDeps(args) {
 		const parsed = JSON.parse(output || "{}");
 		const entries = Object.entries(parsed);
 		if (entries.length === 0) {
-			console.log(chalk.bold.green("Tum bagimliliklar guncel!"));
+			console.log(chalk.bold.green("All dependencies up to date!"));
 			return;
 		}
 
@@ -56,14 +56,12 @@ function devDeps(args) {
 			else patch.push({ name, cur, latest });
 		}
 
-		console.log(chalk.bold(`Toplam guncellenebilir: ${entries.length}`));
+		console.log(chalk.bold(`Total updatable: ${entries.length}`));
 		console.log("");
 
 		if (patch.length > 0) {
 			console.log(
-				chalk.bold.green(
-					`Patch (${patch.length}) — guvenli, otomatik yapilabilir:`,
-				),
+				chalk.bold.green(`Patch (${patch.length}) — safe, can be automated:`),
 			);
 			for (const p of patch)
 				console.log(
@@ -73,7 +71,7 @@ function devDeps(args) {
 		if (minor.length > 0) {
 			console.log("");
 			console.log(
-				chalk.bold.yellow(`Minor (${minor.length}) — dikkatli, test gerekli:`),
+				chalk.bold.yellow(`Minor (${minor.length}) — careful, testing needed:`),
 			);
 			for (const p of minor)
 				console.log(
@@ -84,7 +82,7 @@ function devDeps(args) {
 			console.log("");
 			console.log(
 				chalk.bold.red(
-					`Major (${major.length}) — break change olasi, manuel inceleme:`,
+					`Major (${major.length}) — breaking change likely, manual review:`,
 				),
 			);
 			for (const p of major)
@@ -94,39 +92,39 @@ function devDeps(args) {
 		}
 
 		console.log("");
-		console.log(chalk.bold("Onerilen komutlar:"));
+		console.log(chalk.bold("Recommended commands:"));
 		console.log(
 			chalk.dim(
-				`  ${mgr} update                    # patch + minor (lock file sinirlari)`,
+				`  ${mgr} update                    # patch + minor (lock file limits)`,
 			),
 		);
-		console.log(chalk.dim(`  ${mgr} install [paket]@latest    # major tekil`));
+		console.log(chalk.dim(`  ${mgr} install [package]@latest  # single major`));
 		console.log(
 			chalk.dim(
-				"  npx npm-check-updates -u        # tum major'lari guncelle (dikkatli)",
+				"  npx npm-check-updates -u        # update all majors (careful)",
 			),
 		);
 
 		// Apply flag
 		if (args.includes("--apply-patch") && patch.length > 0) {
 			console.log("");
-			console.log(chalk.cyan("Patch guncellemeleri uygulaniyor..."));
+			console.log(chalk.cyan("Applying patch updates..."));
 			try {
 				execFileSync(mgr, ["update", ...patch.map((p) => p.name)], {
 					stdio: "inherit",
 				});
-				console.log(chalk.green("Patch guncellemeleri uygulandi."));
+				console.log(chalk.green("Patch updates applied."));
 			} catch (e) {
-				console.error(chalk.red(`Hata: ${e.message}`));
+				console.error(chalk.red(`Error: ${e.message}`));
 			}
 		}
 	} catch (e) {
-		// outdated 1 exit code ile donebilir (normal durum)
+		// outdated can return with exit code 1 (normal case)
 		if (e.stdout) {
 			try {
 				const parsed = JSON.parse(e.stdout.toString() || "{}");
 				if (Object.keys(parsed).length === 0) {
-					console.log(chalk.bold.green("Tum bagimliliklar guncel!"));
+					console.log(chalk.bold.green("All dependencies up to date!"));
 					return;
 				}
 			} catch {
@@ -134,7 +132,7 @@ function devDeps(args) {
 			}
 		}
 		console.log(
-			chalk.green("Tum bagimliliklar guncel veya outdated bilgisi alinamadi."),
+			chalk.green("All dependencies up to date, or outdated info unavailable."),
 		);
 	}
 }
@@ -143,15 +141,15 @@ function devDeps(args) {
 
 function devBundle() {
 	showBanner();
-	console.log(chalk.bold("Bundle Size Analizi"));
+	console.log(chalk.bold("Bundle Size Analysis"));
 	console.log("");
 
-	// Framework tespit
+	// Framework detection
 	const pkg = existsSync("package.json")
 		? JSON.parse(readFileSync("package.json", "utf-8"))
 		: null;
 	if (!pkg) {
-		console.error(chalk.red("package.json bulunamadi"));
+		console.error(chalk.red("package.json not found"));
 		process.exit(1);
 	}
 
@@ -161,25 +159,25 @@ function devBundle() {
 	const hasNext = !!deps.next;
 	const hasExpo = !!deps.expo;
 
-	console.log(chalk.bold("Tespit Edilen Framework:"));
+	console.log(chalk.bold("Detected Framework:"));
 	if (hasNext) console.log(`  ${chalk.cyan("Next.js")}`);
 	if (hasVite) console.log(`  ${chalk.cyan("Vite")}`);
 	if (hasWebpack) console.log(`  ${chalk.cyan("Webpack")}`);
 	if (hasExpo) console.log(`  ${chalk.cyan("Expo")}`);
 	if (!hasNext && !hasVite && !hasWebpack && !hasExpo) {
-		console.log(chalk.yellow("  Tespit edilemedi — package.json inceleyin"));
+		console.log(chalk.yellow("  Not detected — check package.json"));
 	}
 
-	// Build output tespit
+	// Build output detection
 	const outDirs = ["dist", "build", ".next/static", "out", "web-build"];
 	const found = outDirs.find((d) => existsSync(d));
 
 	console.log("");
 	if (found) {
-		console.log(chalk.bold("Build Ciktisi:"));
-		console.log(`  Dizin: ${chalk.cyan(found)}`);
+		console.log(chalk.bold("Build Output:"));
+		console.log(`  Directory: ${chalk.cyan(found)}`);
 
-		// Toplam boyut
+		// Total size
 		function dirSize(dir) {
 			let total = 0;
 			for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -196,10 +194,10 @@ function devBundle() {
 		}
 		const bytes = dirSize(found);
 		console.log(
-			`  Toplam: ${chalk.cyan(`${(bytes / (1024 * 1024)).toFixed(2)} MB`)}`,
+			`  Total: ${chalk.cyan(`${(bytes / (1024 * 1024)).toFixed(2)} MB`)}`,
 		);
 
-		// En buyuk JS/CSS dosyalar
+		// Largest JS/CSS files
 		const files = [];
 		function collectFiles(dir) {
 			for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -218,7 +216,7 @@ function devBundle() {
 		files.sort((a, b) => b.size - a.size);
 
 		console.log("");
-		console.log(chalk.bold("En Buyuk 10 Asset:"));
+		console.log(chalk.bold("Largest 10 Assets:"));
 		for (const f of files.slice(0, 10)) {
 			const kb = (f.size / 1024).toFixed(1);
 			const color =
@@ -231,26 +229,26 @@ function devBundle() {
 		}
 
 		console.log("");
-		console.log(chalk.bold("Onerilen Araclar:"));
+		console.log(chalk.bold("Recommended Tools:"));
 		if (hasWebpack)
 			console.log(chalk.dim("  npx webpack-bundle-analyzer [stats.json]"));
 		if (hasVite) console.log(chalk.dim("  npx vite-bundle-visualizer"));
 		if (hasNext) console.log(chalk.dim("  npx @next/bundle-analyzer"));
 	} else {
-		console.log(chalk.yellow("Build ciktisi bulunamadi. Once build alin:"));
+		console.log(chalk.yellow("Build output not found. Build first:"));
 		console.log(chalk.dim("  npm run build"));
 	}
 
-	// Buyuk bagimliliklar
+	// Heavy dependencies
 	const heavyDeps = [
-		["moment", "date-fns (10x kucuk)"],
+		["moment", "date-fns (10x smaller)"],
 		["lodash", "lodash-es + tree-shaking"],
-		["rxjs", "native Promise (cogu durum)"],
+		["rxjs", "native Promise (most cases)"],
 		["axios", "native fetch"],
 		["jquery", "native DOM / modern framework"],
 	];
 	console.log("");
-	console.log(chalk.bold("Alternatif Olan Agir Bagimliliklar:"));
+	console.log(chalk.bold("Heavy Dependencies With Alternatives:"));
 	let foundHeavy = false;
 	for (const [heavy, alt] of heavyDeps) {
 		if (deps[heavy]) {
@@ -258,7 +256,7 @@ function devBundle() {
 			foundHeavy = true;
 		}
 	}
-	if (!foundHeavy) console.log(chalk.green("  Bilinen agir bagimlilik yok."));
+	if (!foundHeavy) console.log(chalk.green("  No known heavy dependencies."));
 }
 
 // ─── badi dev docker-lint ───
@@ -274,7 +272,7 @@ function devDockerLint() {
 			? "dockerfile"
 			: null;
 	if (!dockerfile) {
-		console.error(chalk.red("Dockerfile bulunamadi"));
+		console.error(chalk.red("Dockerfile not found"));
 		process.exit(1);
 	}
 
@@ -283,11 +281,11 @@ function devDockerLint() {
 	let issues = 0;
 
 	function warn(n, msg) {
-		console.log(`  ${chalk.yellow("!!")} Satir ${n}: ${msg}`);
+		console.log(`  ${chalk.yellow("!!")} Line ${n}: ${msg}`);
 		issues++;
 	}
 	function err(n, msg) {
-		console.log(`  ${chalk.red("XX")} Satir ${n}: ${msg}`);
+		console.log(`  ${chalk.red("XX")} Line ${n}: ${msg}`);
 		issues++;
 	}
 
@@ -308,7 +306,7 @@ function devDockerLint() {
 			if (/:latest/.test(trimmed) || !/:/.test(trimmed.split(" ")[1] || "")) {
 				warn(
 					n,
-					"FROM ... :latest veya etiketsiz — versiyonu sabitleyin (guvenlik + reproducibility)",
+					"FROM ... :latest or untagged — pin the version (security + reproducibility)",
 				);
 			}
 		}
@@ -318,31 +316,31 @@ function devDockerLint() {
 		// HEALTHCHECK
 		if (upper.startsWith("HEALTHCHECK ")) hasHealthcheck = true;
 
-		// RUN apt-get install -y ohne --no-install-recommends
+		// RUN apt-get install without --no-install-recommends
 		if (
 			/^RUN .*apt-get install/i.test(trimmed) &&
 			!/--no-install-recommends/.test(trimmed)
 		) {
-			warn(n, "apt-get install ile --no-install-recommends kullanin (boyut)");
+			warn(n, "use --no-install-recommends with apt-get install (size)");
 		}
-		// RUN update + install ayri katmanda
+		// RUN update + install in separate layers
 		if (/^RUN apt-get update/i.test(trimmed) && !/&&/.test(trimmed)) {
 			warn(
 				n,
-				"apt-get update ile install'i ayni RUN'da birlestirin (cache busting)",
+				"combine apt-get update and install in the same RUN (cache busting)",
 			);
 		}
-		// ADD yerine COPY
+		// COPY instead of ADD
 		if (/^ADD /i.test(trimmed) && !/\.tar/.test(trimmed)) {
-			warn(n, "ADD yerine COPY kullanin (daha aciklayici)");
+			warn(n, "use COPY instead of ADD (more explicit)");
 		}
-		// root icin sudo
+		// sudo for root
 		if (/sudo/.test(trimmed)) {
-			warn(n, "sudo container icinde anlamsiz, kaldirin");
+			warn(n, "sudo is meaningless inside a container, remove it");
 		}
 		// chmod 777
 		if (/chmod\s+777/.test(trimmed)) {
-			err(n, "chmod 777 asiri izinli — 755 veya daha sıkı");
+			err(n, "chmod 777 is overly permissive — 755 or stricter");
 		}
 		// Expose < 1024 (root priv)
 		if (/^EXPOSE\s+\d+/i.test(trimmed)) {
@@ -350,32 +348,33 @@ function devDockerLint() {
 			if (port < 1024)
 				warn(
 					n,
-					`EXPOSE ${port} — 1024 altinda root gerekir, mumkunse daha yuksek port`,
+					`EXPOSE ${port} — below 1024 requires root, use a higher port if possible`,
 				);
 		}
 	});
 
-	// Global kontroller
-	if (!hasUser)
-		warn(0, "USER direktifi yok — root olarak calisiyor (guvenlik riski)");
+	// Global checks
+	if (!hasUser) warn(0, "No USER directive — running as root (security risk)");
 	if (!hasHealthcheck)
 		warn(
 			0,
-			"HEALTHCHECK tanimlanmamis — orchestration saglik kontrolu icin eklemeyi dusun",
+			"No HEALTHCHECK defined — consider adding one for orchestration health checks",
 		);
-	if (!fromLine) err(0, "FROM direktifi bulunamadi");
+	if (!fromLine) err(0, "FROM directive not found");
 
-	// .dockerignore kontrolu
+	// .dockerignore check
 	if (!existsSync(".dockerignore")) {
-		warn(0, ".dockerignore dosyasi yok — build context'i sismis olabilir");
+		warn(0, "No .dockerignore file — build context may be bloated");
 	}
 
 	console.log("");
 	if (issues === 0) {
-		console.log(chalk.bold.green("Dockerfile temiz!"));
+		console.log(chalk.bold.green("Dockerfile clean!"));
 	} else {
-		console.log(chalk.bold.yellow(`${issues} sorun tespit edildi.`));
-		console.log(chalk.dim("Detayli analiz: hadolint (brew install hadolint)"));
+		console.log(chalk.bold.yellow(`${issues} issues detected.`));
+		console.log(
+			chalk.dim("Detailed analysis: hadolint (brew install hadolint)"),
+		);
 	}
 }
 
@@ -383,7 +382,7 @@ function devDockerLint() {
 
 function devEnvCheck() {
 	showBanner();
-	console.log(chalk.bold(".env Dogrulama"));
+	console.log(chalk.bold(".env Validation"));
 	console.log("");
 
 	const examples = [".env.example", ".env.template", ".env.sample"];
@@ -391,14 +390,12 @@ function devEnvCheck() {
 	const envFile = existsSync(".env") ? ".env" : null;
 
 	if (!exampleFile) {
-		console.error(
-			chalk.red("Hicbir .env.example/.env.template/.env.sample bulunamadi"),
-		);
+		console.error(chalk.red("No .env.example/.env.template/.env.sample found"));
 		process.exit(1);
 	}
 
-	console.log(chalk.dim(`Referans: ${exampleFile}`));
-	if (envFile) console.log(chalk.dim(`Aktif:    ${envFile}`));
+	console.log(chalk.dim(`Reference: ${exampleFile}`));
+	if (envFile) console.log(chalk.dim(`Active:    ${envFile}`));
 	console.log("");
 
 	function parseEnv(path) {
@@ -422,18 +419,18 @@ function devEnvCheck() {
 
 	let issues = 0;
 
-	// Eksik keys
+	// Missing keys
 	const missing = [];
 	for (const key of expected.keys()) {
 		if (!actual.has(key)) missing.push(key);
 	}
 	if (missing.length > 0) {
-		console.log(chalk.bold.red(`Eksik (${missing.length}):`));
+		console.log(chalk.bold.red(`Missing (${missing.length}):`));
 		for (const k of missing) console.log(`  ${chalk.red("XX")} ${k}`);
 		issues += missing.length;
 	}
 
-	// Extra keys (env'de olup example'da olmayan)
+	// Extra keys (in env but not in example)
 	const extra = [];
 	for (const key of actual.keys()) {
 		if (!expected.has(key)) extra.push(key);
@@ -441,23 +438,23 @@ function devEnvCheck() {
 	if (extra.length > 0) {
 		console.log("");
 		console.log(
-			chalk.bold.yellow(`Fazladan (${extra.length}) — .env.example'a ekleyin:`),
+			chalk.bold.yellow(`Extra (${extra.length}) — add to .env.example:`),
 		);
 		for (const k of extra) console.log(`  ${chalk.yellow("!!")} ${k}`);
 	}
 
-	// Bos deger
+	// Empty value
 	const empty = [];
 	for (const [k, v] of actual) {
 		if (!v || v === '""' || v === "''") empty.push(k);
 	}
 	if (empty.length > 0) {
 		console.log("");
-		console.log(chalk.bold.yellow(`Bos deger (${empty.length}):`));
+		console.log(chalk.bold.yellow(`Empty value (${empty.length}):`));
 		for (const k of empty) console.log(`  ${chalk.yellow("??")} ${k}`);
 	}
 
-	// Placeholder deger (your_key, xxx, changeme)
+	// Placeholder value (your_key, xxx, changeme)
 	const placeholders = [];
 	for (const [k, v] of actual) {
 		if (
@@ -472,7 +469,7 @@ function devEnvCheck() {
 		console.log("");
 		console.log(
 			chalk.bold.red(
-				`Placeholder deger (${placeholders.length}) — guncellenmemis:`,
+				`Placeholder value (${placeholders.length}) — not updated:`,
 			),
 		);
 		for (const { k, v } of placeholders)
@@ -480,21 +477,21 @@ function devEnvCheck() {
 		issues += placeholders.length;
 	}
 
-	// .gitignore kontrolu
+	// .gitignore check
 	const gi = existsSync(".gitignore")
 		? readFileSync(".gitignore", "utf-8")
 		: "";
 	if (envFile && !gi.includes(".env")) {
 		console.log("");
-		console.log(chalk.red("XX .env dosyasi .gitignore'da DEGIL — ACIL!"));
+		console.log(chalk.red("XX .env file is NOT in .gitignore — URGENT!"));
 		issues++;
 	}
 
 	console.log("");
 	if (issues === 0) {
-		console.log(chalk.bold.green(".env dogrulama temiz!"));
+		console.log(chalk.bold.green(".env validation clean!"));
 	} else {
-		console.log(chalk.bold.yellow(`${issues} sorun tespit edildi.`));
+		console.log(chalk.bold.yellow(`${issues} issues detected.`));
 	}
 }
 
@@ -507,22 +504,22 @@ async function devApiTest(args) {
 		console.log(chalk.bold("API Endpoint Tester:"));
 		console.log("");
 		console.log(
-			`  ${chalk.cyan("badi dev api-test")} [url]                    GET istek`,
+			`  ${chalk.cyan("badi dev api-test")} [url]                    GET request`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi dev api-test")} [url] --method POST      HTTP metod`,
+			`  ${chalk.cyan("badi dev api-test")} [url] --method POST      HTTP method`,
 		);
 		console.log(
 			`  ${chalk.cyan("badi dev api-test")} [url] --body '{}'        JSON body`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi dev api-test")} [url] --header 'K: V'    Header ekle`,
+			`  ${chalk.cyan("badi dev api-test")} [url] --header 'K: V'    Add header`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi dev api-test")} [url] --expect 200       Beklenen status`,
+			`  ${chalk.cyan("badi dev api-test")} [url] --expect 200       Expected status`,
 		);
 		console.log("");
-		console.log(chalk.bold("Ornekler:"));
+		console.log(chalk.bold("Examples:"));
 		console.log(`  badi dev api-test https://api.example.com/users`);
 		console.log(
 			`  badi dev api-test https://api.example.com/users --method POST --body '{"name":"X"}'`,
@@ -589,13 +586,13 @@ async function devApiTest(args) {
 				: res.status < 400
 					? chalk.yellow
 					: chalk.red;
-		console.log(chalk.bold("Yanit:"));
+		console.log(chalk.bold("Response:"));
 		console.log(
 			`  Status:   ${statusColor(`${res.status} ${res.statusText}`)}`,
 		);
-		console.log(`  Sure:     ${chalk.cyan(`${duration}ms`)}`);
+		console.log(`  Time:     ${chalk.cyan(`${duration}ms`)}`);
 		console.log(
-			`  Boyut:    ${chalk.cyan(`${(text.length / 1024).toFixed(2)} KB`)}`,
+			`  Size:     ${chalk.cyan(`${(text.length / 1024).toFixed(2)} KB`)}`,
 		);
 		console.log(
 			`  Content:  ${chalk.dim(res.headers.get("content-type") || "?")}`,
@@ -620,51 +617,51 @@ async function devApiTest(args) {
 			console.log("");
 			if (res.status === expectStatus) {
 				console.log(
-					chalk.bold.green(`OK Beklenen status ${expectStatus} eslesti`),
+					chalk.bold.green(`OK Expected status ${expectStatus} matched`),
 				);
 			} else {
 				console.log(
-					chalk.bold.red(`FAIL Beklenen ${expectStatus}, alinan ${res.status}`),
+					chalk.bold.red(`FAIL Expected ${expectStatus}, got ${res.status}`),
 				);
 				process.exit(1);
 			}
 		}
 	} catch (e) {
 		clearTimeout(timeout);
-		console.error(chalk.red(`Hata: ${e.message}`));
+		console.error(chalk.red(`Error: ${e.message}`));
 		process.exit(1);
 	}
 }
 
-// ─── Ana komut ───
+// ─── Main command ───
 
 export async function runDev(args) {
 	const sub = args[0];
 
 	if (!sub || sub === "--help" || sub === "-h") {
 		showBanner();
-		console.log(chalk.bold("DevOps + Kod Kalitesi:"));
+		console.log(chalk.bold("DevOps + Code Quality:"));
 		console.log("");
 		console.log(
-			`  ${chalk.cyan("badi dev deps")}                  Bagimlilik guncelleme analizi`,
+			`  ${chalk.cyan("badi dev deps")}                  Dependency update analysis`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi dev deps --apply-patch")}    Patch guncellemelerini uygula`,
+			`  ${chalk.cyan("badi dev deps --apply-patch")}    Apply patch updates`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi dev bundle")}                Bundle size + framework tespit`,
+			`  ${chalk.cyan("badi dev bundle")}                Bundle size + framework detection`,
 		);
 		console.log(
 			`  ${chalk.cyan("badi dev docker-lint")}           Dockerfile best practice`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi dev env-check")}             .env dogrulama`,
+			`  ${chalk.cyan("badi dev env-check")}             .env validation`,
 		);
 		console.log(
 			`  ${chalk.cyan("badi dev api-test")} [url]        HTTP endpoint tester`,
 		);
 		console.log("");
-		console.log(chalk.bold("Ornekler:"));
+		console.log(chalk.bold("Examples:"));
 		console.log("  badi dev deps");
 		console.log("  badi dev bundle");
 		console.log(
@@ -691,14 +688,14 @@ export async function runDev(args) {
 				await devApiTest(args.slice(1));
 				break;
 			default:
-				console.error(chalk.red(`Bilinmeyen dev komutu: ${sub}`));
+				console.error(chalk.red(`Unknown dev command: ${sub}`));
 				console.log(
-					"Kullanim: badi dev [deps|bundle|docker-lint|env-check|api-test]",
+					"Usage: badi dev [deps|bundle|docker-lint|env-check|api-test]",
 				);
 				process.exit(1);
 		}
 	} catch (e) {
-		console.error(chalk.red(`Hata: ${e.message}`));
+		console.error(chalk.red(`Error: ${e.message}`));
 		process.exit(1);
 	}
 }

--- a/lib/commands/mobile.js
+++ b/lib/commands/mobile.js
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { chalk, showBanner } from "../cli.js";
 import { fetchJsonWithTimeout, hasCommand } from "../helpers.js";
 
-// ─── Yardimcilar ───
+// ─── Helpers ───
 
 function readJson(path) {
 	try {
@@ -21,7 +21,7 @@ const FRAMEWORKS = {
 		cli: "npx",
 		args: (name) => ["react-native@latest", "init", name],
 		check: () => hasCommand("npx"),
-		installHint: "Node.js 18+ kurulu olmali",
+		installHint: "Node.js 18+ must be installed",
 	},
 	flutter: {
 		cli: "flutter",
@@ -33,19 +33,19 @@ const FRAMEWORKS = {
 		cli: "npx",
 		args: (name) => ["create-expo-app@latest", name],
 		check: () => hasCommand("npx"),
-		installHint: "Node.js 18+ kurulu olmali",
+		installHint: "Node.js 18+ must be installed",
 	},
 	swift: {
 		cli: null,
 		args: null,
 		check: () => hasCommand("xcodebuild"),
-		installHint: "Xcode App Store'dan indirin (macOS)",
+		installHint: "Download Xcode from the App Store (macOS)",
 	},
 	kotlin: {
 		cli: null,
 		args: null,
 		check: () => hasCommand("gradle"),
-		installHint: "Android Studio indirin: developer.android.com/studio",
+		installHint: "Download Android Studio: developer.android.com/studio",
 	},
 };
 
@@ -56,7 +56,7 @@ function mobileInit(args) {
 	if (!name || name.startsWith("--")) {
 		console.error(
 			chalk.red(
-				"Proje adi belirtin: badi mobile init [proje-adi] --framework [rn|flutter|expo]",
+				"Specify a project name: badi mobile init [project-name] --framework [rn|flutter|expo]",
 			),
 		);
 		process.exit(1);
@@ -68,20 +68,20 @@ function mobileInit(args) {
 
 	const fw = FRAMEWORKS[framework];
 	if (!fw) {
-		console.error(chalk.red(`Gecersiz framework: ${framework}`));
-		console.log(`Gecerli: ${Object.keys(FRAMEWORKS).join(", ")}`);
+		console.error(chalk.red(`Invalid framework: ${framework}`));
+		console.log(`Valid: ${Object.keys(FRAMEWORKS).join(", ")}`);
 		process.exit(1);
 	}
 
 	if (!fw.check()) {
-		console.error(chalk.red(`${framework} icin gerekli arac bulunamadi.`));
-		console.log(chalk.dim(`Kurulum: ${fw.installHint}`));
+		console.error(chalk.red(`Required tool for ${framework} not found.`));
+		console.log(chalk.dim(`Install: ${fw.installHint}`));
 		process.exit(1);
 	}
 
 	if (!fw.cli) {
 		showBanner();
-		console.log(chalk.bold(`${framework} projesi icin:`));
+		console.log(chalk.bold(`For a ${framework} project:`));
 		console.log("");
 		if (framework === "swift") {
 			console.log("  Xcode -> File -> New -> Project -> App");
@@ -91,31 +91,31 @@ function mobileInit(args) {
 			console.log("  Language: Kotlin");
 		}
 		console.log("");
-		console.log(chalk.bold("Proje olusturduktan sonra:"));
+		console.log(chalk.bold("After creating the project:"));
 		console.log(`  cd ${name}`);
 		console.log("  npx @fatihkan/badi init");
 		return;
 	}
 
 	showBanner();
-	console.log(chalk.bold(`Mobil Proje Olusturuluyor: ${name}`));
+	console.log(chalk.bold(`Creating Mobile Project: ${name}`));
 	console.log(`  Framework: ${chalk.cyan(framework)}`);
 	console.log(
-		`  Komut:     ${chalk.dim(`${fw.cli} ${fw.args(name).join(" ")}`)}`,
+		`  Command:   ${chalk.dim(`${fw.cli} ${fw.args(name).join(" ")}`)}`,
 	);
 	console.log("");
 
 	try {
 		execFileSync(fw.cli, fw.args(name), { stdio: "inherit" });
 		console.log("");
-		console.log(chalk.bold.green(`${framework} projesi olusturuldu: ${name}`));
+		console.log(chalk.bold.green(`${framework} project created: ${name}`));
 		console.log("");
-		console.log(chalk.bold("Sonraki adimlar:"));
+		console.log(chalk.bold("Next steps:"));
 		console.log(`  cd ${name}`);
-		console.log("  npx @fatihkan/badi init   # Badi konfigurasyonu");
+		console.log("  npx @fatihkan/badi init   # Badi configuration");
 		console.log("  badi mobile assets icon ./icon.png");
 	} catch (e) {
-		console.error(chalk.red(`Framework CLI hatasi: ${e.message}`));
+		console.error(chalk.red(`Framework CLI error: ${e.message}`));
 		process.exit(1);
 	}
 }
@@ -123,7 +123,7 @@ function mobileInit(args) {
 // ─── mobile version bump ───
 
 function findIosPlist() {
-	// iOS projelerinde Info.plist konumunu bul
+	// Find the Info.plist location in iOS projects
 	const candidates = ["ios/Info.plist", "ios/RunnerInfo.plist"];
 	for (const c of candidates) {
 		if (existsSync(c)) return c;
@@ -151,7 +151,7 @@ function mobileVersion(args) {
 	const bumpType = args[0];
 	if (!bumpType || !["major", "minor", "patch"].includes(bumpType)) {
 		console.error(
-			chalk.red("Kullanim: badi mobile version bump [major|minor|patch]"),
+			chalk.red("Usage: badi mobile version bump [major|minor|patch]"),
 		);
 		process.exit(1);
 	}
@@ -226,23 +226,23 @@ function mobileVersion(args) {
 	}
 
 	if (updates.length === 0) {
-		console.log(chalk.yellow("Hicbir version dosyasi bulunamadi."));
+		console.log(chalk.yellow("No version file found."));
 		console.log(
 			chalk.dim(
-				"package.json, Info.plist, build.gradle veya pubspec.yaml olmali.",
+				"Expected package.json, Info.plist, build.gradle or pubspec.yaml.",
 			),
 		);
 		process.exit(1);
 	}
 
-	console.log(chalk.bold("Guncellenen Dosyalar:"));
+	console.log(chalk.bold("Updated Files:"));
 	for (const [file, oldV, newV] of updates) {
 		console.log(
 			`  ${chalk.green(file.padEnd(40))} ${chalk.dim(oldV)} -> ${chalk.bold.green(newV)}`,
 		);
 	}
 	console.log("");
-	console.log(chalk.bold.green("Version bump tamamlandi!"));
+	console.log(chalk.bold.green("Version bump complete!"));
 }
 
 // ─── mobile build ───
@@ -250,7 +250,7 @@ function mobileVersion(args) {
 function mobileBuild(args) {
 	const platform = args[0];
 	if (!platform || !["ios", "android"].includes(platform)) {
-		console.error(chalk.red("Kullanim: badi mobile build [ios|android]"));
+		console.error(chalk.red("Usage: badi mobile build [ios|android]"));
 		process.exit(1);
 	}
 
@@ -260,10 +260,10 @@ function mobileBuild(args) {
 
 	if (platform === "ios") {
 		if (!hasCommand("xcodebuild")) {
-			console.error(chalk.red("Xcode bulunamadi. macOS + Xcode gerekli."));
+			console.error(chalk.red("Xcode not found. macOS + Xcode required."));
 			process.exit(1);
 		}
-		// React Native projesi tespit
+		// React Native project detection
 		if (existsSync("ios") && existsSync("package.json")) {
 			console.log(chalk.dim("React Native iOS build..."));
 			try {
@@ -271,7 +271,7 @@ function mobileBuild(args) {
 					stdio: "inherit",
 				});
 			} catch (e) {
-				console.error(chalk.red(`Build hatasi: ${e.message}`));
+				console.error(chalk.red(`Build error: ${e.message}`));
 				process.exit(1);
 			}
 		} else if (existsSync("ios") && existsSync("pubspec.yaml")) {
@@ -280,14 +280,12 @@ function mobileBuild(args) {
 					stdio: "inherit",
 				});
 			} catch (e) {
-				console.error(chalk.red(`Build hatasi: ${e.message}`));
+				console.error(chalk.red(`Build error: ${e.message}`));
 				process.exit(1);
 			}
 		} else {
 			console.log(
-				chalk.yellow(
-					"Proje turu tespit edilemedi. Xcode'dan manuel build yapin.",
-				),
+				chalk.yellow("Project type not detected. Build manually from Xcode."),
 			);
 			console.log(
 				chalk.dim("  xcodebuild -scheme YourScheme -configuration Release"),
@@ -304,7 +302,7 @@ function mobileBuild(args) {
 					stdio: "inherit",
 				});
 			} catch (e) {
-				console.error(chalk.red(`Build hatasi: ${e.message}`));
+				console.error(chalk.red(`Build error: ${e.message}`));
 				process.exit(1);
 			}
 		} else if (existsSync("android") && existsSync("pubspec.yaml")) {
@@ -313,42 +311,42 @@ function mobileBuild(args) {
 					stdio: "inherit",
 				});
 			} catch (e) {
-				console.error(chalk.red(`Build hatasi: ${e.message}`));
+				console.error(chalk.red(`Build error: ${e.message}`));
 				process.exit(1);
 			}
 		} else {
-			console.log(chalk.yellow("Proje turu tespit edilemedi."));
+			console.log(chalk.yellow("Project type not detected."));
 		}
 	}
 }
 
-// ─── mobile release (rehber) ───
+// ─── mobile release (guide) ───
 
 function mobileRelease(args) {
 	const target = args[0];
 	const validTargets = ["testflight", "play-internal", "appstore", "play"];
 	if (!target || !validTargets.includes(target)) {
 		console.error(
-			chalk.red(`Kullanim: badi mobile release [${validTargets.join("|")}]`),
+			chalk.red(`Usage: badi mobile release [${validTargets.join("|")}]`),
 		);
 		process.exit(1);
 	}
 
 	showBanner();
-	console.log(chalk.bold(`Release Rehberi: ${target}`));
+	console.log(chalk.bold(`Release Guide: ${target}`));
 	console.log("");
 
 	const guides = {
 		testflight: [
 			"1. Xcode: Product -> Archive",
 			"2. Organizer -> Distribute App -> App Store Connect",
-			"3. Bekleyin (processing ~30 min)",
-			"4. TestFlight -> Internal/External testers ekleyin",
+			"3. Wait (processing ~30 min)",
+			"4. TestFlight -> add Internal/External testers",
 			"",
-			"Fastlane ile:",
+			"With Fastlane:",
 			"  fastlane ios beta",
 			"",
-			"Komut satirindan:",
+			"From CLI:",
 			"  xcodebuild -scheme X archive -archivePath build.xcarchive",
 			"  xcodebuild -exportArchive -archivePath build.xcarchive -exportPath build/",
 			"  xcrun altool --upload-app -f build/X.ipa -u APPLE_ID -p APP_PASSWORD",
@@ -358,20 +356,20 @@ function mobileRelease(args) {
 			"2. Create new release -> Upload AAB (android/app/build/outputs/bundle/release/app-release.aab)",
 			"3. Review + Rollout",
 			"",
-			"Fastlane ile:",
+			"With Fastlane:",
 			"  fastlane android beta",
 			"",
-			"bundletool ile:",
+			"With bundletool:",
 			"  bundletool build-apks --bundle=app.aab --output=app.apks",
 		],
 		appstore: [
-			"1. Once TestFlight'ta test edin",
+			"1. Test on TestFlight first",
 			"2. App Store Connect -> App Store -> + Version",
-			"3. What's New, Screenshots, Description guncelleyin",
-			"4. Build sec -> Submit for Review",
-			"5. Inceleme 1-3 gun surer",
+			"3. Update What's New, Screenshots, Description",
+			"4. Select build -> Submit for Review",
+			"5. Review takes 1-3 days",
 			"",
-			"Ipucu: badi icerik release-notes --platform ios --version X.Y.Z",
+			"Tip: badi icerik release-notes --platform ios --version X.Y.Z",
 		],
 		play: [
 			"1. Play Console -> Production",
@@ -379,17 +377,17 @@ function mobileRelease(args) {
 			"3. Release notes (500 char limit)",
 			"4. Rollout percentage (1% -> 10% -> 50% -> 100%)",
 			"",
-			"Ipucu: badi icerik release-notes --platform android --version X.Y.Z",
+			"Tip: badi icerik release-notes --platform android --version X.Y.Z",
 		],
 	};
 
 	const guide = guides[target];
 	for (const line of guide) {
 		if (
-			line.startsWith("Fastlane") ||
-			line.startsWith("Komut") ||
-			line.startsWith("bundletool") ||
-			line.startsWith("Ipucu")
+			line.startsWith("With Fastlane") ||
+			line.startsWith("From CLI") ||
+			line.startsWith("With bundletool") ||
+			line.startsWith("Tip")
 		) {
 			console.log(chalk.cyan(line));
 		} else if (
@@ -405,7 +403,7 @@ function mobileRelease(args) {
 	console.log("");
 	console.log(
 		chalk.dim(
-			"Otomatik release icin fastlane veya eas submit kullanin (v2.0 roadmap).",
+			"For automated releases use fastlane or eas submit (v2.0 roadmap).",
 		),
 	);
 }
@@ -414,11 +412,11 @@ function mobileRelease(args) {
 
 function mobileAssetsIcon(source) {
 	showBanner();
-	console.log(chalk.bold("Icon Uretim Rehberi"));
+	console.log(chalk.bold("Icon Generation Guide"));
 	console.log("");
 
 	if (source && !existsSync(source)) {
-		console.error(chalk.red(`Kaynak bulunamadi: ${source}`));
+		console.error(chalk.red(`Source not found: ${source}`));
 		process.exit(1);
 	}
 
@@ -446,22 +444,22 @@ function mobileAssetsIcon(source) {
 		[512, "Play Store"],
 	];
 
-	console.log(chalk.bold("iOS Boyutlari:"));
+	console.log(chalk.bold("iOS Sizes:"));
 	for (const [size, label] of iosSizes) {
 		console.log(`  ${chalk.cyan(`${size}x${size}`.padEnd(12))} ${label}`);
 	}
 	console.log("");
-	console.log(chalk.bold("Android Boyutlari:"));
+	console.log(chalk.bold("Android Sizes:"));
 	for (const [size, label] of androidSizes) {
 		console.log(`  ${chalk.cyan(`${size}x${size}`.padEnd(12))} ${label}`);
 	}
 
 	console.log("");
 	if (source) {
-		console.log(chalk.bold("Otomatik Uretim:"));
+		console.log(chalk.bold("Automatic Generation:"));
 		if (hasCommand("magick") || hasCommand("convert")) {
 			const cmd = hasCommand("magick") ? "magick" : "convert";
-			console.log(chalk.cyan("ImageMagick bulundu. Ornek komutlar:"));
+			console.log(chalk.cyan("ImageMagick found. Example commands:"));
 			for (const [size] of [...iosSizes, ...androidSizes]) {
 				console.log(
 					chalk.dim(
@@ -471,110 +469,110 @@ function mobileAssetsIcon(source) {
 			}
 		} else {
 			console.log(
-				chalk.yellow("ImageMagick bulunamadi (brew install imagemagick)."),
+				chalk.yellow("ImageMagick not found (brew install imagemagick)."),
 			);
 			console.log(
-				chalk.dim("Alternatif: sharp-cli paketi veya https://appicon.co"),
+				chalk.dim("Alternative: sharp-cli package or https://appicon.co"),
 			);
 		}
 	} else {
-		console.log(chalk.dim("Kullanim: badi mobile assets icon [source.png]"));
+		console.log(chalk.dim("Usage: badi mobile assets icon [source.png]"));
 	}
 
 	console.log("");
-	console.log(chalk.bold("Ipuclari:"));
-	console.log("  - 1024x1024 kaynaktan baslayin (en yuksek cozunurluk)");
-	console.log("  - PNG, seffaflik yok (iOS), seffaflik var (Android adaptive)");
-	console.log("  - iOS: kose yumusatma Apple tarafindan otomatik");
+	console.log(chalk.bold("Tips:"));
+	console.log("  - Start from a 1024x1024 source (highest resolution)");
+	console.log(
+		"  - PNG, no transparency (iOS), transparency ok (Android adaptive)",
+	);
+	console.log("  - iOS: corner rounding is automatic via Apple");
 	console.log("  - Android: adaptive icon (foreground + background)");
 }
 
 function mobileAssetsSplash() {
 	showBanner();
-	console.log(chalk.bold("Splash Screen Rehberi"));
+	console.log(chalk.bold("Splash Screen Guide"));
 	console.log("");
 
 	console.log(chalk.bold("iOS LaunchScreen:"));
 	console.log(
-		`  ${chalk.cyan("LaunchScreen.storyboard")}  Xcode ile duzenleyin (responsive)`,
+		`  ${chalk.cyan("LaunchScreen.storyboard")}  Edit with Xcode (responsive)`,
 	);
 	console.log(`  ${chalk.cyan("1242 x 2688 px")}           Portrait @3x base`);
 	console.log(
-		`  ${chalk.cyan("Assets.xcassets")}          Image asset ile kullanin`,
+		`  ${chalk.cyan("Assets.xcassets")}          Use with an image asset`,
 	);
 
 	console.log("");
 	console.log(chalk.bold("Android Splash:"));
-	console.log(`  ${chalk.cyan("drawable/")}                Gecis gorseli`);
+	console.log(`  ${chalk.cyan("drawable/")}                Transition image`);
 	console.log(`  ${chalk.cyan("1080 x 1920 px")}           Portrait xxxhdpi`);
 	console.log(`  ${chalk.cyan("SplashTheme style")}        values/styles.xml`);
 
 	console.log("");
-	console.log(chalk.bold("Modern Yaklasim (Android 12+):"));
-	console.log(chalk.dim("  SplashScreen API kullanin — maksimum 288x288 icon"));
-	console.log(chalk.dim("  Tema: windowSplashScreenAnimatedIcon"));
+	console.log(chalk.bold("Modern Approach (Android 12+):"));
+	console.log(chalk.dim("  Use the SplashScreen API — maximum 288x288 icon"));
+	console.log(chalk.dim("  Theme: windowSplashScreenAnimatedIcon"));
 
 	console.log("");
 	console.log(chalk.bold("Best Practices:"));
-	console.log("  - 2 saniyeden fazla tutmayin");
-	console.log("  - Logo merkezde, mininmum animasyon");
-	console.log("  - Brand rengi + logo yeterli");
-	console.log("  - Dark mode varyasyonu ekleyin");
+	console.log("  - Don't keep it longer than 2 seconds");
+	console.log("  - Logo centered, minimal animation");
+	console.log("  - Brand color + logo is enough");
+	console.log("  - Add a dark mode variation");
 }
 
 function mobileAssetsScreenshots() {
 	showBanner();
-	console.log(chalk.bold("Screenshot Rehberi"));
+	console.log(chalk.bold("Screenshot Guide"));
 	console.log("");
 
-	console.log(chalk.bold("iOS Zorunlu Boyutlar:"));
+	console.log(chalk.bold("iOS Required Sizes:"));
 	console.log(`  ${chalk.cyan('6.7" (iPhone 14 Pro Max)')}   1290 x 2796 px`);
 	console.log(`  ${chalk.cyan('6.5" (iPhone 11 Pro Max)')}   1242 x 2688 px`);
 	console.log(`  ${chalk.cyan('5.5" (iPhone 8 Plus)')}       1242 x 2208 px`);
 	console.log(`  ${chalk.cyan('12.9" iPad Pro (3rd gen+)')}  2048 x 2732 px`);
 
 	console.log("");
-	console.log(chalk.bold("Android Zorunlu Boyutlar:"));
-	console.log(
-		`  ${chalk.cyan("Phone")}              1080 x 1920 px (min 2-8 adet)`,
-	);
-	console.log(`  ${chalk.cyan("Feature Graphic")}    1024 x 500 px (zorunlu)`);
+	console.log(chalk.bold("Android Required Sizes:"));
+	console.log(`  ${chalk.cyan("Phone")}              1080 x 1920 px (min 2-8)`);
+	console.log(`  ${chalk.cyan("Feature Graphic")}    1024 x 500 px (required)`);
 	console.log(`  ${chalk.cyan('7" Tablet')}         1200 x 1920 px`);
 	console.log(`  ${chalk.cyan('10" Tablet')}        1920 x 1200 px`);
 
 	console.log("");
-	console.log(chalk.bold("Tasarim Ilkesi:"));
-	console.log("  1. Ilk screenshot en kritik — value proposition");
-	console.log("  2. Her screenshot'ta max 5 kelime, >= 40pt");
-	console.log("  3. Device frame ekleyin (profesyonel)");
-	console.log("  4. Brand rengi + sade arka plan");
-	console.log("  5. Hikaye akisi: problem -> cozum -> sonuc");
+	console.log(chalk.bold("Design Principles:"));
+	console.log("  1. First screenshot is most critical — value proposition");
+	console.log("  2. Max 5 words per screenshot, >= 40pt");
+	console.log("  3. Add a device frame (professional)");
+	console.log("  4. Brand color + clean background");
+	console.log("  5. Story flow: problem -> solution -> result");
 
 	console.log("");
 	console.log(
-		chalk.bold.green("Otomatik Uretim (app-store-screenshots skill):"),
+		chalk.bold.green("Automatic Generation (app-store-screenshots skill):"),
 	);
 	console.log(
-		`  Badi ile birlikte ${chalk.cyan(".claude/skills/mobile/app-store-screenshots/")} kuruluyor.`,
+		`  Installed alongside Badi at ${chalk.cyan(".claude/skills/mobile/app-store-screenshots/")}.`,
 	);
-	console.log("  Claude Code'da su sekilde tetikleyin:");
+	console.log("  Trigger it in Claude Code like this:");
 	console.log("");
 	console.log(
-		chalk.dim(
-			'  "Habit tracker uygulamam icin 6 App Store screenshot olustur.',
-		),
+		chalk.dim('  "Create 6 App Store screenshots for my habit tracker app.'),
 	);
 	console.log(
 		chalk.dim(
-			'   Temiz/minimal stil, sakin premium his, marka rengi #4F46E5."',
+			'   Clean/minimal style, calm premium feel, brand color #4F46E5."',
 		),
 	);
 	console.log("");
-	console.log("  Skill Next.js iskelesi kurar, slayt basina reklami tasarlar,");
-	console.log("  Apple + Google zorunlu cozunurluklerinde PNG export eder.");
+	console.log("  The skill scaffolds Next.js, designs the pitch per slide,");
+	console.log("  and exports PNG at Apple + Google required resolutions.");
 	console.log("");
 	console.log(
-		chalk.dim('Detayli brief icin: badi icerik gorsel "app store screenshot"'),
+		chalk.dim(
+			'For a detailed brief: badi icerik gorsel "app store screenshot"',
+		),
 	);
 }
 
@@ -582,15 +580,15 @@ function mobileAssets(args) {
 	const sub = args[0];
 	if (!sub) {
 		showBanner();
-		console.log(chalk.bold("Mobil Asset Komutlari:"));
+		console.log(chalk.bold("Mobile Asset Commands:"));
 		console.log(
-			`  ${chalk.cyan("badi mobile assets icon")} [source]        40+ boyut icon rehberi`,
+			`  ${chalk.cyan("badi mobile assets icon")} [source]        40+ size icon guide`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi mobile assets splash")}               Splash screen rehberi`,
+			`  ${chalk.cyan("badi mobile assets splash")}               Splash screen guide`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi mobile assets screenshots")}          Screenshot boyut + tasarim rehberi`,
+			`  ${chalk.cyan("badi mobile assets screenshots")}          Screenshot size + design guide`,
 		);
 		return;
 	}
@@ -605,7 +603,7 @@ function mobileAssets(args) {
 			mobileAssetsScreenshots();
 			break;
 		default:
-			console.error(chalk.red(`Bilinmeyen assets komutu: ${sub}`));
+			console.error(chalk.red(`Unknown assets command: ${sub}`));
 			process.exit(1);
 	}
 }
@@ -620,13 +618,13 @@ function mobileCrashSetup(args) {
 
 	if (!validFw.includes(framework)) {
 		console.error(
-			chalk.red(`Gecersiz framework: ${framework} (${validFw.join("|")})`),
+			chalk.red(`Invalid framework: ${framework} (${validFw.join("|")})`),
 		);
 		process.exit(1);
 	}
 	if (!validProv.includes(provider)) {
 		console.error(
-			chalk.red(`Gecersiz saglayici: ${provider} (${validProv.join("|")})`),
+			chalk.red(`Invalid provider: ${provider} (${validProv.join("|")})`),
 		);
 		process.exit(1);
 	}
@@ -637,14 +635,14 @@ function mobileCrashSetup(args) {
 
 	const snippets = {
 		"react-native-sentry": [
-			[chalk.bold("1. Paket kur:"), "npm install @sentry/react-native"],
+			[chalk.bold("1. Install package:"), "npm install @sentry/react-native"],
 			[chalk.bold("2. Native link (iOS):"), "cd ios && pod install"],
 			[
-				chalk.bold("3. DSN'i al:"),
+				chalk.bold("3. Get the DSN:"),
 				"sentry.io -> Project Settings -> Client Keys",
 			],
 			[
-				chalk.bold("4. App giris noktasinda (App.tsx):"),
+				chalk.bold("4. At the app entry point (App.tsx):"),
 				`import * as Sentry from "@sentry/react-native";
 
 Sentry.init({
@@ -665,20 +663,20 @@ export default Sentry.wrap(App);`,
 		],
 		"react-native-crashlytics": [
 			[
-				chalk.bold("1. Firebase projesi olustur:"),
+				chalk.bold("1. Create a Firebase project:"),
 				"console.firebase.google.com",
 			],
 			[
-				chalk.bold("2. Paketler:"),
+				chalk.bold("2. Packages:"),
 				"npm install @react-native-firebase/app @react-native-firebase/crashlytics",
 			],
 			[
 				chalk.bold("3. iOS config:"),
-				"ios/GoogleService-Info.plist'i ekle (Xcode'da drag-drop)",
+				"add ios/GoogleService-Info.plist (drag-drop in Xcode)",
 			],
 			[
 				chalk.bold("4. Android config:"),
-				"android/app/google-services.json'i ekle",
+				"add android/app/google-services.json",
 			],
 			[
 				chalk.bold("5. App.tsx:"),
@@ -689,7 +687,7 @@ crashlytics().setUserId("user_123");`,
 			],
 			[
 				chalk.bold("6. Test crash:"),
-				`crashlytics().crash();  // Sadece release build'de yakalar`,
+				`crashlytics().crash();  // Only caught in release builds`,
 			],
 		],
 		"flutter-sentry": [
@@ -728,7 +726,7 @@ FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;`,
 		],
 		"ios-sentry": [
 			[
-				chalk.bold("1. SPM paketi:"),
+				chalk.bold("1. SPM package:"),
 				"https://github.com/getsentry/sentry-cocoa",
 			],
 			[
@@ -752,7 +750,7 @@ SentrySDK.start { options in
 			],
 			[
 				chalk.bold("2. GoogleService-Info.plist:"),
-				"Xcode'a ekle (target'a dahil et)",
+				"add to Xcode (include in the target)",
 			],
 			[
 				chalk.bold("3. AppDelegate.swift:"),
@@ -786,7 +784,7 @@ FirebaseApp.configure()`,
 implementation platform("com.google.firebase:firebase-bom:32.0.0")
 implementation "com.google.firebase:firebase-crashlytics"`,
 			],
-			[chalk.bold("3. google-services.json:"), "app/ klasorune ekle"],
+			[chalk.bold("3. google-services.json:"), "add to the app/ folder"],
 		],
 	};
 
@@ -794,7 +792,7 @@ implementation "com.google.firebase:firebase-crashlytics"`,
 	const steps = snippets[key];
 	if (!steps) {
 		console.error(
-			chalk.red(`${framework} + ${provider} kombinasyonu desteklenmiyor`),
+			chalk.red(`${framework} + ${provider} combination not supported`),
 		);
 		process.exit(1);
 	}
@@ -805,53 +803,51 @@ implementation "com.google.firebase:firebase-crashlytics"`,
 		console.log("");
 	}
 
-	console.log(chalk.bold("Dogrulama:"));
-	console.log("  - Sentry/Firebase dashboard'unda test event'i gor");
-	console.log("  - Release build'i cihazda calistir, manuel crash tetikle");
-	console.log("  - Source map / ProGuard mapping upload kontrolu yap");
+	console.log(chalk.bold("Verification:"));
+	console.log("  - See the test event in the Sentry/Firebase dashboard");
+	console.log("  - Run a release build on a device, trigger a manual crash");
+	console.log("  - Check source map / ProGuard mapping upload");
 	console.log("");
 	console.log(
 		chalk.dim(
-			"Detayli rehber: sentry.io/for/react-native | firebase.google.com/docs/crashlytics",
+			"Detailed guide: sentry.io/for/react-native | firebase.google.com/docs/crashlytics",
 		),
 	);
 }
 
 // ─── mobile deeplink ───
-// Not: fetchJsonWithTimeout icinde validateUrl cagrisi private IP + localhost
-// engelliyor — mobile deeplink kullanicinin verdigi domain'i kabul ettigi icin
-// SSRF'e karsi bu guard sart.
+// Note: the validateUrl call inside fetchJsonWithTimeout blocks private IPs +
+// localhost — since mobile deeplink accepts a user-provided domain, this guard
+// is essential against SSRF.
 
 async function mobileDeeplink(args) {
 	const urlOrScheme = args[0];
 	if (!urlOrScheme) {
 		console.error(
-			chalk.red(
-				"Kullanim: badi mobile deeplink [test|validate] <domain|scheme>",
-			),
+			chalk.red("Usage: badi mobile deeplink [test|validate] <domain|scheme>"),
 		);
-		console.error("Ornek:    badi mobile deeplink test example.com");
+		console.error("Example:  badi mobile deeplink test example.com");
 		console.error("          badi mobile deeplink validate myapp://");
 		process.exit(1);
 	}
 
 	showBanner();
-	console.log(chalk.bold("Deep Link Dogrulama"));
+	console.log(chalk.bold("Deep Link Validation"));
 	console.log("");
 
-	// Eger scheme (myapp://)
+	// If a scheme (myapp://)
 	if (urlOrScheme.includes("://") && !urlOrScheme.startsWith("http")) {
 		const schemeMatch = urlOrScheme.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
 		if (!schemeMatch) {
-			console.error(chalk.red("Gecersiz URL scheme (RFC 3986 ihlali)"));
+			console.error(chalk.red("Invalid URL scheme (RFC 3986 violation)"));
 			console.log(
-				chalk.dim("Scheme: [a-z][a-z0-9+.-]*  ornek: myapp, com-sirket-app"),
+				chalk.dim("Scheme: [a-z][a-z0-9+.-]*  example: myapp, com-company-app"),
 			);
 			process.exit(1);
 		}
 		const scheme = schemeMatch[1];
 		console.log(`Scheme: ${chalk.cyan(scheme)}`);
-		console.log(`  ${chalk.green("OK")} RFC 3986 uyumlu`);
+		console.log(`  ${chalk.green("OK")} RFC 3986 compliant`);
 		console.log("");
 		console.log(chalk.bold("iOS Info.plist:"));
 		console.log(
@@ -874,7 +870,7 @@ async function mobileDeeplink(args) {
 </intent-filter>`),
 		);
 		console.log("");
-		console.log(chalk.bold("Test komutlari:"));
+		console.log(chalk.bold("Test commands:"));
 		console.log(
 			chalk.dim(`  iOS:     xcrun simctl openurl booted "${scheme}://test"`),
 		);
@@ -886,7 +882,7 @@ async function mobileDeeplink(args) {
 		return;
 	}
 
-	// Universal Link / App Link dogrulama
+	// Universal Link / App Link validation
 	const host = urlOrScheme.replace(/^https?:\/\//, "").replace(/\/.*/, "");
 	console.log(`Domain: ${chalk.cyan(host)}`);
 	console.log("");
@@ -915,21 +911,19 @@ async function mobileDeeplink(args) {
 					);
 				}
 			} else {
-				console.log(`  ${chalk.yellow("!!")} applinks.details eksik`);
+				console.log(`  ${chalk.yellow("!!")} applinks.details missing`);
 			}
 			aasaFound = true;
 			break;
 		} catch (_e) {
-			/* dene digerini */
+			/* try the other one */
 		}
 	}
 	if (!aasaFound) {
-		console.log(
-			`  ${chalk.red("XX")} AASA dosyasi bulunamadi (${aasaUrls[0]})`,
-		);
+		console.log(`  ${chalk.red("XX")} AASA file not found (${aasaUrls[0]})`);
 		console.log(
 			chalk.dim(
-				`       Content-Type: application/json, HTTPS zorunlu, redirect yok`,
+				`       Content-Type: application/json, HTTPS required, no redirect`,
 			),
 		);
 	}
@@ -954,18 +948,18 @@ async function mobileDeeplink(args) {
 				);
 			}
 		} else {
-			console.log(`  ${chalk.yellow("!!")} Bos veya gecersiz assetlinks`);
+			console.log(`  ${chalk.yellow("!!")} Empty or invalid assetlinks`);
 		}
 	} catch (_e) {
-		console.log(`  ${chalk.red("XX")} ${alUrl} bulunamadi`);
+		console.log(`  ${chalk.red("XX")} ${alUrl} not found`);
 		console.log(
-			chalk.dim(`       Content-Type: application/json, HTTPS zorunlu`),
+			chalk.dim(`       Content-Type: application/json, HTTPS required`),
 		);
 	}
 
-	// Dogrulama arac onerileri
+	// Validation tool suggestions
 	console.log("");
-	console.log(chalk.bold("Harici Dogrulayicilar:"));
+	console.log(chalk.bold("External Validators:"));
 	console.log(
 		chalk.dim(`  iOS:     search.apple.com/open-link?url=https://${host}/test`),
 	);
@@ -984,7 +978,7 @@ function mobileOta(args) {
 	const valid = ["codepush", "expo"];
 	if (!valid.includes(provider)) {
 		console.error(
-			chalk.red(`Gecersiz OTA saglayici: ${provider} (${valid.join("|")})`),
+			chalk.red(`Invalid OTA provider: ${provider} (${valid.join("|")})`),
 		);
 		process.exit(1);
 	}
@@ -994,14 +988,14 @@ function mobileOta(args) {
 	console.log("");
 
 	if (provider === "codepush") {
-		console.log(chalk.bold("1. App Center CLI kur:"));
+		console.log(chalk.bold("1. Install App Center CLI:"));
 		console.log(chalk.dim("  npm install -g appcenter-cli"));
 		console.log(chalk.dim("  appcenter login"));
 		console.log("");
-		console.log(chalk.bold("2. React Native paketi:"));
+		console.log(chalk.bold("2. React Native package:"));
 		console.log(chalk.dim("  npm install react-native-code-push"));
 		console.log("");
-		console.log(chalk.bold("3. App olustur:"));
+		console.log(chalk.bold("3. Create apps:"));
 		console.log(
 			chalk.dim("  appcenter apps create -d MyApp-iOS -o iOS -p React-Native"),
 		);
@@ -1011,7 +1005,7 @@ function mobileOta(args) {
 			),
 		);
 		console.log("");
-		console.log(chalk.bold("4. Deployment key'leri al:"));
+		console.log(chalk.bold("4. Get deployment keys:"));
 		console.log(
 			chalk.dim("  appcenter codepush deployment list -a ORG/MyApp-iOS -k"),
 		);
@@ -1041,7 +1035,7 @@ export default codePush(codePushOptions)(App);`),
 			),
 		);
 		console.log("");
-		console.log(chalk.bold("8. Release komutlari:"));
+		console.log(chalk.bold("8. Release commands:"));
 		console.log(
 			chalk.dim(
 				"  appcenter codepush release-react -a ORG/MyApp-iOS -d Staging",
@@ -1055,19 +1049,19 @@ export default codePush(codePushOptions)(App);`),
 		console.log("");
 		console.log(
 			chalk.yellow(
-				"Uyari: App Center CodePush retire tarihi: Mart 2025. Yeni projeler icin EAS Update dusunun.",
+				"Warning: App Center CodePush retire date: March 2025. For new projects consider EAS Update.",
 			),
 		);
 	} else {
 		// expo / eas
-		console.log(chalk.bold("1. EAS CLI kur:"));
+		console.log(chalk.bold("1. Install EAS CLI:"));
 		console.log(chalk.dim("  npm install -g eas-cli"));
 		console.log(chalk.dim("  eas login"));
 		console.log("");
-		console.log(chalk.bold("2. Expo paketleri:"));
+		console.log(chalk.bold("2. Expo packages:"));
 		console.log(chalk.dim("  npx expo install expo-updates"));
 		console.log("");
-		console.log(chalk.bold("3. eas.json olustur:"));
+		console.log(chalk.bold("3. Create eas.json:"));
 		console.log(chalk.dim("  eas build:configure"));
 		console.log("");
 		console.log(chalk.bold("4. Update channel:"));
@@ -1080,12 +1074,12 @@ export default codePush(codePushOptions)(App);`),
 }`),
 		);
 		console.log("");
-		console.log(chalk.bold("5. Update yayinla:"));
+		console.log(chalk.bold("5. Publish an update:"));
 		console.log(
 			chalk.dim('  eas update --branch production --message "v1.0.1 fix"'),
 		);
 		console.log("");
-		console.log(chalk.bold("6. App.tsx (runtime kontrol):"));
+		console.log(chalk.bold("6. App.tsx (runtime check):"));
 		console.log(
 			chalk.dim(`import * as Updates from "expo-updates";
 
@@ -1111,22 +1105,22 @@ useEffect(() => {
 
 	console.log("");
 	console.log(chalk.bold("Best Practices:"));
-	console.log("  - Native kod degisikligi = yeni binary (OTA degil)");
-	console.log("  - JS-only degisiklik = OTA'ya uygun");
-	console.log("  - Staging -> Production promotion akisi kullan");
-	console.log("  - Yuzdelik rollout: %5 -> %25 -> %100");
+	console.log("  - Native code change = new binary (not OTA)");
+	console.log("  - JS-only change = suitable for OTA");
+	console.log("  - Use the Staging -> Production promotion flow");
+	console.log("  - Percentage rollout: 5% -> 25% -> 100%");
 }
 
-// ─── Ana Komut ───
+// ─── Main Command ───
 
 export async function runMobile(args) {
 	const sub = args[0];
 
 	if (!sub || sub === "--help" || sub === "-h") {
 		showBanner();
-		console.log(chalk.bold("Mobil Gelistirme:"));
+		console.log(chalk.bold("Mobile Development:"));
 		console.log("");
-		console.log(chalk.bold.cyan("Proje:"));
+		console.log(chalk.bold.cyan("Project:"));
 		console.log(
 			`  ${chalk.cyan("badi mobile init")} [name] --framework [rn|flutter|expo|swift|kotlin]`,
 		);
@@ -1142,18 +1136,18 @@ export async function runMobile(args) {
 			`  ${chalk.cyan("badi mobile release")} [testflight|play-internal|appstore|play]`,
 		);
 		console.log("");
-		console.log(chalk.bold.cyan("Asset Uretimi:"));
+		console.log(chalk.bold.cyan("Asset Generation:"));
 		console.log(
-			`  ${chalk.cyan("badi mobile assets icon")} [source.png]            Icon rehberi`,
+			`  ${chalk.cyan("badi mobile assets icon")} [source.png]            Icon guide`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi mobile assets splash")}                        Splash rehberi`,
+			`  ${chalk.cyan("badi mobile assets splash")}                        Splash guide`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi mobile assets screenshots")}                   Screenshot rehberi + skill`,
+			`  ${chalk.cyan("badi mobile assets screenshots")}                   Screenshot guide + skill`,
 		);
 		console.log("");
-		console.log(chalk.bold.cyan("Operasyon (v1.11+):"));
+		console.log(chalk.bold.cyan("Operations (v1.11+):"));
 		console.log(
 			`  ${chalk.cyan("badi mobile crash-setup")} [fw] [provider]          Sentry/Crashlytics scaffold`,
 		);
@@ -1166,16 +1160,16 @@ export async function runMobile(args) {
 		console.log("");
 		console.log(
 			chalk.dim(
-				"  Ipucu: app-store-screenshots skill'i Badi ile birlikte kurulur.",
+				"  Tip: the app-store-screenshots skill is installed alongside Badi.",
 			),
 		);
 		console.log(
 			chalk.dim(
-				'  Claude Code\'a "App Store screenshot olustur" dediginde otomatik tetiklenir.',
+				'  It triggers automatically when you tell Claude Code "create App Store screenshots".',
 			),
 		);
 		console.log("");
-		console.log(chalk.bold("Ornekler:"));
+		console.log(chalk.bold("Examples:"));
 		console.log("  badi mobile init MyApp --framework react-native");
 		console.log("  badi mobile version bump minor");
 		console.log("  badi mobile build android");
@@ -1195,7 +1189,7 @@ export async function runMobile(args) {
 			if (args[1] === "bump") mobileVersion(args.slice(2));
 			else {
 				console.error(
-					chalk.red("Kullanim: badi mobile version bump [major|minor|patch]"),
+					chalk.red("Usage: badi mobile version bump [major|minor|patch]"),
 				);
 				process.exit(1);
 			}
@@ -1219,8 +1213,8 @@ export async function runMobile(args) {
 			mobileOta(args.slice(1));
 			break;
 		default:
-			console.error(chalk.red(`Bilinmeyen mobile komutu: ${sub}`));
-			console.log("Kullanim: badi mobile [init|version|build|release|assets]");
+			console.error(chalk.red(`Unknown mobile command: ${sub}`));
+			console.log("Usage: badi mobile [init|version|build|release|assets]");
 			process.exit(1);
 	}
 }

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -13,7 +13,7 @@ import {
 } from "../harnesses/skills-bundler.js";
 import { hasCommand, shCapture as sh } from "../helpers.js";
 
-// ─── Yardimcilar ───
+// ─── Helpers ───
 
 function bumpVersion(version, type) {
 	const [major, minor, patch] = version.split(".").map(Number);
@@ -60,15 +60,15 @@ function parseFlags(args) {
 		else if (a === "--strict") flags.strict = true;
 	}
 	if (!["patch", "minor", "major"].includes(flags.version)) {
-		throw new Error(`--version gecersiz: ${flags.version} (patch|minor|major)`);
+		throw new Error(`--version invalid: ${flags.version} (patch|minor|major)`);
 	}
 	return flags;
 }
 
-// ─── Skill-bundle akisi (issue #56) ───
+// ─── Skill-bundle flow (issue #56) ───
 
 export async function runSkillBundle(flags) {
-	// v1.17+ opt-in: tum skill'ler artik vault'ta. Eski path'e fallback.
+	// v1.17+ opt-in: all skills now live in the vault. Fall back to the legacy path.
 	const cwd = process.cwd();
 	const vaultPath = join(cwd, ".claude", "skills-vault");
 	const legacyPath = join(cwd, ".claude", "skills");
@@ -95,13 +95,11 @@ export async function runSkillBundle(flags) {
 
 	const result = await bundleSkills({ source, target, dryRun, strict });
 
-	console.log(chalk.bold("Sonuc:"));
-	console.log(
-		`  ${chalk.green(`+ ${result.bundled.length} skill bundle edildi`)}`,
-	);
+	console.log(chalk.bold("Result:"));
+	console.log(`  ${chalk.green(`+ ${result.bundled.length} skills bundled`)}`);
 	if (result.skipped.length > 0) {
 		console.log(
-			`  ${chalk.yellow(`! ${result.skipped.length} skill atlandi`)}`,
+			`  ${chalk.yellow(`! ${result.skipped.length} skills skipped`)}`,
 		);
 	}
 
@@ -114,19 +112,19 @@ export async function runSkillBundle(flags) {
 	if (totalEnriched > 0) {
 		console.log(
 			chalk.dim(
-				`  ${totalEnriched} alan otomatik dolduruldu (license, compatibility, allowed-tools, metadata.*)`,
+				`  ${totalEnriched} fields auto-filled (license, compatibility, allowed-tools, metadata.*)`,
 			),
 		);
 	}
 	if (totalWarnings > 0) {
 		console.log(
-			chalk.dim(`  ${totalWarnings} schema uyarisi (description<50ch, vb.)`),
+			chalk.dim(`  ${totalWarnings} schema warnings (description<50ch, etc.)`),
 		);
 	}
 
 	if (result.skipped.length > 0) {
 		console.log("");
-		console.log(chalk.bold("Atlanan skill'ler:"));
+		console.log(chalk.bold("Skipped skills:"));
 		for (const s of result.skipped) {
 			console.log(`  ${chalk.yellow("-")} ${s.name}: ${s.reason}`);
 			if (s.errors) {
@@ -146,79 +144,81 @@ export async function runSkillBundle(flags) {
 		writeFileSync(join(routerDir, "SKILL.md"), routerContent);
 		console.log("");
 		console.log(
-			chalk.green(`+ Router skill yazildi: ${join(routerDir, "SKILL.md")}`),
+			chalk.green(`+ Router skill written: ${join(routerDir, "SKILL.md")}`),
 		);
 	}
 
 	console.log("");
-	console.log(chalk.bold("Sonraki adimlar:"));
+	console.log(chalk.bold("Next steps:"));
 	if (dryRun) {
-		console.log("  --dry-run modu — disk degisikligi yok");
-		console.log("  Gercek bundle icin: badi publish --skill-bundle");
+		console.log("  --dry-run mode — no disk changes");
+		console.log("  For a real bundle: badi publish --skill-bundle");
 	} else {
-		console.log(`  1. ${chalk.cyan(`cd ${target}`)} — bundle ciktisini incele`);
-		console.log("  2. badi-skills repo'sundaysan: git diff, commit, tag, push");
 		console.log(
-			"  3. npm publish (ayri paket olarak yayinlanacaksa) veya GitHub release",
+			`  1. ${chalk.cyan(`cd ${target}`)} — inspect the bundle output`,
+		);
+		console.log("  2. if in the badi-skills repo: git diff, commit, tag, push");
+		console.log(
+			"  3. npm publish (if released as a separate package) or GitHub release",
 		);
 	}
 	return result;
 }
 
-// ─── Ana orkestrator ───
+// ─── Main orchestrator ───
 
 export async function runPublish(args) {
 	const sub = args[0];
 
 	if (!sub || sub === "--help" || sub === "-h") {
 		showBanner();
-		console.log(chalk.bold("Badi Publish — Release Orkestratoru"));
+		console.log(chalk.bold("Badi Publish — Release Orchestrator"));
 		console.log("");
-		console.log(chalk.bold("Kullanim:"));
+		console.log(chalk.bold("Usage:"));
 		console.log(
-			`  ${chalk.cyan("badi publish")} [secenekler]      Tum akisi calistir`,
+			`  ${chalk.cyan("badi publish")} [options]          Run the full flow`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi publish check")}             Yayin on-kontrol (git temiz mi?)`,
+			`  ${chalk.cyan("badi publish check")}             Pre-release check (is git clean?)`,
 		);
 		console.log("");
-		console.log(chalk.bold("Secenekler:"));
-		console.log("  --version <type>     patch|minor|major (varsayilan: patch)");
-		console.log("  --dry-run            Hicbir sey uygulama, adimlari goster");
-		console.log("  --skip-npm           npm publish'i atla");
-		console.log("  --skip-github        gh release create'i atla");
-		console.log("  --skip-changelog     CHANGELOG kontrolunu atla");
+		console.log(chalk.bold("Options:"));
+		console.log("  --version <type>     patch|minor|major (default: patch)");
+		console.log("  --dry-run            Apply nothing, show the steps");
+		console.log("  --skip-npm           Skip npm publish");
+		console.log("  --skip-github        Skip gh release create");
+		console.log("  --skip-changelog     Skip the CHANGELOG check");
 		console.log(
-			"  --skip-manifest-sync .claude-plugin/*.json sync'ini atla (v1.32+)",
+			"  --skip-manifest-sync Skip .claude-plugin/*.json sync (v1.32+)",
 		);
-		console.log("  -m, --message <str>  Commit mesajinda extra not");
+		console.log("  -m, --message <str>  Extra note in the commit message");
 		console.log("");
 		console.log(chalk.bold("Skill Bundle (issue #56, v1.14+):"));
 		console.log(
 			`  ${chalk.cyan("badi publish --skill-bundle")} [--source <path>] [--target <path>] [--strict] [--dry-run]`,
 		);
-		console.log("    .claude/skills/ -> <target>/skills/ bundle eder.");
-		console.log("    Eksik frontmatter alanlarini otomatik doldurur.");
-		console.log("    Router skill (skills/badi/SKILL.md) uretir.");
+		console.log("    Bundles .claude/skills/ -> <target>/skills/.");
+		console.log("    Auto-fills missing frontmatter fields.");
+		console.log("    Generates a router skill (skills/badi/SKILL.md).");
 		console.log(
-			"    --source kaynak skill dizinini override eder (default: .claude/skills)",
+			"    --source overrides the source skill directory (default: .claude/skills)",
 		);
 		console.log("");
-		console.log(chalk.bold("Adimlar (sirasiyla):"));
-		console.log("  1. Git temiz mi? (temizlik yoksa durur)");
-		console.log("  2. Branch main mi? (degilse uyari)");
-		console.log("  3. CHANGELOG yeni surum girdisi mevcut mu?");
+		console.log(chalk.bold("Steps (in order):"));
+		console.log("  1. Is git clean? (stops if not clean)");
+		console.log("  2. Is branch main? (warns if not)");
+		console.log("  3. Is there a new-version entry in CHANGELOG?");
 		console.log("  4. package.json version bump");
 		console.log(
-			"  5. .claude-plugin/{plugin,marketplace}.json sync (v1.32+, atlatilabilir)",
+			"  5. .claude-plugin/{plugin,marketplace}.json sync (v1.32+, skippable)",
 		);
-		console.log("  6. git commit (chore: release vX.Y.Z) — manifest dahil");
+		console.log("  6. git commit (chore: release vX.Y.Z) — manifest included");
 		console.log("  7. git tag vX.Y.Z");
 		console.log("  8. git push main + tag");
-		console.log("  9. gh release create (varsa)");
+		console.log("  9. gh release create (if available)");
 		console.log("  10. npm publish --access public");
 		console.log("");
-		console.log(chalk.bold("Ornekler:"));
+		console.log(chalk.bold("Examples:"));
 		console.log("  badi publish --dry-run");
 		console.log("  badi publish --version minor");
 		console.log("  badi publish --version patch --skip-github");
@@ -244,23 +244,23 @@ export async function runPublish(args) {
 	);
 	console.log("");
 
-	// 0. On kontroller
+	// 0. Pre-checks
 	if (!existsSync("package.json")) {
-		throw new Error("package.json bulunamadi — proje kokunde calistirin");
+		throw new Error("package.json not found — run from the project root");
 	}
 	const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
 	const oldVersion = pkg.version;
 	const newVersion = bumpVersion(oldVersion, flags.version);
 
-	console.log(chalk.bold("On Durum:"));
-	console.log(`  Paket:    ${chalk.cyan(pkg.name)}`);
+	console.log(chalk.bold("Pre-flight:"));
+	console.log(`  Package:  ${chalk.cyan(pkg.name)}`);
 	console.log(
-		`  Surum:    ${chalk.cyan(oldVersion)} → ${chalk.bold.green(newVersion)}`,
+		`  Version:  ${chalk.cyan(oldVersion)} → ${chalk.bold.green(newVersion)}`,
 	);
-	console.log(`  Tip:      ${chalk.cyan(flags.version)}`);
+	console.log(`  Type:     ${chalk.cyan(flags.version)}`);
 	console.log("");
 
-	// Adim sayaci — skip'ler uygulandiginda numaralar atlamasin
+	// Step counter — keep numbers contiguous when skips are applied
 	let step = 0;
 	const heading = (label) => {
 		step++;
@@ -268,27 +268,29 @@ export async function runPublish(args) {
 	};
 
 	// Git clean
-	heading("Git Durumu:");
+	heading("Git Status:");
 	if (!gitClean()) {
-		console.log(`  ${chalk.red("XX")} Calisma dizini temiz degil`);
-		console.log(chalk.dim("  Once commit et veya stashla."));
-		throw new Error("Git temiz degil");
+		console.log(`  ${chalk.red("XX")} Working directory is not clean`);
+		console.log(chalk.dim("  Commit or stash first."));
+		throw new Error("Git not clean");
 	}
-	console.log(`  ${chalk.green("OK")} Calisma dizini temiz`);
+	console.log(`  ${chalk.green("OK")} Working directory clean`);
 
-	// Branch kontrolu (ayni adimin devami, numara yok)
+	// Branch check (continuation of same step, no number)
 	const branch = currentBranch();
 	console.log(
 		`  ${branch === "main" || branch === "master" ? chalk.green("OK") : chalk.yellow("!!")} Branch: ${chalk.cyan(branch)}`,
 	);
 	if (branch !== "main" && branch !== "master") {
-		console.log(chalk.yellow("  Uyari: main/master disinda bir branch'tesin."));
+		console.log(
+			chalk.yellow("  Warning: you're on a branch other than main/master."),
+		);
 	}
 	console.log("");
 
-	// CHANGELOG kontrolu
+	// CHANGELOG check
 	if (!flags.skipChangelog) {
-		heading("CHANGELOG Kontrolu:");
+		heading("CHANGELOG Check:");
 		const cl = existsSync("CHANGELOG.md")
 			? readFileSync("CHANGELOG.md", "utf-8")
 			: "";
@@ -299,20 +301,20 @@ export async function runPublish(args) {
 		const hasEn = cl.includes(versionMarker);
 		const hasTr = clTr.includes(versionMarker);
 		console.log(
-			`  ${hasEn ? chalk.green("OK") : chalk.red("XX")} CHANGELOG.md icinde ${versionMarker} ${hasEn ? "mevcut" : "eksik"}`,
+			`  ${hasEn ? chalk.green("OK") : chalk.red("XX")} ${versionMarker} ${hasEn ? "present" : "missing"} in CHANGELOG.md`,
 		);
 		if (existsSync("CHANGELOG.tr.md")) {
 			console.log(
-				`  ${hasTr ? chalk.green("OK") : chalk.yellow("!!")} CHANGELOG.tr.md icinde ${versionMarker} ${hasTr ? "mevcut" : "eksik"}`,
+				`  ${hasTr ? chalk.green("OK") : chalk.yellow("!!")} ${versionMarker} ${hasTr ? "present" : "missing"} in CHANGELOG.tr.md`,
 			);
 		}
 		if (!hasEn) {
 			console.log(
 				chalk.dim(
-					"  Once CHANGELOG.md'ye yeni surum girdisi ekle. --skip-changelog ile atlanabilir.",
+					"  Add a new-version entry to CHANGELOG.md first. Can be skipped with --skip-changelog.",
 				),
 			);
-			throw new Error("CHANGELOG eksik");
+			throw new Error("CHANGELOG missing");
 		}
 		console.log("");
 	}
@@ -326,7 +328,7 @@ export async function runPublish(args) {
 	} else {
 		pkg.version = newVersion;
 		writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`, "utf-8");
-		// package-lock.json da varsa
+		// also package-lock.json if present
 		if (existsSync("package-lock.json")) {
 			try {
 				const lock = JSON.parse(readFileSync("package-lock.json", "utf-8"));
@@ -337,10 +339,10 @@ export async function runPublish(args) {
 					`${JSON.stringify(lock, null, 2)}\n`,
 					"utf-8",
 				);
-				console.log(`  ${chalk.green("OK")} package-lock.json da guncellendi`);
+				console.log(`  ${chalk.green("OK")} package-lock.json also updated`);
 			} catch {
 				console.log(
-					`  ${chalk.yellow("!!")} package-lock.json parse edilemedi`,
+					`  ${chalk.yellow("!!")} package-lock.json could not be parsed`,
 				);
 			}
 		}
@@ -351,9 +353,9 @@ export async function runPublish(args) {
 	console.log("");
 
 	// Plugin manifest sync (issue #196)
-	// lastUpdated salt-bilgidir (marketplace "son guncelleme" gosterimi) ve
-	// isManifestStale tarafindan dislanir; o yuzden publish-anindaki toISOString
-	// degeri yeterli — commit tarihiyle eslesmesi gerekmez (PR #197 review K1).
+	// lastUpdated is informational only (marketplace "last updated" display) and
+	// is excluded by isManifestStale; so the publish-time toISOString value is
+	// sufficient — it need not match the commit date (PR #197 review K1).
 	const pluginDirExists = existsSync(".claude-plugin");
 	let manifestSynced = false;
 	if (!flags.skipManifestSync && pluginDirExists) {
@@ -392,12 +394,10 @@ export async function runPublish(args) {
 				}
 				manifestSynced = true;
 			} catch (e) {
-				console.log(
-					`  ${chalk.red("XX")} Manifest sync basarisiz: ${e.message}`,
-				);
+				console.log(`  ${chalk.red("XX")} Manifest sync failed: ${e.message}`);
 				console.log(
 					chalk.dim(
-						"  --skip-manifest-sync ile atlanabilir; sonradan: badi release sync-manifest",
+						"  Can be skipped with --skip-manifest-sync; later: badi release sync-manifest",
 					),
 				);
 				throw e;
@@ -406,8 +406,8 @@ export async function runPublish(args) {
 		console.log("");
 	} else if (flags.skipManifestSync) {
 		heading("Plugin Manifest Sync:");
-		console.log(`  ${chalk.yellow("!!")} --skip-manifest-sync — atlandi`);
-		console.log(chalk.dim("  Sonradan manuel: badi release sync-manifest"));
+		console.log(`  ${chalk.yellow("!!")} --skip-manifest-sync — skipped`);
+		console.log(chalk.dim("  Manually later: badi release sync-manifest"));
 		console.log("");
 	}
 
@@ -436,7 +436,7 @@ export async function runPublish(args) {
 			sh("git", ["commit", "-m", commitMsg]);
 			console.log(`  ${chalk.green("OK")} Commit: ${chalk.cyan(commitMsg)}`);
 		} catch (e) {
-			console.log(`  ${chalk.red("XX")} Commit basarisiz: ${e.message}`);
+			console.log(`  ${chalk.red("XX")} Commit failed: ${e.message}`);
 			throw e;
 		}
 	}
@@ -454,7 +454,7 @@ export async function runPublish(args) {
 			sh("git", ["tag", "-a", tagName, "-m", `Release ${tagName}`]);
 			console.log(`  ${chalk.green("OK")} Tag: ${chalk.cyan(tagName)}`);
 		} catch (e) {
-			console.log(`  ${chalk.red("XX")} Tag basarisiz: ${e.message}`);
+			console.log(`  ${chalk.red("XX")} Tag failed: ${e.message}`);
 			throw e;
 		}
 	}
@@ -472,7 +472,7 @@ export async function runPublish(args) {
 			sh("git", ["push", "origin", tagName]);
 			console.log(`  ${chalk.green("OK")} Tag push: ${chalk.cyan(tagName)}`);
 		} catch (e) {
-			console.log(`  ${chalk.red("XX")} Push basarisiz: ${e.message}`);
+			console.log(`  ${chalk.red("XX")} Push failed: ${e.message}`);
 			throw e;
 		}
 	}
@@ -482,7 +482,7 @@ export async function runPublish(args) {
 	if (!flags.skipGithub) {
 		heading("GitHub Release:");
 		if (!hasCommand("gh")) {
-			console.log(`  ${chalk.yellow("!!")} gh CLI yok — atlaniyor`);
+			console.log(`  ${chalk.yellow("!!")} gh CLI not found — skipping`);
 			console.log(chalk.dim("  brew install gh && gh auth login"));
 		} else {
 			const releaseArgs = [
@@ -503,7 +503,7 @@ export async function runPublish(args) {
 					);
 				} catch (e) {
 					console.log(
-						`  ${chalk.yellow("!!")} GitHub release basarisiz (devam ediliyor): ${e.message.substring(0, 200)}`,
+						`  ${chalk.yellow("!!")} GitHub release failed (continuing): ${e.message.substring(0, 200)}`,
 					);
 				}
 			}
@@ -518,20 +518,20 @@ export async function runPublish(args) {
 			console.log(chalk.dim("  [dry] npm publish --access public"));
 		} else {
 			try {
-				// 2FA gerekebilir — stdio inherit ile etkilesim izin ver
+				// 2FA may be required — allow interaction via stdio inherit
 				const res = spawnSync("npm", ["publish", "--access", "public"], {
 					stdio: "inherit",
 				});
 				if (res.status !== 0) {
 					console.log(
-						`  ${chalk.red("XX")} npm publish basarisiz (npm whoami kontrol et)`,
+						`  ${chalk.red("XX")} npm publish failed (check npm whoami)`,
 					);
-					console.log(chalk.dim("  Login: npm login (2FA gerekli olabilir)"));
+					console.log(chalk.dim("  Login: npm login (2FA may be required)"));
 				} else {
-					console.log(`  ${chalk.green("OK")} npm publish tamamlandi`);
+					console.log(`  ${chalk.green("OK")} npm publish complete`);
 				}
 			} catch (e) {
-				console.log(`  ${chalk.yellow("!!")} npm publish hatasi: ${e.message}`);
+				console.log(`  ${chalk.yellow("!!")} npm publish error: ${e.message}`);
 			}
 		}
 		console.log("");
@@ -539,12 +539,12 @@ export async function runPublish(args) {
 
 	console.log(
 		chalk.bold.green(
-			`${flags.dryRun ? "[DRY RUN] " : ""}Release v${newVersion} hazir!`,
+			`${flags.dryRun ? "[DRY RUN] " : ""}Release v${newVersion} ready!`,
 		),
 	);
 	if (!flags.dryRun) {
 		console.log("");
-		console.log(chalk.bold("Sonraki adimlar:"));
+		console.log(chalk.bold("Next steps:"));
 		console.log(`  - npm: https://www.npmjs.com/package/${pkg.name}`);
 		console.log(`  - GitHub: git log --oneline -1`);
 	}
@@ -552,14 +552,14 @@ export async function runPublish(args) {
 
 function publishCheck() {
 	showBanner();
-	console.log(chalk.bold("Publish On-Kontrol"));
+	console.log(chalk.bold("Publish Pre-check"));
 	console.log("");
 
 	const checks = [];
 
-	// Git temiz
+	// Git clean
 	const clean = gitClean();
-	checks.push([clean, `Git durumu temiz`, clean ? "" : "git status -s"]);
+	checks.push([clean, `Git status clean`, clean ? "" : "git status -s"]);
 
 	// Branch
 	const branch = currentBranch();
@@ -568,44 +568,44 @@ function publishCheck() {
 
 	// package.json
 	const hasPkg = existsSync("package.json");
-	checks.push([hasPkg, `package.json mevcut`, ""]);
+	checks.push([hasPkg, `package.json present`, ""]);
 
 	if (hasPkg) {
 		const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
 		checks.push([
 			!!pkg.version,
-			`package.json version tanimli (${pkg.version || "?"})`,
+			`package.json version defined (${pkg.version || "?"})`,
 			"",
 		]);
 		checks.push([
 			!!pkg.name,
-			`package.json name tanimli (${pkg.name || "?"})`,
+			`package.json name defined (${pkg.name || "?"})`,
 			"",
 		]);
 		const hasFiles = Array.isArray(pkg.files) && pkg.files.length > 0;
 		checks.push([
 			hasFiles,
-			`package.json files array mevcut`,
-			hasFiles ? "" : "npm publish tum dizini gondermeli degil",
+			`package.json files array present`,
+			hasFiles ? "" : "npm publish should not ship the whole directory",
 		]);
 	}
 
 	// CHANGELOG
-	checks.push([existsSync("CHANGELOG.md"), `CHANGELOG.md mevcut`, ""]);
+	checks.push([existsSync("CHANGELOG.md"), `CHANGELOG.md present`, ""]);
 
 	// gh CLI
 	checks.push([
 		hasCommand("gh"),
-		`gh CLI kurulu`,
+		`gh CLI installed`,
 		hasCommand("gh") ? "" : "brew install gh",
 	]);
 
 	// npm auth
 	try {
 		const who = sh("npm", ["whoami"]);
-		checks.push([true, `npm kullanicisi: ${who}`, ""]);
+		checks.push([true, `npm user: ${who}`, ""]);
 	} catch {
-		checks.push([false, `npm whoami basarisiz`, "npm login"]);
+		checks.push([false, `npm whoami failed`, "npm login"]);
 	}
 
 	let ok = 0;
@@ -623,6 +623,6 @@ function publishCheck() {
 	}
 
 	console.log("");
-	console.log(chalk.bold(`${ok}/${total} kontrol gecti`));
+	console.log(chalk.bold(`${ok}/${total} checks passed`));
 	if (ok < total) process.exit(1);
 }

--- a/tests/cli.dev.test.js
+++ b/tests/cli.dev.test.js
@@ -26,7 +26,7 @@ describe("badi dev", () => {
 
 	it("api-test yardim gosterir", () => {
 		const out = run("dev", "api-test");
-		assert.ok(out.includes("API") || out.includes("Kullanim"));
+		assert.ok(out.includes("API") || out.includes("Usage"));
 	});
 
 	it("bilinmeyen komut hata verir", () => {

--- a/tests/cli.mobile.test.js
+++ b/tests/cli.mobile.test.js
@@ -13,14 +13,14 @@ const run = (...args) =>
 describe("badi mobile", () => {
 	it("yardim gosterir", () => {
 		const out = run("mobile", "--help");
-		assert.ok(out.includes("Mobil Gelistirme"));
+		assert.ok(out.includes("Mobile Development"));
 		assert.ok(out.includes("badi mobile init"));
 		assert.ok(out.includes("badi mobile build"));
 	});
 
 	it("argumansiz yardim gosterir", () => {
 		const out = run("mobile");
-		assert.ok(out.includes("Mobil Gelistirme"));
+		assert.ok(out.includes("Mobile Development"));
 	});
 
 	it("init proje adi olmadan hata verir", () => {

--- a/tests/cli.publish.test.js
+++ b/tests/cli.publish.test.js
@@ -15,7 +15,7 @@ const run = (...args) =>
 describe("badi publish", () => {
 	it("--help yardim gosterir", () => {
 		const out = run("publish", "--help");
-		assert.ok(out.includes("Release Orkestratoru") || out.includes("Publish"));
+		assert.ok(out.includes("Release Orchestrator") || out.includes("Publish"));
 		assert.ok(out.includes("--version"));
 		assert.ok(out.includes("--dry-run"));
 		assert.ok(out.includes("--skip-npm"));
@@ -50,7 +50,7 @@ describe("badi publish", () => {
 		const out = run("publish", "--help");
 		assert.ok(out.includes("--skill-bundle"));
 		assert.ok(out.includes("badi-skills"));
-		assert.ok(out.includes("Router skill"));
+		assert.ok(out.includes("router skill"));
 	});
 
 	it("--skip-manifest-sync flag yardim metninde gorunur (#196)", () => {
@@ -64,7 +64,7 @@ describe("badi publish", () => {
 			"manifest sync adimi listed",
 		);
 		assert.ok(
-			out.includes("manifest dahil"),
+			out.includes("manifest included"),
 			"commit adimi manifest'i kapsadigini soyler",
 		);
 	});
@@ -104,7 +104,7 @@ metadata:
 			{ encoding: "utf-8", cwd, timeout: 10000 },
 		);
 		assert.match(out, /DRY RUN/);
-		assert.match(out, /1 skill bundle edildi/);
+		assert.match(out, /1 skills bundled/);
 	});
 
 	it("--skill-bundle gercek modda target dizini yazar", () => {
@@ -115,8 +115,8 @@ metadata:
 			[BIN, "publish", "--skill-bundle", "--target", target],
 			{ encoding: "utf-8", cwd, timeout: 10000 },
 		);
-		assert.match(out, /1 skill bundle edildi/);
-		assert.match(out, /Router skill yazildi/);
+		assert.match(out, /1 skills bundled/);
+		assert.match(out, /Router skill written/);
 		assert.ok(
 			existsSync(join(target, "skills", "frontend-taste", "SKILL.md")),
 			"target SKILL.md should exist",


### PR DESCRIPTION
## Phase 2j — English-only migration (#207)

Translates all user-facing CLI output and comments to English across the **developer-workflow command cluster** (mobile + dev + publish). Subcommand names, flags, and embedded code snippets stay verbatim — no interface renames in this batch.

### Changed
- **mobile.js** (1226 ln) — init / version / build / release / assets / crash-setup / deeplink / ota output, help text, error messages, guide labels. The Sentry/Firebase/EAS/CodePush **code snippets are preserved verbatim** (only their Turkish step labels translated). The `mobileRelease` guide-line color classifier was updated to match the new English headers (`With Fastlane:` / `From CLI:` / `With bundletool:` / `Tip:`).
- **dev.js** (704 ln) — deps / bundle / docker-lint / env-check / api-test output, comments, help text, error messages
- **publish.js** (628 ln) — release orchestrator + skill-bundle output, step headings, CHANGELOG / manifest / commit / tag / push / npm messages, pre-check, help text

### Tests
Updated in lockstep:
- `cli.mobile.test.js` — `Mobil Gelistirme` → `Mobile Development`
- `cli.dev.test.js` — dead `Kullanim` branch → `Usage`
- `cli.publish.test.js` — `Release Orkestratoru`→`Release Orchestrator`, `skill bundle edildi`→`skills bundled`, `Router skill yazildi`→`Router skill written`, `manifest dahil`→`manifest included`, `Router skill`→`router skill`

Turkish `it()` descriptions and test-fixture data left for a later phase, consistent with prior batches.

### Verification
- `npm run lint` — clean (3 files auto-formatted after translation)
- `npm test` — **1132/1132 pass**
- Guard grep — no Turkish console strings remain (8 apparent hits in mobile.js are the substring "proje" inside "**proje**ct")

🤖 Generated with [Claude Code](https://claude.com/claude-code)