### PR TITLE
feat(i18n): English-only Phase 2k — ai, wp CLI output

### DIFF
--- a/lib/commands/ai.js
+++ b/lib/commands/ai.js
@@ -10,7 +10,7 @@ import { homedir } from "node:os";
 import { extname, join, relative } from "node:path";
 import { chalk, showBanner } from "../cli.js";
 
-// Kabaca token sayimi (OpenAI tiktoken'a yakin): 1 token ~= 4 karakter (EN), Turkce'de ~3.5
+// Rough token count (close to OpenAI tiktoken): 1 token ~= 4 chars (EN), ~3.5 in Turkish
 function estimateTokens(text) {
 	return Math.ceil(text.length / 3.8);
 }
@@ -45,12 +45,12 @@ function walkDir(dir, exts = [".md", ".json", ".sh"]) {
 
 function aiToken() {
 	showBanner();
-	console.log(chalk.bold("Token Kullanim Analizi (.claude/)"));
+	console.log(chalk.bold("Token Usage Analysis (.claude/)"));
 	console.log("");
 
 	const claudeDir = join(process.cwd(), ".claude");
 	if (!existsSync(claudeDir)) {
-		console.error(chalk.red(".claude/ dizini bulunamadi"));
+		console.error(chalk.red(".claude/ directory not found"));
 		process.exit(1);
 	}
 
@@ -97,7 +97,7 @@ function aiToken() {
 		claudeMdTokens = estimateTokens(readFileSync(claudeMd, "utf-8"));
 	}
 
-	console.log(chalk.bold("Kategori Bazli:"));
+	console.log(chalk.bold("By Category:"));
 	const maxLabel = 12;
 	for (const [cat, tokens] of Object.entries(categories)) {
 		if (tokens === 0) continue;
@@ -111,19 +111,19 @@ function aiToken() {
 	}
 
 	console.log("");
-	console.log(chalk.bold("Toplam:"));
-	console.log(`  Dosya sayisi:  ${chalk.cyan(totalFiles)}`);
+	console.log(chalk.bold("Total:"));
+	console.log(`  File count:       ${chalk.cyan(totalFiles)}`);
 	console.log(
-		`  Toplam bayt:   ${chalk.cyan(`${(totalBytes / 1024).toFixed(1)} KB`)}`,
+		`  Total bytes:      ${chalk.cyan(`${(totalBytes / 1024).toFixed(1)} KB`)}`,
 	);
 	console.log(
-		`  Tahmini token: ${chalk.bold.cyan(totalTokens)} (~${Math.round(totalTokens / 1000)}K)`,
+		`  Estimated tokens: ${chalk.bold.cyan(totalTokens)} (~${Math.round(totalTokens / 1000)}K)`,
 	);
 	if (claudeMdTokens > 0) {
-		console.log(`  CLAUDE.md:     ${chalk.cyan(claudeMdTokens)} tokens`);
+		console.log(`  CLAUDE.md:        ${chalk.cyan(claudeMdTokens)} tokens`);
 	}
 
-	// v1.17+ opt-in skill bilgilendirmesi: vault yuklenmiyor, ayri raporla
+	// v1.17+ opt-in skill note: the vault is not loaded, report it separately
 	const vaultDir = join(claudeDir, "skills-vault");
 	if (existsSync(vaultDir)) {
 		let vaultTokens = 0;
@@ -136,14 +136,14 @@ function aiToken() {
 		}
 		if (vaultTokens > 0) {
 			console.log(
-				`  ${chalk.dim("Vault (yuklenmez):")}  ${chalk.dim(vaultTokens)} tokens ${chalk.dim("— 'badi skills' ile sec")}`,
+				`  ${chalk.dim("Vault (not loaded):")}  ${chalk.dim(vaultTokens)} tokens ${chalk.dim("— select with 'badi skills'")}`,
 			);
 		}
 	}
 
-	// En buyuk dosyalar
+	// Largest files
 	console.log("");
-	console.log(chalk.bold("En Buyuk 10 Dosya:"));
+	console.log(chalk.bold("Largest 10 Files:"));
 	const allFiles = [
 		...fileList.agents,
 		...fileList.commands,
@@ -157,19 +157,21 @@ function aiToken() {
 		);
 	}
 
-	// Uyarilar
+	// Warnings
 	console.log("");
 	if (totalTokens > 150000) {
 		console.log(
-			chalk.red("UYARI: Toplam token yuksek. Optimizasyon oneriler:"),
+			chalk.red("WARNING: Total tokens are high. Optimization suggestions:"),
 		);
-		console.log(chalk.dim("  - Buyuk SKILL.md'leri referans dosyalara bol"));
-		console.log(chalk.dim("  - Unused commandlari kaldir"));
-		console.log(chalk.dim("  - CLAUDE.md'yi minimize et"));
+		console.log(
+			chalk.dim("  - Split large SKILL.md files into reference files"),
+		);
+		console.log(chalk.dim("  - Remove unused commands"));
+		console.log(chalk.dim("  - Minimize CLAUDE.md"));
 	} else if (totalTokens > 80000) {
-		console.log(chalk.yellow("Token kullanimi orta. Izlemeye devam edin."));
+		console.log(chalk.yellow("Token usage is moderate. Keep monitoring."));
 	} else {
-		console.log(chalk.green("Token kullanimi saglikli."));
+		console.log(chalk.green("Token usage is healthy."));
 	}
 }
 
@@ -177,7 +179,7 @@ function aiToken() {
 
 function aiPromptTest() {
 	showBanner();
-	console.log(chalk.bold("Prompt Regression Testi"));
+	console.log(chalk.bold("Prompt Regression Test"));
 	console.log("");
 
 	const commandsDir = join(process.cwd(), ".claude", "commands");
@@ -190,33 +192,33 @@ function aiPromptTest() {
 		const name = relative(process.cwd(), path);
 		checked++;
 
-		// Bos dosya
+		// Empty file
 		if (content.trim().length < 50) {
 			console.log(
-				`  ${chalk.red("XX")} ${name} — cok kisa (${content.trim().length} char)`,
+				`  ${chalk.red("XX")} ${name} — too short (${content.trim().length} chars)`,
 			);
 			issues++;
 			return;
 		}
 
-		// Agent frontmatter kontrolu
+		// Agent frontmatter check
 		if (type === "agent") {
 			if (!content.startsWith("---")) {
-				console.log(`  ${chalk.red("XX")} ${name} — frontmatter eksik`);
+				console.log(`  ${chalk.red("XX")} ${name} — frontmatter missing`);
 				issues++;
 			} else {
 				const hasName = /^name:\s*\S/m.test(content);
 				const hasDesc = /^description:\s*\S/m.test(content);
 				if (!hasName || !hasDesc) {
 					console.log(
-						`  ${chalk.yellow("!!")} ${name} — name/description eksik`,
+						`  ${chalk.yellow("!!")} ${name} — name/description missing`,
 					);
 					issues++;
 				}
 			}
 		}
 
-		// TODO/TBD/FIXME kontrolu (production icin)
+		// TODO/TBD/FIXME check (for production)
 		const todos = content.match(/\b(TODO|TBD|FIXME|XXX)\b/g);
 		if (todos && todos.length > 0) {
 			console.log(
@@ -225,18 +227,18 @@ function aiPromptTest() {
 			issues++;
 		}
 
-		// Cok uzun tek satir (formatting bozuk olabilir)
+		// Very long single line (formatting may be broken)
 		const lines = content.split("\n");
 		const longLines = lines.filter((l) => l.length > 500).length;
 		if (longLines > 0) {
 			console.log(
-				`  ${chalk.yellow("!!")} ${name} — ${longLines} uzun satir (>500 char)`,
+				`  ${chalk.yellow("!!")} ${name} — ${longLines} long lines (>500 chars)`,
 			);
 			issues++;
 		}
 	}
 
-	console.log(chalk.bold("Slash Komutlari:"));
+	console.log(chalk.bold("Slash Commands:"));
 	if (existsSync(commandsDir)) {
 		for (const f of readdirSync(commandsDir).filter((f) => f.endsWith(".md"))) {
 			checkFile(join(commandsDir, f), "command");
@@ -244,7 +246,7 @@ function aiPromptTest() {
 	}
 
 	console.log("");
-	console.log(chalk.bold("Ajanlar:"));
+	console.log(chalk.bold("Agents:"));
 	if (existsSync(agentsDir)) {
 		for (const f of readdirSync(agentsDir).filter((f) => f.endsWith(".md"))) {
 			checkFile(join(agentsDir, f), "agent");
@@ -253,12 +255,10 @@ function aiPromptTest() {
 
 	console.log("");
 	if (issues === 0) {
-		console.log(chalk.bold.green(`${checked} dosya temiz!`));
+		console.log(chalk.bold.green(`${checked} files clean!`));
 	} else {
 		console.log(
-			chalk.bold.yellow(
-				`${checked} dosya kontrol edildi, ${issues} sorun tespit edildi.`,
-			),
+			chalk.bold.yellow(`${checked} files checked, ${issues} issues found.`),
 		);
 	}
 }
@@ -271,7 +271,7 @@ function aiMemoryDiff() {
 	const globalMemDir = join(homedir(), ".claude", "projects");
 
 	showBanner();
-	console.log(chalk.bold("Memory Analizi"));
+	console.log(chalk.bold("Memory Analysis"));
 	console.log("");
 
 	if (existsSync(memoryFile)) {
@@ -285,12 +285,12 @@ function aiMemoryDiff() {
 				: lines > limit * 0.8
 					? chalk.yellow
 					: chalk.green;
-		console.log(chalk.bold("Oturum Memory (.claude/memory.md):"));
-		console.log(`  Satir: ${color(lines)} / ${limit}`);
+		console.log(chalk.bold("Session Memory (.claude/memory.md):"));
+		console.log(`  Lines: ${color(lines)} / ${limit}`);
 		console.log(`  Token: ${chalk.cyan(tokens)}`);
 		if (lines > limit) {
 			console.log(
-				chalk.yellow("  UYARI: Sinir asildi. Konsolidasyon onerilir."),
+				chalk.yellow("  WARNING: Limit exceeded. Consolidation recommended."),
 			);
 		}
 		console.log("");
@@ -307,35 +307,35 @@ function aiMemoryDiff() {
 				: lines > limit * 0.8
 					? chalk.yellow
 					: chalk.green;
-		console.log(chalk.bold("Bilgi Tabani (.claude/knowledge-base.md):"));
-		console.log(`  Satir: ${color(lines)} / ${limit}`);
+		console.log(chalk.bold("Knowledge Base (.claude/knowledge-base.md):"));
+		console.log(`  Lines: ${color(lines)} / ${limit}`);
 		console.log(`  Token: ${chalk.cyan(tokens)}`);
-		// TBD/TODO kontrol
+		// TBD/TODO check
 		const forbidden = content.match(/\b(TBD|TODO|FIXME)\b/g);
 		if (forbidden && forbidden.length > 0) {
 			console.log(
 				chalk.red(
-					`  UYARI: ${forbidden.length} adet TBD/TODO/FIXME — knowledge-base'de YASAK`,
+					`  WARNING: ${forbidden.length} TBD/TODO/FIXME — FORBIDDEN in knowledge-base`,
 				),
 			);
 		}
 		console.log("");
 	}
 
-	// Global projects karsilastirmasi (varsa)
+	// Global projects comparison (if any)
 	if (existsSync(globalMemDir)) {
 		const projects = readdirSync(globalMemDir, { withFileTypes: true })
 			.filter((d) => d.isDirectory())
 			.map((d) => d.name);
 		if (projects.length > 1) {
-			console.log(chalk.bold(`Global Memory Projeleri (${projects.length}):`));
+			console.log(chalk.bold(`Global Memory Projects (${projects.length}):`));
 			for (const p of projects.slice(0, 10)) {
 				const memFile = join(globalMemDir, p, "memory", "MEMORY.md");
 				if (existsSync(memFile)) {
 					try {
 						const c = readFileSync(memFile, "utf-8");
 						console.log(
-							`  ${chalk.dim(p.padEnd(40))} ${chalk.cyan(`${c.split("\n").length} satir`)}`,
+							`  ${chalk.dim(p.padEnd(40))} ${chalk.cyan(`${c.split("\n").length} lines`)}`,
 						);
 					} catch {
 						/* */
@@ -355,32 +355,32 @@ async function aiReview() {
 
 	const apiKey = process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
 	if (!apiKey) {
-		console.error(chalk.red("ANTHROPIC_API_KEY tanimli degil."));
-		console.log(chalk.dim("Kurulum: export ANTHROPIC_API_KEY=sk-ant-..."));
+		console.error(chalk.red("ANTHROPIC_API_KEY is not set."));
+		console.log(chalk.dim("Setup: export ANTHROPIC_API_KEY=sk-ant-..."));
 		console.log(
-			chalk.dim("Kayit: https://console.anthropic.com/settings/keys"),
+			chalk.dim("Sign up: https://console.anthropic.com/settings/keys"),
 		);
 		process.exit(1);
 	}
 
-	// Staged diff al
+	// Get the staged diff
 	let diff;
 	try {
 		diff = execFileSync("git", ["diff", "--cached"], { encoding: "utf-8" });
 	} catch {
-		console.error(chalk.red("git diff hatasi"));
+		console.error(chalk.red("git diff error"));
 		process.exit(1);
 	}
 
 	if (!diff || diff.trim().length < 50) {
-		console.log(chalk.yellow("Staged degisiklik yok. Once git add ..."));
+		console.log(chalk.yellow("No staged changes. Run git add ... first."));
 		return;
 	}
 
 	if (diff.length > 50000) {
 		console.log(
 			chalk.yellow(
-				`Diff cok buyuk (${(diff.length / 1024).toFixed(1)}KB). Ilk 50KB gonderilecek.`,
+				`Diff too large (${(diff.length / 1024).toFixed(1)}KB). First 50KB will be sent.`,
 			),
 		);
 		diff = diff.substring(0, 50000);
@@ -388,19 +388,19 @@ async function aiReview() {
 
 	console.log(
 		chalk.cyan(
-			`Claude API'ye gonderiliyor (${(diff.length / 1024).toFixed(1)}KB)...`,
+			`Sending to the Claude API (${(diff.length / 1024).toFixed(1)}KB)...`,
 		),
 	);
 	console.log("");
 
-	const systemPrompt = `Sen kidemli bir kod incelemecisisin. Staged git diff'i incele ve su kategorilerde bulgular raporla:
-1. KRITIK guvenlik sorunlari
-2. Bug potansiyeli
-3. Performans sorunlari
-4. Kod kalitesi (DRY, naming, complexity)
-5. Olumlu gozlemler
+	const systemPrompt = `You are a senior code reviewer. Review the staged git diff and report findings in these categories:
+1. CRITICAL security issues
+2. Potential bugs
+3. Performance issues
+4. Code quality (DRY, naming, complexity)
+5. Positive observations
 
-Kisa ve somut ol. Her bulgu icin dosya:satir referansi ver. Turkce yaz.`;
+Be concise and concrete. Give a file:line reference for each finding. Write in English.`;
 
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), 60000);
@@ -421,7 +421,7 @@ Kisa ve somut ol. Her bulgu icin dosya:satir referansi ver. Turkce yaz.`;
 				messages: [
 					{
 						role: "user",
-						content: `Git diff incelemesi:\n\n\`\`\`diff\n${diff}\n\`\`\``,
+						content: `Git diff review:\n\n\`\`\`diff\n${diff}\n\`\`\``,
 					},
 				],
 			}),
@@ -430,14 +430,14 @@ Kisa ve somut ol. Her bulgu icin dosya:satir referansi ver. Turkce yaz.`;
 
 		if (!res.ok) {
 			const err = await res.text();
-			console.error(chalk.red(`API hatasi: ${res.status}`));
+			console.error(chalk.red(`API error: ${res.status}`));
 			console.error(chalk.dim(err.substring(0, 500)));
 			process.exit(1);
 		}
 
 		const data = await res.json();
-		const review = data.content?.[0]?.text || "(bos yanit)";
-		console.log(chalk.bold("Kod Incelemesi:"));
+		const review = data.content?.[0]?.text || "(empty response)";
+		console.log(chalk.bold("Code Review:"));
 		console.log("");
 		console.log(review);
 		console.log("");
@@ -448,7 +448,7 @@ Kisa ve somut ol. Her bulgu icin dosya:satir referansi ver. Turkce yaz.`;
 		);
 	} catch (e) {
 		clearTimeout(timeout);
-		console.error(chalk.red(`Hata: ${e.message}`));
+		console.error(chalk.red(`Error: ${e.message}`));
 		process.exit(1);
 	}
 }
@@ -459,18 +459,18 @@ async function aiTranslate(args) {
 	const sourceFile = args[0];
 	if (!sourceFile) {
 		console.error(
-			chalk.red("Kaynak dosya gerekli: badi ai translate [file.md] --to en"),
+			chalk.red("Source file required: badi ai translate [file.md] --to en"),
 		);
 		process.exit(1);
 	}
 	if (!existsSync(sourceFile)) {
-		console.error(chalk.red(`Dosya bulunamadi: ${sourceFile}`));
+		console.error(chalk.red(`File not found: ${sourceFile}`));
 		process.exit(1);
 	}
 
 	const apiKey = process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
 	if (!apiKey) {
-		console.error(chalk.red("ANTHROPIC_API_KEY tanimli degil."));
+		console.error(chalk.red("ANTHROPIC_API_KEY is not set."));
 		process.exit(1);
 	}
 
@@ -480,13 +480,15 @@ async function aiTranslate(args) {
 
 	const content = readFileSync(sourceFile, "utf-8");
 	if (content.length > 30000) {
-		console.error(chalk.red("Dosya cok buyuk (>30KB). Boleek gonderin."));
+		console.error(chalk.red("File too large (>30KB). Send in chunks."));
 		process.exit(1);
 	}
 
 	showBanner();
 	console.log(
-		chalk.bold(`Icerik Cevirisi: ${sourceFile} -> ${targetLang.toUpperCase()}`),
+		chalk.bold(
+			`Content Translation: ${sourceFile} -> ${targetLang.toUpperCase()}`,
+		),
 	);
 	console.log("");
 
@@ -499,7 +501,7 @@ async function aiTranslate(args) {
 	};
 	const targetName = langMap[targetLang] || targetLang;
 
-	const systemPrompt = `Icerik cevirisi uzmanisin. Sosyal medya/blog icerik tonunu koru. Markdown formatini bozma. Hashtag'leri ve teknik terimleri uygun sekilde lokalize et.`;
+	const systemPrompt = `You are a content translation expert. Preserve the social-media/blog content tone. Don't break the markdown formatting. Localize hashtags and technical terms appropriately.`;
 
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), 60000);
@@ -520,7 +522,7 @@ async function aiTranslate(args) {
 				messages: [
 					{
 						role: "user",
-						content: `Bu icerigi ${targetName}'ya cevir. Markdown yapisini koru.\n\n${content}`,
+						content: `Translate this content to ${targetName}. Preserve the markdown structure.\n\n${content}`,
 					},
 				],
 			}),
@@ -529,7 +531,7 @@ async function aiTranslate(args) {
 
 		if (!res.ok) {
 			const err = await res.text();
-			console.error(chalk.red(`API hatasi: ${res.status}`));
+			console.error(chalk.red(`API error: ${res.status}`));
 			console.error(chalk.dim(err.substring(0, 500)));
 			process.exit(1);
 		}
@@ -537,14 +539,14 @@ async function aiTranslate(args) {
 		const data = await res.json();
 		const translated = data.content?.[0]?.text || "";
 
-		// Dosyaya yaz
+		// Write to file
 		const ext = extname(sourceFile);
 		const base = sourceFile.substring(0, sourceFile.length - ext.length);
 		const outFile = `${base}-${targetLang}${ext}`;
 		writeFileSync(outFile, translated);
 
-		console.log(chalk.bold.green("Ceviri tamamlandi!"));
-		console.log(`  Cikti: ${chalk.cyan(outFile)}`);
+		console.log(chalk.bold.green("Translation complete!"));
+		console.log(`  Output: ${chalk.cyan(outFile)}`);
 		console.log(
 			chalk.dim(
 				`  Model: ${data.model}  Tokens: in=${data.usage?.input_tokens} out=${data.usage?.output_tokens}`,
@@ -552,43 +554,43 @@ async function aiTranslate(args) {
 		);
 	} catch (e) {
 		clearTimeout(timeout);
-		console.error(chalk.red(`Hata: ${e.message}`));
+		console.error(chalk.red(`Error: ${e.message}`));
 		process.exit(1);
 	}
 }
 
-// ─── Ana komut ───
+// ─── Main command ───
 
 export async function runAi(args) {
 	const sub = args[0];
 
 	if (!sub || sub === "--help" || sub === "-h") {
 		showBanner();
-		console.log(chalk.bold("AI/LLM Araclari:"));
+		console.log(chalk.bold("AI/LLM Tools:"));
 		console.log("");
-		console.log(chalk.bold.cyan("Analiz (API gerektirmez):"));
+		console.log(chalk.bold.cyan("Analysis (no API required):"));
 		console.log(
-			`  ${chalk.cyan("badi ai token")}           Token kullanim analizi (.claude/)`,
+			`  ${chalk.cyan("badi ai token")}           Token usage analysis (.claude/)`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi ai prompt-test")}     Slash/ajan dosyalari regression`,
+			`  ${chalk.cyan("badi ai prompt-test")}     Slash/agent files regression`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi ai memory-diff")}     memory.md + knowledge-base limit analizi`,
-		);
-		console.log("");
-		console.log(chalk.bold.cyan("Claude API (ANTHROPIC_API_KEY gerekli):"));
-		console.log(
-			`  ${chalk.cyan("badi ai review")}          Staged diff AI kod review`,
-		);
-		console.log(
-			`  ${chalk.cyan("badi ai translate [file]")} Markdown cevirisi (--to en|de|fr)`,
+			`  ${chalk.cyan("badi ai memory-diff")}     memory.md + knowledge-base limit analysis`,
 		);
 		console.log("");
-		console.log(chalk.bold("API Anahtari:"));
+		console.log(chalk.bold.cyan("Claude API (ANTHROPIC_API_KEY required):"));
+		console.log(
+			`  ${chalk.cyan("badi ai review")}          Staged diff AI code review`,
+		);
+		console.log(
+			`  ${chalk.cyan("badi ai translate [file]")} Markdown translation (--to en|de|fr)`,
+		);
+		console.log("");
+		console.log(chalk.bold("API Key:"));
 		console.log(chalk.dim("  export ANTHROPIC_API_KEY=sk-ant-..."));
 		console.log(
-			chalk.dim("  Kayit: https://console.anthropic.com/settings/keys"),
+			chalk.dim("  Sign up: https://console.anthropic.com/settings/keys"),
 		);
 		return;
 	}
@@ -611,14 +613,14 @@ export async function runAi(args) {
 				await aiTranslate(args.slice(1));
 				break;
 			default:
-				console.error(chalk.red(`Bilinmeyen ai komutu: ${sub}`));
+				console.error(chalk.red(`Unknown ai command: ${sub}`));
 				console.log(
-					"Kullanim: badi ai [token|prompt-test|memory-diff|review|translate]",
+					"Usage: badi ai [token|prompt-test|memory-diff|review|translate]",
 				);
 				process.exit(1);
 		}
 	} catch (e) {
-		console.error(chalk.red(`Hata: ${e.message}`));
+		console.error(chalk.red(`Error: ${e.message}`));
 		process.exit(1);
 	}
 }

--- a/lib/commands/wp.js
+++ b/lib/commands/wp.js
@@ -4,13 +4,13 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { chalk, showBanner } from "../cli.js";
 
-// ─── Site Konfigurasyonu ───
+// ─── Site Configuration ───
 
 const CONFIG_DIR = join(homedir(), ".config", "badi");
 const SITES_FILE = join(CONFIG_DIR, "wp-sites.json");
 
-// Kucuk obfuscation — shoulder surfing'e karsi, gercek sifre koruma degil.
-// v2.0'da keytar entegrasyonu eklenecek.
+// Light obfuscation — against shoulder surfing, not real password protection.
+// keytar integration to be added in v2.0.
 function obfuscate(s) {
 	return s ? `b64:${Buffer.from(s).toString("base64")}` : s;
 }
@@ -33,7 +33,7 @@ function loadSites() {
 			return data;
 		}
 	} catch {
-		/* bozuk dosya */
+		/* corrupt file */
 	}
 	return { sites: [] };
 }
@@ -54,7 +54,7 @@ function findSite(alias) {
 	return data.sites.find((s) => s.alias === alias || s.url === alias);
 }
 
-// ─── WP-CLI Yardimcilari ───
+// ─── WP-CLI Helpers ───
 
 function _hasWpCli() {
 	try {
@@ -88,7 +88,7 @@ function getSiteArgs(site) {
 	return args;
 }
 
-// ─── WP REST API Yardimcilari ───
+// ─── WP REST API Helpers ───
 
 async function _wpApi(site, endpoint) {
 	const baseUrl = site.url.replace(/\/$/, "");
@@ -109,7 +109,7 @@ async function _wpApi(site, endpoint) {
 		return await res.json();
 	} catch (e) {
 		clearTimeout(timeout);
-		throw new Error(`API hatasi: ${e.message}`);
+		throw new Error(`API error: ${e.message}`);
 	}
 }
 
@@ -126,14 +126,14 @@ async function wpApiRoot(site) {
 		return await res.json();
 	} catch (e) {
 		clearTimeout(timeout);
-		throw new Error(`API hatasi: ${e.message}`);
+		throw new Error(`API error: ${e.message}`);
 	}
 }
 
-// ─── Alt Komutlar ───
+// ─── Subcommands ───
 
 async function wpStatus(site) {
-	console.log(chalk.bold(`WordPress Durum: ${site.alias}`));
+	console.log(chalk.bold(`WordPress Status: ${site.alias}`));
 	console.log(`  URL: ${chalk.cyan(site.url)}`);
 	console.log("");
 
@@ -141,7 +141,7 @@ async function wpStatus(site) {
 		const siteArgs = getSiteArgs(site);
 		try {
 			const version = wpCmd(siteArgs, ["core", "version"]);
-			console.log(`  WP Surumu:   ${chalk.green(version)}`);
+			console.log(`  WP Version:  ${chalk.green(version)}`);
 
 			const theme = wpCmd(siteArgs, [
 				"theme",
@@ -153,7 +153,7 @@ async function wpStatus(site) {
 			const themeLines = theme.split("\n").slice(1);
 			for (const line of themeLines) {
 				const [name, ver] = line.split(",");
-				console.log(`  Aktif Tema:  ${chalk.cyan(name)} v${ver}`);
+				console.log(`  Active Theme: ${chalk.cyan(name)} v${ver}`);
 			}
 
 			const plugins = wpCmd(siteArgs, [
@@ -171,7 +171,7 @@ async function wpStatus(site) {
 				if (parts[3] === "available") updateCount++;
 			}
 			console.log(
-				`  Eklentiler:  ${chalk.cyan(activeCount)} aktif, ${updateCount > 0 ? chalk.yellow(`${updateCount} guncelleme bekliyor`) : chalk.green("guncel")}`,
+				`  Plugins:     ${chalk.cyan(activeCount)} active, ${updateCount > 0 ? chalk.yellow(`${updateCount} updates pending`) : chalk.green("up to date")}`,
 			);
 
 			const updates = wpCmd(siteArgs, [
@@ -180,26 +180,26 @@ async function wpStatus(site) {
 				"--format=csv",
 			]).trim();
 			if (updates && !updates.includes("Success")) {
-				console.log(`  Core:        ${chalk.yellow("Guncelleme mevcut")}`);
+				console.log(`  Core:        ${chalk.yellow("Update available")}`);
 			} else {
-				console.log(`  Core:        ${chalk.green("Guncel")}`);
+				console.log(`  Core:        ${chalk.green("Up to date")}`);
 			}
 		} catch (e) {
-			console.error(chalk.red(`WP-CLI hatasi: ${e.message}`));
+			console.error(chalk.red(`WP-CLI error: ${e.message}`));
 		}
 	} else {
 		try {
 			const info = await wpApiRoot(site);
-			console.log(`  Site Adi:    ${chalk.cyan(info.name || "?")}`);
-			console.log(`  Aciklama:    ${chalk.dim(info.description || "?")}`);
+			console.log(`  Site Name:   ${chalk.cyan(info.name || "?")}`);
+			console.log(`  Description: ${chalk.dim(info.description || "?")}`);
 			console.log(
-				`  WP Surumu:   ${chalk.green(info.gmt_offset !== undefined ? "REST API erisimi var" : "?")}`,
+				`  WP Version:  ${chalk.green(info.gmt_offset !== undefined ? "REST API accessible" : "?")}`,
 			);
 			console.log(
 				`  Namespace:   ${chalk.dim((info.namespaces || []).join(", "))}`,
 			);
 		} catch (e) {
-			console.error(chalk.red(`REST API hatasi: ${e.message}`));
+			console.error(chalk.red(`REST API error: ${e.message}`));
 		}
 	}
 }
@@ -208,7 +208,7 @@ function wpPlugins(site) {
 	if (site.method !== "wp-cli") {
 		console.error(
 			chalk.yellow(
-				`Plugin yonetimi icin WP-CLI gerekli. Site method: ${site.method}`,
+				`Plugin management requires WP-CLI. Site method: ${site.method}`,
 			),
 		);
 		return;
@@ -216,42 +216,42 @@ function wpPlugins(site) {
 	const siteArgs = getSiteArgs(site);
 	try {
 		const output = wpCmd(siteArgs, ["plugin", "list", "--format=table"]);
-		console.log(chalk.bold(`Eklentiler: ${site.alias}`));
+		console.log(chalk.bold(`Plugins: ${site.alias}`));
 		console.log(output);
 	} catch (e) {
-		console.error(chalk.red(`Hata: ${e.message}`));
+		console.error(chalk.red(`Error: ${e.message}`));
 	}
 }
 
 function wpThemes(site) {
 	if (site.method !== "wp-cli") {
-		console.error(chalk.yellow("Tema yonetimi icin WP-CLI gerekli."));
+		console.error(chalk.yellow("Theme management requires WP-CLI."));
 		return;
 	}
 	const siteArgs = getSiteArgs(site);
 	try {
 		const output = wpCmd(siteArgs, ["theme", "list", "--format=table"]);
-		console.log(chalk.bold(`Temalar: ${site.alias}`));
+		console.log(chalk.bold(`Themes: ${site.alias}`));
 		console.log(output);
 	} catch (e) {
-		console.error(chalk.red(`Hata: ${e.message}`));
+		console.error(chalk.red(`Error: ${e.message}`));
 	}
 }
 
 function wpUpdate(site, target) {
 	if (site.method !== "wp-cli") {
-		console.error(chalk.yellow("Guncelleme icin WP-CLI gerekli."));
+		console.error(chalk.yellow("Updates require WP-CLI."));
 		return;
 	}
 	const siteArgs = getSiteArgs(site);
 	const longTimeout = { timeout: 120000 };
 	try {
 		if (!target || target === "all") {
-			console.log(chalk.bold("Core guncelleniyor..."));
+			console.log(chalk.bold("Updating core..."));
 			console.log(wpCmd(siteArgs, ["core", "update"], longTimeout));
-			console.log(chalk.bold("Eklentiler guncelleniyor..."));
+			console.log(chalk.bold("Updating plugins..."));
 			console.log(wpCmd(siteArgs, ["plugin", "update", "--all"], longTimeout));
-			console.log(chalk.bold("Temalar guncelleniyor..."));
+			console.log(chalk.bold("Updating themes..."));
 			console.log(wpCmd(siteArgs, ["theme", "update", "--all"], longTimeout));
 		} else if (target === "core") {
 			console.log(wpCmd(siteArgs, ["core", "update"], longTimeout));
@@ -262,24 +262,24 @@ function wpUpdate(site, target) {
 		} else {
 			console.log(wpCmd(siteArgs, ["plugin", "update", target], longTimeout));
 		}
-		console.log(chalk.bold.green("Guncelleme tamamlandi!"));
+		console.log(chalk.bold.green("Update complete!"));
 	} catch (e) {
-		console.error(chalk.red(`Guncelleme hatasi: ${e.message}`));
+		console.error(chalk.red(`Update error: ${e.message}`));
 	}
 }
 
 function wpSecurity(site) {
 	if (site.method !== "wp-cli") {
-		console.error(chalk.yellow("Guvenlik taramasi icin WP-CLI gerekli."));
+		console.error(chalk.yellow("Security scan requires WP-CLI."));
 		return;
 	}
 	const siteArgs = getSiteArgs(site);
-	console.log(chalk.bold(`Guvenlik Taramasi: ${site.alias}`));
+	console.log(chalk.bold(`Security Scan: ${site.alias}`));
 	console.log("");
 
 	let issues = 0;
 
-	// WP surumu
+	// WP version
 	try {
 		const version = wpCmd(siteArgs, ["core", "version"]);
 		const updates = wpCmd(siteArgs, [
@@ -288,16 +288,16 @@ function wpSecurity(site) {
 			"--format=csv",
 		]).trim();
 		if (updates && !updates.includes("Success")) {
-			console.log(`  ${chalk.red("XX")} WP Core guncel degil (${version})`);
+			console.log(`  ${chalk.red("XX")} WP Core not up to date (${version})`);
 			issues++;
 		} else {
-			console.log(`  ${chalk.green("OK")} WP Core guncel (${version})`);
+			console.log(`  ${chalk.green("OK")} WP Core up to date (${version})`);
 		}
 	} catch {
 		/* */
 	}
 
-	// Plugin guncellemeleri
+	// Plugin updates
 	try {
 		const plugins = wpCmd(siteArgs, [
 			"plugin",
@@ -311,19 +311,19 @@ function wpSecurity(site) {
 			.filter((l) => l.includes("available"));
 		if (outdated.length > 0) {
 			console.log(
-				`  ${chalk.red("XX")} ${outdated.length} eklenti guncelleme bekliyor`,
+				`  ${chalk.red("XX")} ${outdated.length} plugins pending update`,
 			);
 			for (const p of outdated)
 				console.log(`       ${chalk.dim(p.split(",")[0])}`);
 			issues++;
 		} else {
-			console.log(`  ${chalk.green("OK")} Tum eklentiler guncel`);
+			console.log(`  ${chalk.green("OK")} All plugins up to date`);
 		}
 	} catch {
 		/* */
 	}
 
-	// Pasif eklentiler
+	// Inactive plugins
 	try {
 		const plugins = wpCmd(siteArgs, [
 			"plugin",
@@ -335,17 +335,17 @@ function wpSecurity(site) {
 		const inactive = plugins.split("\n").slice(1).filter(Boolean);
 		if (inactive.length > 0) {
 			console.log(
-				`  ${chalk.yellow("!!")} ${inactive.length} pasif eklenti (kaldir veya aktifles)`,
+				`  ${chalk.yellow("!!")} ${inactive.length} inactive plugins (remove or activate)`,
 			);
 			issues++;
 		} else {
-			console.log(`  ${chalk.green("OK")} Pasif eklenti yok`);
+			console.log(`  ${chalk.green("OK")} No inactive plugins`);
 		}
 	} catch {
 		/* */
 	}
 
-	// File permissions (lokal site)
+	// File permissions (local site)
 	if (site.path) {
 		try {
 			const wpConfig = join(site.path, "wp-config.php");
@@ -356,19 +356,17 @@ function wpSecurity(site) {
 					content.includes("define( 'WP_DEBUG', true )")
 				) {
 					console.log(
-						`  ${chalk.yellow("!!")} WP_DEBUG acik — uretimde kapatilmali`,
+						`  ${chalk.yellow("!!")} WP_DEBUG is on — should be off in production`,
 					);
 					issues++;
 				} else {
-					console.log(`  ${chalk.green("OK")} WP_DEBUG kapali`);
+					console.log(`  ${chalk.green("OK")} WP_DEBUG is off`);
 				}
 				if (!content.includes("DISALLOW_FILE_EDIT")) {
-					console.log(
-						`  ${chalk.yellow("!!")} DISALLOW_FILE_EDIT tanimlanmamis`,
-					);
+					console.log(`  ${chalk.yellow("!!")} DISALLOW_FILE_EDIT not defined`);
 					issues++;
 				} else {
-					console.log(`  ${chalk.green("OK")} DISALLOW_FILE_EDIT tanimli`);
+					console.log(`  ${chalk.green("OK")} DISALLOW_FILE_EDIT defined`);
 				}
 			}
 		} catch {
@@ -376,7 +374,7 @@ function wpSecurity(site) {
 		}
 	}
 
-	// Admin kullanicisi
+	// Admin user
 	try {
 		const users = wpCmd(siteArgs, [
 			"user",
@@ -388,16 +386,14 @@ function wpSecurity(site) {
 		const admins = users.split("\n").slice(1).filter(Boolean);
 		const hasAdmin = admins.some((u) => u.trim().toLowerCase() === "admin");
 		if (hasAdmin) {
-			console.log(
-				`  ${chalk.red("XX")} 'admin' kullanici adi mevcut — degistirin`,
-			);
+			console.log(`  ${chalk.red("XX")} 'admin' username exists — change it`);
 			issues++;
 		} else {
-			console.log(`  ${chalk.green("OK")} Varsayilan 'admin' kullanici yok`);
+			console.log(`  ${chalk.green("OK")} No default 'admin' user`);
 		}
 		if (admins.length > 3) {
 			console.log(
-				`  ${chalk.yellow("!!")} ${admins.length} admin kullanici — gereksiz yetkileri alin`,
+				`  ${chalk.yellow("!!")} ${admins.length} admin users — revoke unnecessary privileges`,
 			);
 			issues++;
 		}
@@ -407,66 +403,62 @@ function wpSecurity(site) {
 
 	console.log("");
 	if (issues === 0) {
-		console.log(chalk.bold.green("Guvenlik taramasi temiz!"));
+		console.log(chalk.bold.green("Security scan clean!"));
 	} else {
-		console.log(chalk.bold.yellow(`${issues} sorun tespit edildi.`));
+		console.log(chalk.bold.yellow(`${issues} issues detected.`));
 	}
 }
 
-// ─── Ana Komut ───
+// ─── Main Command ───
 
 export async function runWp(args) {
 	const sub = args[0];
 
 	if (!sub || sub === "--help" || sub === "-h") {
 		showBanner();
-		console.log(chalk.bold("WordPress Yonetimi:"));
+		console.log(chalk.bold("WordPress Management:"));
 		console.log("");
-		console.log(chalk.bold.cyan("Site Yonetimi:"));
+		console.log(chalk.bold.cyan("Site Management:"));
+		console.log(`  ${chalk.cyan("badi wp add")} [alias] [url]        Add site`);
 		console.log(
-			`  ${chalk.cyan("badi wp add")} [alias] [url]        Site ekle`,
+			`  ${chalk.cyan("badi wp list")}                     List saved sites`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi wp list")}                     Kayitli siteleri listele`,
-		);
-		console.log(
-			`  ${chalk.cyan("badi wp remove")} [alias]           Site kaldir`,
+			`  ${chalk.cyan("badi wp remove")} [alias]           Remove site`,
 		);
 		console.log("");
-		console.log(chalk.bold.cyan("Durum ve Analiz:"));
+		console.log(chalk.bold.cyan("Status and Analysis:"));
 		console.log(
-			`  ${chalk.cyan("badi wp status")} [alias]           Site durumu (surum, tema, eklenti)`,
+			`  ${chalk.cyan("badi wp status")} [alias]           Site status (version, theme, plugins)`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi wp plugins")} [alias]          Eklenti listesi`,
+			`  ${chalk.cyan("badi wp plugins")} [alias]          Plugin list`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi wp themes")} [alias]           Tema listesi`,
+			`  ${chalk.cyan("badi wp themes")} [alias]           Theme list`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi wp security")} [alias]         Guvenlik taramasi`,
-		);
-		console.log("");
-		console.log(chalk.bold.cyan("Islemler:"));
-		console.log(
-			`  ${chalk.cyan("badi wp update")} [alias] [hedef]   Guncelle (all/core/plugins/themes)`,
+			`  ${chalk.cyan("badi wp security")} [alias]         Security scan`,
 		);
 		console.log("");
-		console.log(chalk.bold("Baglanti Yontemleri:"));
+		console.log(chalk.bold.cyan("Operations:"));
 		console.log(
-			`  --method wp-cli     ${chalk.dim("WP-CLI (lokal veya SSH)")}`,
+			`  ${chalk.cyan("badi wp update")} [alias] [target]  Update (all/core/plugins/themes)`,
 		);
+		console.log("");
+		console.log(chalk.bold("Connection Methods:"));
+		console.log(`  --method wp-cli     ${chalk.dim("WP-CLI (local or SSH)")}`);
 		console.log(`  --method rest       ${chalk.dim("WordPress REST API")}`);
 		console.log(
-			`  --path /var/www/    ${chalk.dim("Lokal WP dizini (wp-cli)")}`,
+			`  --path /var/www/    ${chalk.dim("Local WP directory (wp-cli)")}`,
 		);
-		console.log(`  --ssh user@host     ${chalk.dim("SSH uzerinden WP-CLI")}`);
-		console.log(`  --user admin        ${chalk.dim("REST API kullanici adi")}`);
+		console.log(`  --ssh user@host     ${chalk.dim("WP-CLI over SSH")}`);
+		console.log(`  --user admin        ${chalk.dim("REST API username")}`);
 		console.log(
 			`  --app-password XXX  ${chalk.dim("REST API application password")}`,
 		);
 		console.log("");
-		console.log(chalk.bold("Ornekler:"));
+		console.log(chalk.bold("Examples:"));
 		console.log("  badi wp add blog https://blog.example.com --method rest");
 		console.log(
 			"  badi wp add staging --method wp-cli --ssh user@staging.example.com",
@@ -484,7 +476,7 @@ export async function runWp(args) {
 		const url = args[2] || "";
 		if (!alias) {
 			console.error(
-				chalk.red("Site alias belirtin: badi wp add [alias] [url]"),
+				chalk.red("Specify a site alias: badi wp add [alias] [url]"),
 			);
 			process.exit(1);
 		}
@@ -523,15 +515,15 @@ export async function runWp(args) {
 		const existing = data.sites.findIndex((s) => s.alias === alias);
 		if (existing >= 0) {
 			data.sites[existing] = siteConfig;
-			console.log(chalk.yellow(`Site guncellendi: ${alias}`));
+			console.log(chalk.yellow(`Site updated: ${alias}`));
 		} else {
 			data.sites.push(siteConfig);
-			console.log(chalk.bold.green(`Site eklendi: ${alias}`));
+			console.log(chalk.bold.green(`Site added: ${alias}`));
 		}
 		saveSites(data);
 
 		console.log(`  Alias:   ${chalk.cyan(alias)}`);
-		console.log(`  URL:     ${chalk.cyan(url || "(yok)")}`);
+		console.log(`  URL:     ${chalk.cyan(url || "(none)")}`);
 		console.log(`  Method:  ${chalk.cyan(siteConfig.method)}`);
 		if (siteConfig.path)
 			console.log(`  Path:    ${chalk.cyan(siteConfig.path)}`);
@@ -543,16 +535,16 @@ export async function runWp(args) {
 	if (sub === "list") {
 		const data = loadSites();
 		if (data.sites.length === 0) {
-			console.log(chalk.dim("Kayitli WordPress sitesi yok."));
+			console.log(chalk.dim("No saved WordPress sites."));
 			console.log(
-				chalk.dim("Ekle: badi wp add [alias] [url] --method [wp-cli|rest]"),
+				chalk.dim("Add: badi wp add [alias] [url] --method [wp-cli|rest]"),
 			);
 			return;
 		}
-		console.log(chalk.bold(`WordPress Siteleri (${data.sites.length}):`));
+		console.log(chalk.bold(`WordPress Sites (${data.sites.length}):`));
 		console.log("");
 		console.log(
-			`  ${chalk.dim("Alias".padEnd(15))}${chalk.dim("URL".padEnd(35))}${chalk.dim("Method".padEnd(10))}${chalk.dim("Baglanti")}`,
+			`  ${chalk.dim("Alias".padEnd(15))}${chalk.dim("URL".padEnd(35))}${chalk.dim("Method".padEnd(10))}${chalk.dim("Connection")}`,
 		);
 		console.log(chalk.dim(`  ${"─".repeat(70)}`));
 		for (const s of data.sites) {
@@ -568,31 +560,31 @@ export async function runWp(args) {
 	if (sub === "remove") {
 		const alias = args[1];
 		if (!alias) {
-			console.error(chalk.red("Site alias belirtin."));
+			console.error(chalk.red("Specify a site alias."));
 			process.exit(1);
 		}
 		const data = loadSites();
 		const idx = data.sites.findIndex((s) => s.alias === alias);
 		if (idx === -1) {
-			console.error(chalk.red(`Site bulunamadi: ${alias}`));
+			console.error(chalk.red(`Site not found: ${alias}`));
 			process.exit(1);
 		}
 		data.sites.splice(idx, 1);
 		saveSites(data);
-		console.log(chalk.green(`Site silindi: ${alias}`));
+		console.log(chalk.green(`Site deleted: ${alias}`));
 		return;
 	}
 
-	// Site gerektiren komutlar
+	// Commands that require a site
 	const siteAlias = args[1];
 	if (!siteAlias) {
-		console.error(chalk.red(`Site alias belirtin: badi wp ${sub} [alias]`));
+		console.error(chalk.red(`Specify a site alias: badi wp ${sub} [alias]`));
 		process.exit(1);
 	}
 	const site = findSite(siteAlias);
 	if (!site) {
-		console.error(chalk.red(`Site bulunamadi: ${siteAlias}`));
-		console.log(chalk.dim("Kayitli siteler: badi wp list"));
+		console.error(chalk.red(`Site not found: ${siteAlias}`));
+		console.log(chalk.dim("Saved sites: badi wp list"));
 		process.exit(1);
 	}
 
@@ -613,9 +605,9 @@ export async function runWp(args) {
 			wpSecurity(site);
 			break;
 		default:
-			console.error(chalk.red(`Bilinmeyen wp komutu: ${sub}`));
+			console.error(chalk.red(`Unknown wp command: ${sub}`));
 			console.log(
-				"Kullanim: badi wp [add|list|remove|status|plugins|themes|update|security]",
+				"Usage: badi wp [add|list|remove|status|plugins|themes|update|security]",
 			);
 			process.exit(1);
 	}

--- a/tests/cli.wp.test.js
+++ b/tests/cli.wp.test.js
@@ -38,14 +38,14 @@ describe("badi wp", () => {
 
 	it("yardim gosterir", () => {
 		const out = run("wp", "--help");
-		assert.ok(out.includes("WordPress Yonetimi"));
+		assert.ok(out.includes("WordPress Management"));
 		assert.ok(out.includes("badi wp add"));
 		assert.ok(out.includes("badi wp status"));
 	});
 
 	it("argumansiz yardim gosterir", () => {
 		const out = run("wp");
-		assert.ok(out.includes("WordPress Yonetimi"));
+		assert.ok(out.includes("WordPress Management"));
 	});
 
 	it("site ekler", () => {
@@ -57,7 +57,7 @@ describe("badi wp", () => {
 			"--method",
 			"rest",
 		);
-		assert.ok(out.includes("Site eklendi") || out.includes("Site guncellendi"));
+		assert.ok(out.includes("Site added") || out.includes("Site updated"));
 		assert.ok(out.includes("test-site"));
 	});
 
@@ -68,7 +68,7 @@ describe("badi wp", () => {
 
 	it("site siler", () => {
 		const out = run("wp", "remove", "test-site");
-		assert.ok(out.includes("Site silindi"));
+		assert.ok(out.includes("Site deleted"));
 	});
 
 	it("bilinmeyen site hata verir", () => {


### PR DESCRIPTION
## Phase 2k — English-only migration (#207)

Translates all user-facing CLI output and comments to English in **ai** (AI/LLM tools) and **wp** (WordPress management). Subcommand names and flags stay stable — no interface renames in this batch.

### Changed
- **ai.js** — token / prompt-test / memory-diff / review / translate output, help text, error messages.
  - The `ai review` system prompt now instructs the model to write findings **in English** (was `Turkce yaz`).
  - The `ai translate` system/user prompts are English; `langMap` keeps `tr` as a valid translation **target** (you can still translate *to* Turkish).
- **wp.js** — status / plugins / themes / update / security / add / list / remove output, help text, connection-method labels, error messages. Password obfuscation, WP-CLI invocation, and REST API logic preserved verbatim.

### Tests
Updated in lockstep — `cli.wp.test.js`: `WordPress Yonetimi`→`WordPress Management`, `Site eklendi`→`Site added`, `Site silindi`→`Site deleted`. `cli.ai.test.js` needed no changes (asserts English-stable strings).

### Verification
- `npm run lint` — clean (2 files auto-formatted after translation)
- `npm test` — **1132/1132 pass** (confirmed stable across runs)

### Note (follow-up, out of scope)
The shared `showBanner()` tagline in `lib/cli.js` still reads `Is Akisi Yonetim Sistemi` — it prints on every command. Flagging for a future small batch / the capstone since it's a single shared string, not part of ai/wp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)