### PR TITLE
feat(i18n): English-only Phase 2m — commands, agent CLI output

### DIFF
--- a/lib/commands/agent.js
+++ b/lib/commands/agent.js
@@ -62,17 +62,19 @@ async function subCreate(args, cwd) {
 	}
 	if (!name) {
 		console.error(
-			chalk.red("Kullanim: badi agent create <isim> [--template <isim>]"),
+			chalk.red("Usage: badi agent create <name> [--template <name>]"),
 		);
 		process.exit(1);
 	}
 	if (!/^[a-z0-9][a-z0-9-]{1,63}$/i.test(name)) {
-		console.error(chalk.red(`Gecersiz isim: ${name} (harf/rakam/tire, 2-64)`));
+		console.error(
+			chalk.red(`Invalid name: ${name} (letters/digits/hyphen, 2-64)`),
+		);
 		process.exit(1);
 	}
 	const dest = watcherPath(cwd, name);
 	if (existsSync(dest)) {
-		console.error(chalk.red(`Zaten var: ${dest}`));
+		console.error(chalk.red(`Already exists: ${dest}`));
 		process.exit(1);
 	}
 
@@ -82,7 +84,7 @@ async function subCreate(args, cwd) {
 		if (!tpl) {
 			console.error(
 				chalk.red(
-					`Bilinmeyen template: ${template} (mevcut: ${Object.keys(TEMPLATES).join(", ")})`,
+					`Unknown template: ${template} (available: ${Object.keys(TEMPLATES).join(", ")})`,
 				),
 			);
 			process.exit(1);
@@ -93,8 +95,8 @@ async function subCreate(args, cwd) {
 		);
 	} else {
 		// minimal interactive boilerplate
-		const desc = await ask("Aciklama (bos = atla): ");
-		const every = (await ask("Calistirma araligi [15m]: ")) || "15m";
+		const desc = await ask("Description (empty = skip): ");
+		const every = (await ask("Run interval [15m]: ")) || "15m";
 		content = `---
 name: ${name}
 description: ${desc}
@@ -107,8 +109,8 @@ watch:
 report_to: .claude/workspace/watcher-reports/${name}.md
 ---
 
-## Notlar
-${desc || `"${name}" takipcisi. Watch tiplerini duzenleyerek genislet.`}
+## Notes
+${desc || `"${name}" watcher. Extend it by editing the watch types.`}
 `;
 	}
 
@@ -119,9 +121,9 @@ ${desc || `"${name}" takipcisi. Watch tiplerini duzenleyerek genislet.`}
 		chalk.dim(
 			"  badi agent run " +
 				name +
-				"      # manual calistir\n  badi agent install " +
+				"      # run manually\n  badi agent install " +
 				name +
-				"  # scheduler'a kayit et",
+				"  # register with a scheduler",
 		),
 	);
 }
