### PR TITLE
feat(i18n): English-only Phase 2o — shared lib (cli.js banner + watchers)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -10,7 +10,7 @@ export const VERSION = JSON.parse(
 	readFileSync(resolve(PKG_ROOT, "package.json"), "utf-8"),
 ).version;
 
-// Renkli cikti icin chalk (dinamik import, ESM)
+// chalk for colored output (dynamic import, ESM)
 let chalk;
 try {
 	chalk = (await import("chalk")).default;
@@ -51,7 +51,9 @@ export function showBanner() {
 	} else {
 		console.log(chalk.bold.cyan("\n  B A D I\n"));
 	}
-	console.log(chalk.dim(`  Claude Code Is Akisi Yonetim Sistemi v${VERSION}`));
+	console.log(
+		chalk.dim(`  Claude Code Workflow Management System v${VERSION}`),
+	);
 	console.log("");
 }
 

--- a/lib/watchers/index.js
+++ b/lib/watchers/index.js
@@ -75,7 +75,7 @@ export async function runWatcher(filePath, { cwd = process.cwd() } = {}) {
 			results.push({
 				check,
 				pass: false,
-				message: `Bilinmeyen tip: ${check.type}`,
+				message: `Unknown type: ${check.type}`,
 			});
 			continue;
 		}
@@ -83,7 +83,7 @@ export async function runWatcher(filePath, { cwd = process.cwd() } = {}) {
 			const r = await runner(check, { cwd, state: myState });
 			results.push({ check, ...r });
 		} catch (e) {
-			results.push({ check, pass: false, message: `Hata: ${e.message}` });
+			results.push({ check, pass: false, message: `Error: ${e.message}` });
 		}
 	}
 
