### PR TITLE
feat(i18n): English-only Phase 2n — finish remaining 14 command files

### DIFF
--- a/lib/commands/a11y.js
+++ b/lib/commands/a11y.js
@@ -1,12 +1,12 @@
 import { chalk, showBanner } from "../cli.js";
 
-// PageSpeed Insights API - accessibility kategorisi (axe-core tabanli)
+// PageSpeed Insights API - accessibility category (axe-core based)
 const PSI_API = "https://www.googleapis.com/pagespeedonline/v5/runPagespeed";
 
 function validateUrl(url) {
 	const parsed = new URL(url);
 	if (!["http:", "https:"].includes(parsed.protocol))
-		throw new Error("http/https gerekli");
+		throw new Error("http/https required");
 	return parsed;
 }
 
@@ -27,7 +27,7 @@ async function fetchA11y(url, strategy = "mobile") {
 		return await res.json();
 	} catch (e) {
 		clearTimeout(timeout);
-		throw new Error(`API hatasi: ${e.message}`);
+		throw new Error(`API error: ${e.message}`);
 	}
 }
 
@@ -44,9 +44,9 @@ export async function runA11y(args) {
 			`  ${chalk.cyan("badi a11y")} [url] --desktop    Desktop audit`,
 		);
 		console.log("");
-		console.log(chalk.bold("WCAG 2.1 Seviyesi:"));
-		console.log("  Bu audit A, AA seviyesini kapsar (axe-core).");
-		console.log("  AAA seviyesi icin manuel test gereklidir.");
+		console.log(chalk.bold("WCAG 2.1 Level:"));
+		console.log("  This audit covers levels A, AA (axe-core).");
+		console.log("  Level AAA requires manual testing.");
 		return;
 	}
 