@@ -133,26 +135,26 @@ function subList(cwd) {
 	if (!files.length) {
 		console.log(
 			chalk.dim(
-				"Henuz watcher yok. Ornek: badi agent create proje-saglik --template project-health",
+				"No watchers yet. Example: badi agent create project-health --template project-health",
 			),
 		);
 		return;
 	}
-	console.log(chalk.bold("Watcher'lar:"));
+	console.log(chalk.bold("Watchers:"));
 	for (const f of files) {
 		try {
 			const w = loadWatcher(f);
 			const installed = findInstalled(w.name);
 			const marker = installed.length
 				? chalk.green(`[${installed.map((s) => s.id).join(",")}]`)
-				: chalk.dim("[install edilmemis]");
-			const active = w.active ? "" : chalk.dim(" (pasif)");
+				: chalk.dim("[not installed]");
+			const active = w.active ? "" : chalk.dim(" (inactive)");
 			console.log(
 				`  ${w.name.padEnd(24)} ${marker} ${w.every.padEnd(6)} ${w.watches.length} watch${active}`,
 			);
 		} catch (e) {
 			console.log(
-				`  ${chalk.red(basename(f, ".md"))}  ${chalk.dim(`(bozuk: ${e.message})`)}`,
+				`  ${chalk.red(basename(f, ".md"))}  ${chalk.dim(`(corrupt: ${e.message})`)}`,
 			);
 		}
 	}
@@ -163,12 +165,12 @@ function subList(cwd) {
 async function subRun(args, cwd) {
 	const name = args[0];
 	if (!name) {
-		console.error(chalk.red("Kullanim: badi agent run <isim>"));
+		console.error(chalk.red("Usage: badi agent run <name>"));
 		process.exit(1);
 	}
 	const file = watcherPath(cwd, name);
 	if (!existsSync(file)) {
-		console.error(chalk.red(`Watcher yok: ${file}`));
+		console.error(chalk.red(`No watcher: ${file}`));
 		process.exit(1);
 	}
 	const { watcher, results, overall } = await runWatcher(file, { cwd });
@@ -178,7 +180,7 @@ async function subRun(args, cwd) {
 			: overall === "skipped"
 				? chalk.dim("--")
 				: chalk.red("!!");
-	console.log(`${icon}  ${watcher.name}: ${results.length} kontrol`);
+	console.log(`${icon}  ${watcher.name}: ${results.length} checks`);
 	for (const r of results) {
 		const tag = r.pass ? chalk.green("ok") : chalk.red("fail");
 		console.log(`  [${tag}] ${r.check.type}: ${r.message}`);
@@ -187,7 +189,7 @@ async function subRun(args, cwd) {
 		}
 	}
 	const reportPath = resolve(cwd, watcher.reportTo);
-	console.log(chalk.dim(`  rapor: ${reportPath}`));
+	console.log(chalk.dim(`  report: ${reportPath}`));
 	process.exit(overall === "alert" ? 2 : 0);
 }
 
@@ -206,14 +208,14 @@ async function subInstall(args, cwd) {
 	if (!name) {
 		console.error(
 			chalk.red(
-				"Kullanim: badi agent install <isim> [--scheduler id] [--dry-run] [--yes]",
+				"Usage: badi agent install <name> [--scheduler id] [--dry-run] [--yes]",
 			),
 		);
 		process.exit(1);
 	}
 	const file = watcherPath(cwd, name);
 	if (!existsSync(file)) {
-		console.error(chalk.red(`Watcher yok: ${file}`));
+		console.error(chalk.red(`No watcher: ${file}`));
 		process.exit(1);
 	}
 	const w = loadWatcher(file);
@@ -225,11 +227,11 @@ async function subInstall(args, cwd) {
 	if (hasShell && !dryRun && !yesFlag && process.stdin.isTTY) {
 		const answer = await ask(
 			chalk.yellow(
-				`Dikkat: '${name}' rastgele shell komutu calistiracak. Zamanlayiciya kayit edilsin mi? [y/N]: `,
+				`Warning: '${name}' will run an arbitrary shell command. Register it with the scheduler? [y/N]: `,
 			),
 		);
 		if (!/^y(es)?$/i.test(answer)) {
-			console.log(chalk.dim("Iptal edildi."));
+			console.log(chalk.dim("Cancelled."));
 			return;
 		}
 	}
@@ -248,7 +250,7 @@ async function subInstall(args, cwd) {
 	);
 
 	if (dryRun) {
-		console.log(chalk.bold("DRY-RUN — diske yazilmadi."));
+		console.log(chalk.bold("DRY-RUN — nothing written to disk."));
 		console.log(chalk.dim(`  Scheduler: ${scheduler.id}`));
 		console.log(chalk.dim(`  Plan: ${JSON.stringify(installResult.plan)}`));
 		const c = installResult.content;
@@ -261,27 +263,25 @@ async function subInstall(args, cwd) {
 		}
 		return;
 	}
-	console.log(chalk.green(`+ ${scheduler.id} ile kayit edildi`));
-	console.log(
-		chalk.dim(`  Her ${w.every} bir calisacak (${intervalSeconds}s)`),
-	);
+	console.log(chalk.green(`+ Registered with ${scheduler.id}`));
+	console.log(chalk.dim(`  Will run every ${w.every} (${intervalSeconds}s)`));
 }
 
 function subUninstall(args, cwd) {
 	const name = args[0];
 	if (!name) {
-		console.error(chalk.red("Kullanim: badi agent uninstall <isim>"));
+		console.error(chalk.red("Usage: badi agent uninstall <name>"));
 		process.exit(1);
 	}
 	const installed = findInstalled(name);
 	if (!installed.length) {
-		console.log(chalk.dim(`${name}: kurulu scheduler yok`));
+		console.log(chalk.dim(`${name}: no installed scheduler`));
 		return;
 	}
 	for (const s of installed) {
 		const r = s.uninstall({ name });
 		if (r.existed) {
-			console.log(chalk.green(`- ${s.id}: temizlendi`));
+			console.log(chalk.green(`- ${s.id}: cleaned up`));
 		}
 	}
 	// cwd param used for symmetry with other subcommands; scheduler adapters
@@ -298,18 +298,18 @@ function subTail(args, cwd) {
 		if (args[i] === "-n") n = Number.parseInt(args[++i], 10) || 20;
 	}
 	if (!name) {
-		console.error(chalk.red("Kullanim: badi agent tail <isim> [-n N]"));
+		console.error(chalk.red("Usage: badi agent tail <name> [-n N]"));
 		process.exit(1);
 	}
 	const file = watcherPath(cwd, name);
 	if (!existsSync(file)) {
-		console.error(chalk.red(`Watcher yok: ${file}`));
+		console.error(chalk.red(`No watcher: ${file}`));
 		process.exit(1);
 	}
 	const w = loadWatcher(file);
 	const p = resolve(cwd, w.reportTo);
 	if (!existsSync(p)) {
-		console.log(chalk.dim(`Rapor yok: ${p}`));
+		console.log(chalk.dim(`No report: ${p}`));
 		return;
 	}
 	const lines = readFileSync(p, "utf-8").split("\n");
@@ -345,14 +345,14 @@ function subStatus(args, cwd) {
 		return;
 	}
 	if (!summary.length) {
-		console.log(chalk.dim("Kayitli watcher yok."));
+		console.log(chalk.dim("No registered watcher."));
 		return;
 	}
-	console.log(chalk.bold(`Son ${Math.round(sinceMs / 3_600_000)}h icinde:`));
+	console.log(chalk.bold(`In the last ${Math.round(sinceMs / 3_600_000)}h:`));
 	for (const s of summary) {
 		const label =
-			s.alerts > 0 ? chalk.red(`!! ${s.alerts} uyari`) : chalk.green("OK");
-		console.log(`  ${s.name.padEnd(24)} ${label}  (toplam ${s.total} rapor)`);
+			s.alerts > 0 ? chalk.red(`!! ${s.alerts} alerts`) : chalk.green("OK");
+		console.log(`  ${s.name.padEnd(24)} ${label}  (total ${s.total} reports)`);
 		if (s.alerts > 0) {
 			for (const e of s.alertEntries.slice(-3)) {
 				console.log(chalk.dim(`    ${e.timestamp}:`));
@@ -371,7 +371,7 @@ function subStatus(args, cwd) {
 function subRemove(args, cwd) {
 	const name = args[0];
 	if (!name) {
-		console.error(chalk.red("Kullanim: badi agent remove <isim>"));
+		console.error(chalk.red("Usage: badi agent remove <name>"));
 		process.exit(1);
 	}
 	// first uninstall any scheduler
@@ -379,34 +379,34 @@ function subRemove(args, cwd) {
 	const p = watcherPath(cwd, name);
 	if (existsSync(p)) {
 		unlinkSync(p);
-		console.log(chalk.green(`- ${p} silindi`));
+		console.log(chalk.green(`- ${p} deleted`));
 	} else {
-		console.log(chalk.dim(`${p} zaten yok`));
+		console.log(chalk.dim(`${p} already gone`));
 	}
 }
 
 // ─── help ───
 
 function showAgentHelp() {
-	console.log(chalk.bold("badi agent — arka plan watcher yonetimi"));
+	console.log(chalk.bold("badi agent — background watcher management"));
 	console.log("");
-	console.log("Komutlar:");
-	console.log("  create <isim> [--template project-health|deploy-watchdog]");
+	console.log("Commands:");
+	console.log("  create <name> [--template project-health|deploy-watchdog]");
 	console.log("  list");
-	console.log("  run <isim>                       # manual calistir (test)");
-	console.log("  install <isim> [--scheduler id] [--dry-run] [--yes]");
-	console.log("  uninstall <isim>");
-	console.log("  tail <isim> [-n N]");
+	console.log("  run <name>                       # run manually (test)");
+	console.log("  install <name> [--scheduler id] [--dry-run] [--yes]");
+	console.log("  uninstall <name>");
+	console.log("  tail <name> [-n N]");
 	console.log("  status [--since 24h|7d] [--format text|json]");
 	console.log(
-		"  remove <isim>                    # watcher.md + scheduler'i sil",
+		"  remove <name>                    # delete watcher.md + scheduler",
 	);
 	console.log("");
-	console.log("Desteklenen scheduler'lar:");
+	console.log("Supported schedulers:");
 	for (const s of SCHEDULERS) {
 		const avail = s.isAvailable()
 			? chalk.green("[available]")
-			: chalk.dim("[yok]");
+			: chalk.dim("[unavailable]");
 		console.log(`  ${s.id.padEnd(10)} ${s.platform.padEnd(7)} ${avail}`);
 	}
 }
@@ -440,7 +440,7 @@ export async function runAgent(args) {
 		case "remove":
 			return subRemove(rest, cwd);
 		default:
-			console.error(chalk.red(`Bilinmeyen alt komut: ${sub}`));
+			console.error(chalk.red(`Unknown subcommand: ${sub}`));
 			process.exit(1);
 	}
 }

--- a/lib/commands/commands.js
+++ b/lib/commands/commands.js
@@ -1,10 +1,10 @@
-// Badi commands komutu — profil bazli komut yonetimi.
+// Badi commands command — profile-based command management.
 //
-// .claude/commands-vault/  → tum komutlar (Claude Code yuklemez)
-// .claude/commands/        → aktif profil komutlari (Claude Code yukler)
+// .claude/commands-vault/  → all commands (Claude Code does not load them)
+// .claude/commands/        → active profile commands (Claude Code loads them)
 //
-// Profil etiketleri: core, dev, content, pentest, all
-// "core" her profilde aktif kalir, "all" hepsini acar.
+// Profile tags: core, dev, content, pentest, all
+// "core" stays active in every profile, "all" enables everything.
 
 import {
 	copyFileSync,
@@ -69,9 +69,9 @@ function ensureDir(dir) {
 }
 
 /**
- * Mevcut .claude/commands/ icerigini vault'a kopyala.
- * Vault'ta zaten varsa uzerine yazmaz (canonical-vault prensibi).
- * Geri dondurur: { migrated, skipped }
+ * Copy the current .claude/commands/ contents into the vault.
+ * Does not overwrite if already present in the vault (canonical-vault principle).
+ * Returns: { migrated, skipped }
  */
 function migrateToVault(active, vault) {
 	ensureDir(vault);
@@ -92,14 +92,14 @@ function migrateToVault(active, vault) {
 }
 
 /**
- * Profil degisikligini uygula:
- *  - Vault'taki tum komutlardan, hedef profile uyanlari .claude/commands/'a
- *    kopyala (yoksa).
- *  - Profil disinda kalan komutlari .claude/commands/'tan sil.
- *  - "all" profil = vault icerigini tam yansit.
- *  - Bilinmeyen komutlara (vault'ta olmayan) dokunma (kullanici komutu).
+ * Apply a profile change:
+ *  - From all commands in the vault, copy those matching the target profile
+ *    into .claude/commands/ (if missing).
+ *  - Remove commands outside the profile from .claude/commands/.
+ *  - "all" profile = mirror the vault contents exactly.
+ *  - Don't touch unknown commands (not in the vault) (user commands).
  *
- * Geri dondurur: { added: [], removed: [] }
+ * Returns: { added: [], removed: [] }
  */
 function applyProfile(vault, active, profile) {
 	ensureDir(active);
@@ -110,7 +110,7 @@ function applyProfile(vault, active, profile) {
 	const added = [];
 	const removed = [];
 
-	// Eksikleri ekle
+	// Add missing ones
 	for (const name of vaultCmds) {
 		if (profile === "all" || targetSet.has(name)) {
 			if (!activeCmds.includes(name)) {
@@ -120,9 +120,9 @@ function applyProfile(vault, active, profile) {
 		}
 	}
 
-	// Profil disindakileri sil (sadece COMMAND_PROFILES'ta tanimli olanlari)
+	// Remove those outside the profile (only ones defined in COMMAND_PROFILES)
 	for (const name of activeCmds) {
-		if (!COMMAND_PROFILES[name]) continue; // bilinmeyen = kullanici komutu, dokunma
+		if (!COMMAND_PROFILES[name]) continue; // unknown = user command, don't touch
 		if (profile === "all") continue;
 		if (!targetSet.has(name)) {
 			rmSync(join(active, `${name}.md`));
@@ -147,70 +147,70 @@ function promptChoice(message) {
 }
 
 function showHelp() {
-	console.log(chalk.bold("Commands Yonetimi (Profil bazli, v1.26+):"));
+	console.log(chalk.bold("Commands Management (Profile-based, v1.26+):"));
 	console.log("");
-	console.log(chalk.bold("Durum / Listeleme:"));
+	console.log(chalk.bold("Status / Listing:"));
 	console.log(
-		"  badi commands                    Aktif profil + komut sayilari",
+		"  badi commands                    Active profile + command counts",
 	);
 	console.log(
-		"  badi commands list               Aktif komutlari ve profillerini listele",
+		"  badi commands list               List active commands and their profiles",
 	);
 	console.log(
-		"  badi commands available          Vault'taki tum komutlari listele",
+		"  badi commands available          List all commands in the vault",
 	);
 	console.log(
-		"  badi commands profiles           Profil tanimlarini ve sayilarini goster",
+		"  badi commands profiles           Show profile definitions and counts",
 	);
 	console.log("");
-	console.log(chalk.bold("Profil Yonetimi:"));
-	console.log(`  badi commands profile            Aktif profili goster`);
+	console.log(chalk.bold("Profile Management:"));
+	console.log(`  badi commands profile            Show the active profile`);
 	console.log(
-		`  badi commands profile <ad>       Profili degistir (${PROFILES.join("|")})`,
+		`  badi commands profile <name>     Change the profile (${PROFILES.join("|")})`,
 	);
 	console.log(
-		"  badi commands migrate            Mevcut commands/'i vault'a kopyala (ilk kurulum)",
+		"  badi commands migrate            Copy current commands/ to the vault (first setup)",
 	);
 	console.log(
-		"  badi commands restore            Tum profili 'all'a sifirla (commands/'a tum vault'u koy)",
+		"  badi commands restore            Reset the whole profile to 'all' (put the entire vault in commands/)",
 	);
 	console.log("");
 	console.log(chalk.bold("Prompt-Aware Routing (v1.26+):"));
 	console.log(
-		'  badi commands route "<prompt>"   Prompt\'a uyan komutlari skorla',
+		'  badi commands route "<prompt>"   Score commands matching the prompt',
 	);
-	console.log("  badi commands route < file.txt   Stdin'den prompt oku");
+	console.log("  badi commands route < file.txt   Read prompt from stdin");
 	console.log("");
-	console.log(chalk.bold("Profil komutu flag'leri:"));
+	console.log(chalk.bold("Profile command flags:"));
 	console.log(
-		"  --yes, -y          Onay sormadan uygula (CI/non-TTY icin gerekli)",
+		"  --yes, -y          Apply without asking for confirmation (required for CI/non-TTY)",
 	);
-	console.log("  --dry-run          Sadece preview, dosyaya yazma");
+	console.log("  --dry-run          Preview only, don't write to disk");
 	console.log(
-		"  --force            Ayni profile yeniden uygula (cache temizleme)",
+		"  --force            Re-apply the same profile (cache clearing)",
+	);
+	console.log("  --verbose, -v      List commands to add/remove by name");
+	console.log("");
+	console.log(chalk.bold("Route command flags:"));
+	console.log("  --top N            Top N matches (default: 3)");
+	console.log(
+		"  --inject           Write a hint blob in hook format to stdout",
 	);
 	console.log(
-		"  --verbose, -v      Eklenecek/silinecek komutlari isim-isim listele",
+		"  --json             JSON output (matched/contextLength fields)",
 	);
 	console.log("");
-	console.log(chalk.bold("Route komutu flag'leri:"));
-	console.log("  --top N            En iyi N eslesme (default: 3)");
-	console.log("  --inject           Hook formatinda hint blob'u stdout'a yaz");
-	console.log(
-		"  --json             JSON cikti (matched/contextLength alanlari)",
-	);
+	console.log(chalk.bold("Profile logic:"));
+	console.log("  core    — always active (session, metrics, audit)");
+	console.log("  dev     — code, devops, security, audit tools");
+	console.log("  content — social media, brand, content calendar");
+	console.log("  pentest — authorized pentest engagement (future)");
+	console.log("  all     — everything (default)");
 	console.log("");
-	console.log(chalk.bold("Profil mantigi:"));
-	console.log("  core    — her zaman aktif (oturum, olcum, audit)");
-	console.log("  dev     — kod, devops, security, audit araclari");
-	console.log("  content — sosyal medya, marka, icerik takvimi");
-	console.log("  pentest — yetkili pentest engagement (gelecek)");
-	console.log("  all     — hepsi (default)");
-	console.log("");
-	console.log(chalk.bold("Ornekler:"));
+	console.log(chalk.bold("Examples:"));
 	console.log(chalk.dim("  badi commands profile content --yes"));
 	console.log(chalk.dim("  badi commands profile dev --dry-run --verbose"));
-	console.log(chalk.dim('  badi commands route "yeni post yaz" --top 5'));
+	console.log(chalk.dim('  badi commands route "write a new post" --top 5'));
 	console.log(chalk.dim('  badi commands route "react bug fix" --json'));
 	console.log(
 		chalk.dim('  echo "release plan" | badi commands route --inject'),
@@ -218,16 +218,18 @@ function showHelp() {
 	console.log("");
 	console.log(
 		chalk.dim(
-			"Not: profile degistirmek .claude/commands/ icerigini fiziksel olarak duzenler.",
+			"Note: changing the profile physically edits the .claude/commands/ contents.",
 		),
 	);
 	console.log(
 		chalk.dim(
-			"     Vault canonical kalir; profili her zaman 'all'a geri dondurebilirsin.",
+			"     The vault stays canonical; you can always revert the profile to 'all'.",
 		),
 	);
 	console.log(
-		chalk.dim("     Vault disindaki (kullanici) komutlara dokunulmaz."),
+		chalk.dim(
+			"     Commands outside the vault (user commands) are not touched.",
+		),
 	);
 }
 
@@ -235,7 +237,7 @@ function status(target) {
 	const { vault, active, state } = paths(target);
 	if (!existsSync(vault)) {
 		console.log(
-			chalk.yellow("Vault olusmamis. Ilk kurulum: badi commands migrate"),
+			chalk.yellow("Vault not created. First setup: badi commands migrate"),
 		);
 		return;
 	}
@@ -243,20 +245,20 @@ function status(target) {
 	const activeCmds = listMarkdownFiles(active);
 	const { profile } = readProfileState(state);
 	const counts = profileCounts();
-	console.log(chalk.bold("Commands Durumu"));
+	console.log(chalk.bold("Commands Status"));
 	console.log("");
-	console.log(`  Aktif profil   : ${chalk.cyan(profile)}`);
-	console.log(`  Vault toplam   : ${vaultCmds.length} komut`);
-	console.log(`  Aktif toplam   : ${activeCmds.length} komut`);
+	console.log(`  Active profile : ${chalk.cyan(profile)}`);
+	console.log(`  Vault total    : ${vaultCmds.length} commands`);
+	console.log(`  Active total   : ${activeCmds.length} commands`);
 	console.log("");
-	console.log(chalk.bold("Profil sayilari (vault'tan):"));
+	console.log(chalk.bold("Profile counts (from vault):"));
 	console.log(`  core    ${chalk.green(counts.core)}`);
 	console.log(`  dev     ${chalk.cyan(counts.dev)}`);
 	console.log(`  content ${chalk.magenta(counts.content)}`);
 	console.log(`  pentest ${chalk.yellow(counts.pentest)}`);
 	console.log("");
 	console.log(
-		chalk.dim("Profil degistir: badi commands profile <core|dev|content|all>"),
+		chalk.dim("Change profile: badi commands profile <core|dev|content|all>"),
 	);
 }
 
@@ -265,7 +267,7 @@ function listActive(target) {
 	const cmds = listMarkdownFiles(active);
 	const { profile } = readProfileState(state);
 	console.log(
-		chalk.bold(`Aktif komutlar (${cmds.length}) — profil: ${profile}`),
+		chalk.bold(`Active commands (${cmds.length}) — profile: ${profile}`),
 	);
 	console.log("");
 	for (const name of cmds) {
@@ -288,12 +290,12 @@ function listAvailable(target) {
 	const { vault } = paths(target);
 	if (!existsSync(vault)) {
 		console.log(
-			chalk.yellow("Vault olusmamis. Ilk kurulum: badi commands migrate"),
+			chalk.yellow("Vault not created. First setup: badi commands migrate"),
 		);
 		return;
 	}
 	const cmds = listMarkdownFiles(vault);
-	console.log(chalk.bold(`Vault icerigi (${cmds.length}):`));
+	console.log(chalk.bold(`Vault contents (${cmds.length}):`));
 	console.log("");
 	for (const name of cmds) {
 		const p = COMMAND_PROFILES[name] || "user";
@@ -304,35 +306,35 @@ function listAvailable(target) {
 function showProfiles() {
 	const counts = profileCounts();
 	const total = Object.values(counts).reduce((a, b) => a + b, 0);
-	console.log(chalk.bold("Profil Tanimlari"));
+	console.log(chalk.bold("Profile Definitions"));
 	console.log("");
 	console.log(
-		`  ${chalk.green("core")}    ${counts.core} komut — her zaman aktif`,
+		`  ${chalk.green("core")}    ${counts.core} commands — always active`,
 	);
 	console.log(
-		`  ${chalk.cyan("dev")}     ${counts.dev} komut — gelistirme/devops/audit`,
+		`  ${chalk.cyan("dev")}     ${counts.dev} commands — development/devops/audit`,
 	);
 	console.log(
-		`  ${chalk.magenta("content")} ${counts.content} komut — sosyal medya/marka/icerik`,
+		`  ${chalk.magenta("content")} ${counts.content} commands — social media/brand/content`,
 	);
 	console.log(
-		`  ${chalk.yellow("pentest")} ${counts.pentest} komut — yetkili pentest (gelecek)`,
+		`  ${chalk.yellow("pentest")} ${counts.pentest} commands — authorized pentest (future)`,
 	);
 	console.log("");
-	console.log(`  Toplam tanimli: ${total} komut`);
+	console.log(`  Total defined: ${total} commands`);
 }
 
 async function switchProfile(target, profile, opts = {}) {
 	if (!PROFILES.includes(profile)) {
-		console.error(chalk.red(`Bilinmeyen profil: ${profile}`));
-		console.error(chalk.dim(`Gecerli profiller: ${PROFILES.join(", ")}`));
+		console.error(chalk.red(`Unknown profile: ${profile}`));
+		console.error(chalk.dim(`Valid profiles: ${PROFILES.join(", ")}`));
 		process.exitCode = 1;
 		return;
 	}
 	const { vault, active, state } = paths(target);
 	if (!existsSync(vault)) {
 		console.error(
-			chalk.red("Vault olusmamis. Ilk kurulum icin: badi commands migrate"),
+			chalk.red("Vault not created. For first setup: badi commands migrate"),
 		);
 		process.exitCode = 1;
 		return;
@@ -340,11 +342,9 @@ async function switchProfile(target, profile, opts = {}) {
 
 	const current = readProfileState(state).profile;
 	if (current === profile && !opts.force) {
-		console.log(chalk.green(`✓ Zaten ${profile} profilindesin.`));
+		console.log(chalk.green(`✓ You're already on the ${profile} profile.`));
 		console.log(
-			chalk.dim(
-				`Yeniden uygulamak icin: badi commands profile ${profile} --force`,
-			),
+			chalk.dim(`To re-apply: badi commands profile ${profile} --force`),
 		);
 		return;
 	}
@@ -360,37 +360,37 @@ async function switchProfile(target, profile, opts = {}) {
 		(n) => COMMAND_PROFILES[n] && profile !== "all" && !targetSet.has(n),
 	);
 
-	console.log(chalk.bold(`Profil: ${current} → ${profile}`));
+	console.log(chalk.bold(`Profile: ${current} → ${profile}`));
 	console.log("");
 	if (willAdd.length > 0) {
-		console.log(chalk.green(`  + ${willAdd.length} komut eklenecek`));
+		console.log(chalk.green(`  + ${willAdd.length} commands will be added`));
 		if (opts.verbose) for (const n of willAdd) console.log(`     + ${n}`);
 	}
 	if (willRemove.length > 0) {
-		console.log(chalk.red(`  − ${willRemove.length} komut kaldirilacak`));
+		console.log(chalk.red(`  − ${willRemove.length} commands will be removed`));
 		if (opts.verbose) for (const n of willRemove) console.log(`     − ${n}`);
 	}
 	if (willAdd.length === 0 && willRemove.length === 0) {
-		console.log(chalk.dim("  Degisiklik yok."));
+		console.log(chalk.dim("  No changes."));
 		writeProfileState(state, profile);
 		return;
 	}
 
 	if (opts.dryRun) {
 		console.log("");
-		console.log(chalk.dim("--dry-run aktif: dosyaya yazilmadi."));
+		console.log(chalk.dim("--dry-run active: nothing written to disk."));
 		return;
 	}
 
 	if (!opts.yes) {
 		if (!process.stdin.isTTY) {
-			console.error(chalk.red("Non-TTY: --yes kullan veya TTY'de calistir."));
+			console.error(chalk.red("Non-TTY: use --yes or run in a TTY."));
 			process.exitCode = 1;
 			return;
 		}
-		const ans = await promptChoice("Onayliyor musun? [e/H] ");
-		if (!/^(e|y|yes|evet)$/i.test(ans)) {
-			console.log(chalk.dim("Iptal edildi."));
+		const ans = await promptChoice("Confirm? [y/N] ");
+		if (!/^(y|yes)$/i.test(ans)) {
+			console.log(chalk.dim("Cancelled."));
 			return;
 		}
 	}
@@ -400,7 +400,7 @@ async function switchProfile(target, profile, opts = {}) {
 	console.log("");
 	console.log(
 		chalk.green(
-			`✓ Profil uygulandi: +${result.added.length} / −${result.removed.length}`,
+			`✓ Profile applied: +${result.added.length} / −${result.removed.length}`,
 		),
 	);
 }
@@ -408,7 +408,7 @@ async function switchProfile(target, profile, opts = {}) {
 function runMigrate(target, opts = {}) {
 	const { vault, active, state } = paths(target);
 	if (!existsSync(active)) {
-		console.error(chalk.red(".claude/commands/ bulunamadi."));
+		console.error(chalk.red(".claude/commands/ not found."));
 		process.exitCode = 1;
 		return;
 	}
@@ -416,12 +416,12 @@ function runMigrate(target, opts = {}) {
 	if (!existsSync(state)) writeProfileState(state, "all");
 	console.log(
 		chalk.green(
-			`✓ Migrate: ${result.migrated} kopyalandi, ${result.skipped} zaten vardi.`,
+			`✓ Migrate: ${result.migrated} copied, ${result.skipped} already existed.`,
 		),
 	);
 	console.log(chalk.dim(`Vault: ${vault}`));
 	if (opts.verbose) {
-		console.log(chalk.dim(`Profil state: ${state} (all)`));
+		console.log(chalk.dim(`Profile state: ${state} (all)`));
 	}
 }
 
@@ -466,9 +466,9 @@ export async function commandsCommand(args, opts = {}) {
 			if (!profile) {
 				const { state } = paths(target);
 				const cur = readProfileState(state).profile;
-				console.log(`Aktif profil: ${chalk.cyan(cur)}`);
+				console.log(`Active profile: ${chalk.cyan(cur)}`);
 				console.log(
-					chalk.dim(`Degistir: badi commands profile <${PROFILES.join("|")}>`),
+					chalk.dim(`Change: badi commands profile <${PROFILES.join("|")}>`),
 				);
 				return;
 			}
@@ -504,7 +504,7 @@ export async function commandsCommand(args, opts = {}) {
 				}
 			}
 			if (!prompt) {
-				console.error(chalk.red("Hata: prompt gerekli (arg veya stdin)."));
+				console.error(chalk.red("Error: prompt required (arg or stdin)."));
 				process.exitCode = 1;
 				return;
 			}
@@ -535,20 +535,20 @@ export async function commandsCommand(args, opts = {}) {
 			);
 			console.log("");
 			if (matched.length === 0) {
-				console.log(chalk.dim("(eslesen komut yok)"));
+				console.log(chalk.dim("(no matching command)"));
 				return;
 			}
-			console.log(chalk.bold(`Eslesen komutlar (${matched.length}):`));
+			console.log(chalk.bold(`Matching commands (${matched.length}):`));
 			for (const m of matched) {
 				console.log(
-					`  ${chalk.bold(`/${m.name}`.padEnd(22))} ${chalk.green(`skor ${m.score}`)}`,
+					`  ${chalk.bold(`/${m.name}`.padEnd(22))} ${chalk.green(`score ${m.score}`)}`,
 				);
 			}
 			return;
 		}
 		default:
-			console.error(chalk.red(`Bilinmeyen alt komut: ${sub}`));
-			console.error(chalk.dim("Yardim: badi commands --help"));
+			console.error(chalk.red(`Unknown subcommand: ${sub}`));
+			console.error(chalk.dim("Help: badi commands --help"));
 			process.exitCode = 1;
 	}
 }

--- a/tests/watcher.test.js
+++ b/tests/watcher.test.js
@@ -478,7 +478,7 @@ describe("badi agent CLI", () => {
 				[CLI, "agent", "install", "yok-boyle", "--dry-run"],
 				{ cwd: dir, stdio: "pipe", encoding: "utf-8" },
 			);
-		}, /Watcher yok/);
+		}, /No watcher/);
 	});
 
 	it("agent tail bilinmeyen watcher icin temiz hata", () => {
@@ -488,7 +488,7 @@ describe("badi agent CLI", () => {
 				stdio: "pipe",
 				encoding: "utf-8",
 			});
-		}, /Watcher yok/);
+		}, /No watcher/);
 	});
 
 	it("agent --help install satirinda --yes bayragini gosterir", () => {
@@ -504,7 +504,7 @@ describe("badi agent CLI", () => {
 			cwd: mkTmp(),
 			encoding: "utf-8",
 		});
-		assert.match(r, /Kayitli watcher yok|Son/);
+		assert.match(r, /No registered watcher|In the last/);
 	});
 
 	it("agent remove watcher.md siler", () => {


### PR DESCRIPTION
## Phase 2m — English-only migration (#207)

Translates all user-facing CLI output and comments to English in **commands** (profile-based command management) and **agent** (background watcher management). Subcommand names and flags stay stable — no interface renames in this batch.

### Changed
- **commands.js** — status / list / available / profiles / profile / migrate / restore / route output + help. **Preserved:** profile names (`core`/`dev`/`content`/`pentest`/`all`), command names, and the apply/migrate/route logic. Confirm prompt `[e/H]` → `[y/N]` (regex `/^(y|yes)$/i`).
- **agent.js** — create / list / run / install / uninstall / tail / status / remove output + help. **Preserved:** scheduler/watcher engine wiring, the shell-command consent guard, and watcher frontmatter keys (`name`/`description`/`active`/`every`/`watch`/`report_to`).

### Tests
Updated in lockstep — `watcher.test.js`: `Watcher yok` → `No watcher`, `Kayitli watcher yok|Son` → `No registered watcher|In the last`. `command-profiles.test.js` / `commands-cli.test.js` needed no changes.

### Note (follow-up, out of scope)
The watcher-engine result messages live in `lib/watchers/` and are still Turkish (e.g. `stdout eslesmesi`, `yeni bagimlilik`, the `# Watcher Raporu` report header). Those are a separate batch — `agent.js` only wraps them.

### Verification
- `npm run lint` — clean (2 files auto-formatted after translation)
- `npm test` — **1132/1132 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)