### PR TITLE
feat(i18n): English-only Phase 2l — domain, skills, kb CLI output

### DIFF
--- a/lib/commands/domain.js
+++ b/lib/commands/domain.js
@@ -3,7 +3,7 @@ import { Socket } from "node:net";
 import { connect } from "node:tls";
 import { chalk, showBanner } from "../cli.js";
 
-// ─── URL/domain yardimcilari ───
+// ─── URL/domain helpers ───
 
 function extractDomain(input) {
 	let domain = input.trim().toLowerCase();
@@ -12,7 +12,7 @@ function extractDomain(input) {
 		.replace(/\/.*$/, "")
 		.replace(/:\d+$/, "");
 	if (!/^[a-z0-9][\w.-]*\.[a-z]{2,}$/i.test(domain)) {
-		throw new Error(`Gecersiz domain: ${input}`);
+		throw new Error(`Invalid domain: ${input}`);
 	}
 	return domain;
 }
@@ -39,16 +39,16 @@ function fetchSslCert(domain, port = 443, { insecure = false } = {}) {
 		});
 		socket.on("timeout", () => {
 			socket.destroy();
-			reject(new Error("SSL baglanti zaman asimi"));
+			reject(new Error("SSL connection timeout"));
 		});
-		socket.on("error", (e) => reject(new Error(`SSL hatasi: ${e.message}`)));
+		socket.on("error", (e) => reject(new Error(`SSL error: ${e.message}`)));
 	});
 }
 