@@ -122,7 +122,7 @@ export function writeReport(watcher, results, overall, cwd) {
 
 	if (!existsSync(path)) {
 		const header = [
-			`# Watcher Raporu: ${watcher.name}`,
+			`# Watcher Report: ${watcher.name}`,
 			watcher.description ? `> ${watcher.description}` : null,
 			"",
 			"",

--- a/lib/watchers/parse.js
+++ b/lib/watchers/parse.js
@@ -59,7 +59,7 @@ function parseBlock(tokens, start, baseIndent) {
 		if (t.content.startsWith("- ")) break;
 		const colon = t.content.indexOf(":");
 		if (colon === -1) {
-			throw new WatcherError(`YAML parse hatasi: '${t.raw}'`);
+			throw new WatcherError(`YAML parse error: '${t.raw}'`);
 		}
 		const key = t.content.slice(0, colon).trim();
 		const value = t.content.slice(colon + 1).trim();
@@ -68,7 +68,7 @@ function parseBlock(tokens, start, baseIndent) {
 			i++;
 			continue;
 		}
-		// value bos → sonraki satira bak: ya liste ya nested obje
+		// empty value → look at the next line: either a list or a nested object
 		const next = tokens[i + 1];
 		if (!next || next.indent <= baseIndent) {
 			obj[key] = null;
@@ -116,7 +116,7 @@ function parseList(tokens, start, baseIndent) {
 		const firstKeyLine = t.content.slice(2);
 		const colon = firstKeyLine.indexOf(":");
 		if (colon === -1) {
-			// yalin liste degeri
+			// plain list value
 			list.push(parseScalar(firstKeyLine.trim()));
 			i++;
 			continue;
@@ -126,7 +126,7 @@ function parseList(tokens, start, baseIndent) {
 		const item = {};
 		item[key] = value ? parseScalar(value) : null;
 		i++;
-		// sonraki satirlardan baseIndent+2 ile devam edenler ayni item'in alanlari
+		// lines continuing at baseIndent+2 are fields of the same item
 		const itemIndent = baseIndent + 2;
 		while (i < tokens.length) {
 			const nt = tokens[i];
@@ -153,7 +153,7 @@ function parseList(tokens, start, baseIndent) {
 export function parseFrontmatter(content) {
 	const lines = content.split(/\r?\n/);
 	if (lines[0].trim() !== "---") {
-		throw new WatcherError("Frontmatter bulunamadi (--- ile baslamali)");
+		throw new WatcherError("Frontmatter not found (must start with ---)");
 	}
 	let end = -1;
 	for (let i = 1; i < lines.length; i++) {
@@ -162,7 +162,7 @@ export function parseFrontmatter(content) {
 			break;
 		}
 	}
-	if (end === -1) throw new WatcherError("Frontmatter kapanisi bulunamadi");
+	if (end === -1) throw new WatcherError("Frontmatter closing not found");
 	const body = lines.slice(end + 1).join("\n");
 	const tokens = tokenize(lines.slice(1, end));
 	const meta = parseBlock(tokens, 0, 0);
@@ -175,7 +175,7 @@ export function parseFrontmatter(content) {
  */
 export function loadWatcher(filePath) {
 	if (!existsSync(filePath))
-		throw new WatcherError(`Watcher dosyasi yok: ${filePath}`);
+		throw new WatcherError(`Watcher file not found: ${filePath}`);
 	const content = readFileSync(filePath, "utf-8");
 	const { meta, body } = parseFrontmatter(content);
 	return validateWatcher(
@@ -191,10 +191,10 @@ export function loadWatcher(filePath) {
 
 export function validateWatcher(w, { filePath } = {}) {
 	const name = w.name || w._defaultName;
-	if (!name) throw new WatcherError(`name bos (${filePath || ""})`);
+	if (!name) throw new WatcherError(`name empty (${filePath || ""})`);
 	if (!/^[a-z0-9][a-z0-9-]{1,63}$/i.test(name)) {
 		throw new WatcherError(
-			`Gecersiz name '${name}': harf/rakam/tire, 2-64 kar.`,
+			`Invalid name '${name}': letters/digits/hyphen, 2-64 chars.`,
 		);
 	}
 	const active = w.active !== false;
@@ -202,13 +202,13 @@ export function validateWatcher(w, { filePath } = {}) {
 	parseEvery(every); // validate format
 
 	const watches = Array.isArray(w.watch) ? w.watch : [];
-	if (!watches.length) throw new WatcherError(`${name}: watch listesi bos`);
+	if (!watches.length) throw new WatcherError(`${name}: watch list empty`);
 	for (const [i, c] of watches.entries()) {
 		if (!c || typeof c !== "object")
-			throw new WatcherError(`${name}: watch[${i}] obje degil`);
+			throw new WatcherError(`${name}: watch[${i}] is not an object`);
 		if (!VALID_TYPES.includes(c.type))
 			throw new WatcherError(
-				`${name}: watch[${i}].type gecersiz (${c.type}) — gecerli: ${VALID_TYPES.join(", ")}`,
+				`${name}: watch[${i}].type invalid (${c.type}) — valid: ${VALID_TYPES.join(", ")}`,
 			);
 	}
 
@@ -228,15 +228,15 @@ export function validateWatcher(w, { filePath } = {}) {
 /** "15m" → 900, "1h" → 3600, "daily" → 86400, "cron:..." → null (cron expr) */
 export function parseEvery(spec) {
 	if (typeof spec !== "string" || !spec)
-		throw new WatcherError(`Gecersiz every: ${spec}`);
+		throw new WatcherError(`Invalid every: ${spec}`);
 	if (spec === "daily") return 86400;
 	if (spec === "hourly") return 3600;
 	if (spec.startsWith("cron:")) return null; // raw cron expr
 	const m = spec.match(/^(\d+)([smh])$/);
-	if (!m) throw new WatcherError(`Gecersiz every formati: ${spec}`);
+	if (!m) throw new WatcherError(`Invalid every format: ${spec}`);
 	const n = Number.parseInt(m[1], 10);
 	const seconds = n * EVERY_UNITS[m[2]];
-	if (seconds < 60) throw new WatcherError(`every >= 60s olmali: ${spec}`);
+	if (seconds < 60) throw new WatcherError(`every must be >= 60s: ${spec}`);
 	return seconds;
 }
 

--- a/lib/watchers/types/file.js
+++ b/lib/watchers/types/file.js
@@ -25,10 +25,10 @@ function readPackageDeps(filePath) {
 }
 
 export default function runFileCheck(check, { cwd, state }) {
-	if (!check.path) return { pass: false, message: "path bos" };
+	if (!check.path) return { pass: false, message: "path empty" };
 	const p = resolve(cwd, check.path);
 	if (!existsSync(p)) {
-		return { pass: false, message: `Dosya yok: ${check.path}` };
+		return { pass: false, message: `File not found: ${check.path}` };
 	}
 	const stat = statSync(p);
 	const prev = state[check.path] || {};
@@ -43,10 +43,10 @@ export default function runFileCheck(check, { cwd, state }) {
 		return changed
 			? {
 					pass: false,
-					message: `Dosya degisti: ${check.path}`,
+					message: `File changed: ${check.path}`,
 					details: [`size ${prev.size} → ${now.size}`],
 				}
-			: { pass: true, message: "OK (degismedi)" };
+			: { pass: true, message: "OK (unchanged)" };
 	}
 
 	if (alertOn === "dependency-added" || alertOn === "dependency-removed") {
@@ -54,7 +54,7 @@ export default function runFileCheck(check, { cwd, state }) {
 		if (!currentDeps) {
 			return {
 				pass: false,
-				message: `package.json parse edilemedi: ${check.path}`,
+				message: `Could not parse package.json: ${check.path}`,
 			};
 		}
 		const prevDeps = prev.packageDeps || currentDeps;
@@ -65,19 +65,19 @@ export default function runFileCheck(check, { cwd, state }) {
 		if (alertOn === "dependency-added" && added.length > 0) {
 			return {
 				pass: false,
-				message: `${added.length} yeni bagimlilik`,
+				message: `${added.length} new dependencies`,
 				details: added.map((k) => `${k}@${currentDeps[k]}`).slice(0, 10),
 			};
 		}
 		if (alertOn === "dependency-removed" && removed.length > 0) {
 			return {
 				pass: false,
-				message: `${removed.length} bagimlilik kaldirildi`,
+				message: `${removed.length} dependencies removed`,
 				details: removed.slice(0, 10),
 			};
 		}
-		return { pass: true, message: "OK (deps ayni)" };
+		return { pass: true, message: "OK (deps unchanged)" };
 	}
 
-	return { pass: false, message: `Bilinmeyen alert_on: ${alertOn}` };
+	return { pass: false, message: `Unknown alert_on: ${alertOn}` };
 }

--- a/lib/watchers/types/git.js
+++ b/lib/watchers/types/git.js
@@ -12,7 +12,7 @@ import { spawnSync } from "node:child_process";
  */
 export default function runGitCheck(check, { cwd }) {
 	if (!check.pattern) {
-		return { pass: false, message: "git watch pattern bos" };
+		return { pass: false, message: "git watch pattern empty" };
 	}
 	const scope = check.scope || "last-10-commits";
 	const args = ["log", "--pretty=%H %s"];
@@ -24,14 +24,14 @@ export default function runGitCheck(check, { cwd }) {
 	} else if (scope === "all") {
 		// no extra arg
 	} else {
-		return { pass: false, message: `Bilinmeyen git scope: ${scope}` };
+		return { pass: false, message: `Unknown git scope: ${scope}` };
 	}
 
 	const res = spawnSync("git", args, { cwd, encoding: "utf-8" });
 	if (res.status !== 0) {
 		return {
 			pass: false,
-			message: "git log basarisiz",
+			message: "git log failed",
 			details: [(res.stderr || "").trim()],
 		};
 	}
@@ -42,7 +42,7 @@ export default function runGitCheck(check, { cwd }) {
 	}
 	return {
 		pass: false,
-		message: `${matches.length} commit eslesmesi (/${check.pattern}/)`,
+		message: `${matches.length} commit matches (/${check.pattern}/)`,
 		details: matches.slice(0, 10),
 	};
 }

--- a/lib/watchers/types/http.js
+++ b/lib/watchers/types/http.js
@@ -16,7 +16,7 @@ function parseLatencyThreshold(spec) {
 }
 
 export default async function runHttpCheck(check) {
-	if (!check.url) return { pass: false, message: "url bos" };
+	if (!check.url) return { pass: false, message: "url empty" };
 	const conditions = (check.alert_on || "status-nonok")
 		.split("|")
 		.map((s) => s.trim());
@@ -27,7 +27,7 @@ export default async function runHttpCheck(check) {
 		res = await fetchWithTimeout(check.url, { timeoutMs: 10000 });
 		body = await res.text();
 	} catch (e) {
-		return { pass: false, message: `Fetch hatasi: ${e.message}` };
+		return { pass: false, message: `Fetch error: ${e.message}` };
 	}
 	const latency = Date.now() - start;
 	const failures = [];
@@ -43,13 +43,13 @@ export default async function runHttpCheck(check) {
 		} else if (cond.startsWith("body-match:")) {
 			const pat = cond.slice("body-match:".length);
 			const re = new RegExp(pat, "i");
-			if (re.test(body)) failures.push(`body /${pat}/ eslesti`);
+			if (re.test(body)) failures.push(`body /${pat}/ matched`);
 		} else if (cond.startsWith("body-miss:")) {
 			const pat = cond.slice("body-miss:".length);
 			const re = new RegExp(pat, "i");
-			if (!re.test(body)) failures.push(`body /${pat}/ bulunamadi`);
+			if (!re.test(body)) failures.push(`body /${pat}/ not found`);
 		} else {
-			failures.push(`Bilinmeyen alert_on: ${cond}`);
+			failures.push(`Unknown alert_on: ${cond}`);
 		}
 	}
 

--- a/lib/watchers/types/log.js
+++ b/lib/watchers/types/log.js
@@ -12,23 +12,23 @@ import { resolve } from "node:path";
  * State: { size } — persisted by runner so each run reads only the delta.
  */
 export default function runLogCheck(check, { cwd, state }) {
-	if (!check.path) return { pass: false, message: "path bos" };
+	if (!check.path) return { pass: false, message: "path empty" };
 	const p = resolve(cwd, check.path);
 	if (!existsSync(p)) {
 		state[check.path] = { size: 0 };
-		return { pass: true, message: `Log yok: ${check.path} (ilk kosma)` };
+		return { pass: true, message: `No log: ${check.path} (first run)` };
 	}
 	const stat = statSync(p);
 	const prev = state[check.path] || { size: 0 };
 	const alertOn = check.alert_on || "new-entry";
 
-	// Log rotation detection: boyut kucukseldi → sifirdan oku
+	// Log rotation detection: size shrank → read from zero
 	const start = stat.size < prev.size ? 0 : prev.size;
 	const delta = stat.size - start;
 	state[check.path] = { size: stat.size };
 
 	if (delta === 0) {
-		return { pass: true, message: "OK (yeni giris yok)" };
+		return { pass: true, message: "OK (no new entries)" };
 	}
 
 	let newContent = "";
@@ -47,7 +47,7 @@ export default function runLogCheck(check, { cwd, state }) {
 	if (alertOn === "new-entry") {
 		return {
 			pass: false,
-			message: `${newLines.length} yeni satir`,
+			message: `${newLines.length} new lines`,
 			details: newLines.slice(-5),
 		};
 	}
@@ -58,13 +58,13 @@ export default function runLogCheck(check, { cwd, state }) {
 		return matches.length
 			? {
 					pass: false,
-					message: `${matches.length} satir /${pat}/ ile eslesti`,
+					message: `${matches.length} lines matched /${pat}/`,
 					details: matches.slice(0, 5),
 				}
 			: {
 					pass: true,
-					message: `OK (${newLines.length} yeni satirin hicbiri eslemedi)`,
+					message: `OK (none of the ${newLines.length} new lines matched)`,
 				};
 	}
-	return { pass: false, message: `Bilinmeyen alert_on: ${alertOn}` };
+	return { pass: false, message: `Unknown alert_on: ${alertOn}` };
 }

--- a/lib/watchers/types/shell.js
+++ b/lib/watchers/types/shell.js
@@ -19,7 +19,7 @@ function parseTimeout(t) {
 }
 
 export default function runShellCheck(check, { cwd }) {
-	if (!check.command) return { pass: false, message: "command bos" };
+	if (!check.command) return { pass: false, message: "command empty" };
 	const timeoutMs = parseTimeout(check.timeout);
 	const alertOn = check.alert_on || "exit-nonzero";
 	const res = spawnSync("bash", ["-c", check.command], {
@@ -31,7 +31,7 @@ export default function runShellCheck(check, { cwd }) {
 	if (res.error && res.error.code === "ETIMEDOUT") {
 		return {
 			pass: false,
-			message: `Timeout (${timeoutMs}ms) sonra oldurulmustur`,
+			message: `Killed after timeout (${timeoutMs}ms)`,
 		};
 	}
 	const stdout = (res.stdout || "").trim();
@@ -54,7 +54,7 @@ export default function runShellCheck(check, { cwd }) {
 		return matched
 			? {
 					pass: false,
-					message: `stdout eslesmesi /${pat}/`,
+					message: `stdout match /${pat}/`,
 					details: [stdout.split("\n").find((l) => re.test(l))],
 				}
 			: { pass: true, message: "OK" };
@@ -66,10 +66,10 @@ export default function runShellCheck(check, { cwd }) {
 		return matched
 			? {
 					pass: false,
-					message: `stderr eslesmesi /${pat}/`,
+					message: `stderr match /${pat}/`,
 					details: [stderr.split("\n").find((l) => re.test(l))],
 				}
 			: { pass: true, message: "OK" };
 	}
-	return { pass: false, message: `Bilinmeyen alert_on: ${alertOn}` };
+	return { pass: false, message: `Unknown alert_on: ${alertOn}` };
 }

--- a/tests/watcher.test.js
+++ b/tests/watcher.test.js
@@ -99,7 +99,7 @@ body`;
 	it("validateWatcher: watch listesi bos ise hata", () => {
 		assert.throws(
 			() => validateWatcher({ name: "xy", watch: [] }),
-			/watch listesi bos/,
+			/watch list empty/,
 		);
 	});
 
@@ -110,7 +110,7 @@ body`;
 					name: "xy",
 					watch: [{ type: "invalid" }],
 				}),
-			/gecersiz/i,
+			/invalid/i,
 		);
 	});
 
@@ -121,7 +121,7 @@ body`;
 					name: "Has Space",
 					watch: [{ type: "git" }],
 				}),
-			/Gecersiz name/,
+			/Invalid name/,
 		);
 	});
 
@@ -189,7 +189,7 @@ describe("watcher types", () => {
 			{ cwd: dir, state: {} },
 		);
 		assert.equal(r.pass, false);
-		assert.match(r.message, /stdout eslesmesi/);
+		assert.match(r.message, /stdout match/);
 	});
 
 	it("shell: timeout", () => {
@@ -232,7 +232,7 @@ describe("watcher types", () => {
 			{ cwd: dir, state },
 		);
 		assert.equal(r.pass, false);
-		assert.match(r.message, /degisti/);
+		assert.match(r.message, /changed/);
 	});
 
 	it("file: dependency-added tespit eder", () => {
@@ -249,7 +249,7 @@ describe("watcher types", () => {
 			{ cwd: dir, state },
 		);
 		assert.equal(r.pass, false);
-		assert.match(r.message, /yeni bagimlilik/);
+		assert.match(r.message, /new dependencies/);
 		assert.ok(r.details.some((d) => d.includes("b@")));
 	});
 
@@ -282,7 +282,7 @@ describe("watcher types", () => {
 			{ cwd: dir, state },
 		);
 		assert.equal(r.pass, false);
-		assert.match(r.message, /yeni satir/);
+		assert.match(r.message, /new lines/);
 	});
 
 	it("log: pattern-match ile filtreler", () => {
@@ -397,7 +397,7 @@ describe("runWatcher end-to-end", () => {
 			);
 			assert.ok(existsSync(reportPath));
 			const content = readFileSync(reportPath, "utf-8");
-			assert.match(content, /# Watcher Raporu: e2e/);
+			assert.match(content, /# Watcher Report: e2e/);
 			assert.match(content, /— OK/);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Phase 2o — English-only migration (#207) · shared lib

Translates the remaining Turkish in **shared library code** (not under `lib/commands/`) to English.

### Changed
- **lib/cli.js** — the `showBanner` tagline `Is Akisi Yonetim Sistemi` → `Workflow Management System` (prints under the banner on **every** command) + 1 comment.
- **lib/watchers/** — all watcher check-result messages, the report header (`# Watcher Raporu` → `# Watcher Report`), parser/validation errors, and comments across `index.js`, `parse.js`, and `types/{git,shell,file,log,http}.js`. Check/parse logic unchanged.

### Tests
`watcher.test.js` message assertions retargeted in lockstep (`stdout match`, `changed`, `new dependencies`, `new lines`, `# Watcher Report`, `watch list empty`, `/invalid/i`, `Invalid name`).

`harness.test.js`'s GEMINI.md assertion still references `Is Akisi` — that is `.claude/CLAUDE.md` **project content** (Phase 5), mirrored into GEMINI.md, not the banner. Left as-is (test passes via its `"Badi"` branch).

### Verification
- `npm run lint` — clean
- `npm test` — **1132/1132 pass**
- Guard grep — no residual Turkish in `lib/cli.js` or `lib/watchers/`

### Remaining for #207
Interface-rename capstone (`icerik`→`content`, flags, dirs, gh TaskBoard vocab, `tasarim --ornek`) · Phase 3 (code comments in `lib/` beyond commands) · Phase 4 (command/agent `.md` descriptions) · Phase 5 (`.claude` memory/KB/CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)