@@ -83,12 +83,12 @@ export async function runA11y(args) {
 			: score >= 70
 				? chalk.bold.yellow
 				: chalk.bold.red;
-	console.log(chalk.bold(`A11y Skoru: ${color(`${score}/100`)}`));
+	console.log(chalk.bold(`A11y Score: ${color(`${score}/100`)}`));
 	console.log("");
 
 	const audits = lh.audits;
 
-	// Basarisiz auditler
+	// Failed audits
 	const failed = [];
 	const passed = [];
 	const manual = [];
@@ -104,7 +104,7 @@ export async function runA11y(args) {
 	}
 
 	if (failed.length > 0) {
-		console.log(chalk.bold.red(`Basarisiz Kontroller (${failed.length}):`));
+		console.log(chalk.bold.red(`Failed Checks (${failed.length}):`));
 		for (const a of failed) {
 			console.log(`  ${chalk.red("XX")} ${a.title}`);
 			if (a.description) {
@@ -113,11 +113,11 @@ export async function runA11y(args) {
 					.substring(0, 120);
 				console.log(`     ${chalk.dim(desc)}`);
 			}
-			// Eleman sayisi
+			// Element count
 			const items = a.details?.items || [];
 			if (items.length > 0)
 				console.log(
-					`     ${chalk.yellow(`${items.length} eleman etkileniyor`)}`,
+					`     ${chalk.yellow(`${items.length} elements affected`)}`,
 				);
 		}
 		console.log("");
@@ -125,13 +125,13 @@ export async function runA11y(args) {
 
 	console.log(
 		chalk.bold(
-			`Basarili: ${chalk.green(passed.length)} | Basarisiz: ${chalk.red(failed.length)} | Manuel: ${chalk.yellow(manual.length)}`,
+			`Passed: ${chalk.green(passed.length)} | Failed: ${chalk.red(failed.length)} | Manual: ${chalk.yellow(manual.length)}`,
 		),
 	);
 
 	if (manual.length > 0) {
 		console.log("");
-		console.log(chalk.bold("Manuel Test Gerekli:"));
+		console.log(chalk.bold("Manual Testing Required:"));
 		for (const a of manual.slice(0, 5))
 			console.log(`  ${chalk.yellow("??")} ${a.title}`);
 	}
@@ -139,7 +139,7 @@ export async function runA11y(args) {
 	console.log("");
 	console.log(
 		chalk.dim(
-			"Detayli rapor: https://pagespeed.web.dev/analysis?url=" +
+			"Detailed report: https://pagespeed.web.dev/analysis?url=" +
 				encodeURIComponent(targetUrl),
 		),
 	);

--- a/lib/commands/gh.js
+++ b/lib/commands/gh.js
@@ -1,18 +1,24 @@
-// `badi gh` — GitHub derin entegrasyon komut ailesi (#11 MVP).
+// `badi gh` — GitHub deep-integration command family (#11 MVP).
 //
-// MVP scope: 'badi gh sync' — acik issue'lari .claude/workspace/TaskBoard.md
-// dosyasina priority label'lara gore kategorize ederek senkronize eder.
+// MVP scope: 'badi gh sync' — syncs open issues into the
+// .claude/workspace/TaskBoard.md file, categorized by priority label.
 //
-// Kategorizasyon:
+// Categorization:
 //   - priority:p1-high   -> ## Bugun
 //   - priority:p2-medium -> ## Bu Hafta
 //   - priority:p3-large  -> ## Bekleyen Isler
 //   - priority:p4-future -> ## Bekleyen Isler
-//   - etiket yok         -> ## Bekleyen Isler
+//   - no label           -> ## Bekleyen Isler
 //
-// Idempotent: zaten TaskBoard'da olan issue numaralari tekrar eklenmez.
-// Manuel eklenen "- [ ] (henuz gorev yok)" gibi placeholder'lar issue
-// varsa kaldirilir; manuel gorevler korunur.
+// Idempotent: issue numbers already on the TaskBoard are not re-added.
+// Placeholders like the manually added "- [ ] (henuz gorev yok)" are removed
+// when an issue exists; manual tasks are preserved.
+//
+// NOTE: the TaskBoard section names below (Bugun / Bu Hafta / Bekleyen Isler /
+// Tamamlanan), the "# Gorev Panosu" title, and the placeholder strings are a
+// data contract shared with the .claude/workspace/TaskBoard.md template and
+// the start/sync/wrap-up commands. They are intentionally left untranslated
+// here; renaming them is a coordinated workspace change (Phase 4/5).
 
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -47,27 +53,27 @@ function parseFlags(args) {
 
 function showHelp() {
 	showBanner();
-	console.log(chalk.bold("Badi GitHub — Derin Entegrasyon"));
+	console.log(chalk.bold("Badi GitHub — Deep Integration"));
 	console.log("");
-	console.log(chalk.bold("Kullanim:"));
+	console.log(chalk.bold("Usage:"));
 	console.log(
-		`  ${chalk.cyan("badi gh sync")}              Acik issue'lari TaskBoard'a senkronize et`,
+		`  ${chalk.cyan("badi gh sync")}              Sync open issues to the TaskBoard`,
 	);
 	console.log("");
-	console.log(chalk.bold("Secenekler:"));
-	console.log("  --dry-run        Diski degistirme, plan goster");
-	console.log("  --repo owner/N   Belirli repo (varsayilan: git remote)");
-	console.log("  --state STATE    open|closed|all (varsayilan: open)");
-	console.log("  --limit N        Max issue sayisi (varsayilan: 100)");
+	console.log(chalk.bold("Options:"));
+	console.log("  --dry-run        Don't change disk, show the plan");
+	console.log("  --repo owner/N   Specific repo (default: git remote)");
+	console.log("  --state STATE    open|closed|all (default: open)");
+	console.log("  --limit N        Max issue count (default: 100)");
 	console.log("");
-	console.log(chalk.bold("Gereksinimler:"));
-	console.log("  gh CLI kurulu ve authenticated olmali");
+	console.log(chalk.bold("Requirements:"));
+	console.log("  gh CLI must be installed and authenticated");
 }
 
 /**
- * Aktif GitHub repo'sunu git remote'undan tahmin eder.
- * gh CLI --repo flag'i bos birakildiginda kendi default'u var; biz
- * sadece raporlama icin tahmin ediyoruz.
+ * Guesses the active GitHub repo from the git remote.
+ * The gh CLI has its own default when --repo is left empty; we only
+ * guess for reporting purposes.
  */
 export function detectRepo(cwd) {
 	const result = spawnSync(
@@ -79,13 +85,13 @@ export function detectRepo(cwd) {
 	const url = (result.stdout || "").trim();
 	// SSH: git@github.com:owner/repo.git  -> owner/repo
 	// HTTPS: https://github.com/owner/repo(.git)?  -> owner/repo
-	// .git suffix opsiyonel, owner/repo'da '.' karakteri yok kabul edilir.
+	// .git suffix optional, assume no '.' character in owner/repo.
 	const m = url.match(/github\.com[:/]([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
 	return m ? `${m[1]}/${m[2]}` : null;
 }
 
 /**
- * Issue listesi -> gh CLI uzerinden cekilir. JSON dondurur.
+ * Issue list -> fetched via the gh CLI. Returns JSON.
  */
 function fetchIssues(flags) {
 	const args = [
@@ -99,28 +105,29 @@ function fetchIssues(flags) {
 		"number,title,labels,state",
 	];
 	if (flags.repo) args.push("--repo", flags.repo);
-	// Default maxBuffer 1MB; gh JSON cikti uzun olabilir, genis tutuyoruz.
+	// Default maxBuffer 1MB; gh JSON output can be long, so we keep it wide.
 	const result = spawnSync("gh", args, {
 		encoding: "utf-8",
 		maxBuffer: 50 * 1024 * 1024,
 	});
 	if (result.status !== 0) {
 		throw new Error(
-			`gh CLI hatasi (exit ${result.status}): ${result.stderr || "bilinmeyen hata"}`,
+			`gh CLI error (exit ${result.status}): ${result.stderr || "unknown error"}`,
 		);
 	}
 	try {
 		return JSON.parse(result.stdout || "[]");
 	} catch (e) {
-		throw new Error(`gh JSON parse hatasi: ${e.message}`);
+		throw new Error(`gh JSON parse error: ${e.message}`);
 	}
 }
 
 /**
- * Bir issue icin TaskBoard satirini olusturur:
- *   - [ ] #11 (P3) feat(integration): GitHub derin entegrasyon — github
+ * Builds a TaskBoard line for an issue:
+ *   - [ ] #11 (P3) feat(integration): GitHub deep integration — github
  *
- * Etiket yoksa "P?" yerine bos string, bolum default Bekleyen Isler.
+ * If there's no label, "P?" is an empty string and the section defaults
+ * to Bekleyen Isler.
  */
 export function formatIssueLine(issue) {
 	const labelNames = (issue.labels || []).map((l) => l.name);
@@ -130,8 +137,8 @@ export function formatIssueLine(issue) {
 }
 
 /**
- * Issue'yu hangi bolume yazacagimizi belirler. Etiket yoksa
- * 'Bekleyen Isler' default'una dusen.
+ * Decides which section to write the issue into. Falls back to the
+ * 'Bekleyen Isler' default when there's no label.
  */
 export function sectionForIssue(issue) {
 	const labelNames = (issue.labels || []).map((l) => l.name);
@@ -142,10 +149,10 @@ export function sectionForIssue(issue) {
 }
 
 /**
- * TaskBoard.md'yi bolumlere ayirir. Donus:
+ * Splits TaskBoard.md into sections. Returns:
  *   { sections: { 'Bugun': ['- [ ] ...', ...], ... }, order: [...] }
  *
- * 'order' baslik sirasini korur (rewrite icin onemli).
+ * 'order' preserves the heading order (important for rewrite).
  */
 export function parseTaskBoard(content) {
 	const lines = content.replace(/\r\n/g, "\n").split("\n");
@@ -167,7 +174,7 @@ export function parseTaskBoard(content) {
 			current = [];
 			continue;
 		}
-		if (header === null) continue; // intro/title lines disrarda kalir
+		if (header === null) continue; // intro/title lines stay outside
 		current.push(line);
 	}
 	flush();
@@ -175,10 +182,10 @@ export function parseTaskBoard(content) {
 }
 
 /**
- * Issue'lari TaskBoard.md icerigine merge eder. Idempotent:
- * mevcut '#N' iceren satirlara dokunmaz, yenileri ekler.
+ * Merges issues into TaskBoard.md content. Idempotent:
+ * doesn't touch lines already containing '#N', adds new ones.
  *
- * Donus: { newContent, added: [{number, section}], skipped: [...] }
+ * Returns: { newContent, added: [{number, section}], skipped: [...] }
  */
 export function mergeIssuesIntoTaskBoard(content, issues) {
 	const { sections, order } = parseTaskBoard(content);
@@ -201,12 +208,12 @@ export function mergeIssuesIntoTaskBoard(content, issues) {
 	const skipped = [];
 	for (const issue of issues) {
 		if (existingIssueNums.has(issue.number)) {
-			skipped.push({ number: issue.number, reason: "zaten mevcut" });
+			skipped.push({ number: issue.number, reason: "already exists" });
 			continue;
 		}
 		const target = sectionForIssue(issue);
 		const line = formatIssueLine(issue);
-		// Placeholder "(henuz gorev yok)" satirini temizle
+		// Clear the "(henuz gorev yok)" placeholder line
 		sections[target] = sections[target].filter(
 			(l) => !/\(henuz gorev yok\)/.test(l),
 		);
@@ -214,8 +221,8 @@ export function mergeIssuesIntoTaskBoard(content, issues) {
 		added.push({ number: issue.number, section: target });
 	}
 
-	// Bos bolumlere placeholder geri koy. Tamamlanan farkli format:
-	// checkbox yerine sade "- (henuz yok)" konvansiyonu kullanir.
+	// Put a placeholder back in empty sections. Tamamlanan uses a different
+	// format: a plain "- (henuz yok)" convention instead of a checkbox.
 	for (const s of SECTIONS) {
 		const hasItem = sections[s].some((l) => /^\s*-\s+/.test(l));
 		if (!hasItem) {
@@ -226,14 +233,14 @@ export function mergeIssuesIntoTaskBoard(content, issues) {
 		}
 	}
 
-	// Yeniden ins et
+	// Rebuild
 	const out = ["# Gorev Panosu", ""];
 	for (const s of order) {
 		out.push(`## ${s}`);
 		for (const l of sections[s]) {
 			out.push(l);
 		}
-		// Bolum sonu bos satir garantisi
+		// Guarantee a blank line at the end of the section
 		if (out[out.length - 1] !== "") out.push("");
 	}
 
@@ -244,8 +251,8 @@ function subSync(flags) {
 	const cwd = process.cwd();
 	const taskBoardPath = join(cwd, ".claude", "workspace", "TaskBoard.md");
 	if (!existsSync(taskBoardPath)) {
-		console.error(chalk.red(`TaskBoard yok: ${taskBoardPath}`));
-		console.log(chalk.dim("  Once: badi init"));
+		console.error(chalk.red(`No TaskBoard: ${taskBoardPath}`));
+		console.log(chalk.dim("  First: badi init"));
 		process.exit(1);
 	}
 
@@ -257,12 +264,12 @@ function subSync(flags) {
 		process.exit(1);
 	}
 
-	const repo = flags.repo || detectRepo(cwd) || "(otomatik tespit basarisiz)";
+	const repo = flags.repo || detectRepo(cwd) || "(auto-detect failed)";
 	showBanner();
-	console.log(chalk.bold(`GitHub Issue Senkronizasyonu — ${repo}`));
+	console.log(chalk.bold(`GitHub Issue Sync — ${repo}`));
 	if (flags.dryRun) {
 		console.log(
-			chalk.yellow("  [dry-run] Plan moduunda — disk degistirilmeyecek."),
+			chalk.yellow("  [dry-run] Plan mode — disk will not be changed."),
 		);
 	}
 	console.log("");
@@ -275,10 +282,10 @@ function subSync(flags) {
 
 	if (added.length === 0) {
 		console.log(
-			chalk.dim(`  ${issues.length} issue cekildi, hepsi zaten mevcut.`),
+			chalk.dim(`  ${issues.length} issues fetched, all already present.`),
 		);
 		console.log("");
-		console.log(chalk.green("  Hicbir degisiklik gerekmedi."));
+		console.log(chalk.green("  No changes needed."));
 		return;
 	}
 
@@ -286,18 +293,18 @@ function subSync(flags) {
 		console.log(`  ${chalk.green("+")} #${a.number} -> ${a.section}`);
 	}
 	console.log("");
-	console.log(`  Yeni:           ${chalk.bold(added.length)}`);
-	console.log(`  Zaten mevcut:   ${chalk.dim(skipped.length)}`);
+	console.log(`  New:             ${chalk.bold(added.length)}`);
+	console.log(`  Already present: ${chalk.dim(skipped.length)}`);
 
 	if (flags.dryRun) {
 		console.log("");
-		console.log(chalk.yellow("  [dry-run] TaskBoard.md degistirilmedi."));
+		console.log(chalk.yellow("  [dry-run] TaskBoard.md not changed."));
 		return;
 	}
 
 	writeFileSync(taskBoardPath, newContent);
 	console.log("");
-	console.log(chalk.green(`  ${taskBoardPath} guncellendi.`));
+	console.log(chalk.green(`  ${taskBoardPath} updated.`));
 }
 
 export async function runGh(args) {
@@ -311,7 +318,7 @@ export async function runGh(args) {
 		case "sync":
 			return subSync(flags);
 		default:
-			console.error(chalk.red(`Bilinmeyen alt-komut: ${sub}`));
+			console.error(chalk.red(`Unknown subcommand: ${sub}`));
 			showHelp();
 			process.exit(1);
 	}

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -25,11 +25,11 @@ export function parseMenuAnswer(answer, defaultId, harnesses) {
 	if (Number.isNaN(n)) {
 		const byId = harnesses.find((h) => h.id === answer.toLowerCase());
 		if (byId) return { harnesses: [byId] };
-		return { harnesses: [], error: `Gecersiz secim: ${answer}` };
+		return { harnesses: [], error: `Invalid choice: ${answer}` };
 	}
 	if (n === harnesses.length + 1) return { harnesses: [...harnesses] };
 	if (n < 1 || n > harnesses.length) {
-		return { harnesses: [], error: `Gecersiz secim: ${n}` };
+		return { harnesses: [], error: `Invalid choice: ${n}` };
 	}
 	return { harnesses: [harnesses[n - 1]] };
 }
@@ -49,23 +49,23 @@ function promptChoice(message) {
 
 async function selectHarnessInteractive() {
 	const defId = getPreference("defaultHarness", "claude");
-	console.log(chalk.bold("Hangi LLM CLI'si ile calisiyorsun?"));
+	console.log(chalk.bold("Which LLM CLI are you working with?"));
 	HARNESSES.forEach((h, i) => {
-		const marker = h.id === defId ? chalk.dim(" [varsayilan]") : "";
+		const marker = h.id === defId ? chalk.dim(" [default]") : "";
 		console.log(`  ${i + 1}) ${h.name}${marker}`);
 	});
-	console.log(`  ${HARNESSES.length + 1}) Hepsi`);
+	console.log(`  ${HARNESSES.length + 1}) All`);
 	console.log("");
 
 	if (!process.stdin.isTTY) {
 		console.log(
-			chalk.dim(`  (non-TTY ortam algilandi, varsayilan secildi: ${defId})`),
+			chalk.dim(`  (non-TTY environment detected, default selected: ${defId})`),
 		);
 		return parseMenuAnswer(null, defId, HARNESSES).harnesses;
 	}
 
 	const ans = await promptChoice(
-		`Secim (1-${HARNESSES.length + 1}, Enter = ${defId}): `,
+		`Choice (1-${HARNESSES.length + 1}, Enter = ${defId}): `,
 	);
 	const { harnesses, error } = parseMenuAnswer(ans, defId, HARNESSES);
 	if (error) {
@@ -78,11 +78,11 @@ async function selectHarnessInteractive() {
 function printResult(harness, result) {
 	console.log("");
 	console.log(chalk.bold(`${harness.name}:`));
-	console.log(`  ${chalk.green(result.copied)} dosya kopyalandi`);
-	console.log(`  ${chalk.yellow(result.skipped)} dosya atlandi`);
-	console.log(`  ${chalk.cyan(result.created)} dizin/dosya olusturuldu`);
+	console.log(`  ${chalk.green(result.copied)} files copied`);
+	console.log(`  ${chalk.yellow(result.skipped)} files skipped`);
+	console.log(`  ${chalk.cyan(result.created)} directories/files created`);
 	if (result.skippedComponents?.length) {
-		console.log(chalk.dim("  Desteklenmeyen bilesenler:"));
+		console.log(chalk.dim("  Unsupported components:"));
 		for (const s of result.skippedComponents) {
 			console.log(chalk.dim(`    - ${s.component} (${s.count}) — ${s.reason}`));
 		}
@@ -128,7 +128,9 @@ export async function runInit(args, { showHelp }) {
 	showBanner();
 
 	if (!existsSync(TEMPLATE_DIR)) {
-		console.error(chalk.red(`Hata: Sablon dizini bulunamadi: ${TEMPLATE_DIR}`));
+		console.error(
+			chalk.red(`Error: Template directory not found: ${TEMPLATE_DIR}`),
+		);
 		process.exit(1);
 	}
 
@@ -145,20 +147,20 @@ export async function runInit(args, { showHelp }) {
 			process.exit(1);
 		}
 		if (!selected.length) {
-			console.error(chalk.red("--harness degeri bos olamaz"));
+			console.error(chalk.red("--harness value cannot be empty"));
 			process.exit(1);
 		}
 	} else {
 		selected = await selectHarnessInteractive();
 	}
 
-	console.log(`${chalk.bold("Hedef:")} ${target}`);
+	console.log(`${chalk.bold("Target:")} ${target}`);
 	console.log(
-		`${chalk.bold("Mod:")} ${
+		`${chalk.bold("Mode:")} ${
 			dryRun
-				? chalk.yellow("Kuru calistirma")
+				? chalk.yellow("Dry run")
 				: force
-					? chalk.red("Zorla yazma")
+					? chalk.red("Force write")
 					: chalk.green("Normal")
 		}`,
 	);
@@ -189,24 +191,24 @@ export async function runInit(args, { showHelp }) {
 	}
 
 	console.log("");
-	console.log(chalk.bold.green("Tamamlandi!"));
+	console.log(chalk.bold.green("Done!"));
 
 	if (!dryRun) {
 		console.log("");
-		console.log(chalk.bold("Sonraki adimlar:"));
+		console.log(chalk.bold("Next steps:"));
 		const hints = selected.map((h) => {
 			if (h.id === "claude") {
-				return `  - Claude Code ile ${chalk.cyan("/start")} komutunu calistir`;
+				return `  - Run the ${chalk.cyan("/start")} command with Claude Code`;
 			}
 			if (h.id === "cursor") {
-				return `  - Cursor'da ${chalk.cyan(".cursor/rules/badi-main.mdc")} 'e bak`;
+				return `  - Check ${chalk.cyan(".cursor/rules/badi-main.mdc")} in Cursor`;
 			}
 			if (h.id === "gemini") {
-				return `  - Gemini CLI: ${chalk.cyan("gemini")} ile calistir; ${chalk.cyan("GEMINI.md")} otomatik yuklenir`;
+				return `  - Gemini CLI: run with ${chalk.cyan("gemini")}; ${chalk.cyan("GEMINI.md")} loads automatically`;
 			}
-			return `  - ${h.name} kurulumunu dogrula`;
+			return `  - Verify the ${h.name} installation`;
 		});
 		for (const h of hints) console.log(h);
-		console.log(`  - Dogrulama: ${chalk.cyan("badi doctor")}`);
+		console.log(`  - Verify: ${chalk.cyan("badi doctor")}`);
 	}
 }

--- a/lib/commands/lighthouse.js
+++ b/lib/commands/lighthouse.js
@@ -6,7 +6,7 @@ const PSI_API = "https://www.googleapis.com/pagespeedonline/v5/runPagespeed";
 function validateUrl(url) {
 	const parsed = new URL(url);
 	if (!["http:", "https:"].includes(parsed.protocol))
-		throw new Error("http/https gerekli");
+		throw new Error("http/https required");
 	return parsed;
 }
 
@@ -34,7 +34,7 @@ async function fetchPsi(url, strategy = "mobile") {
 		return await res.json();
 	} catch (e) {
 		clearTimeout(timeout);
-		throw new Error(`PageSpeed API hatasi: ${e.message}`);
+		throw new Error(`PageSpeed API error: ${e.message}`);
 	}
 }
 
@@ -57,19 +57,19 @@ export async function runLighthouse(args) {
 		console.log(chalk.bold("Lighthouse (PageSpeed Insights):"));
 		console.log("");
 		console.log(
-			`  ${chalk.cyan("badi lighthouse")} [url]               Mobile audit (varsayilan)`,
+			`  ${chalk.cyan("badi lighthouse")} [url]               Mobile audit (default)`,
 		);
 		console.log(
 			`  ${chalk.cyan("badi lighthouse")} [url] --desktop     Desktop audit`,
 		);
 		console.log("");
-		console.log(chalk.bold("Ne Olculur:"));
+		console.log(chalk.bold("What's Measured:"));
 		console.log("  Performance  - FCP, LCP, TBT, CLS, Speed Index");
-		console.log("  Accessibility - WCAG uyumu (axe-core)");
+		console.log("  Accessibility - WCAG compliance (axe-core)");
 		console.log("  Best Practices - HTTPS, console errors, permissions");
 		console.log("  SEO - meta tags, crawlability, mobile-friendly");
 		console.log("");
-		console.log(chalk.bold("Ornekler:"));
+		console.log(chalk.bold("Examples:"));
 		console.log("  badi lighthouse https://example.com");
 		console.log("  badi lighthouse https://example.com --desktop");
 		return;
@@ -82,14 +82,14 @@ export async function runLighthouse(args) {
 	try {
 		validateUrl(targetUrl);
 	} catch (e) {
-		console.error(chalk.red(`Gecersiz URL: ${e.message}`));
+		console.error(chalk.red(`Invalid URL: ${e.message}`));
 		process.exit(1);
 	}
 
 	showBanner();
 	console.log(chalk.bold(`Lighthouse Audit: ${targetUrl}`));
 	console.log(chalk.dim(`Strategy: ${strategy}`));
-	console.log(chalk.dim("PageSpeed Insights API cagriliyor (60s timeout)..."));
+	console.log(chalk.dim("Calling PageSpeed Insights API (60s timeout)..."));
 	console.log("");
 
 	let data;
@@ -102,12 +102,12 @@ export async function runLighthouse(args) {
 
 	const lh = data.lighthouseResult;
 	if (!lh) {
-		console.error(chalk.red("Lighthouse sonuclari alinamadi"));
+		console.error(chalk.red("Could not retrieve Lighthouse results"));
 		process.exit(1);
 	}
 
-	// Kategori skorlari
-	console.log(chalk.bold("Kategori Skorlari (0-100):"));
+	// Category scores
+	console.log(chalk.bold("Category Scores (0-100):"));
 	const cats = lh.categories;
 	for (const [key, label] of [
 		["performance", "Performance   "],
@@ -140,9 +140,9 @@ export async function runLighthouse(args) {
 		console.log(`  ${label.padEnd(34)} ${color(display)}`);
 	}
 
-	// Iyilestirme firsatlari
+	// Improvement opportunities
 	console.log("");
-	console.log(chalk.bold("En Onemli Iyilestirme Firsatlari:"));
+	console.log(chalk.bold("Top Improvement Opportunities:"));
 	const opps = Object.values(audits)
 		.filter(
 			(a) =>
@@ -150,29 +150,29 @@ export async function runLighthouse(args) {
 		)
 		.sort((a, b) => (b.numericValue || 0) - (a.numericValue || 0))
 		.slice(0, 5);
-	if (opps.length === 0) console.log(chalk.dim("  (onemli firsat yok)"));
+	if (opps.length === 0) console.log(chalk.dim("  (no major opportunities)"));
 	else
 		for (const o of opps) {
 			const saving = o.numericValue
-				? ` (${formatMs(o.numericValue)} kazanim)`
+				? ` (${formatMs(o.numericValue)} savings)`
 				: "";
 			console.log(`  ${chalk.yellow("!!")} ${o.title}${chalk.dim(saving)}`);
 		}
 
-	// Accessibility hatalari
+	// Accessibility errors
 	console.log("");
-	console.log(chalk.bold("Accessibility Hatalari:"));
+	console.log(chalk.bold("Accessibility Errors:"));
 	const a11yFails = Object.values(audits)
 		.filter((a) => a.score === 0 && a.details?.type === "table")
 		.slice(0, 5);
-	if (a11yFails.length === 0) console.log(chalk.dim("  (kritik hata yok)"));
+	if (a11yFails.length === 0) console.log(chalk.dim("  (no critical errors)"));
 	else
 		for (const a of a11yFails) console.log(`  ${chalk.red("XX")} ${a.title}`);
 
 	console.log("");
 	console.log(
 		chalk.dim(
-			"Detayli rapor: https://pagespeed.web.dev/analysis?url=" +
+			"Detailed report: https://pagespeed.web.dev/analysis?url=" +
 				encodeURIComponent(targetUrl),
 		),
 	);

--- a/lib/commands/outputstyle.js
+++ b/lib/commands/outputstyle.js
@@ -1,10 +1,10 @@
-// Badi outputstyle komutu — Claude Code output styles yonetimi.
+// Badi outputstyle command — Claude Code output styles management.
 //
 // .claude/output-styles/<name>.md  → Claude Code per-style prompt extension.
 //
-// Yerlesik profiller (built-in): terse, verbose, eli5.
-// Kullanici `badi outputstyle add <name>` ile yukler, Claude Code'da
-// `/output-style <name>` ile aktive eder.
+// Built-in profiles: terse, verbose, eli5.
+// The user installs with `badi outputstyle add <name>`, and activates it in
+// Claude Code with `/output-style <name>`.
 
 import {
 	existsSync,
@@ -20,18 +20,18 @@ import { chalk, showBanner } from "../cli.js";
 const BUILTINS = {
 	terse: {
 		description:
-			"Kisa ve ozlu cevaplar; gereksiz aciklama yok, tek cumle ozet, minimum tablo/bullet.",
-		body: `Cevaplarini kisa ve direkt tut. Tek cumle ile ozetle. Tablo veya bullet kullanma sorulmadikca. Hata mesaji varsa sadece kok neden + cozum yaz. Kod ornegi isterken minimum gerekli olani goster — yorum eklemeden, baslica desen disinda. End-of-turn ozetleri tek cumle olsun.`,
+			"Short, concise answers; no unnecessary explanation, one-sentence summary, minimal tables/bullets.",
+		body: `Keep your answers short and direct. Summarize in one sentence. Don't use tables or bullets unless asked. For error messages, write only the root cause + fix. When showing a code example, show the minimum necessary — no comments, beyond the main pattern. End-of-turn summaries should be one sentence.`,
 	},
 	verbose: {
 		description:
-			"Detayli ve contextli cevaplar; karar gerekcelerini, alternatifleri ve trade-off'lari ac.",
-		body: `Cevaplarinda kararlarin arkasindaki gerekceyi ac. En az bir alternatif yaklasim ve neden secilmedigini belirt. Trade-off'lari listele (performans, okunabilirlik, esneklik). Kod degisikliginden once mevcut yapinin neden boyle oldugunu ozetle. End-of-turn'da: ne degisti, neden, takip onerileri.`,
+			"Detailed, contextual answers; spell out decision rationale, alternatives, and trade-offs.",
+		body: `In your answers, spell out the rationale behind decisions. State at least one alternative approach and why it wasn't chosen. List the trade-offs (performance, readability, flexibility). Before a code change, summarize why the existing structure is the way it is. At end-of-turn: what changed, why, follow-up suggestions.`,
 	},
 	eli5: {
 		description:
-			"Basit dilde ('5 yasinda biri anlasin') aciklamalar; teknik jargonu metafor ile destekle.",
-		body: `Karmasik kavramlari basit dilde anlat. Teknik terim kullanmak zorunda kaldiginda metafor + ornek ile destekle. Her cumlede en fazla bir teknik kavram. Kod gosterirken her satirin altina kisa bir aciklama ekle (gerekiyorsa). Hata aciklarken once 'su olmasi gerekiyordu, ama su oldu' formatinda anlat.`,
+			"Explanations in plain language ('so a 5-year-old understands'); back technical jargon with metaphors.",
+		body: `Explain complex concepts in plain language. When you must use a technical term, back it with a metaphor + example. At most one technical concept per sentence. When showing code, add a short explanation under each line (if needed). When explaining an error, first describe it in the 'this should have happened, but this happened' format.`,
 	},
 };
 
@@ -75,22 +75,20 @@ function showHelp() {
 	console.log(`${chalk.bold("badi outputstyle")} — Claude Code output styles`);
 	console.log("");
 	console.log(
-		"  add <name>      Yerlesik profili .claude/output-styles/'a yukle",
+		"  add <name>      Install a built-in profile to .claude/output-styles/",
 	);
-	console.log("  remove <name>   Yuklu profili kaldir");
-	console.log("  list            Yuklu profilleri goster");
-	console.log("  available       Yerlesik profilleri goster");
-	console.log("  clear           Tum yuklu profilleri sil");
+	console.log("  remove <name>   Remove an installed profile");
+	console.log("  list            Show installed profiles");
+	console.log("  available       Show built-in profiles");
+	console.log("  clear           Delete all installed profiles");
 	console.log("");
-	console.log(chalk.bold("Yerlesik profiller:"));
+	console.log(chalk.bold("Built-in profiles:"));
 	for (const [name, p] of Object.entries(BUILTINS)) {
 		console.log(`  ${chalk.cyan(name.padEnd(10))} ${chalk.dim(p.description)}`);
 	}
 	console.log("");
 	console.log(
-		chalk.dim(
-			"Kullanim: Claude Code icinde /output-style <name> ile aktif et.",
-		),
+		chalk.dim("Usage: activate inside Claude Code with /output-style <name>."),
 	);
 }
 
@@ -106,7 +104,7 @@ export async function runOutputstyle(args) {
 	}
 
 	if (sub === "available") {
-		console.log(chalk.bold("Yerlesik profiller:"));
+		console.log(chalk.bold("Built-in profiles:"));
 		for (const [name, p] of Object.entries(BUILTINS)) {
 			console.log(`  ${chalk.cyan(name)} — ${p.description}`);
 		}
@@ -116,15 +114,13 @@ export async function runOutputstyle(args) {
 	if (sub === "list") {
 		const installed = listInstalled(dir);
 		if (installed.length === 0) {
-			console.log(chalk.dim("(yuklu profil yok)"));
+			console.log(chalk.dim("(no installed profiles)"));
 			console.log(
-				chalk.dim(
-					"Yerlesik profilleri gormek icin: badi outputstyle available",
-				),
+				chalk.dim("To see built-in profiles: badi outputstyle available"),
 			);
 			return;
 		}
-		console.log(chalk.bold(`Yuklu profiller (${installed.length}):`));
+		console.log(chalk.bold(`Installed profiles (${installed.length}):`));
 		for (const name of installed) {
 			const desc = readDescription(dir, name) || "";
 			console.log(`  ${chalk.green(name)} ${chalk.dim(desc)}`);
@@ -135,14 +131,14 @@ export async function runOutputstyle(args) {
 	if (sub === "add") {
 		const name = rest[0];
 		if (!name) {
-			console.error(chalk.red("Hata: profil adi gerekli"));
-			console.error("Ornek: badi outputstyle add terse");
+			console.error(chalk.red("Error: profile name required"));
+			console.error("Example: badi outputstyle add terse");
 			process.exit(1);
 		}
 		if (!BUILTINS[name]) {
-			console.error(chalk.red(`Hata: bilinmeyen profil "${name}"`));
+			console.error(chalk.red(`Error: unknown profile "${name}"`));
 			console.error(
-				`Mevcut: ${Object.keys(BUILTINS)
+				`Available: ${Object.keys(BUILTINS)
 					.map((n) => chalk.cyan(n))
 					.join(", ")}`,
 			);
@@ -154,11 +150,11 @@ export async function runOutputstyle(args) {
 		writeFileSync(file, styleFile(name), "utf-8");
 		console.log(
 			existed
-				? chalk.yellow(`~ guncellendi: .claude/output-styles/${name}.md`)
-				: chalk.green(`+ yuklendi: .claude/output-styles/${name}.md`),
+				? chalk.yellow(`~ updated: .claude/output-styles/${name}.md`)
+				: chalk.green(`+ installed: .claude/output-styles/${name}.md`),
 		);
 		console.log(
-			chalk.dim(`Aktif et: Claude Code icinde /output-style ${name}`),
+			chalk.dim(`Activate: /output-style ${name} inside Claude Code`),
 		);
 		return;
 	}
@@ -166,33 +162,33 @@ export async function runOutputstyle(args) {
 	if (sub === "remove") {
 		const name = rest[0];
 		if (!name) {
-			console.error(chalk.red("Hata: profil adi gerekli"));
+			console.error(chalk.red("Error: profile name required"));
 			process.exit(1);
 		}
 		const file = join(dir, `${name}.md`);
 		if (!existsSync(file)) {
-			console.error(chalk.red(`Hata: "${name}" yuklu degil`));
+			console.error(chalk.red(`Error: "${name}" not installed`));
 			process.exit(1);
 		}
 		rmSync(file);
-		console.log(chalk.yellow(`- silindi: .claude/output-styles/${name}.md`));
+		console.log(chalk.yellow(`- deleted: .claude/output-styles/${name}.md`));
 		return;
 	}
 
 	if (sub === "clear") {
 		if (!existsSync(dir)) {
-			console.log(chalk.dim("(zaten bos)"));
+			console.log(chalk.dim("(already empty)"));
 			return;
 		}
 		const installed = listInstalled(dir);
 		for (const name of installed) {
 			rmSync(join(dir, `${name}.md`));
 		}
-		console.log(chalk.yellow(`- ${installed.length} profil silindi`));
+		console.log(chalk.yellow(`- ${installed.length} profiles deleted`));
 		return;
 	}
 
-	console.error(chalk.red(`Bilinmeyen alt komut: ${sub}`));
+	console.error(chalk.red(`Unknown subcommand: ${sub}`));
 	showHelp();
 	process.exit(1);
 }

--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -11,14 +11,14 @@ import { hasCommand, shCapture as sh } from "../helpers.js";
 
 // Release pre-flight verifier.
 //
-// `badi release check` calistirir, ekrana raporlar — dosya yazmaz, commit
-// etmez, bump etmez. Publish-oncesi durumu standalone kontrol etmek icin.
+// `badi release check` runs and reports to the screen — it doesn't write
+// files, commit, or bump. For checking the pre-publish state standalone.
 //
-// v1.30 review C2 fix: monolitik prosedural yapidan CHECKS array'ine
-// refactor. Her kontrol pure-function olarak ayri tanimli ve test
-// edilebilir. CHECKS dizisi public; ileride plugin'ler kontrol ekleyebilir.
+// v1.30 review C2 fix: refactored from a monolithic procedural structure to a
+// CHECKS array. Each check is defined separately as a pure function and is
+// testable. The CHECKS array is public; plugins may add checks in the future.
 
-// ─── Yardimcilar ───
+// ─── Helpers ───
 
 function gitClean() {
 	try {
@@ -81,7 +81,7 @@ function runLint() {
 		timeout: 60_000,
 	});
 	const out = `${r.stdout || ""}${r.stderr || ""}`;
-	// biome "Found N errors" satirini yakala (info/hint icin).
+	// Capture biome's "Found N errors" line (for info/hint).
 	const errMatch = out.match(/Found\s+(\d+)\s+error/i);
 	return {
 		exitCode: r.status,
@@ -109,16 +109,16 @@ function npmPackDryRun() {
 	}
 }
 
-// ─── Pure CHECK fonksiyonlari ───
+// ─── Pure CHECK functions ───
 //
-// Her check ctx alir ({ pkg, targetVersion, skipTest }), {pass, level, label,
-// hint, info?} doner. level ∈ {"ok","warn","fail"}.
+// Each check takes ctx ({ pkg, targetVersion, skipTest }) and returns
+// {pass, level, label, hint, info?}. level ∈ {"ok","warn","fail"}.
 
 function checkGitClean() {
 	const clean = gitClean();
 	return {
 		name: "git-clean",
-		label: "Git durumu temiz",
+		label: "Git status clean",
 		pass: clean,
 		level: clean ? "ok" : "fail",
 		hint: clean ? null : "git status -s",
@@ -132,7 +132,7 @@ function checkBranch() {
 		name: "branch",
 		label: onMain
 			? `Branch main/master (${branch})`
-			: `Branch main/master degil (${branch ?? "?"})`,
+			: `Not on branch main/master (${branch ?? "?"})`,
 		pass: onMain,
 		level: onMain ? "ok" : "warn",
 		hint: null,
@@ -143,7 +143,7 @@ function checkPackageJson(ctx) {
 	if (!ctx.pkg) {
 		return {
 			name: "package-json",
-			label: "package.json okunabilir",
+			label: "package.json readable",
 			pass: false,
 			level: "fail",
 			hint: null,
@@ -151,7 +151,7 @@ function checkPackageJson(ctx) {
 	}
 	return {
 		name: "package-json",
-		label: `package.json mevcut (${ctx.pkg.name} v${ctx.pkg.version})`,
+		label: `package.json present (${ctx.pkg.name} v${ctx.pkg.version})`,
 		pass: true,
 		level: "ok",
 	};
@@ -162,18 +162,18 @@ function checkChangelogEn(ctx) {
 	if (r === null) {
 		return {
 			name: "changelog-en",
-			label: "CHANGELOG.md mevcut",
+			label: "CHANGELOG.md present",
 			pass: false,
 			level: "fail",
-			hint: "dosya yok",
+			hint: "file missing",
 		};
 	}
 	return {
 		name: "changelog-en",
-		label: `CHANGELOG.md icinde [${ctx.targetVersion}]`,
+		label: `[${ctx.targetVersion}] in CHANGELOG.md`,
 		pass: r,
 		level: r ? "ok" : "fail",
-		hint: r ? null : "yeni surum girdisi eksik",
+		hint: r ? null : "new-version entry missing",
 	};
 }
 
@@ -184,10 +184,10 @@ function checkChangelogTr(ctx) {
 	const r = changelogHasVersion("CHANGELOG.tr.md", ctx.targetVersion);
 	return {
 		name: "changelog-tr",
-		label: `CHANGELOG.tr.md icinde [${ctx.targetVersion}]`,
+		label: `[${ctx.targetVersion}] in CHANGELOG.tr.md`,
 		pass: r,
 		level: r ? "ok" : "warn",
-		hint: r ? null : "TR cevirisi de gunceleyin",
+		hint: r ? null : "update the TR translation too",
 	};
 }
 
@@ -195,7 +195,7 @@ function checkNpmTest(ctx) {
 	if (ctx.skipTest) {
 		return {
 			name: "test",
-			label: "Test atlandi (--skip-test)",
+			label: "Test skipped (--skip-test)",
 			pass: true,
 			level: "warn",
 			hint: null,
@@ -210,7 +210,7 @@ function checkNpmTest(ctx) {
 		level: ok ? "ok" : "fail",
 		info: ok
 			? t.passed != null
-				? `${t.passed} test gecti`
+				? `${t.passed} tests passed`
 				: null
 			: `exit ${t.exitCode}${t.failed ? `, ${t.failed} fail` : ""}`,
 	};
@@ -220,7 +220,7 @@ function checkLint(ctx) {
 	if (ctx.skipLint) {
 		return {
 			name: "lint",
-			label: "Lint atlandi (--skip-lint)",
+			label: "Lint skipped (--skip-lint)",
 			pass: true,
 			level: "warn",
 			hint: null,
@@ -233,10 +233,10 @@ function checkLint(ctx) {
 		label: "Lint (biome check)",
 		pass: ok,
 		level: ok ? "ok" : "fail",
-		info: ok ? "temiz" : null,
+		info: ok ? "clean" : null,
 		hint: ok
 			? null
-			: `${r.errors != null ? `${r.errors} hata` : "lint hatasi"} — npm run lint:fix`,
+			: `${r.errors != null ? `${r.errors} errors` : "lint error"} — npm run lint:fix`,
 	};
 }
 
@@ -244,7 +244,7 @@ function checkGhCli() {
 	const ok = hasCommand("gh");
 	return {
 		name: "gh-cli",
-		label: ok ? "gh CLI kurulu" : "gh CLI kurulu degil",
+		label: ok ? "gh CLI installed" : "gh CLI not installed",
 		pass: ok,
 		level: ok ? "ok" : "warn",
 		hint: ok ? null : "brew install gh",
@@ -263,16 +263,16 @@ function checkMarketplaceManifest() {
 	if (status.missing) {
 		return {
 			name: "marketplace-manifest",
-			label: ".claude-plugin/plugin.json mevcut",
+			label: ".claude-plugin/plugin.json present",
 			pass: false,
 			level: "fail",
-			hint: "badi release sync-manifest ile uret",
+			hint: "generate with badi release sync-manifest",
 		};
 	}
 	if (status.stale) {
 		return {
 			name: "marketplace-manifest",
-			label: ".claude-plugin/plugin.json guncel",
+			label: ".claude-plugin/plugin.json up to date",
 			pass: false,
 			level: "warn",
 			hint: `${status.reason || "stale"} — badi release sync-manifest`,
@@ -280,7 +280,7 @@ function checkMarketplaceManifest() {
 	}
 	return {
 		name: "marketplace-manifest",
-		label: ".claude-plugin/plugin.json guncel",
+		label: ".claude-plugin/plugin.json up to date",
 		pass: true,
 		level: "ok",
 	};
@@ -294,23 +294,23 @@ function checkNpmPack() {
 			label: "npm pack dry-run",
 			pass: false,
 			level: "warn",
-			hint: "calistirilamadi",
+			hint: "could not run",
 		};
 	}
 	const sizeKb = pack.size ? (pack.size / 1024).toFixed(1) : "?";
 	const tooBig = pack.size && pack.size > 5 * 1024 * 1024;
 	return {
 		name: "npm-pack",
-		label: tooBig ? `Paket boyutu buyuk (${sizeKb} KB)` : "npm pack dry-run",
+		label: tooBig ? `Package size large (${sizeKb} KB)` : "npm pack dry-run",
 		pass: !tooBig,
 		level: tooBig ? "warn" : "ok",
 		info: tooBig ? null : `${sizeKb} KB tarball`,
-		hint: tooBig ? "package.json files array kontrol edin" : null,
+		hint: tooBig ? "check the package.json files array" : null,
 	};
 }
 
-// Public CHECK registry — plugin'ler push() ile genisletebilir.
-// Sirayla calistirilir; null donen check'ler atlanir.
+// Public CHECK registry — plugins can extend it with push().
+// Run in order; checks that return null are skipped.
 export const CHECKS = [
 	checkGitClean,
 	checkBranch,
@@ -325,7 +325,7 @@ export const CHECKS = [
 ];
 
 /**
- * Pure runner — UI'siz, sadece sonuc dizisi doner. Test edilebilir.
+ * Pure runner — no UI, returns only the result array. Testable.
  * Returns: [{name, label, pass, level, hint, info}, ...]
  */
 export function runChecks(ctx) {
@@ -356,31 +356,33 @@ function renderResult(r) {
 function printSummary(pass, warnings, fail, strict, targetVersion) {
 	console.log("");
 	console.log(
-		`${chalk.bold("Sonuc:")} ${chalk.green(`${pass} OK`)} / ${chalk.yellow(`${warnings} UYARI`)} / ${chalk.red(`${fail} HATA`)}`,
+		`${chalk.bold("Result:")} ${chalk.green(`${pass} OK`)} / ${chalk.yellow(`${warnings} WARN`)} / ${chalk.red(`${fail} FAIL`)}`,
 	);
 	if (targetVersion) {
-		console.log(chalk.dim(`  Hedef surum: ${targetVersion}`));
+		console.log(chalk.dim(`  Target version: ${targetVersion}`));
 	}
 	console.log("");
 
 	if (fail > 0) {
-		console.log(chalk.red("Publish'a hazir degil. Hatalari giderin."));
+		console.log(chalk.red("Not ready to publish. Fix the errors."));
 		process.exit(1);
 	}
 	if (strict && warnings > 0) {
 		console.log(
-			chalk.yellow("--strict modu: uyarilar hata sayilir. Publish iptal."),
+			chalk.yellow(
+				"--strict mode: warnings count as errors. Publish cancelled.",
+			),
 		);
 		process.exit(1);
 	}
 	if (warnings > 0) {
 		console.log(
 			chalk.dim(
-				"Publish'a hazir (uyarilar var). --strict ile CI'da blok edilebilir.",
+				"Ready to publish (with warnings). Can be blocked in CI with --strict.",
 			),
 		);
 	} else {
-		console.log(chalk.green("Publish'a hazir."));
+		console.log(chalk.green("Ready to publish."));
 	}
 }
 
@@ -420,8 +422,8 @@ export function runReleaseCheck(args = []) {
 	const ctx = { pkg, targetVersion, skipTest, skipLint };
 	const results = runChecks(ctx);
 
-	// Note: bazi check'ler uzun surer (npm test). Inline'da "calisiyor" mesaji
-	// bilgisi olmadan basla; sonuc gelince renderResult.
+	// Note: some checks take a while (npm test). Start inline without a
+	// "running" message; render with renderResult once the result arrives.
 	let pass = 0;
 	let warnings = 0;
 	let fail = 0;
@@ -436,38 +438,38 @@ export function runReleaseCheck(args = []) {
 }
 
 function printHelp() {
-	console.log(chalk.bold("Release Komutlari:"));
+	console.log(chalk.bold("Release Commands:"));
 	console.log("");
 	console.log(
-		`  badi release check                ${chalk.dim("Publish-oncesi pre-flight kontroller")}`,
+		`  badi release check                ${chalk.dim("Pre-publish pre-flight checks")}`,
 	);
 	console.log(
-		`  badi release sync-manifest        ${chalk.dim(".claude-plugin/{plugin,marketplace}.json uret (v1.30.1+)")}`,
+		`  badi release sync-manifest        ${chalk.dim("Generate .claude-plugin/{plugin,marketplace}.json (v1.30.1+)")}`,
 	);
 	console.log("");
-	console.log(chalk.bold("'check' Secenekleri:"));
+	console.log(chalk.bold("'check' Options:"));
 	console.log(
-		`  --version <X.Y.Z>                 Hedef surum (CHANGELOG kontrolu icin)`,
+		`  --version <X.Y.Z>                 Target version (for the CHANGELOG check)`,
 	);
 	console.log(
-		`  --bump <patch|minor|major>        package.json'dan otomatik bump hesapla`,
+		`  --bump <patch|minor|major>        Auto-compute the bump from package.json`,
 	);
 	console.log(
-		`  --strict                          Uyariyi da hata say (CI'da kullanin)`,
+		`  --strict                          Count warnings as errors (use in CI)`,
 	);
 	console.log(
-		`  --skip-test                       Test asamasini atla (hizli check)`,
+		`  --skip-test                       Skip the test stage (fast check)`,
 	);
 	console.log(
-		`  --skip-lint                       Lint (biome) asamasini atla`,
-	);
-	console.log("");
-	console.log(chalk.bold("'sync-manifest' Secenekleri:"));
-	console.log(
-		`  --dry-run                         Yazma; sadece neyin uretilecegini goster`,
+		`  --skip-lint                       Skip the lint (biome) stage`,
 	);
 	console.log("");
-	console.log(chalk.bold("Ornekler:"));
+	console.log(chalk.bold("'sync-manifest' Options:"));
+	console.log(
+		`  --dry-run                         Don't write; just show what would be generated`,
+	);
+	console.log("");
+	console.log(chalk.bold("Examples:"));
 	console.log(`  badi release check`);
 	console.log(`  badi release check --bump minor`);
 	console.log(`  badi release check --version 1.30.0 --strict`);
@@ -476,19 +478,22 @@ function printHelp() {
 }
 
 /**
- * `badi release sync-manifest` — `.claude-plugin/{plugin,marketplace}.json`
- * dosyalarini regenerate eder. `--dry-run` ile diff goster.
+ * `badi release sync-manifest` — regenerates the
+ * `.claude-plugin/{plugin,marketplace}.json` files. Use `--dry-run` to show
+ * the diff.
  */
 export function runSyncManifest(args = []) {
 	const dryRun = args.includes("--dry-run");
 	const pluginDir = ".claude-plugin";
 	if (!existsSync(pluginDir)) {
-		console.error(chalk.red(`Hata: ${pluginDir}/ dizini yok. Once olusturun.`));
+		console.error(
+			chalk.red(`Error: ${pluginDir}/ directory missing. Create it first.`),
+		);
 		process.exit(1);
 	}
 	const pkg = readPackageJson();
 	if (!pkg) {
-		console.error(chalk.red("Hata: package.json okunamadi."));
+		console.error(chalk.red("Error: could not read package.json."));
 		process.exit(1);
 	}
 	const plugin = buildPluginManifest({ pkg, claudeDir: ".claude" });
@@ -505,7 +510,7 @@ export function runSyncManifest(args = []) {
 	});
 
 	if (dryRun) {
-		console.log(chalk.yellow("DRY RUN — dosyalar yazilmadi"));
+		console.log(chalk.yellow("DRY RUN — files not written"));
 	}
 	console.log(chalk.bold("Manifest sync:"));
 	for (const p of result.synced) {
@@ -530,7 +535,7 @@ export async function runRelease(args = []) {
 	if (sub === "sync-manifest") {
 		return runSyncManifest(args.slice(1));
 	}
-	console.error(chalk.red(`Bilinmeyen release komutu: ${sub}`));
+	console.error(chalk.red(`Unknown release command: ${sub}`));
 	printHelp();
 	process.exit(1);
 }

--- a/lib/commands/schedule.js
+++ b/lib/commands/schedule.js
@@ -4,13 +4,6 @@ import { join } from "node:path";
 import { chalk } from "../cli.js";
 
 export const DAY_MAP = {
-	pzt: 1,
-	sal: 2,
-	car: 3,
-	per: 4,
-	cum: 5,
-	cts: 6,
-	paz: 0,
 	mon: 1,
 	tue: 2,
 	wed: 3,
@@ -19,14 +12,14 @@ export const DAY_MAP = {
 	sat: 6,
 	sun: 0,
 };
-export const DAY_NAMES = ["Paz", "Pzt", "Sal", "Car", "Per", "Cum", "Cts"];
+export const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 export function loadSchedules() {
 	const file = join(homedir(), ".config", "badi", "schedules.json");
 	try {
 		if (existsSync(file)) return JSON.parse(readFileSync(file, "utf-8"));
 	} catch {
-		// Bozuk dosya
+		// Corrupt file
 	}
 	return { version: 1, schedules: [] };
 }
@@ -40,9 +33,9 @@ export function saveSchedules(data) {
 export function parseTimeSpec(timeStr, daysStr) {
 	let hours = 9;
 	let minutes = 0;
-	let days = null; // null = her gun
+	let days = null; // null = every day
 
-	// Zaman parse
+	// Parse time
 	const timeMatch = timeStr.match(/(\d{1,2}):(\d{2})/);
 	if (timeMatch) {
 		hours = Number.parseInt(timeMatch[1], 10);
@@ -50,17 +43,17 @@ export function parseTimeSpec(timeStr, daysStr) {
 		if (hours > 23 || minutes > 59) {
 			console.error(
 				chalk.red(
-					`Gecersiz saat: ${hours}:${String(minutes).padStart(2, "0")} (0-23:0-59 araliginda olmali)`,
+					`Invalid time: ${hours}:${String(minutes).padStart(2, "0")} (must be within 0-23:0-59)`,
 				),
 			);
 			process.exit(1);
 		}
 	}
 
-	// Gun parse — "mon-fri", "mon,wed,fri", "daily", veya tek gun
+	// Parse days — "mon-fri", "mon,wed,fri", "daily", or a single day
 	if (daysStr) {
 		const lower = daysStr.toLowerCase();
-		if (lower === "daily" || lower === "gunluk") {
+		if (lower === "daily") {
 			days = null;
 		} else if (lower.includes("-")) {
 			const [start, end] = lower.split("-");
@@ -81,7 +74,7 @@ export function parseTimeSpec(timeStr, daysStr) {
 		}
 	}
 
-	// timeStr icinde gun ismi varsa
+	// If timeStr contains a day name
 	if (!daysStr) {
 		for (const [name, idx] of Object.entries(DAY_MAP)) {
 			if (timeStr.toLowerCase().includes(name)) {
@@ -100,10 +93,10 @@ export function isScheduleDue(schedule, now) {
 	const nowHour = now.getHours();
 	const nowMin = now.getMinutes();
 
-	// Gun kontrolu
+	// Day check
 	if (days && !days.includes(nowDay)) return false;
 
-	// Saat penceresi kontrolu (60dk tolerans)
+	// Time-window check (60min tolerance)
 	const scheduleMin = hours * 60 + minutes;
 	const nowMinTotal = nowHour * 60 + nowMin;
 	return nowMinTotal >= scheduleMin && nowMinTotal < scheduleMin + 60;
@@ -113,30 +106,30 @@ export function runSchedule(args) {
 	const sub = args[0];
 
 	if (!sub || sub === "--help" || sub === "-h") {
-		console.log(chalk.bold("Zamanlanmis Hatirlaticilar:"));
+		console.log(chalk.bold("Scheduled Reminders:"));
 		console.log("");
 		console.log(
-			`  badi schedule add [komut] --at [saat] --days [gunler]  ${chalk.dim("Hatirlatici ekle")}`,
+			`  badi schedule add [command] --at [time] --days [days]  ${chalk.dim("Add a reminder")}`,
 		);
 		console.log(
-			`  badi schedule list                                     ${chalk.dim("Listele")}`,
+			`  badi schedule list                                     ${chalk.dim("List")}`,
 		);
 		console.log(
-			`  badi schedule remove [id]                              ${chalk.dim("Sil")}`,
+			`  badi schedule remove [id]                              ${chalk.dim("Remove")}`,
 		);
 		console.log(
-			`  badi schedule check                                    ${chalk.dim("Zamani gelenleri goster")}`,
+			`  badi schedule check                                    ${chalk.dim("Show due reminders")}`,
 		);
 		console.log("");
-		console.log(chalk.bold("Ornekler:"));
+		console.log(chalk.bold("Examples:"));
 		console.log(
 			'  badi schedule add "icerik basla" --at "09:00" --days "mon-fri"',
 		);
 		console.log('  badi schedule add "wrap-up" --at "18:00"');
 		console.log('  badi schedule add "icerik plan" --at "sun 20:00"');
 		console.log("");
-		console.log(chalk.bold("Shell Entegrasyonu:"));
-		console.log(chalk.dim("  ~/.bashrc veya ~/.zshrc'ye ekleyin:"));
+		console.log(chalk.bold("Shell Integration:"));
+		console.log(chalk.dim("  Add to ~/.bashrc or ~/.zshrc:"));
 		console.log(
 			"  command -v badi &>/dev/null && badi schedule check 2>/dev/null",
 		);
@@ -162,7 +155,9 @@ export function runSchedule(args) {
 		const cmdStr = cmdParts.join(" ");
 		if (!cmdStr) {
 			console.error(
-				chalk.red('Komut belirtin: badi schedule add "komut" --at "09:00"'),
+				chalk.red(
+					'Specify a command: badi schedule add "command" --at "09:00"',
+				),
 			);
 			process.exit(1);
 		}
@@ -189,30 +184,28 @@ export function runSchedule(args) {
 		saveSchedules(data);
 
 		const timeLabel = `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
-		const daysLabel = days
-			? days.map((d) => DAY_NAMES[d]).join(", ")
-			: "Gunluk";
+		const daysLabel = days ? days.map((d) => DAY_NAMES[d]).join(", ") : "Daily";
 
-		console.log(chalk.bold.green("Hatirlatici olusturuldu!"));
-		console.log(`  ID:     ${chalk.cyan(newSchedule.id)}`);
-		console.log(`  Komut:  ${chalk.cyan(newSchedule.command)}`);
-		console.log(`  Zaman:  ${chalk.cyan(timeLabel)}`);
-		console.log(`  Gunler: ${chalk.cyan(daysLabel)}`);
+		console.log(chalk.bold.green("Reminder created!"));
+		console.log(`  ID:      ${chalk.cyan(newSchedule.id)}`);
+		console.log(`  Command: ${chalk.cyan(newSchedule.command)}`);
+		console.log(`  Time:    ${chalk.cyan(timeLabel)}`);
+		console.log(`  Days:    ${chalk.cyan(daysLabel)}`);
 		return;
 	}
 
 	if (sub === "list") {
 		const data = loadSchedules();
 		if (data.schedules.length === 0) {
-			console.log(chalk.dim("Henuz hatirlatici yok."));
-			console.log(chalk.dim('Ekle: badi schedule add "komut" --at "09:00"'));
+			console.log(chalk.dim("No reminders yet."));
+			console.log(chalk.dim('Add: badi schedule add "command" --at "09:00"'));
 			return;
 		}
 
-		console.log(chalk.bold("Zamanlanmis Hatirlaticilar:"));
+		console.log(chalk.bold("Scheduled Reminders:"));
 		console.log("");
 		console.log(
-			`  ${chalk.dim("ID".padEnd(5))}${chalk.dim("Komut".padEnd(30))}${chalk.dim("Zaman".padEnd(8))}${chalk.dim("Gunler".padEnd(20))}${chalk.dim("Durum")}`,
+			`  ${chalk.dim("ID".padEnd(5))}${chalk.dim("Command".padEnd(30))}${chalk.dim("Time".padEnd(8))}${chalk.dim("Days".padEnd(20))}${chalk.dim("Status")}`,
 		);
 		console.log(chalk.dim(`  ${"─".repeat(70)}`));
 
@@ -220,10 +213,10 @@ export function runSchedule(args) {
 			const timeLabel = `${String(s.hours).padStart(2, "0")}:${String(s.minutes).padStart(2, "0")}`;
 			const daysLabel = s.days
 				? s.days.map((d) => DAY_NAMES[d]).join(",")
-				: "Gunluk";
-			const durum = s.active ? chalk.green("Aktif") : chalk.dim("Pasif");
+				: "Daily";
+			const status = s.active ? chalk.green("Active") : chalk.dim("Inactive");
 			console.log(
-				`  ${String(s.id).padEnd(5)}${(s.command || "").substring(0, 28).padEnd(30)}${timeLabel.padEnd(8)}${daysLabel.padEnd(20)}${durum}`,
+				`  ${String(s.id).padEnd(5)}${(s.command || "").substring(0, 28).padEnd(30)}${timeLabel.padEnd(8)}${daysLabel.padEnd(20)}${status}`,
 			);
 		}
 		return;
@@ -232,19 +225,19 @@ export function runSchedule(args) {
 	if (sub === "remove") {
 		const removeId = Number.parseInt(args[1], 10);
 		if (!removeId) {
-			console.error(chalk.red("Silinecek hatirlatici ID'si belirtin."));
+			console.error(chalk.red("Specify the reminder ID to remove."));
 			process.exit(1);
 		}
 		const data = loadSchedules();
 		const idx = data.schedules.findIndex((s) => s.id === removeId);
 		if (idx === -1) {
-			console.error(chalk.red(`Hatirlatici bulunamadi: ID ${removeId}`));
+			console.error(chalk.red(`Reminder not found: ID ${removeId}`));
 			process.exit(1);
 		}
 		const removed = data.schedules.splice(idx, 1)[0];
 		saveSchedules(data);
 		console.log(
-			chalk.green(`Hatirlatici silindi: ${removed.command} (ID: ${removeId})`),
+			chalk.green(`Reminder removed: ${removed.command} (ID: ${removeId})`),
 		);
 		return;
 	}
@@ -258,14 +251,14 @@ export function runSchedule(args) {
 			if (!s.active) continue;
 			if (!isScheduleDue(s, now)) continue;
 
-			// Ayni saat icinde tekrar gosterme
+			// Don't show again within the same hour
 			if (s.lastChecked) {
 				const lastCheck = new Date(s.lastChecked);
 				if (now.getTime() - lastCheck.getTime() < 3600000) continue;
 			}
 
 			if (!anyDue) {
-				console.log(chalk.bold.yellow("Badi Hatirlatici:"));
+				console.log(chalk.bold.yellow("Badi Reminder:"));
 				console.log("");
 			}
 			anyDue = true;
@@ -283,7 +276,7 @@ export function runSchedule(args) {
 		return;
 	}
 
-	console.error(chalk.red(`Bilinmeyen schedule komutu: ${sub}`));
-	console.log("Kullanim: badi schedule [add|list|remove|check]");
+	console.error(chalk.red(`Unknown schedule command: ${sub}`));
+	console.log("Usage: badi schedule [add|list|remove|check]");
 	process.exit(1);
 }

--- a/lib/commands/secret-scan.js
+++ b/lib/commands/secret-scan.js
@@ -1,7 +1,7 @@
-// Badi secret-scan — projeyi ve git history'sini sir/credential icin tarar.
+// Badi secret-scan — scans the project and its git history for secrets/credentials.
 //
 // Pattern registry: lib/data/secret-patterns.js (canonical).
-// Tum davranis bayraklari --help cikti'sinda dokumante edilmistir.
+// All behavior flags are documented in the --help output.
 
 import { execFileSync } from "node:child_process";
 import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
@@ -18,19 +18,19 @@ import {
 	SKIP_DIRS,
 } from "../data/secret-patterns.js";
 
-// Path-traversal/sistem-disi yazma koruma. assertWithinProject baseDir
-// disindaki yollari engeller. Yalniz read-only/disk-write hedef dosyalari
-// icin kullaniyoruz.
+// Path-traversal / out-of-system write protection. assertWithinProject blocks
+// paths outside baseDir. We use it only for read-only / disk-write target
+// files.
 function assertWithinProject(baseDir, candidate, flag) {
 	const rel = relative(baseDir, candidate);
 	if (rel.startsWith("..") || rel.startsWith("/")) {
 		throw new Error(
-			`${flag} proje koku disinda: ${candidate} (cwd: ${baseDir})`,
+			`${flag} outside project root: ${candidate} (cwd: ${baseDir})`,
 		);
 	}
 }
 
-// ─── Yardimcilar ──────────────────────────────────────────────────────────
+// ─── Helpers ──────────────────────────────────────────────────────────────
 
 function maskSecret(val) {
 	if (val.length <= 8) return "*".repeat(val.length);
@@ -47,7 +47,7 @@ function loadCustomPatterns(filePath) {
 		id: String(p.id || ""),
 		name: String(p.name || p.id || "Custom"),
 		regex: new RegExp(p.regex, p.flags || "g"),
-		severity: String(p.severity || "ORTA"),
+		severity: String(p.severity || "MEDIUM"),
 		context: p.context ? new RegExp(p.context, "i") : undefined,
 	}));
 }
@@ -64,7 +64,7 @@ function loadIgnoreList(filePath) {
 	return ids;
 }
 
-// ─── Tarama cekirdek ──────────────────────────────────────────────────────
+// ─── Scan core ──────────────────────────────────────────────────────────────
 
 function scanContent(content, filePath, patterns) {
 	const findings = [];
@@ -114,7 +114,7 @@ function walkDir({ dir, baseDir, patterns, maxFiles }) {
 		for (const entry of entries) {
 			if (fileCount >= maxFiles) return;
 
-			// Y1: Symlink'leri her zaman atla — cycle ve proje-disi traversal riski.
+			// Y1: Always skip symlinks — cycle and out-of-project traversal risk.
 			if (entry.isSymbolicLink()) {
 				symlinksSkipped++;
 				continue;
@@ -152,7 +152,7 @@ function walkDir({ dir, baseDir, patterns, maxFiles }) {
 						results.push(...findings);
 						fileCount++;
 					} catch {
-						/* okunmaz dosya */
+						/* unreadable file */
 					}
 				}
 			}
@@ -193,7 +193,7 @@ function scanGitHistory({ baseDir, patterns, maxCommits }) {
 					),
 				);
 			} catch {
-				/* buyuk commit skip */
+				/* skip large commit */
 			}
 		}
 		return {
@@ -203,14 +203,14 @@ function scanGitHistory({ baseDir, patterns, maxCommits }) {
 			truncated,
 		};
 	} catch {
-		return { findings: [], commitCount: 0, error: "Git repo degil" };
+		return { findings: [], commitCount: 0, error: "Not a git repo" };
 	}
 }
 
-// ─── Cikti yardimcilari ───────────────────────────────────────────────────
+// ─── Output helpers ───────────────────────────────────────────────────────
 
 function dedupFindings(findings) {
-	// K2: anahtara file + rawMatch dahil — masked-only collision kaldirildi.
+	// K2: key includes file + rawMatch — removed masked-only collision.
 	const seen = new Set();
 	const unique = [];
 	for (const f of findings) {
@@ -228,7 +228,7 @@ function applyIgnore(findings, ignoreIds) {
 }
 
 function groupBySeverity(findings) {
-	const map = { KRITIK: [], YUKSEK: [], ORTA: [], DUSUK: [] };
+	const map = { CRITICAL: [], HIGH: [], MEDIUM: [], LOW: [] };
 	for (const f of findings) map[f.severity]?.push(f);
 	return map;
 }
@@ -236,9 +236,9 @@ function groupBySeverity(findings) {
 function computeExitCode(findings, mode) {
 	if (mode === "never") return 0;
 	if (mode === "strict") return findings.length > 0 ? 1 : 0;
-	// default: "critical" — KRITIK + YUKSEK exit 1
+	// default: "critical" — CRITICAL + HIGH exit 1
 	const critical = findings.filter(
-		(f) => f.severity === "KRITIK" || f.severity === "YUKSEK",
+		(f) => f.severity === "CRITICAL" || f.severity === "HIGH",
 	).length;
 	return critical > 0 ? 1 : 0;
 }
@@ -255,36 +255,38 @@ function printText({
 }) {
 	console.log(
 		chalk.bold(
-			`Taranan: ${fileCount} dosya${scanGit ? `, ${commitCount} commit` : ""}`,
+			`Scanned: ${fileCount} files${scanGit ? `, ${commitCount} commits` : ""}`,
 		),
 	);
 	if (truncated) {
 		console.error(
 			chalk.yellow(
-				`UYARI: git history ${totalCommits} commit iceriyor; sadece ilk ${commitCount} tarandi. ` +
-					"--max-commits N ile siniri arttir.",
+				`WARNING: git history has ${totalCommits} commits; only the first ${commitCount} were scanned. ` +
+					"Increase the limit with --max-commits N.",
 			),
 		);
 	}
 	if (symlinksSkipped > 0) {
 		console.log(
-			chalk.dim(`(${symlinksSkipped} sembolik link atlandi — cycle koruma)`),
+			chalk.dim(
+				`(${symlinksSkipped} symbolic links skipped — cycle protection)`,
+			),
 		);
 	}
-	console.log(chalk.bold(`Sure: ${durationMs}ms`));
+	console.log(chalk.bold(`Time: ${durationMs}ms`));
 	console.log("");
 
 	if (findings.length === 0) {
-		console.log(chalk.bold.green("Hic sir/secret tespit edilmedi!"));
+		console.log(chalk.bold.green("No secrets detected!"));
 		return;
 	}
 
 	const bySeverity = groupBySeverity(findings);
 	const colorMap = {
-		KRITIK: chalk.bold.red,
-		YUKSEK: chalk.bold.yellow,
-		ORTA: chalk.yellow,
-		DUSUK: chalk.dim,
+		CRITICAL: chalk.bold.red,
+		HIGH: chalk.bold.yellow,
+		MEDIUM: chalk.yellow,
+		LOW: chalk.dim,
 	};
 	for (const [sev, items] of Object.entries(bySeverity)) {
 		if (items.length === 0) continue;
@@ -296,12 +298,10 @@ function printText({
 		console.log("");
 	}
 
-	const critical = bySeverity.KRITIK.length + bySeverity.YUKSEK.length;
+	const critical = bySeverity.CRITICAL.length + bySeverity.HIGH.length;
 	if (critical > 0) {
-		console.log(chalk.bold.red(`${critical} yuksek/kritik sir tespit edildi!`));
-		console.log(
-			chalk.dim("  Rotate edin, .gitignore'a ekleyin, .env kullanin."),
-		);
+		console.log(chalk.bold.red(`${critical} high/critical secrets detected!`));
+		console.log(chalk.dim("  Rotate them, add to .gitignore, use .env."));
 	}
 }
 
@@ -397,61 +397,59 @@ function showHelp() {
 	showBanner();
 	console.log(chalk.bold("Secret Scanner:"));
 	console.log("");
-	console.log(chalk.bold("Kullanim:"));
+	console.log(chalk.bold("Usage:"));
 	console.log(
 		`  ${chalk.cyan("badi secret-scan")}                  Working tree scan`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi secret-scan --git")}            + son N commit (varsayilan 100)`,
+		`  ${chalk.cyan("badi secret-scan --git")}            + last N commits (default 100)`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi secret-scan --format json")}    JSON cikti`,
+		`  ${chalk.cyan("badi secret-scan --format json")}    JSON output`,
 	);
 	console.log("");
-	console.log(chalk.bold("Bayraklar:"));
+	console.log(chalk.bold("Flags:"));
 	console.log("  --exit-code <mode>     critical (default) | strict | never");
-	console.log("                         critical: KRITIK+YUKSEK -> exit 1");
+	console.log("                         critical: CRITICAL+HIGH -> exit 1");
+	console.log("                         strict:   any finding -> exit 1");
 	console.log(
-		"                         strict:   herhangi bir bulgu -> exit 1",
+		"                         never:    exit 0 regardless of findings",
 	);
-	console.log("                         never:    bulguya bakmaksizin exit 0");
+	console.log("  --max-commits N        Git history scan limit (default 100)");
+	console.log("  --max-files N          File scan limit (default 5000)");
 	console.log(
-		"  --max-commits N        Git history tarama siniri (default 100)",
-	);
-	console.log("  --max-files N          Dosya tarama siniri (default 5000)");
-	console.log(
-		"  --ignore id1,id2,...   Belirli pattern-id'leri yoksay (orn: jwt,github-pat)",
+		"  --ignore id1,id2,...   Ignore specific pattern-ids (e.g. jwt,github-pat)",
 	);
 	console.log(
-		"  --ignore-file <path>   .secretignore-benzeri dosyadan pattern-id oku",
+		"  --ignore-file <path>   Read pattern-ids from a .secretignore-like file",
 	);
 	console.log(
-		"  --patterns <path>      Ek pattern JSON dosyasi yukle (custom kurum)",
+		"  --patterns <path>      Load an additional pattern JSON file (custom org)",
 	);
 	console.log("");
-	console.log(chalk.bold("Cikis kodlari:"));
+	console.log(chalk.bold("Exit codes:"));
 	console.log(
-		"  0   Bulgu yok (veya --exit-code never; veya sadece ORTA/DUSUK default)",
+		"  0   No findings (or --exit-code never; or only MEDIUM/LOW by default)",
 	);
-	console.log("  1   KRITIK veya YUKSEK bulgu (CI fail icin uygun)");
+	console.log("  1   CRITICAL or HIGH finding (suitable for CI fail)");
 	console.log("");
-	console.log(chalk.bold("Tespit Edilenler (17 pattern):"));
+	console.log(chalk.bold("Detected (17 patterns):"));
 	console.log("  AWS Access/Secret, GCP, GitHub PAT (classic + fine-grained),");
 	console.log("  Slack, Stripe, OpenAI, Anthropic, npm, SendGrid, Twilio,");
 	console.log("  JWT, MongoDB/Postgres URI, RSA/EC private keys, generic.");
 	console.log("");
-	console.log(chalk.bold("Kapsam:"));
+	console.log(chalk.bold("Scope:"));
 	console.log(
-		chalk.dim("  Symlink'ler atlanir (cycle + path traversal koruma)."),
+		chalk.dim("  Symlinks are skipped (cycle + path traversal protection)."),
 	);
 	console.log(
 		chalk.dim(
-			"  Git stash / reflog / packed-refs taranmaz (--git reachable commits).",
+			"  Git stash / reflog / packed-refs are not scanned (--git reachable commits).",
 		),
 	);
 }
 
-// ─── Ana komut ────────────────────────────────────────────────────────────
+// ─── Main command ─────────────────────────────────────────────────────────
 
 export async function runSecretScan(args) {
 	if (args[0] === "--help" || args[0] === "-h") {
@@ -476,7 +474,7 @@ export async function runSecretScan(args) {
 		? [...DEFAULT_PATTERNS, ...loadCustomPatterns(patternsPath)]
 		: DEFAULT_PATTERNS;
 
-	// Ignore listesi: --ignore flag + --ignore-file + .secretignore (cwd)
+	// Ignore list: --ignore flag + --ignore-file + .secretignore (cwd)
 	const ignore = new Set(flags.ignore);
 	const defaultIgnoreFile = join(baseDir, ".secretignore");
 	for (const id of loadIgnoreList(defaultIgnoreFile)) ignore.add(id);
@@ -494,7 +492,7 @@ export async function runSecretScan(args) {
 	if (!flags.jsonOutput) {
 		showBanner();
 		console.log(chalk.bold("Secret Scanner"));
-		console.log(chalk.dim(`Hedef: ${baseDir}`));
+		console.log(chalk.dim(`Target: ${baseDir}`));
 		console.log("");
 	}
 
@@ -540,7 +538,7 @@ export async function runSecretScan(args) {
 		printText(payload);
 	}
 
-	// K1: exit code'u format-bagimsiz tek noktada uygula.
+	// K1: apply the exit code at a single format-independent point.
 	const code = computeExitCode(filtered, flags.exitMode);
 	if (code !== 0) process.exit(code);
 }
@@ -560,9 +558,9 @@ export {
 	walkDir,
 };
 
-// v1.31.0+ K1 hotfix: doğrudan `node lib/commands/secret-scan.js ...` cagrildiginda
-// runSecretScan'i tetikle. `badi security baseline` bu yolu kullanir.
-// Test/import path'i etkilenmez — yalniz process.argv[1] bu dosya ise calisir.
+// v1.31.0+ K1 hotfix: when invoked directly as `node lib/commands/secret-scan.js ...`,
+// trigger runSecretScan. `badi security baseline` uses this path.
+// The test/import path is unaffected — runs only when process.argv[1] is this file.
 if (
 	import.meta.url.startsWith("file:") &&
 	process.argv[1] &&

--- a/lib/commands/security.js
+++ b/lib/commands/security.js
@@ -4,21 +4,22 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chalk } from "../cli.js";
 
-// `badi security` — Anthropic /security-review native komutuna kopru.
+// `badi security` — bridge to Anthropic's native /security-review command.
 //
-// v1.31.0+ — Anthropic 2.1.140 ile /security-review native slash command olarak
-// Claude Code'a gomulu. Bu modul AI cagirisi yapmaz; baseline (deterministic) +
-// triage (rapor okuma) + init (CI scaffold) ile kopru/orkestrasyon saglar.
+// v1.31.0+ — As of Anthropic 2.1.140, /security-review is embedded in Claude
+// Code as a native slash command. This module makes no AI calls; it provides a
+// bridge/orchestration via baseline (deterministic) + triage (report reading) +
+// init (CI scaffold).
 //
-// Subkomutlar:
+// Subcommands:
 //   badi security baseline           — secret-scan + npm audit deterministic baseline
-//   badi security triage [report]    — son /security-review raporunu severity'ye gore filtrele
-//   badi security init [--ci]        — GitHub Action scaffold (anthropics/claude-code-security-review wrap)
+//   badi security triage [report]    — filter the latest /security-review report by severity
+//   badi security init [--ci]        — GitHub Action scaffold (wraps anthropics/claude-code-security-review)
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// v1.31.0+ Y3 hotfix: git proje koku tespiti — cwd-relative dosya kontrollerinden
-// daha guvenli (subdirectory'den cagrildiginda lock dosyalari bulunamaz hatasi).
+// v1.31.0+ Y3 hotfix: git project root detection — safer than cwd-relative file
+// checks (avoids "lock files not found" when called from a subdirectory).
 function projectRoot() {
 	try {
 		return execFileSync("git", ["rev-parse", "--show-toplevel"], {
@@ -43,7 +44,7 @@ export function runSecurity(args) {
 		case "init":
 			return runInit(args.slice(1));
 		default:
-			console.error(chalk.red(`Bilinmeyen security subkomut: ${sub}`));
+			console.error(chalk.red(`Unknown security subcommand: ${sub}`));
 			showHelp();
 			process.exit(1);
 	}
@@ -51,25 +52,25 @@ export function runSecurity(args) {
 
 function showHelp() {
 	console.log(`
-${chalk.bold("badi security")} — Guvenlik orkestrasyonu (Anthropic /security-review kopru)
+${chalk.bold("badi security")} — Security orchestration (Anthropic /security-review bridge)
 
-${chalk.bold("Subkomutlar:")}
+${chalk.bold("Subcommands:")}
   ${chalk.cyan("baseline [--json]")}     Deterministic baseline scan (secret-scan + npm audit)
-  ${chalk.cyan("triage [report]")}       Son /security-review raporunu filtrele/ozetle
-  ${chalk.cyan("init --ci [--force]")}   GitHub Action scaffold (Anthropic resmi action wrap)
+  ${chalk.cyan("triage [report]")}       Filter/summarize the latest /security-review report
+  ${chalk.cyan("init --ci [--force]")}   GitHub Action scaffold (wraps Anthropic's official action)
 
-${chalk.bold("Onerilen akis:")}
-  1. ${chalk.cyan("badi security baseline")}     # deterministic taban (sirlar + bagimliliklar)
-  2. Claude Code icinde ${chalk.cyan("/security-review")} (native, semantic AI)
-  3. ${chalk.cyan("badi security triage")}      # rapor varsa severity'ye gore filtrele
-  4. CI: ${chalk.cyan("badi security init --ci")} (PR'larda otomatik review)
+${chalk.bold("Recommended flow:")}
+  1. ${chalk.cyan("badi security baseline")}     # deterministic baseline (secrets + dependencies)
+  2. ${chalk.cyan("/security-review")} inside Claude Code (native, semantic AI)
+  3. ${chalk.cyan("badi security triage")}      # filter by severity if a report exists
+  4. CI: ${chalk.cyan("badi security init --ci")} (automatic review on PRs)
 
 ${chalk.bold("Cross-ref:")}
   /security-review  → Anthropic native (Claude Code 2.1.140+)
   /security-scan    → Badi slash (sc-orchestrator skill)
-  badi secret-scan  → Deterministic regex (17 pattern)
+  badi secret-scan  → Deterministic regex (17 patterns)
 
-Detay: ${chalk.cyan("docs/enterprise.md")} ve ${chalk.cyan("badi security <subkomut> --help")}
+Details: ${chalk.cyan("docs/enterprise.md")} and ${chalk.cyan("badi security <subcommand> --help")}
 `);
 }
 
@@ -77,15 +78,15 @@ Detay: ${chalk.cyan("docs/enterprise.md")} ve ${chalk.cyan("badi security <subko
 
 function runBaseline(args) {
 	const jsonOut = args.includes("--format=json") || args.includes("--json");
-	const root = projectRoot(); // Y3 hotfix: cwd yerine git root
+	const root = projectRoot(); // Y3 hotfix: git root instead of cwd
 	const sections = [];
 
 	console.log(
-		chalk.bold("\n🔒 Baseline (deterministic) — sirlar + bagimliliklar\n"),
+		chalk.bold("\n🔒 Baseline (deterministic) — secrets + dependencies\n"),
 	);
 
-	// 1) secret-scan — K1 hotfix: secret-scan.js artik CLI entry point'e sahip
-	// (v1.31.0 hotfix), bu cagri gercekten taramayi tetikler.
+	// 1) secret-scan — K1 hotfix: secret-scan.js now has a CLI entry point
+	// (v1.31.0 hotfix), so this call actually triggers the scan.
 	const ss = spawnSync(
 		process.execPath,
 		[resolve(__dirname, "secret-scan.js"), "--format", "json"],
@@ -98,17 +99,17 @@ function runBaseline(args) {
 		secretCount = Array.isArray(parsed.findings) ? parsed.findings.length : 0;
 		secretParsed = true;
 	} catch (e) {
-		// O2 hotfix: silent fail yerine kullaniciya bildir
+		// O2 hotfix: notify the user instead of failing silently
 		console.error(
-			chalk.yellow(`  ⚠ secret-scan ciktisi parse edilemedi: ${e.message}`),
+			chalk.yellow(`  ⚠ could not parse secret-scan output: ${e.message}`),
 		);
 		console.error(chalk.dim(`    stderr: ${(ss.stderr || "").slice(0, 200)}`));
 	}
 	const secretLine = !secretParsed
-		? chalk.yellow("  ⚠ secret-scan calistirilamadi")
+		? chalk.yellow("  ⚠ could not run secret-scan")
 		: secretCount > 0
-			? chalk.red(`  ✗ ${secretCount} sir bulgu`)
-			: chalk.green("  ✓ Sir bulgu yok");
+			? chalk.red(`  ✗ ${secretCount} secret findings`)
+			: chalk.green("  ✓ No secret findings");
 	console.log(`${chalk.cyan("[1/2]")} secret-scan`);
 	console.log(secretLine);
 	sections.push({
@@ -117,12 +118,12 @@ function runBaseline(args) {
 		parsed: secretParsed,
 	});
 
-	// 2) npm audit (Y3 hotfix: root-relative lock dosyasi kontrolu)
+	// 2) npm audit (Y3 hotfix: root-relative lock file check)
 	const npmLock = join(root, "package-lock.json");
 	const yarnLock = join(root, "yarn.lock");
 	if (existsSync(npmLock) || existsSync(yarnLock)) {
 		const manager = existsSync(yarnLock) ? "yarn" : "npm";
-		// Y2 hotfix: dead code (identical ternary) kaldirildi
+		// Y2 hotfix: removed dead code (identical ternary)
 		const audit = spawnSync(manager, ["audit", "--json"], {
 			encoding: "utf-8",
 			timeout: 60_000,
@@ -144,26 +145,30 @@ function runBaseline(args) {
 		} catch (e) {
 			console.error(
 				chalk.yellow(
-					`  ⚠ ${manager} audit ciktisi parse edilemedi: ${e.message}`,
+					`  ⚠ could not parse ${manager} audit output: ${e.message}`,
 				),
 			);
 		}
 		console.log(`${chalk.cyan("[2/2]")} ${manager} audit`);
 		if (critical > 0)
-			console.log(chalk.red(`  ✗ ${critical} kritik bagimlilik acigi`));
+			console.log(
+				chalk.red(`  ✗ ${critical} critical dependency vulnerabilities`),
+			);
 		if (high > 0)
-			console.log(chalk.yellow(`  ⚠ ${high} yuksek bagimlilik acigi`));
+			console.log(chalk.yellow(`  ⚠ ${high} high dependency vulnerabilities`));
 		if (critical === 0 && high === 0)
-			console.log(chalk.green("  ✓ Kritik/yuksek bagimlilik acigi yok"));
+			console.log(
+				chalk.green("  ✓ No critical/high dependency vulnerabilities"),
+			);
 		sections.push({ check: `${manager} audit`, critical, high });
 	} else {
 		console.log(
-			`${chalk.cyan("[2/2]")} npm audit ${chalk.gray("(atlandi — lock dosyasi yok)")}`,
+			`${chalk.cyan("[2/2]")} npm audit ${chalk.gray("(skipped — no lock file)")}`,
 		);
 	}
 
 	console.log(
-		chalk.dim("\nSemantic AI review icin: Claude Code icinde /security-review"),
+		chalk.dim("\nFor semantic AI review: /security-review inside Claude Code"),
 	);
 
 	if (jsonOut) {
@@ -178,8 +183,8 @@ function runBaseline(args) {
 
 // ─── triage ───
 //
-// K2 hotfix: regex'ler word-boundary ile + markdown heading'lere oncelik veriyor.
-// Eski versiyon "/low/gi" ile "below", "follow", "yellow" kelimelerini sayardi.
+// K2 hotfix: patterns use word boundaries + prioritize markdown headings.
+// The old version counted "below", "follow", "yellow" with "/low/gi".
 
 const SEVERITY_PATTERNS = {
 	critical: /\b(critical|kritik|KRITIK)\b/gi,
@@ -188,8 +193,8 @@ const SEVERITY_PATTERNS = {
 	low: /\b(low|dusuk|DUSUK)\b/gi,
 };
 
-// Markdown heading-based count: `##? KRITIK SQLi` gibi yapilarda en guvenilir
-// sayim. /security-review default raporu bu formati kullanir.
+// Markdown heading-based count: most reliable on structures like `##? KRITIK SQLi`.
+// The default /security-review report uses this format.
 const HEADING_PATTERNS = {
 	critical: /^#{1,4}\s+(?:critical|kritik|KRITIK)\b/gim,
 	high: /^#{1,4}\s+(?:high|yuksek|YUKSEK)\b/gim,
@@ -203,14 +208,14 @@ function countMatches(text, re) {
 }
 
 function runTriage(args) {
-	const root = projectRoot(); // Y3: cwd-relative degil
+	const root = projectRoot(); // Y3: not cwd-relative
 	const reportPath =
 		args[0] || join(root, "security-report", "SECURITY-REPORT.md");
 	if (!existsSync(reportPath)) {
-		console.error(chalk.red(`Rapor yok: ${reportPath}`));
+		console.error(chalk.red(`No report: ${reportPath}`));
 		console.error(
 			chalk.dim(
-				"\n/security-review calistirildiktan sonra security-report/ dizini olusur.",
+				"\nThe security-report/ directory is created after running /security-review.",
 			),
 		);
 		process.exit(1);
@@ -218,8 +223,8 @@ function runTriage(args) {
 
 	const body = readFileSync(reportPath, "utf-8");
 
-	// Once markdown heading'leri dene (en guvenilir); 0 ise word-boundary
-	// regex'e dus (heading-less rapor formatlari icin).
+	// Try markdown headings first (most reliable); if 0, fall back to the
+	// word-boundary regex (for heading-less report formats).
 	const headingCounts = {
 		critical: countMatches(body, HEADING_PATTERNS.critical),
 		high: countMatches(body, HEADING_PATTERNS.high),
@@ -238,24 +243,26 @@ function runTriage(args) {
 				};
 
 	console.log(chalk.bold("\n📋 Security Report Triage\n"));
-	console.log(`  Kaynak: ${chalk.cyan(reportPath)}`);
+	console.log(`  Source: ${chalk.cyan(reportPath)}`);
 	console.log(
-		`  Sayim yontemi: ${headingTotal > 0 ? "markdown heading" : "word-boundary regex"}`,
+		`  Count method: ${headingTotal > 0 ? "markdown heading" : "word-boundary regex"}`,
 	);
-	console.log(`  ${chalk.red("Kritik")}: ${counts.critical}`);
-	console.log(`  ${chalk.yellow("Yuksek")}: ${counts.high}`);
-	console.log(`  ${chalk.blue("Orta")}:  ${counts.medium}`);
-	console.log(`  ${chalk.gray("Dusuk")}:  ${counts.low}`);
+	console.log(`  ${chalk.red("Critical")}: ${counts.critical}`);
+	console.log(`  ${chalk.yellow("High")}: ${counts.high}`);
+	console.log(`  ${chalk.blue("Medium")}: ${counts.medium}`);
+	console.log(`  ${chalk.gray("Low")}: ${counts.low}`);
 
 	if (counts.critical > 0) {
 		console.log(
-			chalk.red("\n  ➜ KRITIK bulgular merge'i bloklamali. Once cozun."),
+			chalk.red(
+				"\n  ➜ CRITICAL findings should block the merge. Fix them first.",
+			),
 		);
 		process.exit(1);
 	}
 	if (counts.high > 0) {
 		console.log(
-			chalk.yellow("\n  ➜ Yuksek bulgular merge oncesi gozden gecirilmeli."),
+			chalk.yellow("\n  ➜ High findings should be reviewed before merge."),
 		);
 	}
 	process.exit(0);
@@ -268,7 +275,7 @@ function runInit(args) {
 	if (!ci) {
 		console.log(
 			chalk.yellow(
-				"Su an yalniz --ci destekleniyor. Calistir: badi security init --ci",
+				"Only --ci is supported right now. Run: badi security init --ci",
 			),
 		);
 		process.exit(1);
@@ -286,30 +293,30 @@ function runInit(args) {
 	);
 
 	if (!existsSync(distTemplate)) {
-		console.error(chalk.red(`Sablon bulunamadi: ${distTemplate}`));
+		console.error(chalk.red(`Template not found: ${distTemplate}`));
 		console.error(
-			chalk.dim("Badi kurulumu eksik olabilir. badi doctor calistir."),
+			chalk.dim("Badi installation may be incomplete. Run badi doctor."),
 		);
 		process.exit(1);
 	}
 
 	if (existsSync(wfPath) && !args.includes("--force")) {
-		console.error(chalk.yellow(`Var olan dosyayi yazmaz: ${wfPath}`));
-		console.error(chalk.dim("Uzerine yazmak icin --force flag'i kullan."));
+		console.error(chalk.yellow(`Won't overwrite existing file: ${wfPath}`));
+		console.error(chalk.dim("Use the --force flag to overwrite."));
 		process.exit(1);
 	}
 
 	mkdirSync(wfDir, { recursive: true });
 	writeFileSync(wfPath, readFileSync(distTemplate, "utf-8"), "utf-8");
 
-	console.log(chalk.green(`✓ ${wfPath} olusturuldu`));
-	console.log(chalk.bold("\nSonraki adimlar:"));
+	console.log(chalk.green(`✓ ${wfPath} created`));
+	console.log(chalk.bold("\nNext steps:"));
 	console.log(
-		`  1. Repo Settings → Secrets → ${chalk.cyan("ANTHROPIC_API_KEY")} ekle`,
+		`  1. Repo Settings → Secrets → add ${chalk.cyan("ANTHROPIC_API_KEY")}`,
 	);
-	console.log(`  2. PR ac — workflow otomatik calisir`);
+	console.log(`  2. Open a PR — the workflow runs automatically`);
 	console.log(
-		`  3. Custom prompt (opsiyonel): ${chalk.cyan(".claude/security-review-instructions.md")}`,
+		`  3. Custom prompt (optional): ${chalk.cyan(".claude/security-review-instructions.md")}`,
 	);
 	process.exit(0);
 }

--- a/lib/commands/session.js
+++ b/lib/commands/session.js
@@ -14,36 +14,34 @@ function truncate(s, n = 80) {
 
 function renderHeader(s) {
 	console.log(chalk.bold(`Session ${chalk.cyan(shortSessionId(s.sessionId))}`));
-	console.log(chalk.dim(`  Tam ID: ${s.sessionId}`));
-	console.log(chalk.dim(`  Proje:  ${s.project || "?"}  (${s.cwd || "?"})`));
-	console.log(chalk.dim(`  Branch: ${s.gitBranch || "-"}`));
+	console.log(chalk.dim(`  Full ID: ${s.sessionId}`));
+	console.log(chalk.dim(`  Project: ${s.project || "?"}  (${s.cwd || "?"})`));
+	console.log(chalk.dim(`  Branch:  ${s.gitBranch || "-"}`));
 	console.log(
 		chalk.dim(
-			`  Zaman:  ${(s.firstTs || "?").slice(0, 19)} → ${(s.lastTs || "?").slice(0, 19)} (${formatDuration(s.durationMs)})`,
+			`  Time:    ${(s.firstTs || "?").slice(0, 19)} → ${(s.lastTs || "?").slice(0, 19)} (${formatDuration(s.durationMs)})`,
 		),
 	);
 	console.log(
 		chalk.dim(
-			`  Model:  ${s.models.filter((m) => m && m !== "<synthetic>").join(", ") || "-"}`,
+			`  Model:   ${s.models.filter((m) => m && m !== "<synthetic>").join(", ") || "-"}`,
 		),
 	);
 	console.log(
 		chalk.dim(
-			`  Token:  in=${s.usage.input.toLocaleString()} out=${s.usage.output.toLocaleString()} cacheR=${s.usage.cacheRead.toLocaleString()} cacheW=${s.usage.cacheCreate.toLocaleString()}`,
+			`  Token:   in=${s.usage.input.toLocaleString()} out=${s.usage.output.toLocaleString()} cacheR=${s.usage.cacheRead.toLocaleString()} cacheW=${s.usage.cacheCreate.toLocaleString()}`,
 		),
 	);
-	console.log(chalk.dim(`  Cost:   $${s.costUsd.toFixed(2)}`));
+	console.log(chalk.dim(`  Cost:    $${s.costUsd.toFixed(2)}`));
 	console.log(
-		chalk.dim(
-			`  Promptlar: ${s.promptCount}  Tool kullanim: ${s.toolUseCount}`,
-		),
+		chalk.dim(`  Prompts: ${s.promptCount}  Tool uses: ${s.toolUseCount}`),
 	);
 }
 
 function renderToolBreakdown(s) {
 	const rows = Object.entries(s.toolCounts).sort((a, b) => b[1] - a[1]);
 	if (rows.length === 0) {
-		console.log(chalk.dim("  Tool kullanimi yok."));
+		console.log(chalk.dim("  No tool usage."));
 		return;
 	}
 	const maxLabel = Math.max(...rows.map(([k]) => k.length));
@@ -51,12 +49,12 @@ function renderToolBreakdown(s) {
 		console.log(`  ${name.padEnd(maxLabel)}  ${chalk.yellow(count)}`);
 	}
 	if (rows.length > 15)
-		console.log(chalk.dim(`  ... ${rows.length - 15} tool daha`));
+		console.log(chalk.dim(`  ... ${rows.length - 15} more tools`));
 }
 
 function renderFilesTouched(s) {
 	if (s.filesTouched.length === 0) {
-		console.log(chalk.dim("  Dosya islemi yok."));
+		console.log(chalk.dim("  No file operations."));
 		return;
 	}
 	const list = s.filesTouched.slice(0, 20);
@@ -64,12 +62,12 @@ function renderFilesTouched(s) {
 		console.log(`  ${chalk.dim(f)}`);
 	}
 	if (s.filesTouched.length > 20)
-		console.log(chalk.dim(`  ... ${s.filesTouched.length - 20} dosya daha`));
+		console.log(chalk.dim(`  ... ${s.filesTouched.length - 20} more files`));
 }
 
 function renderTimeline(events, limit) {
 	if (events.length === 0) {
-		console.log(chalk.dim("  Timeline bos."));
+		console.log(chalk.dim("  Timeline empty."));
 		return;
 	}
 	const slice = events.slice(0, limit);
@@ -93,27 +91,27 @@ function renderTimeline(events, limit) {
 	if (events.length > limit)
 		console.log(
 			chalk.dim(
-				`  ... ${events.length - limit} event daha (--full ile tum timeline)`,
+				`  ... ${events.length - limit} more events (--full for the whole timeline)`,
 			),
 		);
 }
 
 export function runSession(args) {
 	if (!args[0] || args[0] === "--help" || args[0] === "-h") {
-		console.log(chalk.bold("Session Detay:"));
+		console.log(chalk.bold("Session Detail:"));
 		console.log("");
 		console.log(
-			`  badi session <id>           ${chalk.dim("Tek session ozet + timeline (ilk 30 event)")}`,
+			`  badi session <id>           ${chalk.dim("Single session summary + timeline (first 30 events)")}`,
 		);
-		console.log(`  badi session <id> --full    ${chalk.dim("Tam timeline")}`);
+		console.log(`  badi session <id> --full    ${chalk.dim("Full timeline")}`);
 		console.log(
-			`  badi session <id> --tools   ${chalk.dim("Sadece tool dagilimi")}`,
+			`  badi session <id> --tools   ${chalk.dim("Tool distribution only")}`,
 		);
 		console.log(
-			`  badi session <id> --files   ${chalk.dim("Sadece dokunulan dosyalar")}`,
+			`  badi session <id> --files   ${chalk.dim("Touched files only")}`,
 		);
 		console.log("");
-		console.log(chalk.dim("  ID kismi prefix de olabilir (orn. c026ac75)"));
+		console.log(chalk.dim("  The ID can be a partial prefix (e.g. c026ac75)"));
 		return;
 	}
 
@@ -135,14 +133,14 @@ export function runSession(args) {
 		throw e;
 	}
 	if (!entry) {
-		console.error(chalk.red(`Session bulunamadi: ${idOrPrefix}`));
-		console.log(chalk.dim("Mevcut session'lari listele: badi stats --session"));
+		console.error(chalk.red(`Session not found: ${idOrPrefix}`));
+		console.log(chalk.dim("List existing sessions: badi stats --session"));
 		process.exit(1);
 	}
 
 	const s = parseSessionWithEvents(entry.path);
 	if (!s) {
-		console.error(chalk.red(`Session okunamadi: ${entry.path}`));
+		console.error(chalk.red(`Could not read session: ${entry.path}`));
 		process.exit(1);
 	}
 
@@ -151,20 +149,20 @@ export function runSession(args) {
 	console.log("");
 
 	if (opts.toolsOnly) {
-		console.log(chalk.bold("Tool Dagilimi:"));
+		console.log(chalk.bold("Tool Distribution:"));
 		renderToolBreakdown(s);
 		return;
 	}
 	if (opts.filesOnly) {
-		console.log(chalk.bold("Dokunulan Dosyalar:"));
+		console.log(chalk.bold("Touched Files:"));
 		renderFilesTouched(s);
 		return;
 	}
 
-	console.log(chalk.bold("Tool Dagilimi:"));
+	console.log(chalk.bold("Tool Distribution:"));
 	renderToolBreakdown(s);
 	console.log("");
-	console.log(chalk.bold("Dokunulan Dosyalar:"));
+	console.log(chalk.bold("Touched Files:"));
 	renderFilesTouched(s);
 	console.log("");
 	console.log(chalk.bold("Timeline:"));

--- a/lib/commands/statusline.js
+++ b/lib/commands/statusline.js
@@ -1,7 +1,7 @@
-// Badi statusline komutu — Claude Code status line yonetimi.
+// Badi statusline command — Claude Code status line management.
 //
-// settings.json'a statusLine alani yazar/siler.
-// Yerlesik profiller: git, skill-chip.
+// Writes/removes the statusLine field in settings.json.
+// Built-in profiles: git, skill-chip.
 
 import {
 	chmodSync,
@@ -15,7 +15,7 @@ import { chalk, showBanner } from "../cli.js";
 
 const PROFILES = {
 	git: {
-		description: "Git branch + dirty mark (* varsa).",
+		description: "Git branch + dirty mark (if any *).",
 		script: `#!/usr/bin/env bash
 # Badi statusline: git
 dir="\${CLAUDE_PROJECT_DIR:-.}"
@@ -27,7 +27,7 @@ echo "[$branch$mark]"
 `,
 	},
 	"skill-chip": {
-		description: "Git branch + aktif skill sayisi chip.",
+		description: "Git branch + active skill count chip.",
 		script: `#!/usr/bin/env bash
 # Badi statusline: skill-chip
 dir="\${CLAUDE_PROJECT_DIR:-.}"
@@ -63,12 +63,14 @@ function writeSettings(file, settings) {
 function showHelp() {
 	console.log(`${chalk.bold("badi statusline")} — Claude Code status line`);
 	console.log("");
-	console.log("  set <profile>   settings.json'a statusLine alani ekle");
-	console.log("  list            Mevcut konfigi goster");
-	console.log("  available       Yerlesik profilleri goster");
-	console.log("  reset           statusLine alanini settings.json'dan kaldir");
+	console.log("  set <profile>   Add a statusLine field to settings.json");
+	console.log("  list            Show the current config");
+	console.log("  available       Show built-in profiles");
+	console.log(
+		"  reset           Remove the statusLine field from settings.json",
+	);
 	console.log("");
-	console.log(chalk.bold("Yerlesik profiller:"));
+	console.log(chalk.bold("Built-in profiles:"));
 	for (const [name, p] of Object.entries(PROFILES)) {
 		console.log(`  ${chalk.cyan(name.padEnd(12))} ${chalk.dim(p.description)}`);
 	}
@@ -86,7 +88,7 @@ export async function runStatusline(args) {
 	}
 
 	if (sub === "available") {
-		console.log(chalk.bold("Yerlesik profiller:"));
+		console.log(chalk.bold("Built-in profiles:"));
 		for (const [name, p] of Object.entries(PROFILES)) {
 			console.log(`  ${chalk.cyan(name)} — ${p.description}`);
 		}
@@ -96,7 +98,7 @@ export async function runStatusline(args) {
 	if (sub === "list") {
 		const settings = readSettings(sFile);
 		if (!settings.statusLine) {
-			console.log(chalk.dim("(statusLine konfigure edilmemis)"));
+			console.log(chalk.dim("(statusLine not configured)"));
 			return;
 		}
 		console.log(chalk.bold("statusLine:"));
@@ -108,14 +110,14 @@ export async function runStatusline(args) {
 	if (sub === "set") {
 		const name = rest[0];
 		if (!name) {
-			console.error(chalk.red("Hata: profil adi gerekli"));
-			console.error("Ornek: badi statusline set git");
+			console.error(chalk.red("Error: profile name required"));
+			console.error("Example: badi statusline set git");
 			process.exit(1);
 		}
 		if (!PROFILES[name]) {
-			console.error(chalk.red(`Hata: bilinmeyen profil "${name}"`));
+			console.error(chalk.red(`Error: unknown profile "${name}"`));
 			console.error(
-				`Mevcut: ${Object.keys(PROFILES)
+				`Available: ${Object.keys(PROFILES)
 					.map((n) => chalk.cyan(n))
 					.join(", ")}`,
 			);
@@ -128,7 +130,7 @@ export async function runStatusline(args) {
 		try {
 			chmodSync(sPath, 0o755);
 		} catch {
-			/* yetki yoksa atla */
+			/* skip if no permission */
 		}
 
 		const settings = readSettings(sFile);
@@ -138,26 +140,26 @@ export async function runStatusline(args) {
 		};
 		writeSettings(sFile, settings);
 		console.log(
-			chalk.green(`+ statusLine ayarlandi: .claude/status-line/${name}.sh`),
+			chalk.green(`+ statusLine set: .claude/status-line/${name}.sh`),
 		);
-		console.log(chalk.dim("Claude Code'u yeniden baslatip etkisini gor."));
+		console.log(chalk.dim("Restart Claude Code to see the effect."));
 		return;
 	}
 
 	if (sub === "reset") {
 		const settings = readSettings(sFile);
 		if (!settings.statusLine) {
-			console.log(chalk.dim("(zaten konfigure edilmemis)"));
+			console.log(chalk.dim("(not configured)"));
 			return;
 		}
 		settings.statusLine = undefined;
 		delete settings.statusLine;
 		writeSettings(sFile, settings);
-		console.log(chalk.yellow("- statusLine kaldirildi"));
+		console.log(chalk.yellow("- statusLine removed"));
 		return;
 	}
 
-	console.error(chalk.red(`Bilinmeyen alt komut: ${sub}`));
+	console.error(chalk.red(`Unknown subcommand: ${sub}`));
 	showHelp();
 	process.exit(1);
 }

--- a/lib/commands/tasarim.js
+++ b/lib/commands/tasarim.js
@@ -15,8 +15,9 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 import { chalk, showBanner } from "../cli.js";
 
-// Verilen yol proje koku icinde mi? '..' ile baslayan veya mutlak proje-disi
-// yol false doner. Path-traversal/yanlislikla sistem dosyasini ezme koruma.
+// Is the given path within the project root? A path starting with '..' or an
+// absolute path outside the project returns false. Guards against path
+// traversal / accidentally overwriting a system file.
 function isWithinProject(baseDir, candidate) {
 	const rel = relative(baseDir, candidate);
 	if (!rel || rel === "") return true;
@@ -29,11 +30,11 @@ function assertProjectPath(flag, candidate) {
 	const baseDir = process.cwd();
 	if (!isWithinProject(baseDir, candidate)) {
 		console.error(
-			chalk.red(`${flag} proje koku disinda: ${candidate} (cwd: ${baseDir})`),
+			chalk.red(`${flag} outside project root: ${candidate} (cwd: ${baseDir})`),
 		);
 		console.error(
 			chalk.dim(
-				"  Yalniz mevcut dizin ve alti yazma hedefi olarak kabul edilir.",
+				"  Only the current directory and below are accepted as write targets.",
 			),
 		);
 		process.exit(1);
@@ -169,47 +170,49 @@ function parseFlags(args) {
 
 function showHelp() {
 	showBanner();
-	console.log(chalk.bold("Badi Tasarim — Gorsel Kimlik Komutu"));
+	console.log(chalk.bold("Badi Design — Visual Identity Command"));
 	console.log("");
-	console.log(chalk.bold("Kullanim:"));
+	console.log(chalk.bold("Usage:"));
 	console.log(
-		`  ${chalk.cyan("badi tasarim init")}                      Yeni DESIGN.md olustur`,
+		`  ${chalk.cyan("badi tasarim init")}                      Create a new DESIGN.md`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi tasarim init --ornek <ad>")}          Ornek sablondan kopyala`,
+		`  ${chalk.cyan("badi tasarim init --ornek <name>")}        Copy from an example template`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi tasarim lint")}                      DESIGN.md'i dogrula`,
+		`  ${chalk.cyan("badi tasarim lint")}                      Validate DESIGN.md`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi tasarim export --format tailwind")}   Tailwind config uret`,
+		`  ${chalk.cyan("badi tasarim export --format tailwind")}   Generate Tailwind config`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi tasarim export --format dtcg")}       DTCG token JSON uret`,
+		`  ${chalk.cyan("badi tasarim export --format dtcg")}       Generate DTCG token JSON`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi tasarim show --tokens")}              Sadece frontmatter (tokens)`,
+		`  ${chalk.cyan("badi tasarim show --tokens")}              Frontmatter only (tokens)`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi tasarim show --prose")}               Sadece markdown body (rationale)`,
+		`  ${chalk.cyan("badi tasarim show --prose")}               Markdown body only (rationale)`,
 	);
 	console.log("");
-	console.log(chalk.bold("Secenekler:"));
+	console.log(chalk.bold("Options:"));
 	console.log(
-		`  --out <yol>      DESIGN.md dosya yolu (varsayilan: ${DEFAULT_PATH})`,
+		`  --out <path>     DESIGN.md file path (default: ${DEFAULT_PATH})`,
 	);
 	console.log(
-		`                   init: yazma hedefi · lint/show/export: okunan kaynak`,
+		`                   init: write target · lint/show/export: read source`,
 	);
 	console.log(
-		`  --write <yol>    Export ciktisini dosyaya yaz (stdout yerine)`,
+		`  --write <path>   Write export output to a file (instead of stdout)`,
 	);
-	console.log(`  --force          Var olan DESIGN.md'i overwrite et`);
-	console.log(`  --ornek <ad>     ${EXAMPLES.join(" | ")}`);
+	console.log(`  --force          Overwrite an existing DESIGN.md`);
+	console.log(`  --ornek <name>   ${EXAMPLES.join(" | ")}`);
 	console.log(`  --strict         Lint warnings -> errors`);
 	console.log("");
-	console.log(chalk.bold("Gereksinimler:"));
-	console.log("  Internet (ilk npx cagrisi paketi indirir, sonra cache)");
+	console.log(chalk.bold("Requirements:"));
+	console.log(
+		"  Internet (the first npx call downloads the package, then cache)",
+	);
 	console.log(`  Pinned: ${PINNED_PACKAGE}`);
 }
 
@@ -225,7 +228,7 @@ function runDesignMd(args, opts = {}) {
 	});
 	if (result.error) {
 		throw new Error(
-			`npx ${PINNED_PACKAGE} cagrisi basarisiz: ${result.error.message}. Internet baglantisini kontrol edin.`,
+			`npx ${PINNED_PACKAGE} call failed: ${result.error.message}. Check your internet connection.`,
 		);
 	}
 	if (result.status !== 0 && !opts.captureStdout) {
@@ -238,8 +241,8 @@ function subInit(flags) {
 	const target = resolve(process.cwd(), flags.out || DEFAULT_PATH);
 
 	if (existsSync(target) && !flags.force) {
-		console.error(chalk.red(`Dosya zaten var: ${target}`));
-		console.log(chalk.dim("  Uzerine yazmak icin --force kullanin."));
+		console.error(chalk.red(`File already exists: ${target}`));
+		console.log(chalk.dim("  Use --force to overwrite."));
 		process.exit(1);
 	}
 
@@ -247,7 +250,7 @@ function subInit(flags) {
 		if (!EXAMPLES.includes(flags.ornek)) {
 			console.error(
 				chalk.red(
-					`Bilinmeyen ornek: ${flags.ornek}. Gecerli: ${EXAMPLES.join(", ")}`,
+					`Unknown example: ${flags.ornek}. Valid: ${EXAMPLES.join(", ")}`,
 				),
 			);
 			process.exit(1);
@@ -256,22 +259,22 @@ function subInit(flags) {
 		// Fallback: write a comment pointing user to examples upstream
 		ensureDir(target);
 		const stub = `---
-# DESIGN.md — '${flags.ornek}' ornegi
-# Tam ornek icin: https://github.com/google-labs-code/design.md/tree/main/examples/${flags.ornek}
+# DESIGN.md — '${flags.ornek}' example
+# For the full example: https://github.com/google-labs-code/design.md/tree/main/examples/${flags.ornek}
 ---
 
 # ${flags.ornek}
 
-Tam ornek gerekiyorsa yukaridaki URL'den DESIGN.md'i kopyalayip uzerine yazin.
-Iskelet baslangici icin: badi tasarim init --force
+If you need the full example, copy DESIGN.md from the URL above and overwrite this.
+For a skeleton start: badi tasarim init --force
 `;
 		writeFileSync(target, stub);
 		showBanner();
 		console.log(chalk.green(`+ ${target}`));
-		console.log(chalk.dim(`  Ornek: ${flags.ornek}`));
+		console.log(chalk.dim(`  Example: ${flags.ornek}`));
 		console.log(
 			chalk.dim(
-				`  Detay: https://github.com/google-labs-code/design.md/tree/main/examples/${flags.ornek}`,
+				`  Details: https://github.com/google-labs-code/design.md/tree/main/examples/${flags.ornek}`,
 			),
 		);
 		return;
@@ -282,14 +285,14 @@ Iskelet baslangici icin: badi tasarim init --force
 	showBanner();
 	console.log(chalk.green(`+ ${target}`));
 	console.log(
-		chalk.dim("  Frontmatter token'lari + 8 bolum prose iskeleti yazildi."),
+		chalk.dim("  Wrote frontmatter tokens + an 8-section prose skeleton."),
 	);
-	console.log(chalk.dim("  Sonraki: badi tasarim lint"));
+	console.log(chalk.dim("  Next: badi tasarim lint"));
 }
 
 /**
- * Lint ciktisindan exit code'u belirle. process.exit cagrisi yapmaz —
- * test edilebilir saf fonksiyon. Donus: 0 (basarili) veya >0 (hata).
+ * Determine the exit code from lint output. Does not call process.exit —
+ * a testable pure function. Returns: 0 (success) or >0 (error).
  */
 export function resolveLintExit(stdout, status) {
 	try {
@@ -298,7 +301,7 @@ export function resolveLintExit(stdout, status) {
 		if (errors > 0 || status !== 0) return status || 1;
 		return 0;
 	} catch {
-		// JSON disi format: paket exit code'una guven
+		// Non-JSON format: trust the package exit code
 		return status !== 0 ? status : 0;
 	}
 }
@@ -306,8 +309,8 @@ export function resolveLintExit(stdout, status) {
 function subLint(flags) {
 	const target = resolve(process.cwd(), flags.out || DEFAULT_PATH);
 	if (!existsSync(target)) {
-		console.error(chalk.red(`DESIGN.md yok: ${target}`));
-		console.log(chalk.dim("  Once: badi tasarim init"));
+		console.error(chalk.red(`No DESIGN.md: ${target}`));
+		console.log(chalk.dim("  First: badi tasarim init"));
 		process.exit(1);
 	}
 	const args = ["lint", target];
@@ -321,21 +324,19 @@ function subLint(flags) {
 
 function subExport(flags) {
 	if (!flags.format) {
-		console.error(
-			chalk.red("--format belirtilmesi gerekiyor (tailwind | dtcg)"),
-		);
+		console.error(chalk.red("--format must be specified (tailwind | dtcg)"));
 		process.exit(1);
 	}
 	if (!["tailwind", "dtcg"].includes(flags.format)) {
 		console.error(
-			chalk.red(`Gecersiz format: ${flags.format}. Gecerli: tailwind | dtcg`),
+			chalk.red(`Invalid format: ${flags.format}. Valid: tailwind | dtcg`),
 		);
 		process.exit(1);
 	}
 	const target = resolve(process.cwd(), flags.out || DEFAULT_PATH);
 	if (!existsSync(target)) {
-		console.error(chalk.red(`DESIGN.md yok: ${target}`));
-		console.log(chalk.dim("  Once: badi tasarim init"));
+		console.error(chalk.red(`No DESIGN.md: ${target}`));
+		console.log(chalk.dim("  First: badi tasarim init"));
 		process.exit(1);
 	}
 	const args = ["export", "--format", flags.format, target];
@@ -344,18 +345,18 @@ function subExport(flags) {
 		assertProjectPath("--write", writePath);
 		const result = runDesignMd(args, { captureStdout: true });
 		const stdout = result.stdout || "";
-		// Empty-on-error guard: paket hata verdi veya bos cikti uretti ise yazma.
-		// Aksi halde bozuk/eksik dosya disk'e basilir.
+		// Empty-on-error guard: don't write if the package errored or produced
+		// empty output. Otherwise a broken/incomplete file gets written to disk.
 		if (result.status !== 0) {
 			console.error(
-				chalk.red(
-					`Export hata verdi (exit ${result.status}); dosya yazilmadi.`,
-				),
+				chalk.red(`Export failed (exit ${result.status}); file not written.`),
 			);
 			process.exit(result.status);
 		}
 		if (!stdout.trim()) {
-			console.error(chalk.red("Export bos cikti dondurdu; dosya yazilmadi."));
+			console.error(
+				chalk.red("Export returned empty output; file not written."),
+			);
 			process.exit(1);
 		}
 		ensureDir(writePath);
@@ -370,8 +371,8 @@ function subExport(flags) {
 function subShow(flags) {
 	const target = resolve(process.cwd(), flags.out || DEFAULT_PATH);
 	if (!existsSync(target)) {
-		console.error(chalk.red(`DESIGN.md yok: ${target}`));
-		console.log(chalk.dim("  Once: badi tasarim init"));
+		console.error(chalk.red(`No DESIGN.md: ${target}`));
+		console.log(chalk.dim("  First: badi tasarim init"));
 		process.exit(1);
 	}
 	const content = readFileSync(target, "utf-8");
@@ -380,7 +381,7 @@ function subShow(flags) {
 	if (!m) {
 		console.error(
 			chalk.red(
-				"DESIGN.md frontmatter parse edilemedi (--- ile sarmalanmis YAML bekliyor)",
+				"Could not parse DESIGN.md frontmatter (expects YAML wrapped in ---)",
 			),
 		);
 		process.exit(1);
@@ -426,9 +427,9 @@ export async function runTasarim(args) {
 		case "show":
 			return subShow(flags);
 		default:
-			console.error(chalk.red(`Bilinmeyen alt komut: ${sub}`));
-			console.log(chalk.dim("  Gecerli: init | lint | export | show"));
-			console.log(chalk.dim("  Yardim: badi tasarim --help"));
+			console.error(chalk.red(`Unknown subcommand: ${sub}`));
+			console.log(chalk.dim("  Valid: init | lint | export | show"));
+			console.log(chalk.dim("  Help: badi tasarim --help"));
 			process.exit(1);
 	}
 }

--- a/lib/commands/taste.js
+++ b/lib/commands/taste.js
@@ -124,16 +124,16 @@ function showList() {
 function showShow(id) {
 	const variant = VARIANTS.find((v) => v.id === id);
 	if (!variant) {
-		console.error(chalk.red(`Bilinmeyen varyant: ${id}`));
-		console.error(`Kullanilabilirler: ${VARIANTS.map((v) => v.id).join(", ")}`);
+		console.error(chalk.red(`Unknown variant: ${id}`));
+		console.error(`Available: ${VARIANTS.map((v) => v.id).join(", ")}`);
 		process.exit(1);
 	}
 
 	const file = join(SKILL_ROOT, variant.id, "SKILL.md");
 	if (!existsSync(file)) {
-		console.error(chalk.red(`Skill dosyasi bulunamadi: ${file}`));
+		console.error(chalk.red(`Skill file not found: ${file}`));
 		console.error(
-			chalk.yellow("Once 'badi update' calistirarak skill'i yukleyin."),
+			chalk.yellow("Install the skill first by running 'badi update'."),
 		);
 		process.exit(1);
 	}
@@ -147,11 +147,11 @@ function showShow(id) {
 function showPrompt(id) {
 	const variant = VARIANTS.find((v) => v.id === id);
 	if (!variant) {
-		console.error(chalk.red(`Bilinmeyen varyant: ${id}`));
+		console.error(chalk.red(`Unknown variant: ${id}`));
 		process.exit(1);
 	}
-	console.log(chalk.bold.cyan(`\nOrnek prompt (${variant.label}):`));
-	console.log(chalk.dim("Claude Code'a bunu yapistirin:\n"));
+	console.log(chalk.bold.cyan(`\nExample prompt (${variant.label}):`));
+	console.log(chalk.dim("Paste this into Claude Code:\n"));
 	console.log(`  ${variant.prompt}\n`);
 }
 
@@ -162,43 +162,45 @@ function showHelp() {
 	console.log(chalk.bold("badi taste - Frontend Taste Skills"));
 	console.log(
 		chalk.dim(
-			"Premium UI uretimi icin 9 varyant. AI'nin uretebilecegi jenerik tasarima engel.",
+			"9 variants for premium UI generation. Stops the generic design AI tends to produce.",
 		),
 	);
 	console.log("");
-	console.log(chalk.bold("Komutlar:"));
+	console.log(chalk.bold("Commands:"));
 	console.log(
-		`  ${chalk.cyan("badi taste")}                 Varyant listesini goster`,
+		`  ${chalk.cyan("badi taste")}                 Show the variant list`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi taste list")}            Varyant listesini goster (ayni)`,
+		`  ${chalk.cyan("badi taste list")}            Show the variant list (same)`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi taste show <id>")}       Bir varyantin tam SKILL.md icerigini yazdir`,
+		`  ${chalk.cyan("badi taste show <id>")}       Print a variant's full SKILL.md content`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi taste prompt <id>")}     Ornek tetikleme prompt'u goster`,
+		`  ${chalk.cyan("badi taste prompt <id>")}     Show an example trigger prompt`,
 	);
 	console.log(
-		`  ${chalk.cyan("badi taste status")}          Kurulum durumunu kontrol et`,
+		`  ${chalk.cyan("badi taste status")}          Check installation status`,
 	);
 	console.log("");
-	console.log(chalk.bold("Varyant ID'leri:"));
+	console.log(chalk.bold("Variant IDs:"));
 	console.log(`  ${VARIANTS.map((v) => chalk.cyan(v.id)).join(", ")}`);
 	console.log("");
-	console.log(chalk.bold("Ornekler:"));
+	console.log(chalk.bold("Examples:"));
 	console.log("  badi taste");
 	console.log("  badi taste show default");
 	console.log("  badi taste prompt brutalist");
 	console.log("  badi taste status");
 	console.log("");
-	console.log(chalk.bold("Nasil kullanilir:"));
+	console.log(chalk.bold("How to use:"));
 	console.log(
-		chalk.dim("  Claude Code oturumunda prompt icinde varyant ismini gecirin."),
+		chalk.dim(
+			"  Pass the variant name in your prompt during a Claude Code session.",
+		),
 	);
 	console.log(
 		chalk.dim(
-			'  Ornek: "Build a premium hero. Use the frontend-taste/default skill."',
+			'  Example: "Build a premium hero. Use the frontend-taste/default skill."',
 		),
 	);
 	console.log("");
@@ -206,35 +208,35 @@ function showHelp() {
 	if (!state.installed) {
 		console.log(
 			chalk.yellow(
-				"! Skill'ler kurulu degil. Bu paket surumunu kullaniyor olabilirsiniz.",
+				"! Skills not installed. You may be on a package-only version.",
 			),
 		);
 		console.log(
 			chalk.yellow(
-				"  Cozum: 'badi update' veya 'npm i -g @fatihkan/badi@latest' sonra 'badi init'",
+				"  Fix: 'badi update' or 'npm i -g @fatihkan/badi@latest' then 'badi init'",
 			),
 		);
 	} else if (state.missing.length > 0) {
 		console.log(
-			chalk.yellow(`! Eksik varyant(lar): ${state.missing.join(", ")}`),
+			chalk.yellow(`! Missing variant(s): ${state.missing.join(", ")}`),
 		);
 		console.log(
-			chalk.yellow("  'badi update --force' calistirarak duzeltebilirsiniz."),
+			chalk.yellow("  You can fix it by running 'badi update --force'."),
 		);
 	} else {
-		console.log(chalk.green("+ 9/9 varyant kurulu."));
+		console.log(chalk.green("+ 9/9 variants installed."));
 	}
 }
 
 function showStatus() {
 	showBanner();
 	const state = checkInstalled();
-	console.log(chalk.bold("Frontend Taste - Kurulum Durumu"));
+	console.log(chalk.bold("Frontend Taste - Installation Status"));
 	console.log("");
 
 	if (!state.installed) {
-		console.log(chalk.red("- .claude/skills/frontend-taste/ bulunamadi"));
-		console.log(chalk.yellow("  'badi init' veya 'badi update' calistirin."));
+		console.log(chalk.red("- .claude/skills/frontend-taste/ not found"));
+		console.log(chalk.yellow("  Run 'badi init' or 'badi update'."));
 		return;
 	}
 
@@ -247,7 +249,9 @@ function showStatus() {
 	}
 	console.log("");
 	const total = VARIANTS.length - state.missing.length;
-	console.log(chalk.bold(`Sonuc: ${total}/${VARIANTS.length} varyant kurulu.`));
+	console.log(
+		chalk.bold(`Result: ${total}/${VARIANTS.length} variants installed.`),
+	);
 }
 
 export async function runTaste(args) {
@@ -256,9 +260,7 @@ export async function runTaste(args) {
 	if (!sub || sub === "list") {
 		showList();
 		console.log(
-			chalk.dim(
-				"Detay icin: 'badi taste show <id>' - Yardim: 'badi taste --help'",
-			),
+			chalk.dim("Details: 'badi taste show <id>' - Help: 'badi taste --help'"),
 		);
 		return;
 	}
@@ -275,10 +277,8 @@ export async function runTaste(args) {
 		case "show": {
 			const id = args[1];
 			if (!id) {
-				console.error(chalk.red("Varyant ID girin: badi taste show <id>"));
-				console.error(
-					`Kullanilabilirler: ${VARIANTS.map((v) => v.id).join(", ")}`,
-				);
+				console.error(chalk.red("Enter a variant ID: badi taste show <id>"));
+				console.error(`Available: ${VARIANTS.map((v) => v.id).join(", ")}`);
 				process.exit(1);
 			}
 			showShow(id);
@@ -287,15 +287,15 @@ export async function runTaste(args) {
 		case "prompt": {
 			const id = args[1];
 			if (!id) {
-				console.error(chalk.red("Varyant ID girin: badi taste prompt <id>"));
+				console.error(chalk.red("Enter a variant ID: badi taste prompt <id>"));
 				process.exit(1);
 			}
 			showPrompt(id);
 			return;
 		}
 		default:
-			console.error(chalk.red(`Bilinmeyen alt komut: ${sub}`));
-			console.error(`Yardim icin: ${chalk.cyan('"badi taste --help"')}`);
+			console.error(chalk.red(`Unknown subcommand: ${sub}`));
+			console.error(`For help: ${chalk.cyan('"badi taste --help"')}`);
 			process.exit(1);
 	}
 }

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -6,15 +6,13 @@ function printResult(harness, result, force) {
 	console.log("");
 	console.log(chalk.bold(`${harness.name}:`));
 	if (force) {
-		console.log(
-			`  ${chalk.green(result.copied)} dosya guncellendi (ustune yazildi)`,
-		);
-		console.log(`  ${chalk.gray(result.skipped)} kullanici dosyasi korundu`);
+		console.log(`  ${chalk.green(result.copied)} files updated (overwritten)`);
+		console.log(`  ${chalk.gray(result.skipped)} user files preserved`);
 	} else {
-		console.log(`  ${chalk.green(result.copied)} yeni dosya eklendi`);
-		console.log(`  ${chalk.gray(result.skipped)} mevcut dosya korundu`);
+		console.log(`  ${chalk.green(result.copied)} new files added`);
+		console.log(`  ${chalk.gray(result.skipped)} existing files preserved`);
 	}
-	console.log(`  ${chalk.cyan(result.created)} yeni dizin olusturuldu`);
+	console.log(`  ${chalk.cyan(result.created)} new directories created`);
 }
 
 export function runUpdate(args, { showHelp }) {
@@ -66,29 +64,29 @@ export function runUpdate(args, { showHelp }) {
 	if (!selected.length) {
 		console.error(
 			chalk.red(
-				"Hata: Bu dizinde hicbir harness kurulumu tespit edilmedi. Once 'badi init' calistirin.",
+				"Error: No harness installation detected in this directory. Run 'badi init' first.",
 			),
 		);
 		process.exit(1);
 	}
 
-	console.log(`${chalk.bold("Hedef:")} ${target}`);
+	console.log(`${chalk.bold("Target:")} ${target}`);
 	if (force) {
 		console.log(
-			`${chalk.bold("Mod:")} ${chalk.red("Zorla guncelleme")} (user-customizable dosyalar HARIC hepsini yazar)`,
+			`${chalk.bold("Mode:")} ${chalk.red("Force update")} (writes everything EXCEPT user-customizable files)`,
 		);
 		console.log(
 			chalk.dim(
-				"  Korunan: memory.md, knowledge-base.md, workspace/, plugins/",
+				"  Preserved: memory.md, knowledge-base.md, workspace/, plugins/",
 			),
 		);
 	} else {
 		console.log(
-			`${chalk.bold("Mod:")} ${chalk.cyan("Guvenli guncelleme")} (mevcut dosyalar korunur, yenisini ekler)`,
+			`${chalk.bold("Mode:")} ${chalk.cyan("Safe update")} (existing files preserved, adds new ones)`,
 		);
 		console.log(
 			chalk.dim(
-				"  Tum slash komut + ajan + hook'lari zorla yenilemek icin: --force",
+				"  To force-refresh all slash commands + agents + hooks: --force",
 			),
 		);
 	}
@@ -109,15 +107,13 @@ export function runUpdate(args, { showHelp }) {
 	}
 
 	console.log("");
-	console.log(chalk.bold.green("Guncelleme tamamlandi!"));
+	console.log(chalk.bold.green("Update complete!"));
 
 	if (!force && totalCopied === 0) {
 		console.log("");
-		console.log(chalk.yellow("Hicbir yeni dosya eklenmedi."));
+		console.log(chalk.yellow("No new files added."));
 		console.log(
-			chalk.dim(
-				"Mevcut dosyalarda guncelleme varsa almak icin: badi update --force",
-			),
+			chalk.dim("To pull updates to existing files: badi update --force"),
 		);
 	}
 }

--- a/lib/data/secret-patterns.js
+++ b/lib/data/secret-patterns.js
@@ -4,59 +4,59 @@
 //   id       — kebab-case unique identifier (used in --ignore list)
 //   name     — human-readable label shown in reports
 //   regex    — global pattern (must include /g)
-//   severity — KRITIK | YUKSEK | ORTA | DUSUK
+//   severity — CRITICAL | HIGH | MEDIUM | LOW
 //   context  — optional secondary regex; finding only fires if a 200-char
 //              window around the match also matches this regex
 //
 // Severity guide:
-//   KRITIK — cloud root credentials, payment, AI provider keys, private keys
-//   YUKSEK — service tokens (npm, sendgrid, twilio), DB URIs with creds
-//   ORTA   — short-lived tokens (JWT) where rotation is cheap
-//   DUSUK  — heuristic patterns with material false-positive rate
+//   CRITICAL — cloud root credentials, payment, AI provider keys, private keys
+//   HIGH     — service tokens (npm, sendgrid, twilio), DB URIs with creds
+//   MEDIUM   — short-lived tokens (JWT) where rotation is cheap
+//   LOW      — heuristic patterns with material false-positive rate
 
 export const PATTERNS = [
 	{
 		id: "aws-access-key",
 		name: "AWS Access Key",
 		regex: /AKIA[0-9A-Z]{16}/g,
-		severity: "KRITIK",
+		severity: "CRITICAL",
 	},
 	{
 		id: "aws-secret",
 		name: "AWS Secret Key",
 		regex:
 			/(?:aws[_-]?secret[_-]?(?:access[_-]?)?key|AWS_SECRET)[\s:="']*([A-Za-z0-9/+=]{40})/gi,
-		severity: "KRITIK",
+		severity: "CRITICAL",
 	},
 	{
 		id: "gcp-key",
 		name: "GCP API Key",
 		regex: /AIza[0-9A-Za-z\-_]{35}/g,
-		severity: "KRITIK",
+		severity: "CRITICAL",
 	},
 	{
 		id: "github-pat",
 		name: "GitHub PAT (classic)",
 		regex: /(?:ghp_|gho_|ghu_|ghs_|ghr_)[A-Za-z0-9]{36,40}/g,
-		severity: "KRITIK",
+		severity: "CRITICAL",
 	},
 	{
 		id: "github-pat-fine",
 		name: "GitHub PAT (fine-grained)",
 		regex: /github_pat_[A-Za-z0-9_]{82}/g,
-		severity: "KRITIK",
+		severity: "CRITICAL",
 	},
 	{
 		id: "slack-token",
 		name: "Slack Token",
 		regex: /xox[baprs]-[A-Za-z0-9-]{10,}/g,
-		severity: "KRITIK",
+		severity: "CRITICAL",
 	},
 	{
 		id: "stripe-key",
 		name: "Stripe Key",
 		regex: /(?:sk|rk|pk)_(?:test|live)_[A-Za-z0-9]{24,}/g,
-		severity: "KRITIK",
+		severity: "CRITICAL",
 	},
 	{
 		// NOTE: OpenAI and Anthropic keys both begin with "sk-" but Anthropic
@@ -67,62 +67,62 @@ export const PATTERNS = [
 		id: "openai-key",
 		name: "OpenAI Key",
 		regex: /sk-[A-Za-z0-9]{20,}/g,
-		severity: "KRITIK",
+		severity: "CRITICAL",
 	},
 	{
 		id: "anthropic-key",
 		name: "Anthropic Key",
 		regex: /sk-ant-[A-Za-z0-9\-_]{40,}/g,
-		severity: "KRITIK",
+		severity: "CRITICAL",
 	},
 	{
 		id: "npm-token",
 		name: "npm Token",
 		regex: /npm_[A-Za-z0-9]{36}/g,
-		severity: "YUKSEK",
+		severity: "HIGH",
 	},
 	{
 		id: "sendgrid",
 		name: "SendGrid API Key",
 		regex: /SG\.[A-Za-z0-9_-]{16,32}\.[A-Za-z0-9_-]{32,64}/g,
-		severity: "YUKSEK",
+		severity: "HIGH",
 	},
 	{
 		id: "twilio",
 		name: "Twilio API Key",
 		regex: /SK[0-9a-fA-F]{32}/g,
-		severity: "YUKSEK",
+		severity: "HIGH",
 	},
 	{
 		id: "private-key",
 		name: "RSA/EC Private Key",
 		regex: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/g,
-		severity: "KRITIK",
+		severity: "CRITICAL",
 	},
 	{
 		id: "jwt",
 		name: "JWT Token",
 		regex: /eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g,
-		severity: "ORTA",
+		severity: "MEDIUM",
 	},
 	{
 		id: "mongodb-uri",
 		name: "MongoDB URI (credentials)",
 		regex: /mongodb(?:\+srv)?:\/\/[^:]+:[^@]+@/g,
-		severity: "YUKSEK",
+		severity: "HIGH",
 	},
 	{
 		id: "postgres-uri",
 		name: "PostgreSQL URI (credentials)",
 		regex: /postgres(?:ql)?:\/\/[^:]+:[^@]+@/g,
-		severity: "YUKSEK",
+		severity: "HIGH",
 	},
 	{
 		id: "generic-secret",
 		name: "Generic Secret Variable",
 		regex:
 			/(?:api[_-]?key|secret|password|passwd|pwd|token)["'\s:=]{1,5}["']([A-Za-z0-9+/_-]{20,64})["']/gi,
-		severity: "DUSUK",
+		severity: "LOW",
 	},
 ];
 

--- a/tests/cli.gh.test.js
+++ b/tests/cli.gh.test.js
@@ -287,12 +287,12 @@ describe("badi gh: subprocess akisi", () => {
 			encoding: "utf-8",
 		});
 		assert.equal(r.status, 1);
-		assert.match(r.stderr, /TaskBoard yok/);
+		assert.match(r.stderr, /No TaskBoard/);
 	});
 
 	it("bilinmeyen alt-komut exit 1 + help", () => {
 		const r = spawnSync("node", [BADI, "gh", "bogus"], { encoding: "utf-8" });
 		assert.equal(r.status, 1);
-		assert.match(r.stderr, /Bilinmeyen alt-komut/);
+		assert.match(r.stderr, /Unknown subcommand/);
 	});
 });

--- a/tests/cli.integration.test.js
+++ b/tests/cli.integration.test.js
@@ -67,13 +67,13 @@ describe("badi CLI", () => {
 
 		it("dry-run dosya olusturmaz", () => {
 			const output = run(["init", "--target", TMP, "--dry-run"]);
-			assert.ok(output.includes("Kuru calistirma"));
+			assert.ok(output.includes("Dry run"));
 			// Dry-run'da .claude/ olusmamalı (ama dizin olusturulmus olabilir)
 		});
 
 		it("init dosyalari kopyalar", () => {
 			const output = run(["init", "--target", TMP]);
-			assert.ok(output.includes("Tamamlandi"));
+			assert.ok(output.includes("Done"));
 			assert.ok(existsSync(join(TMP, ".claude")));
 			assert.ok(existsSync(join(TMP, ".claude", "settings.json")));
 			assert.ok(existsSync(join(TMP, ".claude", "memory.md")));
@@ -83,7 +83,7 @@ describe("badi CLI", () => {
 
 		it("ikinci init mevcut dosyalari atlar", () => {
 			const output = run(["init", "--target", TMP]);
-			assert.ok(output.includes("atlandi"));
+			assert.ok(output.includes("skipped"));
 		});
 	});
 

--- a/tests/cli.observability.test.js
+++ b/tests/cli.observability.test.js
@@ -79,13 +79,13 @@ describe("badi session", () => {
 	it("argumansiz help gosterir", () => {
 		const r = run(["session"]);
 		assert.equal(r.code, 0);
-		assert.ok(r.stdout.includes("Session Detay"));
+		assert.ok(r.stdout.includes("Session Detail"));
 	});
 
 	it("bilinmeyen ID hatasi exit 1", () => {
 		const r = run(["session", "zzzzzzzz"]);
 		assert.notEqual(r.code, 0);
-		assert.ok((r.stderr || r.stdout).includes("bulunamadi"));
+		assert.ok((r.stderr || r.stdout).includes("not found"));
 	});
 });
 

--- a/tests/cli.outputstyle.test.js
+++ b/tests/cli.outputstyle.test.js
@@ -49,7 +49,7 @@ describe("outputstyle CLI", () => {
 
 	it("list bos durumda nasil davraniyor", () => {
 		const out = run(dir, ["list"]);
-		assert.match(out, /yuklu profil yok/);
+		assert.match(out, /no installed profiles/);
 	});
 
 	it("add terse dosya olusturur", () => {
@@ -92,7 +92,7 @@ describe("outputstyle CLI", () => {
 		run(dir, ["add", "verbose"]);
 		run(dir, ["clear"]);
 		const out = run(dir, ["list"]);
-		assert.match(out, /yuklu profil yok/);
+		assert.match(out, /no installed profiles/);
 	});
 
 	it("--help banner + komut listesi", () => {

--- a/tests/cli.schedule.test.js
+++ b/tests/cli.schedule.test.js
@@ -46,7 +46,7 @@ describe("badi schedule", () => {
 
 	it("--help yardim gosterir", () => {
 		const output = run(["schedule"]);
-		assert.ok(output.includes("Hatirlatici"));
+		assert.ok(output.includes("Reminder"));
 		assert.ok(output.includes("add"));
 		assert.ok(output.includes("list"));
 		assert.ok(output.includes("remove"));
@@ -55,8 +55,7 @@ describe("badi schedule", () => {
 	it("list bos liste gosterir", () => {
 		const output = run(["schedule", "list"]);
 		assert.ok(
-			output.includes("Henuz hatirlatici yok") ||
-				output.includes("Hatirlatici"),
+			output.includes("No reminders yet") || output.includes("Reminder"),
 		);
 	});
 
@@ -70,7 +69,7 @@ describe("badi schedule", () => {
 			"--days",
 			"mon-fri",
 		]);
-		assert.ok(output.includes("olusturuldu"));
+		assert.ok(output.includes("created"));
 		assert.ok(output.includes("09:00"));
 
 		const data = JSON.parse(readFileSync(SCHEDULE_FILE, "utf-8"));
@@ -88,7 +87,7 @@ describe("badi schedule", () => {
 
 	it("add ikinci hatirlatici ekler", () => {
 		const output = run(["schedule", "add", "wrap-up", "--at", "18:00"]);
-		assert.ok(output.includes("olusturuldu"));
+		assert.ok(output.includes("created"));
 		assert.ok(output.includes("18:00"));
 	});
 
@@ -96,7 +95,7 @@ describe("badi schedule", () => {
 		const data = JSON.parse(readFileSync(SCHEDULE_FILE, "utf-8"));
 		const lastId = data.schedules[data.schedules.length - 1].id;
 		const output = run(["schedule", "remove", String(lastId)]);
-		assert.ok(output.includes("silindi"));
+		assert.ok(output.includes("removed"));
 	});
 
 	it("remove mevcut olmayan ID hata verir", () => {

--- a/tests/cli.secret-scan.test.js
+++ b/tests/cli.secret-scan.test.js
@@ -111,7 +111,7 @@ describe("secret-scan: pure helpers", () => {
 			line: 1,
 			pattern: "AWS",
 			patternId: "aws-access-key",
-			severity: "KRITIK",
+			severity: "CRITICAL",
 			rawMatch: "X",
 			masked: "X",
 		};
@@ -124,7 +124,7 @@ describe("secret-scan: pure helpers", () => {
 			line: 1,
 			pattern: "OpenAI",
 			patternId: "openai-key",
-			severity: "KRITIK",
+			severity: "CRITICAL",
 			rawMatch: "sk-AAAA111BBBB",
 			masked: "sk-A...BBBB",
 		};
@@ -138,7 +138,7 @@ describe("secret-scan: pure helpers", () => {
 			line: 1,
 			pattern: "OpenAI",
 			patternId: "openai-key",
-			severity: "KRITIK",
+			severity: "CRITICAL",
 			rawMatch: "sk-XYZ",
 			masked: "x",
 		};
@@ -148,8 +148,8 @@ describe("secret-scan: pure helpers", () => {
 
 	it("applyIgnore pattern-id'leri filtreler", () => {
 		const findings = [
-			{ patternId: "jwt", severity: "ORTA" },
-			{ patternId: "aws-access-key", severity: "KRITIK" },
+			{ patternId: "jwt", severity: "MEDIUM" },
+			{ patternId: "aws-access-key", severity: "CRITICAL" },
 		];
 		const filtered = applyIgnore(findings, new Set(["jwt"]));
 		assert.equal(filtered.length, 1);
@@ -158,28 +158,28 @@ describe("secret-scan: pure helpers", () => {
 
 	it("groupBySeverity her seviyeyi listeler", () => {
 		const g = groupBySeverity([
-			{ severity: "KRITIK" },
-			{ severity: "YUKSEK" },
-			{ severity: "YUKSEK" },
+			{ severity: "CRITICAL" },
+			{ severity: "HIGH" },
+			{ severity: "HIGH" },
 		]);
-		assert.equal(g.KRITIK.length, 1);
-		assert.equal(g.YUKSEK.length, 2);
-		assert.equal(g.ORTA.length, 0);
+		assert.equal(g.CRITICAL.length, 1);
+		assert.equal(g.HIGH.length, 2);
+		assert.equal(g.MEDIUM.length, 0);
 	});
 
-	it("computeExitCode critical (default): KRITIK -> 1", () => {
-		assert.equal(computeExitCode([{ severity: "KRITIK" }], "critical"), 1);
-		assert.equal(computeExitCode([{ severity: "ORTA" }], "critical"), 0);
+	it("computeExitCode critical (default): CRITICAL -> 1", () => {
+		assert.equal(computeExitCode([{ severity: "CRITICAL" }], "critical"), 1);
+		assert.equal(computeExitCode([{ severity: "MEDIUM" }], "critical"), 0);
 		assert.equal(computeExitCode([], "critical"), 0);
 	});
 
 	it("computeExitCode strict: herhangi bir bulgu -> 1", () => {
-		assert.equal(computeExitCode([{ severity: "DUSUK" }], "strict"), 1);
+		assert.equal(computeExitCode([{ severity: "LOW" }], "strict"), 1);
 		assert.equal(computeExitCode([], "strict"), 0);
 	});
 
 	it("computeExitCode never: her zaman 0", () => {
-		assert.equal(computeExitCode([{ severity: "KRITIK" }], "never"), 0);
+		assert.equal(computeExitCode([{ severity: "CRITICAL" }], "never"), 0);
 	});
 
 	it("parseArgs default'lari atar", () => {
@@ -229,14 +229,14 @@ describe("secret-scan: CLI end-to-end", () => {
 		});
 		assert.ok(out.includes("Secret"));
 		assert.ok(out.includes("--exit-code"));
-		assert.ok(out.includes("Cikis kodlari"));
+		assert.ok(out.includes("Exit codes"));
 	});
 
 	it("temiz proje bulamaz, exit 0", () => {
 		writeFileSync(join(TMP, "index.js"), "const x = 'hello world';");
 		const r = runRaw(TMP);
 		assert.equal(r.status, 0);
-		assert.ok(r.stdout.includes("tespit edilmedi"));
+		assert.ok(r.stdout.includes("No secrets detected"));
 	});
 
 	it("AWS key text mode exit 1", () => {
@@ -246,10 +246,10 @@ describe("secret-scan: CLI end-to-end", () => {
 		);
 		const r = runRaw(TMP);
 		assert.equal(r.status, 1);
-		assert.ok(r.stdout.includes("KRITIK"));
+		assert.ok(r.stdout.includes("CRITICAL"));
 	});
 
-	it("K1 fix: JSON mode KRITIK bulguda exit 1 dondurur", () => {
+	it("K1 fix: JSON mode CRITICAL bulguda exit 1 dondurur", () => {
 		writeFileSync(
 			join(TMP, "leak.js"),
 			`const key = "${SAMPLES["aws-access-key"]}";`,
@@ -260,7 +260,7 @@ describe("secret-scan: CLI end-to-end", () => {
 		assert.ok(parsed.findings.length >= 1);
 	});
 
-	it("--exit-code never KRITIK olsa bile 0 dondurur", () => {
+	it("--exit-code never CRITICAL olsa bile 0 dondurur", () => {
 		writeFileSync(
 			join(TMP, "leak.js"),
 			`const key = "${SAMPLES["aws-access-key"]}";`,
@@ -269,7 +269,7 @@ describe("secret-scan: CLI end-to-end", () => {
 		assert.equal(r.status, 0);
 	});
 
-	it("--exit-code strict ORTA bulguda exit 1", () => {
+	it("--exit-code strict MEDIUM bulguda exit 1", () => {
 		writeFileSync(join(TMP, "leak.js"), `const t = "${SAMPLES.jwt}";`);
 		const r = runRaw(TMP, "--exit-code", "strict");
 		assert.equal(r.status, 1);
@@ -284,7 +284,7 @@ describe("secret-scan: CLI end-to-end", () => {
 		assert.equal(parsed.scanned.symlinksSkipped, 0);
 	});
 
-	it("--ignore patternId KRITIK'i yoksayinca exit 0", () => {
+	it("--ignore patternId CRITICAL'i yoksayinca exit 0", () => {
 		writeFileSync(
 			join(TMP, "leak.js"),
 			`const key = "${SAMPLES["aws-access-key"]}";`,
@@ -344,7 +344,7 @@ describe("secret-scan: CLI end-to-end", () => {
 		);
 	});
 
-	it("Y2 fix: 40-char hex (SHA-1) yorum icinde DUSUK uyarisi vermez", () => {
+	it("Y2 fix: 40-char hex (SHA-1) yorum icinde LOW uyarisi vermez", () => {
 		// Eski github-classic pattern false-positive yariyordu; yeni surumde
 		// pattern kaldirildi, hex artik match etmemeli.
 		writeFileSync(
@@ -432,7 +432,7 @@ describe("secret-scan: --git history", () => {
 
 		// --git: tarihte yakalamali + exit 1 (K1 ek vaka)
 		const gh = runRaw(TMP, "--git", "--format", "json");
-		assert.equal(gh.status, 1, "git history'deki KRITIK bulguda exit 1");
+		assert.equal(gh.status, 1, "git history'deki CRITICAL bulguda exit 1");
 		const parsed = JSON.parse(gh.stdout);
 		assert.ok(parsed.findings.some((f) => f.patternId === "aws-access-key"));
 	});

--- a/tests/cli.statusline.test.js
+++ b/tests/cli.statusline.test.js
@@ -48,7 +48,7 @@ describe("statusline CLI", () => {
 
 	it("list konfigure edilmemis durumu gosterir", () => {
 		const out = run(dir, ["list"]);
-		assert.match(out, /konfigure edilmemis/);
+		assert.match(out, /not configured/);
 	});
 
 	it("set git settings.json'a yazar", () => {

--- a/tests/cli.tasarim-lint.test.js
+++ b/tests/cli.tasarim-lint.test.js
@@ -36,7 +36,7 @@ describe("badi tasarim lint: DESIGN.md yok ise", () => {
 	it("exit 1 dondurur + stderr 'DESIGN.md yok' icerir", () => {
 		const r = runBadi(["tasarim", "lint"], { cwd: dir });
 		assert.equal(r.status, 1, `expected exit 1, got ${r.status}`);
-		assert.match(r.stderr, /DESIGN\.md yok/);
+		assert.match(r.stderr, /No DESIGN\.md/);
 		assert.match(r.stdout, /badi tasarim init/);
 	});
 
@@ -45,7 +45,7 @@ describe("badi tasarim lint: DESIGN.md yok ise", () => {
 			cwd: dir,
 		});
 		assert.equal(r.status, 1);
-		assert.match(r.stderr, /DESIGN\.md yok/);
+		assert.match(r.stderr, /No DESIGN\.md/);
 		assert.match(r.stderr, /missing\/path\.md/);
 	});
 });
@@ -121,7 +121,7 @@ describe("badi tasarim export --write: empty-on-error guard (#138)", () => {
 		);
 		assert.equal(r.status, 1);
 		assert.equal(existsSync(target), false, "Hata durumunda dosya yazilmamali");
-		assert.match(r.stderr, /DESIGN\.md yok/);
+		assert.match(r.stderr, /No DESIGN\.md/);
 	});
 
 	it("--format eksik ise --write dosya yazmaz, exit 1", () => {

--- a/tests/cli.tasarim.test.js
+++ b/tests/cli.tasarim.test.js
@@ -36,7 +36,7 @@ afterEach(() => {
 describe("tasarim: --help", () => {
 	it("yardim metni alt komutlari listeler", () => {
 		const out = run(["tasarim", "--help"]);
-		assert.match(out, /Gorsel Kimlik/);
+		assert.match(out, /Visual Identity/);
 		assert.match(out, /init/);
 		assert.match(out, /lint/);
 		assert.match(out, /export/);
@@ -45,7 +45,7 @@ describe("tasarim: --help", () => {
 
 	it("argumansiz cagri --help'i tetikler", () => {
 		const out = run(["tasarim"]);
-		assert.match(out, /Gorsel Kimlik/);
+		assert.match(out, /Visual Identity/);
 	});
 
 	it("ornek isim listesi gorunur", () => {
@@ -78,7 +78,7 @@ describe("tasarim: init", () => {
 		writeFileSync(target, "# existing");
 		assert.throws(
 			() => run(["tasarim", "init"], { cwd: tmp }),
-			/Dosya zaten var/,
+			/File already exists/,
 		);
 	});
 
@@ -101,7 +101,7 @@ describe("tasarim: init", () => {
 	it("gecersiz --ornek hata verir", () => {
 		assert.throws(
 			() => run(["tasarim", "init", "--ornek", "no-such-thing"], { cwd: tmp }),
-			/Bilinmeyen ornek/,
+			/Unknown example/,
 		);
 	});
 });
@@ -138,7 +138,7 @@ describe("tasarim: show", () => {
 		try {
 			assert.throws(
 				() => run(["tasarim", "show"], { cwd: fresh }),
-				/DESIGN\.md yok/,
+				/No DESIGN\.md/,
 			);
 		} finally {
 			rmSync(fresh, { recursive: true, force: true });
@@ -154,21 +154,21 @@ describe("tasarim: export validation", () => {
 	it("--format eksikse hata", () => {
 		assert.throws(
 			() => run(["tasarim", "export"], { cwd: tmp }),
-			/--format belirtilmesi/,
+			/--format must be specified/,
 		);
 	});
 
 	it("gecersiz --format hata verir", () => {
 		assert.throws(
 			() => run(["tasarim", "export", "--format", "scss"], { cwd: tmp }),
-			/Gecersiz format/,
+			/Invalid format/,
 		);
 	});
 });
 
 describe("tasarim: bilinmeyen alt komut", () => {
 	it("hata + yardim onerisi gosterir", () => {
-		assert.throws(() => run(["tasarim", "blah"]), /Bilinmeyen alt komut/);
+		assert.throws(() => run(["tasarim", "blah"]), /Unknown subcommand/);
 	});
 });
 
@@ -176,11 +176,11 @@ describe("tasarim: --help yeni flag'lari icerir", () => {
 	it("yardim --write flag'ini tanitir", () => {
 		const out = run(["tasarim", "--help"]);
 		assert.match(out, /--write/);
-		assert.match(out, /stdout yerine/);
+		assert.match(out, /instead of stdout/);
 	});
 
 	it("--out aciklamasi DESIGN.md yolu oldugunu netler", () => {
 		const out = run(["tasarim", "--help"]);
-		assert.match(out, /DESIGN\.md dosya yolu/);
+		assert.match(out, /DESIGN\.md file path/);
 	});
 });

--- a/tests/cli.update.test.js
+++ b/tests/cli.update.test.js
@@ -43,14 +43,14 @@ describe("badi update", () => {
 	it("mevcut dosyalari korur", () => {
 		const output = run(["update", "--target", TMP]);
 		assert.ok(
-			output.includes("korundu") || output.includes("Guncelleme tamamlandi"),
+			output.includes("preserved") || output.includes("Update complete"),
 		);
 	});
 
 	it("dry-run calisiyor", () => {
 		const output = run(["update", "--target", TMP, "--dry-run"]);
 		assert.ok(
-			output.includes("mevcut") || output.includes("Guncelleme tamamlandi"),
+			output.includes("existing") || output.includes("Update complete"),
 		);
 	});
 });

--- a/tests/harness.test.js
+++ b/tests/harness.test.js
@@ -498,18 +498,18 @@ describe("parseMenuAnswer (offline)", () => {
 	it("sinir disi sayi icin error dondurur", () => {
 		const r = parseMenuAnswer("9", "claude", h);
 		assert.equal(r.harnesses.length, 0);
-		assert.match(r.error, /Gecersiz secim/);
+		assert.match(r.error, /Invalid choice/);
 	});
 
 	it("negatif / sifir sayi icin error dondurur", () => {
-		assert.match(parseMenuAnswer("0", "claude", h).error, /Gecersiz/);
-		assert.match(parseMenuAnswer("-1", "claude", h).error, /Gecersiz/);
+		assert.match(parseMenuAnswer("0", "claude", h).error, /Invalid/);
+		assert.match(parseMenuAnswer("-1", "claude", h).error, /Invalid/);
 	});
 
 	it("bilinmeyen id string icin error dondurur", () => {
 		const r = parseMenuAnswer("bogus", "claude", h);
 		assert.equal(r.harnesses.length, 0);
-		assert.match(r.error, /Gecersiz secim/);
+		assert.match(r.error, /Invalid choice/);
 	});
 
 	it("default id listede yoksa ilk item'a duser", () => {

--- a/tests/security-hardening.test.js
+++ b/tests/security-hardening.test.js
@@ -120,7 +120,7 @@ describe("O3a — tasarim export --write project root scope", () => {
 		if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
 	});
 
-	it("--write '../escape.css' proje koku disinda reddedilir", () => {
+	it("--write '../escape.css' outside project root reddedilir", () => {
 		const r = run(
 			TMP,
 			"tasarim",
@@ -133,8 +133,8 @@ describe("O3a — tasarim export --write project root scope", () => {
 		// Hata mesaji veya assert exit 1
 		assert.ok(r.status !== 0);
 		assert.ok(
-			r.stderr.includes("proje koku disinda") ||
-				r.stdout.includes("proje koku disinda"),
+			r.stderr.includes("outside project root") ||
+				r.stdout.includes("outside project root"),
 		);
 	});
 });
@@ -149,8 +149,8 @@ describe("O3b — secret-scan --ignore-file / --patterns project root scope", ()
 		const r = run(TMP, "secret-scan", "--ignore-file", "/etc/passwd");
 		assert.ok(r.status !== 0);
 		assert.ok(
-			r.stderr.includes("proje koku disinda") ||
-				r.stdout.includes("proje koku disinda"),
+			r.stderr.includes("outside project root") ||
+				r.stdout.includes("outside project root"),
 		);
 	});
 
@@ -158,8 +158,8 @@ describe("O3b — secret-scan --ignore-file / --patterns project root scope", ()
 		const r = run(TMP, "secret-scan", "--patterns", "../foo.json");
 		assert.ok(r.status !== 0);
 		assert.ok(
-			r.stderr.includes("proje koku disinda") ||
-				r.stdout.includes("proje koku disinda"),
+			r.stderr.includes("outside project root") ||
+				r.stdout.includes("outside project root"),
 		);
 	});
 

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -68,7 +68,7 @@ describe("badi security command", () => {
 
 			const r = runBadi(["security", "init", "--ci"], { cwd: tmp });
 			assert.equal(r.status, 1);
-			assert.match(r.stderr, /Var olan dosyayi yazmaz/);
+			assert.match(r.stderr, /Won't overwrite existing file/);
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
 		}
@@ -79,7 +79,7 @@ describe("badi security command", () => {
 		try {
 			const r = runBadi(["security", "triage"], { cwd: tmp });
 			assert.equal(r.status, 1);
-			assert.match(r.stderr, /Rapor yok/);
+			assert.match(r.stderr, /No report/);
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
 		}
@@ -103,8 +103,8 @@ describe("badi security command", () => {
 				/\[1\/2\].*secret-scan/,
 				`secret-scan satiri yok. stdout: ${r.stdout.slice(0, 300)}`,
 			);
-			assert.match(r.stdout, /Sir bulgu yok|sir bulgu/);
-			assert.match(r.stdout, /atlandi.*lock dosyasi yok/);
+			assert.match(r.stdout, /No secret findings|secret findings/);
+			assert.match(r.stdout, /skipped.*no lock file/);
 			// K1 regression check: secret-scan ciktisi parse edilemedi yazmamali
 			assert.doesNotMatch(
 				r.stderr,
@@ -130,11 +130,7 @@ describe("badi security command", () => {
 
 			const r = runBadi(["security", "triage"], { cwd: tmp });
 			// Heading-based count: tam 1 DUSUK olmali, asla 4+ degil
-			assert.match(
-				r.stdout,
-				/Dusuk.*1\b/,
-				`K2 regression. stdout: ${r.stdout}`,
-			);
+			assert.match(r.stdout, /Low.*1\b/, `K2 regression. stdout: ${r.stdout}`);
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
 		}
@@ -153,8 +149,8 @@ describe("badi security command", () => {
 			const r = runBadi(["security", "triage"], { cwd: tmp });
 			// Kritik bulgu varsa exit 1 — beklenir
 			assert.equal(r.status, 1);
-			assert.match(r.stdout, /Kritik.*1/);
-			assert.match(r.stdout, /Yuksek.*1/);
+			assert.match(r.stdout, /Critical.*1/);
+			assert.match(r.stdout, /High.*1/);
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Phase 2n — English-only migration (#207) · CLI-output **complete**

Translates the final **14 `lib/commands` files** to English, finishing the Phase 2 CLI-output migration: `update, a11y, statusline, session, lighthouse, outputstyle, init, gh, schedule, taste, security, tasarim, release, secret-scan`.

### Coordinated data renames (lockstep)
- **secret-scan**: severity vocabulary `KRITIK/YUKSEK/ORTA/DUSUK` → `CRITICAL/HIGH/MEDIUM/LOW` across `lib/data/secret-patterns.js` (registry) + `secret-scan.js` (`groupBySeverity`/`computeExitCode`/`colorMap`) + tests.
- **schedule**: `DAY_NAMES` → English; dropped the Turkish day-input aliases (`pzt`/`sal`/… and `gunluk`) since English keys already existed.
- Confirm prompts `[e/H]` → `[y/N]`.

### Intentionally kept (flagged for a later coordinated pass)
- **gh.js** TaskBoard section vocabulary (`Bugun`/`Bu Hafta`/`Bekleyen Isler`/`Tamamlanan`, `# Gorev Panosu`, placeholders) — a **data contract** with `.claude/workspace/TaskBoard.md` + the start/sync/wrap-up commands. Renaming needs all of them together.
- **security.js** triage severity-detection regex keeps Turkish alternatives (`kritik|yuksek|…`) — it parses `/security-review` report *text*, which may be Turkish.
- **tasarim.js** `--ornek` flag + command names (`tasarim`) — interface, deferred to the rename capstone.

### Tests
Updated in lockstep across 13 test files. The `security` triage fixtures keep Turkish headings on purpose (they exercise the kept Turkish-detection alternatives); only the display-label assertions changed.

### Verification
- `npm run lint` — clean
- `npm test` — **1132/1132 pass**
- Guard grep — no residual Turkish console strings (excluding the kept data vocab above)

### After this
Phase 2 (CLI output) is done. Remaining: shared `lib/cli.js` banner + `lib/watchers/` engine messages; then the interface-rename capstone (`icerik`→`content`, flags, dirs); Phase 3 (remaining code comments); Phase 4 (command/agent `.md` descriptions); Phase 5 (`.claude` memory/KB/CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)