-// Once strict TLS dogrulamasi dene; sertifika dogrulanamiyorsa (expired,
-// hostname mismatch, self-signed) raporlama amaciyla insecure mode'da
-// retry et. Insecure mode tek amac analiz icin — donulen veride
-// `validForDomain: false` ile is aretlenir.
+// Try strict TLS verification first; if the cert can't be verified (expired,
+// hostname mismatch, self-signed) retry in insecure mode for reporting
+// purposes only. Insecure mode is solely for analysis — the returned data
+// is flagged with `validForDomain: false`.
 async function fetchSslCertWithFallback(domain, port = 443) {
 	try {
 		const r = await fetchSslCert(domain, port);
@@ -73,13 +73,13 @@ async function fetchSslCertWithFallback(domain, port = 443) {
 
 async function runSsl(domain) {
 	showBanner();
-	console.log(chalk.bold(`SSL Sertifika Analizi: ${domain}`));
+	console.log(chalk.bold(`SSL Certificate Analysis: ${domain}`));
 	console.log("");
 
 	const { cert, protocol, cipher, validForDomain, verifyError } =
 		await fetchSslCertWithFallback(domain);
 	if (!cert?.subject) {
-		console.log(chalk.red("Sertifika bilgisi alinamadi."));
+		console.log(chalk.red("Could not retrieve certificate info."));
 		return;
 	}
 
@@ -89,7 +89,7 @@ async function runSsl(domain) {
 	const daysLeft = Math.floor((validTo - now) / 86400000);
 	const totalDays = Math.floor((validTo - validFrom) / 86400000);
 
-	console.log(chalk.bold("Sertifika:"));
+	console.log(chalk.bold("Certificate:"));
 	console.log(`  Subject CN:    ${chalk.cyan(cert.subject.CN || "?")}`);
 	console.log(
 		`  Issuer:        ${chalk.cyan(cert.issuer.CN || cert.issuer.O || "?")}`,
@@ -100,12 +100,12 @@ async function runSsl(domain) {
 	console.log(`  Serial:        ${chalk.dim(cert.serialNumber)}`);
 
 	console.log("");
-	console.log(chalk.bold("Gecerlilik:"));
+	console.log(chalk.bold("Validity:"));
 	console.log(
-		`  Baslangic:     ${chalk.cyan(validFrom.toISOString().substring(0, 10))}`,
+		`  Start:         ${chalk.cyan(validFrom.toISOString().substring(0, 10))}`,
 	);
 	console.log(
-		`  Bitis:         ${chalk.cyan(validTo.toISOString().substring(0, 10))}`,
+		`  End:           ${chalk.cyan(validTo.toISOString().substring(0, 10))}`,
 	);
 	const expColor =
 		daysLeft < 14
@@ -114,37 +114,37 @@ async function runSsl(domain) {
 				? chalk.bold.yellow
 				: chalk.bold.green;
 	console.log(
-		`  Kalan:         ${expColor(`${daysLeft} gun`)} (${totalDays} gun toplam)`,
+		`  Remaining:     ${expColor(`${daysLeft} days`)} (${totalDays} days total)`,
 	);
 
 	console.log("");
-	console.log(chalk.bold("Protokol:"));
+	console.log(chalk.bold("Protocol:"));
 	console.log(`  Version:       ${chalk.cyan(protocol || "?")}`);
 	console.log(`  Cipher:        ${chalk.cyan(cipher?.name || "?")}`);
 	console.log(`  Bit strength:  ${chalk.cyan(cipher?.standardName || "?")}`);
 
 	console.log("");
-	console.log(chalk.bold("Durum:"));
+	console.log(chalk.bold("Status:"));
 	let issues = 0;
 	const check = (label, ok) => {
 		console.log(`  ${ok ? chalk.green("OK") : chalk.red("XX")} ${label}`);
 		if (!ok) issues++;
 	};
-	check("Sertifika zincir/hostname dogrulamasi", validForDomain);
+	check("Certificate chain/hostname verification", validForDomain);
 	if (validForDomain === false && verifyError) {
 		console.log(chalk.dim(`     ${verifyError}`));
 	}
-	check("Sertifika gecerli", daysLeft > 0);
-	check("Expire 30 gunden uzak", daysLeft >= 30);
-	check("TLS 1.2+ kullaniliyor", ["TLSv1.2", "TLSv1.3"].includes(protocol));
-	check("TLS 1.3 kullaniliyor", protocol === "TLSv1.3");
+	check("Certificate valid", daysLeft > 0);
+	check("Expiry more than 30 days away", daysLeft >= 30);
+	check("TLS 1.2+ in use", ["TLSv1.2", "TLSv1.3"].includes(protocol));
+	check("TLS 1.3 in use", protocol === "TLSv1.3");
 	check("Modern cipher", !/RC4|3DES|MD5/.test(cipher?.name || ""));
 
 	console.log("");
 	console.log(
 		issues === 0
-			? chalk.bold.green("SSL saglikli!")
-			: chalk.bold.yellow(`${issues} sorun tespit edildi.`),
+			? chalk.bold.green("SSL healthy!")
+			: chalk.bold.yellow(`${issues} issues detected.`),
 	);
 }
 
@@ -180,7 +180,7 @@ async function resolveAll(domain, type) {
 
 async function runDns(domain) {
 	showBanner();
-	console.log(chalk.bold(`DNS Kayitlari: ${domain}`));
+	console.log(chalk.bold(`DNS Records: ${domain}`));
 	console.log("");
 
 	const [a, aaaa, mx, txt, ns, caa, soa] = await Promise.all([
@@ -194,17 +194,17 @@ async function runDns(domain) {
 	]);
 
 	console.log(chalk.bold("A (IPv4):"));
-	if (a.length === 0) console.log(chalk.dim("  (kayit yok)"));
+	if (a.length === 0) console.log(chalk.dim("  (no records)"));
 	else for (const ip of a) console.log(`  ${chalk.cyan(ip)}`);
 
 	console.log("");
 	console.log(chalk.bold("AAAA (IPv6):"));
-	if (aaaa.length === 0) console.log(chalk.dim("  (kayit yok)"));
+	if (aaaa.length === 0) console.log(chalk.dim("  (no records)"));
 	else for (const ip of aaaa) console.log(`  ${chalk.cyan(ip)}`);
 
 	console.log("");
 	console.log(chalk.bold(`MX (Mail, ${mx.length}):`));
-	if (mx.length === 0) console.log(chalk.dim("  (kayit yok)"));
+	if (mx.length === 0) console.log(chalk.dim("  (no records)"));
 	else {
 		mx.sort((a, b) => a.priority - b.priority);
 		for (const r of mx)
@@ -237,12 +237,12 @@ async function runDns(domain) {
 		console.log(
 			`  ${chalk.green("SPF")}    ${chalk.dim(spf[0].substring(0, 90))}`,
 		);
-	else console.log(`  ${chalk.yellow("SPF")}    ${chalk.dim("tanimli degil")}`);
+	else console.log(`  ${chalk.yellow("SPF")}    ${chalk.dim("not defined")}`);
 
 	for (const d of dmarc)
 		console.log(`  ${chalk.green("DMARC")}  ${chalk.dim(d.substring(0, 90))}`);
 	if (dmarc.length === 0)
-		console.log(`  ${chalk.yellow("DMARC")}  ${chalk.dim("tanimli degil")}`);
+		console.log(`  ${chalk.yellow("DMARC")}  ${chalk.dim("not defined")}`);
 
 	for (const v of verification)
 		console.log(`  ${chalk.dim("Verify")} ${chalk.dim(v.substring(0, 90))}`);
@@ -252,9 +252,7 @@ async function runDns(domain) {
 	console.log("");
 	console.log(chalk.bold(`CAA (Certificate Authority, ${caa.length}):`));
 	if (caa.length === 0)
-		console.log(
-			chalk.dim("  (kayit yok — herhangi bir CA sertifika verebilir)"),
-		);
+		console.log(chalk.dim("  (no records — any CA can issue a certificate)"));
 	else
 		for (const c of caa)
 			console.log(`  ${chalk.cyan(c.issue || c.issuewild || c.iodef)}`);
@@ -271,16 +269,16 @@ async function runDns(domain) {
 		);
 	}
 
-	// Email guvenlik skoru
+	// Email security score
 	console.log("");
-	console.log(chalk.bold("Email Guvenlik:"));
+	console.log(chalk.bold("Email Security:"));
 	const issues = [];
-	if (spf.length === 0) issues.push("SPF tanimli degil (spoofing riski)");
-	if (dmarc.length === 0) issues.push("DMARC tanimli degil (phishing riski)");
+	if (spf.length === 0) issues.push("SPF not defined (spoofing risk)");
+	if (dmarc.length === 0) issues.push("DMARC not defined (phishing risk)");
 	if (mx.length > 0 && caa.length === 0)
-		issues.push("CAA kaydi yok (her CA cert verebilir)");
+		issues.push("No CAA record (any CA can issue a cert)");
 	if (issues.length === 0)
-		console.log(chalk.bold.green("  Temel guvenlik kayitlari mevcut"));
+		console.log(chalk.bold.green("  Basic security records present"));
 	else for (const i of issues) console.log(`  ${chalk.yellow("!!")} ${i}`);
 }
 
@@ -300,7 +298,7 @@ function queryWhois(server, query, port = 43) {
 			socket.destroy();
 			reject(new Error("WHOIS timeout"));
 		});
-		socket.on("error", (e) => reject(new Error(`WHOIS hatasi: ${e.message}`)));
+		socket.on("error", (e) => reject(new Error(`WHOIS error: ${e.message}`)));
 	});
 }
 
@@ -317,7 +315,7 @@ async function runWhois(domain) {
 	console.log(chalk.bold(`WHOIS: ${domain}`));
 	console.log("");
 
-	// TLD bazli sunucu (basit set)
+	// TLD-based server (simple set)
 	const tld = domain.split(".").pop().toLowerCase();
 	const servers = {
 		com: "whois.verisign-grs.com",
@@ -335,13 +333,13 @@ async function runWhois(domain) {
 	let raw;
 	try {
 		raw = await queryWhois(server, domain);
-		// Bazi sunucular redirect eder
+		// Some servers redirect
 		const referral = extractField(raw, ["Registrar WHOIS Server", "whois"]);
 		if (referral && referral !== server && referral.startsWith("whois.")) {
 			raw = await queryWhois(referral, domain);
 		}
 	} catch (e) {
-		console.log(chalk.red(`WHOIS sunucusuna ulasilamadi: ${e.message}`));
+		console.log(chalk.red(`Could not reach WHOIS server: ${e.message}`));
 		return;
 	}
 
@@ -373,13 +371,13 @@ async function runWhois(domain) {
 			.match(/^\s*Name Server\s*:\s*(.+)$/gim)
 			?.map((l) => l.split(":").slice(1).join(":").trim().toLowerCase()) || [];
 
-	console.log(chalk.bold("Tescil Bilgisi:"));
+	console.log(chalk.bold("Registration Info:"));
 	console.log(`  Registrar:     ${chalk.cyan(registrar || "?")}`);
 	console.log(
-		`  Olusturulma:   ${chalk.cyan(created ? created.substring(0, 10) : "?")}`,
+		`  Created:       ${chalk.cyan(created ? created.substring(0, 10) : "?")}`,
 	);
 	console.log(
-		`  Son guncelleme: ${chalk.cyan(updated ? updated.substring(0, 10) : "?")}`,
+		`  Last updated:  ${chalk.cyan(updated ? updated.substring(0, 10) : "?")}`,
 	);
 
 	if (expires) {
@@ -392,7 +390,7 @@ async function runWhois(domain) {
 					? chalk.bold.yellow
 					: chalk.bold.green;
 		console.log(
-			`  Expire:        ${chalk.cyan(expires.substring(0, 10))} (${expColor(`${daysLeft} gun`)})`,
+			`  Expiry:        ${chalk.cyan(expires.substring(0, 10))} (${expColor(`${daysLeft} days`)})`,
 		);
 	}
 
@@ -402,46 +400,46 @@ async function runWhois(domain) {
 
 	if (status.length > 0) {
 		console.log("");
-		console.log(chalk.bold(`Domain Durumu (${status.length}):`));
+		console.log(chalk.bold(`Domain Status (${status.length}):`));
 		for (const s of status.slice(0, 10))
 			console.log(`  ${chalk.dim(s.replace(/https?:\/\/\S+/, "").trim())}`);
 	}
 
-	// Guvenlik onerileri
+	// Security recommendations
 	console.log("");
-	console.log(chalk.bold("Guvenlik Onerileri:"));
+	console.log(chalk.bold("Security Recommendations:"));
 	const hasTransferLock = status.some((s) =>
 		/clientTransferProhibited/i.test(s),
 	);
 	const hasUpdateLock = status.some((s) => /clientUpdateProhibited/i.test(s));
 	console.log(
-		`  ${hasTransferLock ? chalk.green("OK") : chalk.yellow("!!")} Transfer Lock (domain hijacking koruma)`,
+		`  ${hasTransferLock ? chalk.green("OK") : chalk.yellow("!!")} Transfer Lock (domain hijacking protection)`,
 	);
 	console.log(
 		`  ${hasUpdateLock ? chalk.green("OK") : chalk.yellow("!!")} Update Lock`,
 	);
 }
 
-// ─── Ana komut ───
+// ─── Main command ───
 
 export async function runDomain(args) {
 	const sub = args[0];
 
 	if (!sub || sub === "--help" || sub === "-h") {
 		showBanner();
-		console.log(chalk.bold("Domain Saglik Araclari:"));
+		console.log(chalk.bold("Domain Health Tools:"));
 		console.log("");
 		console.log(
-			`  ${chalk.cyan("badi ssl")} [domain]     SSL sertifika analizi (expire, TLS, cipher)`,
+			`  ${chalk.cyan("badi ssl")} [domain]     SSL certificate analysis (expiry, TLS, cipher)`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi dns")} [domain]     DNS kayitlari (A/AAAA/MX/TXT/SPF/DMARC/CAA)`,
+			`  ${chalk.cyan("badi dns")} [domain]     DNS records (A/AAAA/MX/TXT/SPF/DMARC/CAA)`,
 		);
 		console.log(
-			`  ${chalk.cyan("badi whois")} [domain]   Domain tescil + expire + transfer lock`,
+			`  ${chalk.cyan("badi whois")} [domain]   Domain registration + expiry + transfer lock`,
 		);
 		console.log("");
-		console.log(chalk.bold("Ornekler:"));
+		console.log(chalk.bold("Examples:"));
 		console.log("  badi ssl example.com");
 		console.log("  badi dns github.com");
 		console.log("  badi whois badi.dev");
@@ -450,33 +448,33 @@ export async function runDomain(args) {
 
 	try {
 		const domain = extractDomain(args[1] || sub);
-		const cmd = args[1] ? sub : "__alias__"; // badi ssl [domain] veya direkt domain
+		const cmd = args[1] ? sub : "__alias__"; // badi ssl [domain] or domain directly
 		if (["ssl", "dns", "whois"].includes(cmd)) {
 			if (cmd === "ssl") await runSsl(domain);
 			else if (cmd === "dns") await runDns(domain);
 			else if (cmd === "whois") await runWhois(domain);
 		} else {
-			console.error(chalk.red(`Bilinmeyen domain komutu: ${sub}`));
+			console.error(chalk.red(`Unknown domain command: ${sub}`));
 			process.exit(1);
 		}
 	} catch (e) {
-		console.error(chalk.red(`Hata: ${e.message}`));
+		console.error(chalk.red(`Error: ${e.message}`));
 		process.exit(1);
 	}
 }
 
-// Her komut icin ayri wrapper export
+// Separate wrapper export for each command
 export async function runSslCmd(args) {
 	const domain = args[0];
 	if (!domain || ["--help", "-h"].includes(domain)) {
-		console.log(chalk.bold("Kullanim: badi ssl [domain]"));
+		console.log(chalk.bold("Usage: badi ssl [domain]"));
 		console.log(chalk.dim("  badi ssl example.com"));
 		return;
 	}
 	try {
 		await runSsl(extractDomain(domain));
 	} catch (e) {
-		console.error(chalk.red(`Hata: ${e.message}`));
+		console.error(chalk.red(`Error: ${e.message}`));
 		process.exit(1);
 	}
 }
@@ -484,13 +482,13 @@ export async function runSslCmd(args) {
 export async function runDnsCmd(args) {
 	const domain = args[0];
 	if (!domain || ["--help", "-h"].includes(domain)) {
-		console.log(chalk.bold("Kullanim: badi dns [domain]"));
+		console.log(chalk.bold("Usage: badi dns [domain]"));
 		return;
 	}
 	try {
 		await runDns(extractDomain(domain));
 	} catch (e) {
-		console.error(chalk.red(`Hata: ${e.message}`));
+		console.error(chalk.red(`Error: ${e.message}`));
 		process.exit(1);
 	}
 }
@@ -498,13 +496,13 @@ export async function runDnsCmd(args) {
 export async function runWhoisCmd(args) {
 	const domain = args[0];
 	if (!domain || ["--help", "-h"].includes(domain)) {
-		console.log(chalk.bold("Kullanim: badi whois [domain]"));
+		console.log(chalk.bold("Usage: badi whois [domain]"));
 		return;
 	}
 	try {
 		await runWhois(extractDomain(domain));
 	} catch (e) {
-		console.error(chalk.red(`Hata: ${e.message}`));
+		console.error(chalk.red(`Error: ${e.message}`));
 		process.exit(1);
 	}
 }

--- a/lib/commands/kb.js
+++ b/lib/commands/kb.js
@@ -1,19 +1,19 @@
-// `badi kb` — Bilgi tabani grafigi komutu (#12 MVP).
+// `badi kb` — knowledge base graph command (#12 MVP).
 //
-// Alt komutlar:
-//   badi kb graph                  Tum dosyalar + interaktif SVG HTML uretir
-//   badi kb backlinks <dosya>      Belirli dosyaya gelen referanslari listeler
-//   badi kb orphans                Hicbir dosyadan referans almayan dosyalari listeler
-//   badi kb stats                  Genel istatistikler
+// Subcommands:
+//   badi kb graph                  Generate an interactive SVG HTML of all files
+//   badi kb backlinks <file>       List references pointing to a specific file
+//   badi kb orphans                List files that no other file references
+//   badi kb stats                  General statistics
 //
-// MVP scope disinda kalan ve gelecek surumlere itelenenler:
-//   - --topic filtresi (etiket/baslik bazli filtreleme)
-//   - Otomatik tarayicida acma (sadece dosya yolu raporlanir)
-//   - Kirik link tespiti (extends edilebilir, su an warn vermiyor)
+// Pushed beyond the MVP scope to future releases:
+//   - --topic filter (tag/title-based filtering)
+//   - Auto-open in the browser (only the file path is reported)
+//   - Broken-link detection (extendable, currently no warning)
 //
-// Tarama kapsami: .claude/ altindaki *.md dosyalari (skills-vault ve
-// backups haric). Wikilink ([[dosya]]) ve markdown link ([metin](yol))
-// desenleri yakalanir.
+// Scan scope: *.md files under .claude/ (excluding skills-vault and
+// backups). Wikilink ([[file]]) and markdown link ([text](path))
+// patterns are captured.
 
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
@@ -28,9 +28,9 @@ const SKIP_DIRS = new Set([
 ]);
 
 const WIKILINK_RE = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
-// Markdown link: `[text](url)`. Nested parantezleri tolere etmek icin
-// `(?:\([^)]*\)|[^)])*` kullanir — orn. Wikipedia URL'lerinde
-// "Foo_(bar)" gibi ic parantezler tek bir link icinde kalir.
+// Markdown link: `[text](url)`. Uses `(?:\([^)]*\)|[^)])*` to tolerate
+// nested parentheses — e.g. in Wikipedia URLs, inner parens like
+// "Foo_(bar)" stay inside a single link.
 const MARKDOWN_LINK_RE = /\[[^\]]*\]\(((?:\([^)]*\)|[^)])*)\)/g;
 
 function parseFlags(args) {
@@ -48,31 +48,29 @@ function parseFlags(args) {
 
 function showHelp() {
 	showBanner();
-	console.log(chalk.bold("Badi KB Graph — Bilgi Tabani Grafigi"));
+	console.log(chalk.bold("Badi KB Graph — Knowledge Base Graph"));
 	console.log("");
-	console.log(chalk.bold("Kullanim:"));
+	console.log(chalk.bold("Usage:"));
 	console.log(
-		`  ${chalk.cyan("badi kb graph")}              HTML grafik dosyasi uret`,
+		`  ${chalk.cyan("badi kb graph")}              Generate an HTML graph file`,
+	);
+	console.log(`  ${chalk.cyan("badi kb backlinks <file>")}   List backlinks`);
+	console.log(
+		`  ${chalk.cyan("badi kb orphans")}            Find unreferenced files`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi kb backlinks <dosya>")}  Geri referanslari listele`,
-	);
-	console.log(
-		`  ${chalk.cyan("badi kb orphans")}            Referanssiz dosyalari bul`,
-	);
-	console.log(
-		`  ${chalk.cyan("badi kb stats")}              Genel istatistikler`,
+		`  ${chalk.cyan("badi kb stats")}              General statistics`,
 	);
 	console.log("");
-	console.log(chalk.bold("Secenekler:"));
-	console.log("  --target <dir>   Tarama kok dizini (varsayilan: .claude)");
+	console.log(chalk.bold("Options:"));
+	console.log("  --target <dir>   Scan root directory (default: .claude)");
 	console.log(
-		"  --out <yol>      HTML cikti yolu (varsayilan: .claude/workspace/knowledge-graph.html)",
+		"  --out <path>     HTML output path (default: .claude/workspace/knowledge-graph.html)",
 	);
 }
 
 /**
- * Dizini recursive tarar ve .md dosyalarini bulur. SKIP_DIRS atlanir.
+ * Recursively scans a directory and finds .md files. SKIP_DIRS is skipped.
  */
 export function scanFiles(root) {
 	const out = [];
@@ -95,13 +93,13 @@ export function scanFiles(root) {
 }
 
 /**
- * Bir markdown dosyasindan cikan link'leri cikarir.
- * Donus: Set<string> — relative path veya wikilink hedefi.
+ * Extracts the links emitted from a markdown file.
+ * Returns: Set<string> — relative path or wikilink target.
  *
- * Wikilink "[[memory]]" -> "memory" (uzantisiz)
+ * Wikilink "[[memory]]" -> "memory" (no extension)
  * Markdown "[x](./memory.md)" -> "./memory.md"
  *
- * Eksternal URL'ler (http, https, mailto, vb.) atlanir.
+ * External URLs (http, https, mailto, etc.) are skipped.
  */
 export function extractLinks(content) {
 	const links = new Set();
@@ -113,7 +111,7 @@ export function extractLinks(content) {
 		const target = m[1].trim();
 		if (!target) continue;
 		if (/^(https?:|mailto:|tel:|#)/.test(target)) continue;
-		// Anchor + path ayri tut
+		// Keep anchor + path separate
 		const cleaned = target.split("#")[0];
 		if (cleaned) links.add(cleaned);
 	}
@@ -121,12 +119,12 @@ export function extractLinks(content) {
 }
 
 /**
- * Dosya turunu yola gore tahmin eder (renk/kategorizasyon icin).
+ * Guesses the file type from its path (for color/categorization).
  */
 export function classifyFile(relPath) {
 	const lower = relPath.toLowerCase().replace(/\\/g, "/");
-	// Path 'agents/foo.md' veya 'sub/agents/foo.md' olabilir; her iki
-	// duruma da matching olsun diye basta '/' veya satir basini kabul et.
+	// Path can be 'agents/foo.md' or 'sub/agents/foo.md'; accept a leading
+	// '/' or line start so both cases match.
 	const has = (segment) => new RegExp(`(^|/)${segment}/`).test(lower);
 	if (basename(lower) === "memory.md") return "memory";
 	if (basename(lower) === "knowledge-base.md") return "knowledge";
@@ -142,14 +140,14 @@ export function classifyFile(relPath) {
 }
 
 /**
- * Bir link hedefini absolute file path'e cozer.
- * - Relative path -> source dosyaya gore cozer
- * - Wikilink (uzantisiz) -> kok altinda matching basename arar
+ * Resolves a link target to an absolute file path.
+ * - Relative path -> resolved against the source file
+ * - Wikilink (no extension) -> searches for a matching basename under the root
  *
- * Bulamazsa null doner (kirik link).
+ * Returns null if not found (broken link).
  *
- * Performans: O(1) lookup icin index'ler buildGraph tarafindan once
- * hesaplanir (fileSet + basenameIndex).
+ * Performance: indexes are precomputed by buildGraph for O(1) lookup
+ * (fileSet + basenameIndex).
  */
 function resolveLink(target, sourceFile, fileSet, basenameIndex) {
 	if (
@@ -169,18 +167,18 @@ function resolveLink(target, sourceFile, fileSet, basenameIndex) {
 }
 
 /**
- * Tum dosyalardan yonlu graf insa eder.
+ * Builds a directed graph from all files.
  *
- * Donus: {
+ * Returns: {
  *   nodes: [{ id, path, type, title }],
  *   edges: [{ source, target }],
  *   brokenLinks: [{ source, target }]
  * }
  *
- * 'id' = relative path (root'a gore).
+ * 'id' = relative path (relative to root).
  */
 export function buildGraph(files, root) {
-	// Tek pass icerik okuma + index hesaplama (Y2/O1).
+	// Single-pass content read + index computation (Y2/O1).
 	const contents = new Map();
 	const fileSet = new Set(files);
 	const basenameIndex = new Map();
@@ -232,8 +230,8 @@ function extractTitle(content) {
 }
 
 /**
- * Bir dosyaya gelen referanslari listeler.
- * Donus: [{ source: id, count: number }]
+ * Lists references pointing to a file.
+ * Returns: [{ source: id, count: number }]
  */
 export function findBacklinks(graph, targetId) {
 	const counts = new Map();
@@ -248,7 +246,7 @@ export function findBacklinks(graph, targetId) {
 }
 
 /**
- * Hicbir dosyadan referans almayan dosyalari listeler.
+ * Lists files that no file references.
  */
 export function findOrphans(graph) {
 	const referenced = new Set(graph.edges.map((e) => e.target));
@@ -259,7 +257,7 @@ export function findOrphans(graph) {
 }
 
 /**
- * Genel istatistikler hesaplar.
+ * Computes general statistics.
  */
 export function computeStats(graph) {
 	const incoming = new Map();
@@ -297,13 +295,13 @@ const TYPE_COLORS = {
 };
 
 /**
- * Self-contained HTML uretir (CDN bagimliligi yok). Vanilla SVG +
- * minimal force-directed simulation inline JS.
+ * Generates self-contained HTML (no CDN dependency). Vanilla SVG +
+ * minimal force-directed simulation in inline JS.
  */
 /**
- * JSON.stringify HTML-safe degil — bir node basligi '</script>' icerirse
- * inline <script> tag'i erken kapanir (XSS). '<' karakterini Unicode
- * escape ile gizleyerek tag-injection'i engelleriz.
+ * JSON.stringify is not HTML-safe — if a node title contains '</script>'
+ * the inline <script> tag closes early (XSS). We hide the '<' character
+ * with a Unicode escape to prevent tag injection.
  */
 function safeJsonForScript(value) {
 	return JSON.stringify(value).replace(/</g, "\\u003c");
@@ -329,7 +327,7 @@ export function renderHtml(graph) {
 		.join("");
 
 	return `<!DOCTYPE html>
-<html lang="tr">
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>Badi KB Graph</title>
@@ -353,7 +351,7 @@ export function renderHtml(graph) {
 <body>
 <header>
   <h1>Badi KB Graph</h1>
-  <div class="stats">${stats.totalFiles} dosya · ${stats.totalEdges} baglanti · ${stats.orphans} yetim · ${stats.brokenLinks} kirik</div>
+  <div class="stats">${stats.totalFiles} files · ${stats.totalEdges} links · ${stats.orphans} orphans · ${stats.brokenLinks} broken</div>
 </header>
 <div class="legend">${legendItems}</div>
 <svg id="graph" width="100%" height="900"></svg>
@@ -439,14 +437,14 @@ const nodeEls = nodes.map(n => {
   group.appendChild(c);
   group.appendChild(t);
   group.addEventListener('mouseenter', (e) => {
-    // textContent + DOM API ile XSS engelle (title/id markdown'dan geliyor).
+    // Prevent XSS via textContent + DOM API (title/id come from markdown).
     tooltip.replaceChildren();
     const strong = document.createElement('strong');
     strong.textContent = n.title;
     const idSpan = document.createElement('span');
     idSpan.style.color = '#94a3b8';
     idSpan.textContent = n.id;
-    tooltip.append(strong, document.createElement('br'), idSpan, document.createElement('br'), 'tur: ' + n.type);
+    tooltip.append(strong, document.createElement('br'), idSpan, document.createElement('br'), 'type: ' + n.type);
     tooltip.style.opacity = 1;
   });
   group.addEventListener('mousemove', (e) => {
@@ -519,30 +517,30 @@ function subGraph(flags) {
 	const target = flags.target ? resolve(flags.target) : defaultTarget();
 	const outPath = flags.out ? resolve(flags.out) : defaultOutPath();
 	if (!existsSync(target)) {
-		console.error(chalk.red(`Hedef dizin yok: ${target}`));
+		console.error(chalk.red(`Target directory does not exist: ${target}`));
 		process.exit(1);
 	}
 	const files = scanFiles(target);
 	showBanner();
 	console.log(chalk.bold("Badi KB Graph"));
 	console.log("");
-	console.log(chalk.dim(`  Tarama: ${target}`));
+	console.log(chalk.dim(`  Scan: ${target}`));
 	const graph = buildGraph(files, target);
 	const html = renderHtml(graph);
 	writeFileSync(outPath, html);
 	const stats = computeStats(graph);
 	console.log(
-		`  ${stats.totalFiles} dosya · ${stats.totalEdges} baglanti · ${stats.orphans} yetim · ${stats.brokenLinks} kirik`,
+		`  ${stats.totalFiles} files · ${stats.totalEdges} links · ${stats.orphans} orphans · ${stats.brokenLinks} broken`,
 	);
 	console.log("");
 	console.log(chalk.green(`  ${outPath}`));
-	console.log(chalk.dim("  Tarayicida ac: file:// + yukaridaki yol"));
+	console.log(chalk.dim("  Open in browser: file:// + the path above"));
 }
 
 function subBacklinks(flags) {
 	const file = flags._[0];
 	if (!file) {
-		console.error(chalk.red("Dosya yolu gerekli: badi kb backlinks <dosya>"));
+		console.error(chalk.red("File path required: badi kb backlinks <file>"));
 		process.exit(1);
 	}
 	const target = flags.target ? resolve(flags.target) : defaultTarget();
@@ -554,15 +552,15 @@ function subBacklinks(flags) {
 		(n) => n.id === file || basename(n.id) === basename(file),
 	);
 	if (!matchId) {
-		console.error(chalk.red(`Dosya bulunamadi: ${file}`));
+		console.error(chalk.red(`File not found: ${file}`));
 		process.exit(1);
 	}
 	const links = findBacklinks(graph, matchId.id);
 	showBanner();
-	console.log(chalk.bold(`${matchId.id} icin geri referanslar:`));
+	console.log(chalk.bold(`Backlinks for ${matchId.id}:`));
 	console.log("");
 	if (links.length === 0) {
-		console.log(chalk.dim("  (referans yok — yetim dosya)"));
+		console.log(chalk.dim("  (no references — orphan file)"));
 		return;
 	}
 	for (const { source, count } of links) {
@@ -576,10 +574,10 @@ function subOrphans(flags) {
 	const graph = buildGraph(files, target);
 	const orphans = findOrphans(graph);
 	showBanner();
-	console.log(chalk.bold(`Referanssiz dosyalar: ${orphans.length}`));
+	console.log(chalk.bold(`Unreferenced files: ${orphans.length}`));
 	console.log("");
 	if (orphans.length === 0) {
-		console.log(chalk.green("  Hicbir yetim dosya yok."));
+		console.log(chalk.green("  No orphan files."));
 		return;
 	}
 	for (const id of orphans) {
@@ -593,19 +591,19 @@ function subStats(flags) {
 	const graph = buildGraph(files, target);
 	const stats = computeStats(graph);
 	showBanner();
-	console.log(chalk.bold("Bilgi Tabani Istatistikleri"));
+	console.log(chalk.bold("Knowledge Base Statistics"));
 	console.log("");
-	console.log(`  Toplam dosya:        ${stats.totalFiles}`);
-	console.log(`  Toplam baglanti:     ${stats.totalEdges}`);
-	console.log(`  Yetim dosya:         ${stats.orphans}`);
-	console.log(`  Kirik link:          ${stats.brokenLinks}`);
+	console.log(`  Total files:         ${stats.totalFiles}`);
+	console.log(`  Total links:         ${stats.totalEdges}`);
+	console.log(`  Orphan files:        ${stats.orphans}`);
+	console.log(`  Broken links:        ${stats.brokenLinks}`);
 	console.log("");
-	console.log(chalk.bold("  En cok referans alan:"));
+	console.log(chalk.bold("  Most referenced:"));
 	for (const { id, count } of stats.topReferenced) {
 		console.log(`    ${count}  ${id}`);
 	}
 	console.log("");
-	console.log(chalk.bold("  Tur dagilimi:"));
+	console.log(chalk.bold("  Type distribution:"));
 	for (const [type, count] of Object.entries(stats.typeCounts).sort(
 		(a, b) => b[1] - a[1],
 	)) {
@@ -630,7 +628,7 @@ export async function runKb(args) {
 		case "stats":
 			return subStats(flags);
 		default:
-			console.error(chalk.red(`Bilinmeyen alt-komut: ${sub}`));
+			console.error(chalk.red(`Unknown subcommand: ${sub}`));
 			showHelp();
 			process.exit(1);
 	}

--- a/lib/commands/skills.js
+++ b/lib/commands/skills.js
@@ -1,9 +1,9 @@
-// Badi skills komutu — opt-in skill yonetimi.
+// Badi skills command — opt-in skill management.
 //
-// .claude/skills-vault/  → tum skill'ler (Claude Code yuklemez)
-// .claude/skills/        → kullanici secimi (Claude Code yukler)
+// .claude/skills-vault/  → all skills (Claude Code does not load them)
+// .claude/skills/        → user selection (Claude Code loads them)
 //
-// Token tasarrufu icin: kurulu skill'ler 0 ile baslar, kullanici secer.
+// To save tokens: installed skills start at 0, the user selects.
 
 import {
 	cpSync,
@@ -33,8 +33,8 @@ function paths(target) {
 	};
 }
 
-// Skill kategorilerinin meşru ad formati. Path-traversal saldirilarini
-// engeller: '../', '/', '\', '.' icermez.
+// Legitimate name format for skill categories. Blocks path-traversal
+// attacks: contains no '../', '/', '\', '.'.
 const SKILL_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
 
 export function isValidSkillName(name) {
@@ -112,12 +112,12 @@ function parseSelection(input, max) {
 
 function copySkill(vault, active, name) {
 	if (!isValidSkillName(name)) {
-		throw new Error(`Gecersiz skill adi: ${name}`);
+		throw new Error(`Invalid skill name: ${name}`);
 	}
 	const src = join(vault, name);
 	const dst = join(active, name);
 	if (!existsSync(src)) {
-		throw new Error(`Vault'ta bulunamadi: ${name}`);
+		throw new Error(`Not found in vault: ${name}`);
 	}
 	if (existsSync(dst)) {
 		return { added: false };
@@ -128,7 +128,7 @@ function copySkill(vault, active, name) {
 
 function removeSkill(active, name) {
 	if (!isValidSkillName(name)) {
-		throw new Error(`Gecersiz skill adi: ${name}`);
+		throw new Error(`Invalid skill name: ${name}`);
 	}
 	const dst = join(active, name);
 	if (!existsSync(dst)) return { removed: false };
@@ -143,7 +143,7 @@ function ensureActiveDir(active) {
 function printStatusTable({ vaultList, activeSet }) {
 	const total = vaultList.length;
 	const active = activeSet.size;
-	console.log(chalk.bold(`Skills durumu: ${active}/${total} aktif`));
+	console.log(chalk.bold(`Skills status: ${active}/${total} active`));
 	console.log("");
 	const W = 22;
 	for (let i = 0; i < vaultList.length; i++) {
@@ -168,13 +168,13 @@ function summarizeDetection(result, vaultList) {
 function printDetectResult(result, vaultList, activeSet) {
 	const { proposedSet } = summarizeDetection(result, vaultList);
 	console.log(
-		chalk.bold(`Stack tespit: ${result.technologies.length} teknoloji`),
+		chalk.bold(`Stack detected: ${result.technologies.length} technologies`),
 	);
 	console.log("");
 	if (result.technologies.length === 0) {
 		console.log(
 			chalk.dim(
-				"  (eslesme yok — package.json/configFile/manifest dosyalari taranir)",
+				"  (no match — package.json/configFile/manifest files are scanned)",
 			),
 		);
 		return;
@@ -182,20 +182,20 @@ function printDetectResult(result, vaultList, activeSet) {
 	for (const t of result.technologies) {
 		const skillTxt = t.skills.length
 			? chalk.dim(`→ ${t.skills.join(", ")}`)
-			: chalk.dim("→ (skill yok)");
+			: chalk.dim("→ (no skill)");
 		console.log(
 			`  ${chalk.green("✓")} ${chalk.cyan(t.name.padEnd(18))} ${chalk.dim(`[${t.source}]`)}  ${skillTxt}`,
 		);
 	}
 	console.log("");
-	console.log(chalk.bold(`Onerilen skill kategorileri: ${proposedSet.size}`));
+	console.log(chalk.bold(`Suggested skill categories: ${proposedSet.size}`));
 	const sorted = [...proposedSet].sort();
 	for (const name of sorted) {
 		const isActive = activeSet.has(name);
 		const marker = isActive ? chalk.green("[v]") : chalk.yellow("[ ]");
 		const tag = isActive
-			? chalk.dim("(zaten aktif)")
-			: chalk.dim("(aktif degil)");
+			? chalk.dim("(already active)")
+			: chalk.dim("(not active)");
 		console.log(`  ${marker} ${chalk.cyan(name.padEnd(20))} ${tag}`);
 	}
 	const inactive = sorted.filter((n) => !activeSet.has(n));
@@ -203,7 +203,7 @@ function printDetectResult(result, vaultList, activeSet) {
 		console.log("");
 		console.log(
 			chalk.dim(
-				`Aktive etmek icin: badi skills auto-install  (veya tek tek: badi skills add ${inactive.join(" ")})`,
+				`To activate: badi skills auto-install  (or individually: badi skills add ${inactive.join(" ")})`,
 			),
 		);
 	}
@@ -222,18 +222,18 @@ async function runAutoInstall({
 	const { proposedSet } = summarizeDetection(result, vaultList);
 
 	if (result.technologies.length === 0) {
-		console.log(chalk.dim("Stack tespit edilmedi — degisiklik yok."));
+		console.log(chalk.dim("No stack detected — no changes."));
 		return;
 	}
 
 	if (proposedSet.size === 0) {
 		console.log(
 			chalk.yellow(
-				"Tespit edilen teknolojiler icin vault'ta uygun skill kategorisi yok.",
+				"No suitable skill category in the vault for the detected technologies.",
 			),
 		);
 		console.log(
-			chalk.dim("(stack-map.js'te eslesme yok veya kategori kaldirilmis)"),
+			chalk.dim("(no match in stack-map.js or the category was removed)"),
 		);
 		return;
 	}
@@ -241,13 +241,13 @@ async function runAutoInstall({
 	const toAdd = [...proposedSet].filter((s) => !activeSet.has(s)).sort();
 	if (toAdd.length === 0) {
 		console.log(
-			chalk.green("✓ Onerilen tum skill'ler zaten aktif. Degisiklik yok."),
+			chalk.green("✓ All suggested skills are already active. No changes."),
 		);
 		return;
 	}
 
 	console.log(
-		chalk.bold(`Stack tespit: ${result.technologies.length} teknoloji`),
+		chalk.bold(`Stack detected: ${result.technologies.length} technologies`),
 	);
 	for (const t of result.technologies) {
 		console.log(
@@ -255,14 +255,14 @@ async function runAutoInstall({
 		);
 	}
 	console.log("");
-	console.log(chalk.bold(`Eklenecek skill'ler (${toAdd.length}):`));
+	console.log(chalk.bold(`Skills to add (${toAdd.length}):`));
 	for (const name of toAdd) {
 		console.log(`  ${chalk.yellow("+")} ${chalk.cyan(name)}`);
 	}
 	console.log("");
 
 	if (dryRun) {
-		console.log(chalk.dim("--dry-run aktif: dosyaya yazilmadi."));
+		console.log(chalk.dim("--dry-run active: nothing written to disk."));
 		return;
 	}
 
@@ -270,17 +270,15 @@ async function runAutoInstall({
 		if (!process.stdin.isTTY) {
 			console.error(
 				chalk.red(
-					"Non-TTY: onay alinamiyor. --yes kullan veya TTY'de calistir.",
+					"Non-TTY: cannot get confirmation. Use --yes or run in a TTY.",
 				),
 			);
 			process.exitCode = 1;
 			return;
 		}
-		const ans = await promptChoice(
-			`${toAdd.length} skill aktive edilsin mi? [e/H] `,
-		);
-		if (!/^(e|y|yes|evet)$/i.test(ans)) {
-			console.log(chalk.dim("Iptal edildi."));
+		const ans = await promptChoice(`Activate ${toAdd.length} skills? [y/N] `);
+		if (!/^(y|yes)$/i.test(ans)) {
+			console.log(chalk.dim("Cancelled."));
 			return;
 		}
 	}
@@ -299,79 +297,73 @@ async function runAutoInstall({
 	}
 	console.log("");
 	console.log(
-		`${chalk.green(added)} eklendi, toplam aktif: ${activeSet.size + added}/${vaultList.length}`,
+		`${chalk.green(added)} added, total active: ${activeSet.size + added}/${vaultList.length}`,
 	);
 }
 
 function showHelp() {
-	console.log(chalk.bold("Skills Yonetimi (Opt-in):"));
+	console.log(chalk.bold("Skills Management (Opt-in):"));
 	console.log(
-		"  badi skills                     Durum tablosu + interaktif secim",
+		"  badi skills                     Status table + interactive selection",
 	);
-	console.log(
-		"  badi skills available           Vault'taki tum skill'leri listele",
-	);
-	console.log("  badi skills list                Aktif skill'leri listele");
-	console.log(
-		"  badi skills add <ad...>         Bir veya birden fazla skill aktif et",
-	);
-	console.log("  badi skills remove <ad...>      Aktif skill'i kaldir");
-	console.log("  badi skills clear               Tum aktif skill'leri sifirla");
-	console.log("  badi skills reset               clear ile ayni");
+	console.log("  badi skills available           List all skills in the vault");
+	console.log("  badi skills list                List active skills");
+	console.log("  badi skills add <name...>       Activate one or more skills");
+	console.log("  badi skills remove <name...>    Remove an active skill");
+	console.log("  badi skills clear               Reset all active skills");
+	console.log("  badi skills reset               Same as clear");
 	console.log("");
-	console.log(chalk.bold("Stack-aware kurulum (v1.24+):"));
+	console.log(chalk.bold("Stack-aware install (v1.24+):"));
 	console.log(
-		"  badi skills detect              Projeyi tara, eslesen skill'leri listele (read-only)",
+		"  badi skills detect              Scan the project, list matching skills (read-only)",
 	);
 	console.log(
-		"  badi skills auto-install        Detect + interaktif onay + skill aktive et",
+		"  badi skills auto-install        Detect + interactive confirmation + activate skills",
 	);
 	console.log(
-		"    --yes / -y                    Onay sormadan eslesenleri aktive et",
+		"    --yes / -y                    Activate matches without asking for confirmation",
 	);
-	console.log(
-		"    --dry-run                     Sadece goster, dosyaya dokunma",
-	);
+	console.log("    --dry-run                     Show only, don't touch disk");
 	console.log("");
 	console.log(chalk.bold("Auto-router (v1.20+):"));
 	console.log(
-		'  badi skills route "<prompt>"    Prompt → eslesen skill\'leri puanla',
+		'  badi skills route "<prompt>"    Prompt → score matching skills',
 	);
-	console.log("  badi skills route < file.txt    Stdin'den prompt oku");
+	console.log("  badi skills route < file.txt    Read prompt from stdin");
 	console.log(
-		"  badi skills auto on             UserPromptSubmit hook'unu aktif et",
+		"  badi skills auto on             Enable the UserPromptSubmit hook",
 	);
-	console.log("  badi skills auto off            Hook'u kaldir");
-	console.log("  badi skills auto status         Hook durumunu goster");
+	console.log("  badi skills auto off            Remove the hook");
+	console.log("  badi skills auto status         Show hook status");
 	console.log("");
-	console.log(chalk.bold("Route komutu flag'leri:"));
+	console.log(chalk.bold("Route command flags:"));
+	console.log("    --top N                       Top N matches (default: 3)");
 	console.log(
-		"    --top N                       En iyi N eslesme (default: 3)",
+		"    --inject                      Write matches as SKILL.md body (for the hook)",
 	);
 	console.log(
-		"    --inject                      Match'lenenleri SKILL.md govdesi olarak yaz (hook icin)",
-	);
-	console.log(
-		"    --json                        JSON cikti (matched/contextLength)",
+		"    --json                        JSON output (matched/contextLength)",
 	);
 	console.log("");
-	console.log(chalk.dim("Ornek:"));
+	console.log(chalk.dim("Example:"));
 	console.log(chalk.dim("  badi skills add seo marketing security"));
-	console.log(chalk.dim('  badi skills route "Instagram post yaz"'));
+	console.log(chalk.dim('  badi skills route "write an Instagram post"'));
 	console.log(chalk.dim('  badi skills route "expo eas build" --top 5'));
 	console.log(chalk.dim('  echo "react bug" | badi skills route --inject'));
 	console.log(
-		chalk.dim("  badi skills auto on   # her prompt'tan once otomatik route"),
+		chalk.dim("  badi skills auto on   # auto route before every prompt"),
 	);
 	console.log("");
-	console.log(chalk.bold("Kategoriler (v1.27):"));
+	console.log(chalk.bold("Categories (v1.27):"));
 	console.log(
 		chalk.dim(
-			"  25 genel + 25 pentest-* + 12 expo-* = 62 kategori (opt-in vault).",
+			"  25 general + 25 pentest-* + 12 expo-* = 62 categories (opt-in vault).",
 		),
 	);
 	console.log(
-		chalk.dim("  pentest-*: advisory/defensive, yetkili engagement disiplini."),
+		chalk.dim(
+			"  pentest-*: advisory/defensive, authorized-engagement discipline.",
+		),
 	);
 	console.log(
 		chalk.dim(
@@ -379,7 +371,7 @@ function showHelp() {
 		),
 	);
 	console.log(
-		chalk.dim("  Aile gormek icin: badi skills available | grep <prefix>"),
+		chalk.dim("  To see a family: badi skills available | grep <prefix>"),
 	);
 }
 
@@ -388,8 +380,10 @@ export async function runSkills(args) {
 	const { vault, active } = paths(target);
 
 	if (!existsSync(vault)) {
-		console.error(chalk.red(`skills-vault bulunamadi: ${vault}`));
-		console.log(chalk.dim("Once 'badi update' calistirip kurulumu tazeleyin."));
+		console.error(chalk.red(`skills-vault not found: ${vault}`));
+		console.log(
+			chalk.dim("Run 'badi update' first to refresh the installation."),
+		);
 		process.exit(1);
 	}
 
@@ -407,35 +401,35 @@ export async function runSkills(args) {
 
 	switch (sub) {
 		case undefined: {
-			// Interaktif mod (TTY) veya sadece tablo (non-TTY)
+			// Interactive mode (TTY) or table only (non-TTY)
 			printStatusTable({ vaultList, activeSet });
 
 			if (!process.stdin.isTTY) {
-				console.log(chalk.dim("Etkilesim icin TTY gerekir. Sub-komut kullan:"));
+				console.log(chalk.dim("Interaction requires a TTY. Use a subcommand:"));
 				console.log(
-					chalk.dim("  badi skills add <ad>   |   badi skills clear"),
+					chalk.dim("  badi skills add <name>   |   badi skills clear"),
 				);
 				return;
 			}
 
-			console.log(chalk.bold("Aktif edilecek skill'leri sec:"));
+			console.log(chalk.bold("Select skills to activate:"));
 			console.log(
 				chalk.dim(
-					"  Numara/aralik (1,3,5-7), 'all', 'none' (sifirla) veya Enter = iptal",
+					"  Number/range (1,3,5-7), 'all', 'none' (reset) or Enter = cancel",
 				),
 			);
 			const ans = await promptChoice("> ");
 			if (!ans) {
-				console.log(chalk.dim("Iptal edildi, degisiklik yok."));
+				console.log(chalk.dim("Cancelled, no changes."));
 				return;
 			}
 			const { indices, action } = parseSelection(ans, vaultList.length);
 			if (action === "cancel") {
-				console.log(chalk.dim("Iptal edildi."));
+				console.log(chalk.dim("Cancelled."));
 				return;
 			}
 
-			// Set semantik: secilenler aktif, secilmeyenler kaldirilir
+			// Set semantics: selected become active, unselected are removed
 			const targetNames = new Set(indices.map((i) => vaultList[i]));
 			let added = 0;
 			let removed = 0;
@@ -452,13 +446,13 @@ export async function runSkills(args) {
 			}
 			console.log("");
 			console.log(
-				`${chalk.green(`+${added}`)} eklendi  ${chalk.yellow(`-${removed}`)} kaldirildi  ${chalk.cyan(targetNames.size)} aktif`,
+				`${chalk.green(`+${added}`)} added  ${chalk.yellow(`-${removed}`)} removed  ${chalk.cyan(targetNames.size)} active`,
 			);
 			break;
 		}
 
 		case "available": {
-			console.log(chalk.bold(`Vault (${vaultList.length} skill):`));
+			console.log(chalk.bold(`Vault (${vaultList.length} skills):`));
 			for (const name of vaultList) {
 				const desc = readSkillDescription(join(vault, name));
 				const marker = activeSet.has(name)
@@ -474,9 +468,9 @@ export async function runSkills(args) {
 
 		case "list": {
 			const activeList = [...activeSet].sort();
-			console.log(chalk.bold(`Aktif skill'ler (${activeList.length}):`));
+			console.log(chalk.bold(`Active skills (${activeList.length}):`));
 			if (activeList.length === 0) {
-				console.log(chalk.dim("  (hicbiri — 'badi skills' ile sec)"));
+				console.log(chalk.dim("  (none — select with 'badi skills')"));
 				return;
 			}
 			for (const name of activeList) {
@@ -488,16 +482,16 @@ export async function runSkills(args) {
 		case "add": {
 			const names = args.slice(1).filter(Boolean);
 			if (names.length === 0) {
-				console.error(chalk.red("Hata: en az bir skill adi gerekli."));
-				console.log(chalk.dim("Ornek: badi skills add seo marketing"));
+				console.error(chalk.red("Error: at least one skill name required."));
+				console.log(chalk.dim("Example: badi skills add seo marketing"));
 				process.exit(1);
 			}
 			let added = 0;
 			let skipped = 0;
 			for (const name of names) {
 				if (!isSkillCategory(vault, name)) {
-					console.error(chalk.red(`Vault'ta bulunamadi: ${name}`));
-					console.log(chalk.dim("'badi skills available' ile listeyi gor."));
+					console.error(chalk.red(`Not found in vault: ${name}`));
+					console.log(chalk.dim("See the list with 'badi skills available'."));
 					process.exit(1);
 				}
 				const r = copySkill(vault, active, name);
@@ -506,14 +500,14 @@ export async function runSkills(args) {
 					added++;
 				} else {
 					console.log(
-						`  ${chalk.dim("=")} ${name} ${chalk.dim("(zaten aktif)")}`,
+						`  ${chalk.dim("=")} ${name} ${chalk.dim("(already active)")}`,
 					);
 					skipped++;
 				}
 			}
 			console.log("");
 			console.log(
-				`${chalk.green(added)} eklendi, ${chalk.yellow(skipped)} atlandi.`,
+				`${chalk.green(added)} added, ${chalk.yellow(skipped)} skipped.`,
 			);
 			break;
 		}
@@ -522,8 +516,8 @@ export async function runSkills(args) {
 		case "rm": {
 			const names = args.slice(1).filter(Boolean);
 			if (names.length === 0) {
-				console.error(chalk.red("Hata: en az bir skill adi gerekli."));
-				console.log(chalk.dim("Ornek: badi skills remove seo"));
+				console.error(chalk.red("Error: at least one skill name required."));
+				console.log(chalk.dim("Example: badi skills remove seo"));
 				process.exit(1);
 			}
 			let removed = 0;
@@ -535,14 +529,14 @@ export async function runSkills(args) {
 					removed++;
 				} else {
 					console.log(
-						`  ${chalk.dim("=")} ${name} ${chalk.dim("(zaten pasif)")}`,
+						`  ${chalk.dim("=")} ${name} ${chalk.dim("(already inactive)")}`,
 					);
 					missing++;
 				}
 			}
 			console.log("");
 			console.log(
-				`${chalk.yellow(removed)} kaldirildi, ${chalk.dim(missing)} atlandi.`,
+				`${chalk.yellow(removed)} removed, ${chalk.dim(missing)} skipped.`,
 			);
 			break;
 		}
@@ -572,9 +566,9 @@ export async function runSkills(args) {
 				}
 			}
 			if (!prompt) {
-				console.error(chalk.red("Hata: prompt gerekli (arg veya stdin)."));
+				console.error(chalk.red("Error: prompt required (arg or stdin)."));
 				console.log(
-					chalk.dim('Ornek: badi skills route "SEO icin meta tag yaz"'),
+					chalk.dim('Example: badi skills route "write meta tags for SEO"'),
 				);
 				process.exit(1);
 			}
@@ -606,12 +600,12 @@ export async function runSkills(args) {
 			if (matched.length === 0) {
 				console.log(
 					chalk.dim(
-						"(eslesen skill yok — 'badi skills available' ile listeyi gor)",
+						"(no matching skill — see the list with 'badi skills available')",
 					),
 				);
 				return;
 			}
-			console.log(chalk.bold(`Eslesen skill'ler (${matched.length}):`));
+			console.log(chalk.bold(`Matching skills (${matched.length}):`));
 			for (const m of matched) {
 				const trigText = m.matched.triggers.length
 					? chalk.cyan(`triggers: ${m.matched.triggers.join(", ")}`)
@@ -620,7 +614,7 @@ export async function runSkills(args) {
 					? chalk.dim(`desc: ${m.matched.description.join(", ")}`)
 					: "";
 				console.log(
-					`  ${chalk.bold(m.name.padEnd(20))} ${chalk.green(`skor ${m.score}`.padEnd(10))} ${trigText} ${descText}`,
+					`  ${chalk.bold(m.name.padEnd(20))} ${chalk.green(`score ${m.score}`.padEnd(10))} ${trigText} ${descText}`,
 				);
 			}
 			break;
@@ -634,7 +628,7 @@ export async function runSkills(args) {
 				try {
 					settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
 				} catch {
-					console.error(chalk.red("settings.json gecersiz JSON"));
+					console.error(chalk.red("settings.json invalid JSON"));
 					process.exit(1);
 				}
 			}
@@ -657,21 +651,21 @@ export async function runSkills(args) {
 
 			if (onOff === "on") {
 				if (hasEntry) {
-					console.log(chalk.dim("Auto-router zaten aktif."));
+					console.log(chalk.dim("Auto-router already active."));
 					return;
 				}
 				settings.hooks.UserPromptSubmit.push(HOOK_ENTRY);
 				writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
-				console.log(chalk.green("✓ Auto-router aktif"));
+				console.log(chalk.green("✓ Auto-router enabled"));
 				console.log(
 					chalk.dim(
-						"Her prompt'tan once vault taranir, eslesen skill'ler context'e inject edilir.",
+						"The vault is scanned before every prompt, matching skills are injected into the context.",
 					),
 				);
-				console.log(chalk.dim("Kapatmak icin: badi skills auto off"));
+				console.log(chalk.dim("To disable: badi skills auto off"));
 			} else if (onOff === "off") {
 				if (!hasEntry) {
-					console.log(chalk.dim("Auto-router zaten kapali."));
+					console.log(chalk.dim("Auto-router already disabled."));
 					return;
 				}
 				settings.hooks.UserPromptSubmit =
@@ -682,19 +676,17 @@ export async function runSkills(args) {
 					delete settings.hooks.UserPromptSubmit;
 				}
 				writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
-				console.log(chalk.yellow("✓ Auto-router kapatildi"));
+				console.log(chalk.yellow("✓ Auto-router disabled"));
 			} else if (!onOff || onOff === "status") {
 				console.log(
 					chalk.bold(
-						`Auto-router: ${hasEntry ? chalk.green("AKTIF") : chalk.dim("kapali")}`,
+						`Auto-router: ${hasEntry ? chalk.green("ACTIVE") : chalk.dim("disabled")}`,
 					),
 				);
-				console.log(chalk.dim("Acmak icin:  badi skills auto on"));
-				console.log(chalk.dim("Kapatmak:    badi skills auto off"));
+				console.log(chalk.dim("To enable:   badi skills auto on"));
+				console.log(chalk.dim("To disable:  badi skills auto off"));
 			} else {
-				console.error(
-					chalk.red(`Bilinmeyen: ${onOff}. Kullan: on / off / status`),
-				);
+				console.error(chalk.red(`Unknown: ${onOff}. Use: on / off / status`));
 				process.exit(1);
 			}
 			break;
@@ -726,21 +718,19 @@ export async function runSkills(args) {
 		case "reset": {
 			const names = [...activeSet];
 			if (names.length === 0) {
-				console.log(chalk.dim("Aktif skill yok, sifirlamaya gerek yok."));
+				console.log(chalk.dim("No active skills, nothing to reset."));
 				return;
 			}
 			for (const name of names) removeSkill(active, name);
-			console.log(`${chalk.yellow(names.length)} aktif skill sifirlandi.`);
+			console.log(`${chalk.yellow(names.length)} active skills reset.`);
 			console.log(
-				chalk.dim(
-					"Yeniden secmek icin: 'badi skills' veya 'badi skills add <ad>'",
-				),
+				chalk.dim("To select again: 'badi skills' or 'badi skills add <name>'"),
 			);
 			break;
 		}
 
 		default:
-			console.error(chalk.red(`Bilinmeyen alt komut: ${sub}`));
+			console.error(chalk.red(`Unknown subcommand: ${sub}`));
 			showHelp();
 			process.exit(1);
 	}

--- a/tests/cli.kb.test.js
+++ b/tests/cli.kb.test.js
@@ -326,7 +326,7 @@ describe("badi kb: subprocess akisi", () => {
 			encoding: "utf-8",
 		});
 		assert.equal(r.status, 0);
-		assert.match(r.stdout, /Toplam dosya/);
+		assert.match(r.stdout, /Total files/);
 	});
 
 	it("backlinks: dosya gerekli flag eksikse exit 1", () => {
@@ -335,7 +335,7 @@ describe("badi kb: subprocess akisi", () => {
 			encoding: "utf-8",
 		});
 		assert.equal(r.status, 1);
-		assert.match(r.stderr, /Dosya yolu gerekli/);
+		assert.match(r.stderr, /File path required/);
 	});
 
 	it("hedef dizin yok ise exit 1", () => {
@@ -344,7 +344,7 @@ describe("badi kb: subprocess akisi", () => {
 			encoding: "utf-8",
 		});
 		assert.equal(r.status, 1);
-		assert.match(r.stderr, /Hedef dizin yok/);
+		assert.match(r.stderr, /Target directory does not exist/);
 	});
 
 	it("bilinmeyen alt-komut exit 1", () => {
@@ -353,6 +353,6 @@ describe("badi kb: subprocess akisi", () => {
 			encoding: "utf-8",
 		});
 		assert.equal(r.status, 1);
-		assert.match(r.stderr, /Bilinmeyen alt-komut/);
+		assert.match(r.stderr, /Unknown subcommand/);
 	});
 });

--- a/tests/cli.skills-router.test.js
+++ b/tests/cli.skills-router.test.js
@@ -265,7 +265,7 @@ describe("skills-router: CLI integration", () => {
 			encoding: "utf-8",
 			timeout: 10000,
 		});
-		assert.match(out, /kapali/);
+		assert.match(out, /disabled/);
 	});
 
 	it("badi skills auto on settings.json'a hook ekler", () => {

--- a/tests/cli.skills.auto.test.js
+++ b/tests/cli.skills.auto.test.js
@@ -91,7 +91,7 @@ describe("badi skills detect", () => {
 			encoding: "utf-8",
 		});
 		assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-		assert.match(r.stdout, /Stack tespit: 1 teknoloji/);
+		assert.match(r.stdout, /Stack detected: 1 technologies/);
 		assert.match(r.stdout, /React/);
 		assert.match(r.stdout, /design/);
 		assert.match(r.stdout, /frontend-taste/);
@@ -104,7 +104,7 @@ describe("badi skills detect", () => {
 			encoding: "utf-8",
 		});
 		assert.equal(r.status, 0);
-		assert.match(r.stdout, /eslesme yok|0 teknoloji/);
+		assert.match(r.stdout, /no match|0 technologies/);
 	});
 
 	it("Next.js eklenirse SEO kategorileri gelir", () => {
@@ -136,7 +136,7 @@ describe("badi skills auto-install", () => {
 			encoding: "utf-8",
 		});
 		assert.equal(r.status, 0);
-		assert.match(r.stdout, /--dry-run aktif/);
+		assert.match(r.stdout, /--dry-run active/);
 		// .claude/skills/ olusturulmus olabilir ama design KOPYALANMAMIS olmali
 		const installed = join(dir, ".claude", "skills", "design");
 		assert.equal(existsSync(installed), false);
@@ -149,7 +149,7 @@ describe("badi skills auto-install", () => {
 			encoding: "utf-8",
 		});
 		assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-		assert.match(r.stdout, /\d+ eklendi/);
+		assert.match(r.stdout, /\d+ added/);
 		assert.equal(existsSync(join(dir, ".claude", "skills", "design")), true);
 		assert.equal(
 			existsSync(join(dir, ".claude", "skills", "frontend-taste")),
@@ -170,7 +170,7 @@ describe("badi skills auto-install", () => {
 			encoding: "utf-8",
 		});
 		assert.equal(r.status, 0);
-		assert.match(r.stdout, /zaten aktif/);
+		assert.match(r.stdout, /already active/);
 	});
 
 	it("stack yok -> degisiklik yok mesaji", () => {
@@ -180,7 +180,7 @@ describe("badi skills auto-install", () => {
 			encoding: "utf-8",
 		});
 		assert.equal(r.status, 0);
-		assert.match(r.stdout, /Stack tespit edilmedi|degisiklik yok/);
+		assert.match(r.stdout, /No stack detected|no changes/);
 	});
 
 	it("non-TTY + --yes yoksa exit 1 (CI guvenligi)", () => {
@@ -191,7 +191,7 @@ describe("badi skills auto-install", () => {
 			stdio: ["ignore", "pipe", "pipe"],
 		});
 		assert.equal(r.status, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
-		assert.match(r.stderr, /--yes kullan|TTY/);
+		assert.match(r.stderr, /--yes|TTY/);
 	});
 
 	it("--yes + --dry-run: dry-run kazanir, dosya yazilmaz", () => {
@@ -202,7 +202,7 @@ describe("badi skills auto-install", () => {
 			{ cwd: dir, encoding: "utf-8" },
 		);
 		assert.equal(r.status, 0);
-		assert.match(r.stdout, /--dry-run aktif/);
+		assert.match(r.stdout, /--dry-run active/);
 		assert.equal(existsSync(join(dir, ".claude", "skills", "design")), false);
 	});
 
@@ -222,7 +222,7 @@ describe("badi skills auto-install", () => {
 			encoding: "utf-8",
 		});
 		assert.equal(r.status, 0);
-		assert.match(r.stdout, /vault'ta uygun skill kategorisi yok/);
+		assert.match(r.stdout, /No suitable skill category in the vault/);
 	});
 });
 

--- a/tests/cli.skills.test.js
+++ b/tests/cli.skills.test.js
@@ -58,7 +58,7 @@ describe("badi skills", () => {
 
 	it("--help kullanim gosterir", () => {
 		const out = run(["skills", "--help"], cwd);
-		assert.match(out, /Skills Yonetimi/);
+		assert.match(out, /Skills Management/);
 		assert.match(out, /add/);
 		assert.match(out, /clear/);
 	});
@@ -68,13 +68,13 @@ describe("badi skills", () => {
 		assert.match(out, /seo/);
 		assert.match(out, /marketing/);
 		assert.match(out, /security/);
-		assert.match(out, /Vault \(3 skill\)/);
+		assert.match(out, /Vault \(3 skills\)/);
 	});
 
 	it("list bos durumda hicbiri gosterir", () => {
 		const out = run(["skills", "list"], cwd);
-		assert.match(out, /Aktif skill'ler \(0\)/);
-		assert.match(out, /hicbiri/);
+		assert.match(out, /Active skills \(0\)/);
+		assert.match(out, /none/);
 	});
 
 	it("add tek skill'i aktif eder", () => {
@@ -94,7 +94,7 @@ describe("badi skills", () => {
 	it("add ayni skill'i tekrarlamayi atlar", () => {
 		run(["skills", "add", "seo"], cwd);
 		const out = run(["skills", "add", "seo"], cwd);
-		assert.match(out, /zaten aktif/);
+		assert.match(out, /already active/);
 	});
 
 	it("add olmayan skill icin hata firlatir", () => {
@@ -103,7 +103,7 @@ describe("badi skills", () => {
 			assert.fail("Hata bekleniyor");
 		} catch (e) {
 			assert.equal(e.status, 1);
-			assert.match(e.stderr || e.stdout, /Vault'ta bulunamadi/);
+			assert.match(e.stderr || e.stdout, /Not found in vault/);
 		}
 	});
 
@@ -118,26 +118,26 @@ describe("badi skills", () => {
 	it("clear tum aktif skill'leri sifirlar", () => {
 		run(["skills", "add", "seo", "marketing", "security"], cwd);
 		const out = run(["skills", "clear"], cwd);
-		assert.match(out, /3 aktif skill sifirlandi/);
+		assert.match(out, /3 active skills reset/);
 		const list = run(["skills", "list"], cwd);
-		assert.match(list, /Aktif skill'ler \(0\)/);
+		assert.match(list, /Active skills \(0\)/);
 	});
 
 	it("reset clear ile ayni isi yapar", () => {
 		run(["skills", "add", "seo"], cwd);
 		const out = run(["skills", "reset"], cwd);
-		assert.match(out, /1 aktif skill sifirlandi/);
+		assert.match(out, /1 active skills reset/);
 	});
 
 	it("clear bos listede sessizce uyarir", () => {
 		const out = run(["skills", "clear"], cwd);
-		assert.match(out, /sifirlamaya gerek yok/);
+		assert.match(out, /nothing to reset/);
 	});
 
 	it("argumansiz cagri durum tablosu gosterir (non-TTY)", () => {
 		const out = run(["skills"], cwd);
-		assert.match(out, /Skills durumu: 0\/3 aktif/);
-		assert.match(out, /TTY gerekir/);
+		assert.match(out, /Skills status: 0\/3 active/);
+		assert.match(out, /requires a TTY/);
 	});
 
 	it("vault yoksa hata firlatir", () => {
@@ -148,7 +148,7 @@ describe("badi skills", () => {
 			assert.fail("Hata bekleniyor");
 		} catch (e) {
 			assert.equal(e.status, 1);
-			assert.match(e.stderr || e.stdout, /skills-vault bulunamadi/);
+			assert.match(e.stderr || e.stdout, /skills-vault not found/);
 		}
 	});
 });

--- a/tests/security-hardening.test.js
+++ b/tests/security-hardening.test.js
@@ -66,8 +66,8 @@ describe("Y1 — skills name validation (path traversal)", () => {
 			const r = run(TMP, "skills", "add", "../external-secrets");
 			assert.ok(
 				r.status !== 0 ||
-					r.stderr.includes("bulunamadi") ||
-					r.stdout.includes("bulunamadi"),
+					r.stderr.includes("Not found in vault") ||
+					r.stdout.includes("Not found in vault"),
 				"path traversal reddedilmeli",
 			);
 			// External secrets active skills'e kopyalanmamali


### PR DESCRIPTION
## Phase 2l — English-only migration (#207)

Translates all user-facing CLI output and comments to English across **domain** (SSL/DNS/WHOIS health), **skills** (opt-in skill management), and **kb** (knowledge-base graph). Subcommand names and flags stay stable — no interface renames in this batch.

### Changed
- **domain.js** — ssl / dns / whois output, help, error messages. **Preserved verbatim:** the strict-TLS-first fallback (`rejectUnauthorized: !insecure`), DNS/WHOIS query logic, and the google/apple/ms DNS-verification TXT detection patterns.
- **skills.js** — status / available / list / add / remove / route / auto / detect / auto-install / clear output + help. **Preserved verbatim:** path-traversal validation (`SKILL_NAME_RE`), `settings.json` hook manipulation, routing logic. The confirm prompt changed from `[e/H]` to `[y/N]` (and its regex to `/^(y|yes)$/i`). Also pluralized "Vault (N skills)" / "Active skills (N)".
- **kb.js** — graph / backlinks / orphans / stats output + help + JSDoc. The **self-contained HTML/SVG graph template is preserved byte-for-byte** (only `lang="en"`, the stats line, one XSS comment, and `'type:'` translated).

### Tests
Updated in lockstep: `cli.skills.test.js`, `cli.skills.auto.test.js`, `cli.skills-router.test.js`, `cli.kb.test.js`, plus the `security-hardening.test.js` path-traversal assertion (`bulunamadi` → `Not found in vault`; the `status !== 0` check remains the primary guard, so rejection is still enforced). `cli.domain.test.js` needed no changes.

### Verification
- `npm run lint` — clean (3 files auto-formatted after translation)
- `npm test` — **1132/1132 pass**
- Guard greps — no Turkish console strings remain (false positives: "**sec**urity", "**proje**ct")

🤖 Generated with [Claude Code](https://claude.com/claude-code)