### PR TITLE
feat(i18n): English-only Phase 2p — list, plan, plugin subcommands

### DIFF
--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -10,9 +10,7 @@ import { countFiles, listDirs, listMdFiles } from "../helpers.js";
 function renderMcpUsage() {
 	const files = listTranscriptFiles();
 	if (files.length === 0) {
-		console.log(
-			chalk.dim("  ~/.claude/projects/ icinde transcript bulunamadi."),
-		);
+		console.log(chalk.dim("  No transcripts found in ~/.claude/projects/."));
 		return;
 	}
 	const agg = {};
@@ -25,7 +23,7 @@ function renderMcpUsage() {
 		const keys = Object.keys(s.mcpToolCounts);
 		if (keys.length > 0) sessionsWithMcp++;
 		for (const [k, v] of Object.entries(s.mcpToolCounts)) {
-			// "mcp__servername__toolname" formati — server adini cikar
+			// "mcp__servername__toolname" format — extract the server name
 			const m = k.match(/^mcp__([^_]+(?:_[^_]+)*?)__/);
 			const server = m ? m[1] : k;
 			agg[server] = agg[server] || { calls: 0, tools: new Set() };
@@ -35,18 +33,18 @@ function renderMcpUsage() {
 	}
 	const rows = Object.entries(agg).sort((a, b) => b[1].calls - a[1].calls);
 	if (rows.length === 0) {
-		console.log(chalk.dim("  MCP tool kullanimi yok."));
+		console.log(chalk.dim("  No MCP tool usage."));
 		return;
 	}
 	const maxLabel = Math.max(...rows.map(([k]) => k.length));
 	for (const [server, info] of rows) {
 		console.log(
-			`  ${chalk.magenta("⚙")} ${server.padEnd(maxLabel)}  ${chalk.yellow(String(info.calls).padStart(5))} cagri  ${chalk.dim(`${info.tools.size} tool`)}`,
+			`  ${chalk.magenta("⚙")} ${server.padEnd(maxLabel)}  ${chalk.yellow(String(info.calls).padStart(5))} calls  ${chalk.dim(`${info.tools.size} tool`)}`,
 		);
 	}
 	console.log("");
 	console.log(
-		chalk.dim(`  ${sessionsWithMcp}/${totalSessions} session MCP kullaniyor`),
+		chalk.dim(`  ${sessionsWithMcp}/${totalSessions} sessions use MCP`),
 	);
 }
 
@@ -93,7 +91,7 @@ export function runList(args, { showHelp }) {
 
 	if (showAll || showAgents) {
 		const agents = listMdFiles(join(claudeDir, "agents"));
-		console.log(chalk.bold(`Ajanlar (${agents.length}):`));
+		console.log(chalk.bold(`Agents (${agents.length}):`));
 		for (const a of agents) {
 			console.log(`  ${chalk.cyan("-")} ${a}`);
 		}
@@ -102,7 +100,7 @@ export function runList(args, { showHelp }) {
 
 	if (showAll || showCommands) {
 		const commands = listMdFiles(join(claudeDir, "commands"));
-		console.log(chalk.bold(`Komutlar (${commands.length}):`));
+		console.log(chalk.bold(`Commands (${commands.length}):`));
 		for (const c of commands) {
 			console.log(`  ${chalk.cyan("/")} ${c}`);
 		}
@@ -114,7 +112,7 @@ export function runList(args, { showHelp }) {
 		const hooks = existsSync(hooksDir)
 			? readdirSync(hooksDir).filter((f) => f.endsWith(".sh"))
 			: [];
-		console.log(chalk.bold(`Hook'lar (${hooks.length}):`));
+		console.log(chalk.bold(`Hooks (${hooks.length}):`));
 		for (const h of hooks) {
 			console.log(`  ${chalk.cyan("*")} ${h}`);
 		}
@@ -129,7 +127,7 @@ export function runList(args, { showHelp }) {
 		}, 0);
 		console.log(
 			chalk.bold(
-				`Skill Kategorileri (${categories.length} kategori, ${totalSkills} skill):`,
+				`Skill Categories (${categories.length} categories, ${totalSkills} skills):`,
 			),
 		);
 		for (const cat of categories.sort()) {
@@ -140,7 +138,7 @@ export function runList(args, { showHelp }) {
 	}
 
 	if (showMcp) {
-		console.log(chalk.bold("MCP Server Kullanimi (transcript bazli):"));
+		console.log(chalk.bold("MCP Server Usage (transcript-based):"));
 		renderMcpUsage();
 		console.log("");
 		return;
@@ -150,7 +148,7 @@ export function runList(args, { showHelp }) {
 	if (existsSync(pluginsDir)) {
 		const plugins = listDirs(pluginsDir);
 		if (plugins.length > 0 || showAll) {
-			console.log(chalk.bold(`Plugin'ler (${plugins.length}):`));
+			console.log(chalk.bold(`Plugins (${plugins.length}):`));
 			for (const p of plugins) {
 				const manifestPath = join(pluginsDir, p, "badi-plugin.json");
 				if (existsSync(manifestPath)) {

--- a/lib/commands/plan.js
+++ b/lib/commands/plan.js
@@ -11,9 +11,9 @@ import { basename, join } from "node:path";
 import { chalk } from "../cli.js";
 
 // Local file-based plan approval workflow.
-// Plan dosyalari .claude/plans/ altinda yasar; .approved/.denied marker
-// dosyalari onay durumunu ifade eder. Hook (badi-plan-gate) ExitPlanMode
-// cagrildiginda bu dosyalari kontrol edebilir.
+// Plan files live under .claude/plans/; .approved/.denied marker files
+// express the approval state. The hook (badi-plan-gate) can inspect these
+// files when ExitPlanMode is called.
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
@@ -47,7 +47,7 @@ export function listPlans(cwd) {
 }
 
 export function planStatus(slug, cwd) {
-	if (!isValidSlug(slug)) throw new Error(`Gecersiz plan slug: ${slug}`);
+	if (!isValidSlug(slug)) throw new Error(`Invalid plan slug: ${slug}`);
 	const dir = plansDir(cwd);
 	const md = join(dir, `${slug}.md`);
 	const ap = join(dir, `${slug}.approved`);
@@ -93,37 +93,37 @@ function printHelp() {
 	console.log(chalk.bold("Plan Approval Workflow:"));
 	console.log("");
 	console.log(
-		`  badi plan list                ${chalk.dim("Tum planlar + durum")}`,
+		`  badi plan list                ${chalk.dim("All plans + state")}`,
 	);
 	console.log(
-		`  badi plan new <slug>          ${chalk.dim("Plan iskelet markdown olustur")}`,
+		`  badi plan new <slug>          ${chalk.dim("Create a plan skeleton markdown")}`,
 	);
-	console.log(`  badi plan show <slug>         ${chalk.dim("Plan icerigi")}`);
+	console.log(`  badi plan show <slug>         ${chalk.dim("Plan contents")}`);
 	console.log(
-		`  badi plan status <slug>       ${chalk.dim("Onay durumu (hook icin --format json)")}`,
-	);
-	console.log(
-		`  badi plan approve <slug>      ${chalk.dim("Onayla (.approved marker)")}`,
+		`  badi plan status <slug>       ${chalk.dim("Approval state (--format json for hook)")}`,
 	);
 	console.log(
-		`  badi plan deny <slug> [neden] ${chalk.dim("Reddet (.denied marker)")}`,
+		`  badi plan approve <slug>      ${chalk.dim("Approve (.approved marker)")}`,
 	);
 	console.log(
-		`  badi plan reset <slug>        ${chalk.dim("Onay/red marker'larini sil")}`,
+		`  badi plan deny <slug> [reason] ${chalk.dim("Deny (.denied marker)")}`,
+	);
+	console.log(
+		`  badi plan reset <slug>        ${chalk.dim("Remove approve/deny markers")}`,
 	);
 	console.log("");
 	console.log(
-		chalk.dim("  Marker dosyalari .claude/plans/<slug>.{approved,denied}"),
+		chalk.dim("  Marker files: .claude/plans/<slug>.{approved,denied}"),
 	);
 }
 
 function cmdList(cwd) {
 	const plans = listPlans(cwd);
 	if (plans.length === 0) {
-		console.log(chalk.dim("Plan yok. `badi plan new <slug>` ile baslayin."));
+		console.log(chalk.dim("No plans. Start with `badi plan new <slug>`."));
 		return;
 	}
-	console.log(chalk.bold("Planlar:"));
+	console.log(chalk.bold("Plans:"));
 	const maxLabel = Math.max(...plans.map((p) => p.slug.length));
 	for (const p of plans) {
 		const stateColor =
@@ -145,46 +145,46 @@ function cmdList(cwd) {
 
 function cmdNew(slug, cwd) {
 	if (!isValidSlug(slug)) {
-		console.error(chalk.red(`Gecersiz slug: ${slug} (kebab-case, [a-z0-9-])`));
+		console.error(chalk.red(`Invalid slug: ${slug} (kebab-case, [a-z0-9-])`));
 		process.exit(1);
 	}
 	const dir = plansDir(cwd);
 	ensureDir(dir);
 	const path = join(dir, `${slug}.md`);
 	if (existsSync(path)) {
-		console.error(chalk.yellow(`Zaten var: ${path}`));
+		console.error(chalk.yellow(`Already exists: ${path}`));
 		process.exit(1);
 	}
 	const template = `# Plan: ${slug}
 
-> Olusturma: ${new Date().toISOString()}
-> Durum: pending — \`badi plan approve ${slug}\` ile onayla, \`badi plan deny ${slug}\` ile reddet.
+> Created: ${new Date().toISOString()}
+> State: pending — approve with \`badi plan approve ${slug}\`, reject with \`badi plan deny ${slug}\`.
 
-## Hedef
-<!-- Ne yapilacak? -->
+## Goal
+<!-- What will be done? -->
 
-## Adimlar
+## Steps
 1. ...
 2. ...
 
-## Test plani
+## Test plan
 - [ ] ...
 
-## Riskler
+## Risks
 - ...
 `;
 	writeFileSync(path, template);
-	console.log(chalk.green(`Plan olusturuldu: ${path}`));
+	console.log(chalk.green(`Plan created: ${path}`));
 }
 
 function cmdShow(slug, cwd) {
 	if (!isValidSlug(slug)) {
-		console.error(chalk.red(`Gecersiz slug: ${slug}`));
+		console.error(chalk.red(`Invalid slug: ${slug}`));
 		process.exit(1);
 	}
 	const p = planStatus(slug, cwd);
 	if (!p.hasPlan) {
-		console.error(chalk.red(`Plan dosyasi yok: ${p.planPath}`));
+		console.error(chalk.red(`Plan file not found: ${p.planPath}`));
 		process.exit(1);
 	}
 	console.log(readFileSync(p.planPath, "utf-8"));
@@ -192,7 +192,7 @@ function cmdShow(slug, cwd) {
 
 function cmdStatus(slug, cwd, format) {
 	if (!isValidSlug(slug)) {
-		console.error(chalk.red(`Gecersiz slug: ${slug}`));
+		console.error(chalk.red(`Invalid slug: ${slug}`));
 		process.exit(1);
 	}
 	const p = planStatus(slug, cwd);
@@ -213,7 +213,7 @@ function cmdStatus(slug, cwd, format) {
 
 function cmdApprove(slug, cwd) {
 	if (!isValidSlug(slug)) {
-		console.error(chalk.red(`Gecersiz slug: ${slug}`));
+		console.error(chalk.red(`Invalid slug: ${slug}`));
 		process.exit(1);
 	}
 	const dir = plansDir(cwd);
@@ -227,7 +227,7 @@ function cmdApprove(slug, cwd) {
 
 function cmdDeny(slug, reason, cwd) {
 	if (!isValidSlug(slug)) {
-		console.error(chalk.red(`Gecersiz slug: ${slug}`));
+		console.error(chalk.red(`Invalid slug: ${slug}`));
 		process.exit(1);
 	}
 	const dir = plansDir(cwd);
@@ -241,7 +241,7 @@ function cmdDeny(slug, reason, cwd) {
 
 function cmdReset(slug, cwd) {
 	if (!isValidSlug(slug)) {
-		console.error(chalk.red(`Gecersiz slug: ${slug}`));
+		console.error(chalk.red(`Invalid slug: ${slug}`));
 		process.exit(1);
 	}
 	const dir = plansDir(cwd);

--- a/lib/commands/plugin/doctor.js
+++ b/lib/commands/plugin/doctor.js
@@ -9,7 +9,7 @@ import { loadAllPluginManifests, pluginsDir } from "./_shared.js";
 export function runDoctor() {
 	const plugins = loadAllPluginManifests(pluginsDir(process.cwd()));
 	if (plugins.length === 0) {
-		console.log(chalk.dim("Yuklu plugin yok."));
+		console.log(chalk.dim("No plugins installed."));
 		return;
 	}
 	console.log(chalk.bold(`Plugin Doctor (${plugins.length} plugin):`));
@@ -37,8 +37,8 @@ export function runDoctor() {
 			issues++;
 		}
 		if (c.warning) {
-			// A2/B1 fix: parseRange format taninmadi -> doctor uyari versir
-			// (eskiden permissive fallback yaniltici "OK" yaziyordu).
+			// A2/B1 fix: unrecognized parseRange format -> doctor emits a warning
+			// (the old permissive fallback misleadingly printed "OK").
 			console.log(chalk.yellow(`       - ${c.warning}`));
 			issues++;
 		}
@@ -52,11 +52,11 @@ export function runDoctor() {
 	const unsat = findUnsatisfied(plugins);
 	if (unsat.length) {
 		console.log("");
-		console.log(chalk.bold("Bagimlilik sorunlari:"));
+		console.log(chalk.bold("Dependency issues:"));
 		for (const u of unsat) {
 			console.log(
 				chalk.red(
-					`  - ${u.plugin}: ${u.dep}@${u.requested} ${u.reason === "missing" ? "(yuklu degil)" : `(yuklu ${u.installed})`}`,
+					`  - ${u.plugin}: ${u.dep}@${u.requested} ${u.reason === "missing" ? "(not installed)" : `(installed ${u.installed})`}`,
 				),
 			);
 			issues++;
@@ -65,8 +65,8 @@ export function runDoctor() {
 
 	console.log("");
 	if (issues > 0) {
-		console.log(chalk.red(`${issues} sorun tespit edildi.`));
+		console.log(chalk.red(`${issues} issue(s) detected.`));
 		process.exit(1);
 	}
-	console.log(chalk.green("Tum plugin'ler saglikli."));
+	console.log(chalk.green("All plugins are healthy."));
 }

--- a/lib/commands/plugin/graph.js
+++ b/lib/commands/plugin/graph.js
@@ -5,7 +5,7 @@ import { loadAllPluginManifests, pluginsDir } from "./_shared.js";
 export function runGraph() {
 	const plugins = loadAllPluginManifests(pluginsDir(process.cwd()));
 	if (plugins.length === 0) {
-		console.log(chalk.dim("Yuklu plugin yok."));
+		console.log(chalk.dim("No plugins installed."));
 		return;
 	}
 	let sorted;
@@ -15,7 +15,7 @@ export function runGraph() {
 		console.error(chalk.red(e.message));
 		process.exit(1);
 	}
-	console.log(chalk.bold("Plugin Bagimlilik Agaci (load sirasi):"));
+	console.log(chalk.bold("Plugin Dependency Tree (load order):"));
 	console.log("");
 	for (let i = 0; i < sorted.length; i++) {
 		const p = sorted[i];

--- a/lib/commands/plugin/help.js
+++ b/lib/commands/plugin/help.js
@@ -1,15 +1,15 @@
 import { chalk } from "../../cli.js";
 
 export function runHelp() {
-	console.log(chalk.bold("Plugin Yonetimi:"));
-	console.log(`  badi plugin install <kaynak>   Plugin yukle`);
-	console.log(`  badi plugin remove <isim>      Plugin kaldir`);
-	console.log(`  badi plugin list               Yuklu plugin'leri listele`);
-	console.log(`  badi plugin show <isim>        Plugin detayi (v1.29+)`);
+	console.log(chalk.bold("Plugin Management:"));
+	console.log(`  badi plugin install <source>   Install a plugin`);
+	console.log(`  badi plugin remove <name>      Remove a plugin`);
+	console.log(`  badi plugin list               List installed plugins`);
+	console.log(`  badi plugin show <name>        Plugin details (v1.29+)`);
 	console.log(
-		`  badi plugin doctor             Tum plugin'lerin saglik denetimi (v1.30+)`,
+		`  badi plugin doctor             Health check for all plugins (v1.30+)`,
 	);
 	console.log(
-		`  badi plugin graph              Plugin bagimlilik agacini yazdir (v1.30+)`,
+		`  badi plugin graph              Print the plugin dependency tree (v1.30+)`,
 	);
 }

--- a/lib/commands/plugin/index.js
+++ b/lib/commands/plugin/index.js
@@ -7,8 +7,8 @@ import { runList } from "./list.js";
 import { runRemove } from "./remove.js";
 import { runShow } from "./show.js";
 
-// plugin.js v1.30 review C3 fix — eskiden tek dosyada 437 satirdi.
-// Su anda icerik/ pattern'inde alt komutlar ayri dosyalarda.
+// plugin.js v1.30 review C3 fix — was previously 437 lines in a single file.
+// Sub-commands now live in separate files, following the icerik/ pattern.
 
 export function runPlugin(args) {
 	const sub = args[0];
@@ -30,10 +30,8 @@ export function runPlugin(args) {
 		case "graph":
 			return runGraph();
 		default:
-			console.error(chalk.red(`Bilinmeyen plugin komutu: ${sub}`));
-			console.log(
-				"Kullanim: badi plugin [install|remove|list|show|doctor|graph]",
-			);
+			console.error(chalk.red(`Unknown plugin command: ${sub}`));
+			console.log("Usage: badi plugin [install|remove|list|show|doctor|graph]");
 			process.exit(1);
 	}
 }

--- a/lib/commands/plugin/install.js
+++ b/lib/commands/plugin/install.js
@@ -14,20 +14,18 @@ export function runInstall(args) {
 	const source = args[0];
 
 	if (!source) {
-		console.error(chalk.red("Hata: Plugin kaynagi belirtilmedi."));
-		console.log("Kullanim: badi plugin install <git-url|npm-paket>");
+		console.error(chalk.red("Error: No plugin source specified."));
+		console.log("Usage: badi plugin install <git-url|npm-package>");
 		process.exit(1);
 	}
 
-	// Argument injection koruma (v1.28.1 O1): '-' ile baslayan kaynak git veya
-	// npm tarafindan flag olarak yorumlanabilir. Reject + `--` separator alt.
+	// Argument injection guard (v1.28.1 O1): a source starting with '-' could be
+	// interpreted as a flag by git or npm. Reject + `--` separator below.
 	if (source.startsWith("-")) {
 		console.error(
-			chalk.red(`Gecersiz kaynak: '-' ile baslayan deger kabul edilmiyor.`),
+			chalk.red(`Invalid source: values starting with '-' are not accepted.`),
 		);
-		console.log(
-			chalk.dim("Yerel yol veriyorsaniz './<dizin>' veya tam yol kullanin."),
-		);
+		console.log(chalk.dim("For a local path, use './<dir>' or a full path."));
 		process.exit(1);
 	}
 
@@ -39,7 +37,7 @@ export function runInstall(args) {
 		isGitHubUrl =
 			u.hostname === "github.com" || u.hostname.endsWith(".github.com");
 	} catch {
-		// non-URL kaynak
+		// non-URL source
 	}
 
 	let pluginName;
@@ -48,38 +46,46 @@ export function runInstall(args) {
 		const destDir = join(dir, pluginName);
 		if (existsSync(destDir)) {
 			console.error(
-				chalk.yellow(`Plugin '${pluginName}' zaten yuklu. Once kaldirin.`),
+				chalk.yellow(
+					`Plugin '${pluginName}' is already installed. Remove it first.`,
+				),
 			);
 			process.exit(1);
 		}
-		console.log(chalk.cyan(`Plugin indiriliyor: ${source}`));
+		console.log(chalk.cyan(`Downloading plugin: ${source}`));
 		try {
 			execFileSync("git", ["clone", "--depth", "1", "--", source, destDir], {
 				stdio: "pipe",
 			});
 			const gitDir = join(destDir, ".git");
 			if (existsSync(gitDir)) rmSync(gitDir, { recursive: true });
-			console.log(chalk.green(`Plugin '${pluginName}' basariyla yuklendi!`));
+			console.log(
+				chalk.green(`Plugin '${pluginName}' installed successfully!`),
+			);
 		} catch (e) {
-			console.error(chalk.red(`Plugin yuklenemedi: ${e.message}`));
+			console.error(chalk.red(`Plugin install failed: ${e.message}`));
 			process.exit(1);
 		}
 	} else {
 		pluginName = source.replace(/^@.*\//, "").replace(/^badi-plugin-/, "");
 		const destDir = join(dir, pluginName);
 		if (existsSync(destDir)) {
-			console.error(chalk.yellow(`Plugin '${pluginName}' zaten yuklu.`));
+			console.error(
+				chalk.yellow(`Plugin '${pluginName}' is already installed.`),
+			);
 			process.exit(1);
 		}
-		console.log(chalk.cyan(`Plugin npm'den indiriliyor: ${source}`));
+		console.log(chalk.cyan(`Downloading plugin from npm: ${source}`));
 		try {
 			mkdirSync(destDir, { recursive: true });
 			execFileSync("npm", ["pack", source, "--pack-destination", destDir], {
 				stdio: "pipe",
 			});
-			console.log(chalk.green(`Plugin '${pluginName}' basariyla yuklendi!`));
+			console.log(
+				chalk.green(`Plugin '${pluginName}' installed successfully!`),
+			);
 		} catch (e) {
-			console.error(chalk.red(`Plugin yuklenemedi: ${e.message}`));
+			console.error(chalk.red(`Plugin install failed: ${e.message}`));
 			if (existsSync(destDir)) rmSync(destDir, { recursive: true });
 			process.exit(1);
 		}
@@ -90,7 +96,7 @@ export function runInstall(args) {
 	if (!existsSync(manifestPath)) {
 		console.log(
 			chalk.yellow(
-				"Uyari: badi-plugin.json bulunamadi. Plugin yapilandirmasi eksik olabilir.",
+				"Warning: badi-plugin.json not found. The plugin configuration may be incomplete.",
 			),
 		);
 		return;
@@ -100,7 +106,7 @@ export function runInstall(args) {
 		const validation = validateManifest(manifest);
 		if (!validation.valid) {
 			console.log("");
-			console.log(chalk.yellow("Manifest validation uyarilari:"));
+			console.log(chalk.yellow("Manifest validation warnings:"));
 			for (const err of validation.errors) {
 				console.log(chalk.yellow(`  - ${err}`));
 			}
@@ -110,25 +116,25 @@ export function runInstall(args) {
 			console.log("");
 			console.log(
 				chalk.yellow(
-					`Uyari: Plugin apiVersion='${compat.range}' Badi v${VERSION} ile uyumsuz olabilir. Test edip raporlayin.`,
+					`Warning: Plugin apiVersion='${compat.range}' may be incompatible with Badi v${VERSION}. Test and report.`,
 				),
 			);
 		}
 		if (compat.warning) {
 			console.log("");
-			console.log(chalk.yellow(`Uyari: ${compat.warning}`));
+			console.log(chalk.yellow(`Warning: ${compat.warning}`));
 		}
 
 		console.log("");
-		console.log(chalk.bold("Plugin icerigi:"));
+		console.log(chalk.bold("Plugin contents:"));
 		if (manifest.agents?.length)
-			console.log(`  Ajanlar: ${manifest.agents.join(", ")}`);
+			console.log(`  Agents: ${manifest.agents.join(", ")}`);
 		if (manifest.commands?.length)
-			console.log(`  Komutlar: ${manifest.commands.join(", ")}`);
+			console.log(`  Commands: ${manifest.commands.join(", ")}`);
 		if (manifest.hooks?.length)
-			console.log(`  Hook'lar: ${manifest.hooks.join(", ")}`);
+			console.log(`  Hooks: ${manifest.hooks.join(", ")}`);
 		if (manifest.skills)
-			console.log(`  Skill'ler: ${Object.keys(manifest.skills).join(", ")}`);
+			console.log(`  Skills: ${Object.keys(manifest.skills).join(", ")}`);
 		if (manifest.badi?.apiVersion) {
 			console.log(chalk.dim(`  apiVersion: ${manifest.badi.apiVersion}`));
 		}
@@ -138,6 +144,6 @@ export function runInstall(args) {
 			);
 		}
 	} catch {
-		// manifest okunamadiysa ses cikarma
+		// stay silent if the manifest cannot be read
 	}
 }

--- a/lib/commands/plugin/list.js
+++ b/lib/commands/plugin/list.js
@@ -7,15 +7,15 @@ import { pluginsDir } from "./_shared.js";
 export function runList() {
 	const dir = pluginsDir(process.cwd());
 	if (!existsSync(dir)) {
-		console.log(chalk.dim("Yuklu plugin yok."));
+		console.log(chalk.dim("No plugins installed."));
 		return;
 	}
 	const plugins = listDirs(dir);
 	if (plugins.length === 0) {
-		console.log(chalk.dim("Yuklu plugin yok."));
+		console.log(chalk.dim("No plugins installed."));
 		return;
 	}
-	console.log(chalk.bold(`Yuklu Plugin'ler (${plugins.length}):`));
+	console.log(chalk.bold(`Installed Plugins (${plugins.length}):`));
 	for (const p of plugins) {
 		const manifestPath = join(dir, p, "badi-plugin.json");
 		if (existsSync(manifestPath)) {

--- a/lib/commands/plugin/remove.js
+++ b/lib/commands/plugin/remove.js
@@ -6,14 +6,14 @@ import { pluginsDir } from "./_shared.js";
 export function runRemove(args) {
 	const name = args[0];
 	if (!name) {
-		console.error(chalk.red("Hata: Plugin adi belirtilmedi."));
+		console.error(chalk.red("Error: No plugin name specified."));
 		process.exit(1);
 	}
 	const dir = join(pluginsDir(process.cwd()), name);
 	if (!existsSync(dir)) {
-		console.error(chalk.red(`Plugin '${name}' bulunamadi.`));
+		console.error(chalk.red(`Plugin '${name}' not found.`));
 		process.exit(1);
 	}
 	rmSync(dir, { recursive: true });
-	console.log(chalk.green(`Plugin '${name}' basariyla kaldirildi.`));
+	console.log(chalk.green(`Plugin '${name}' removed successfully.`));
 }

--- a/lib/commands/plugin/show.js
+++ b/lib/commands/plugin/show.js
@@ -10,13 +10,13 @@ import { pluginsDir } from "./_shared.js";
 export function runShow(args) {
 	const name = args[0];
 	if (!name) {
-		console.error(chalk.red("Hata: Plugin adi belirtilmedi."));
-		console.log("Kullanim: badi plugin show <isim>");
+		console.error(chalk.red("Error: No plugin name specified."));
+		console.log("Usage: badi plugin show <name>");
 		process.exit(1);
 	}
 	const dir = join(pluginsDir(process.cwd()), name);
 	if (!existsSync(dir)) {
-		console.error(chalk.red(`Plugin '${name}' bulunamadi.`));
+		console.error(chalk.red(`Plugin '${name}' not found.`));
 		process.exit(1);
 	}
 	const manifestPath = join(dir, "badi-plugin.json");
@@ -25,7 +25,7 @@ export function runShow(args) {
 		try {
 			manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
 		} catch (e) {
-			console.error(chalk.red(`Manifest parse hatasi: ${e.message}`));
+			console.error(chalk.red(`Manifest parse error: ${e.message}`));
 		}
 	}
 
@@ -38,7 +38,9 @@ export function runShow(args) {
 
 	if (manifest?.badi?.apiVersion) {
 		const compat = checkApiCompat(manifest, VERSION);
-		const tag = compat.ok ? chalk.green("uyumlu") : chalk.red("UYUMSUZ");
+		const tag = compat.ok
+			? chalk.green("compatible")
+			: chalk.red("INCOMPATIBLE");
 		console.log(
 			`${chalk.dim(`  apiVersion:  ${manifest.badi.apiVersion}`)} (${tag})`,
 		);
@@ -48,7 +50,7 @@ export function runShow(args) {
 	} else if (manifest) {
 		console.log(
 			chalk.dim(
-				`  apiVersion:  (belirtilmemis, ${BADI_DEFAULT_API_VERSION} varsayilir)`,
+				`  apiVersion:  (unspecified, ${BADI_DEFAULT_API_VERSION} assumed)`,
 			),
 		);
 	}
@@ -64,20 +66,20 @@ export function runShow(args) {
 	const hookCount = manifest?.hooks?.length || 0;
 	const skillCount = manifest?.skills ? Object.keys(manifest.skills).length : 0;
 
-	console.log(chalk.bold("Icerik:"));
-	console.log(`  ${chalk.cyan("Ajanlar")}:  ${agentCount}`);
+	console.log(chalk.bold("Contents:"));
+	console.log(`  ${chalk.cyan("Agents")}:  ${agentCount}`);
 	if (manifest?.agents?.length) {
 		for (const a of manifest.agents) console.log(`    - ${a}`);
 	}
-	console.log(`  ${chalk.cyan("Komutlar")}: ${commandCount}`);
+	console.log(`  ${chalk.cyan("Commands")}: ${commandCount}`);
 	if (manifest?.commands?.length) {
 		for (const c of manifest.commands) console.log(`    - ${c}`);
 	}
-	console.log(`  ${chalk.cyan("Hook'lar")}: ${hookCount}`);
+	console.log(`  ${chalk.cyan("Hooks")}: ${hookCount}`);
 	if (manifest?.hooks?.length) {
 		for (const h of manifest.hooks) console.log(`    - ${h}`);
 	}
-	console.log(`  ${chalk.cyan("Skill'ler")}: ${skillCount}`);
+	console.log(`  ${chalk.cyan("Skills")}: ${skillCount}`);
 	if (manifest?.skills) {
 		for (const [cat, items] of Object.entries(manifest.skills)) {
 			const count = Array.isArray(items) ? items.length : 0;
@@ -85,6 +87,6 @@ export function runShow(args) {
 		}
 	}
 	if (!manifest) {
-		console.log(chalk.yellow("  badi-plugin.json bulunamadi"));
+		console.log(chalk.yellow("  badi-plugin.json not found"));
 	}
 }

--- a/lib/icerik-helpers.js
+++ b/lib/icerik-helpers.js
@@ -28,7 +28,7 @@ export function parseLanguageFlag(args) {
 	const remaining = [];
 	for (let i = 0; i < args.length; i++) {
 		if (args[i] === "--lang") {
-			i++; // deger varsa atla — icerik English-only (faz 1), --lang no-op
+			i++; // skip the value if present — content is English-only (phase 1), --lang is a no-op
 		} else {
 			remaining.push(args[i]);
 		}
@@ -129,7 +129,7 @@ export function resolveTemplate(name, visited = new Set()) {
 	visited.add(name);
 	const tmpl = loadCustomTemplate(name);
 	if (!tmpl) {
-		console.error(chalk.red(`Sablon bulunamadi: ${name}`));
+		console.error(chalk.red(`Template not found: ${name}`));
 		process.exit(1);
 	}
 	const validBases = ["post", "karousel", "video", "gorsel", "takvim"];

--- a/tests/cli.integration.test.js
+++ b/tests/cli.integration.test.js
@@ -88,14 +88,14 @@ describe("badi CLI", () => {
 	});
 
 	describe("list", () => {
-		it("bilesenleri listeler", () => {
+		it("lists components", () => {
 			const output = run(["list"]);
-			assert.ok(output.includes("Ajanlar") || output.includes("Komutlar"));
+			assert.ok(output.includes("Agents") || output.includes("Commands"));
 		});
 
-		it("--agents bayragi calisiyor", () => {
+		it("--agents flag works", () => {
 			const output = run(["list", "--agents"]);
-			assert.ok(output.includes("Ajanlar"));
+			assert.ok(output.includes("Agents"));
 		});
 	});
 });

--- a/tests/cli.list.test.js
+++ b/tests/cli.list.test.js
@@ -18,15 +18,15 @@ describe("badi list", () => {
 	it("tum bilesenleri listeler", () => {
 		const output = run(["list"]);
 		assert.ok(
-			output.includes("Ajanlar") ||
-				output.includes("Komutlar") ||
+			output.includes("Agents") ||
+				output.includes("Commands") ||
 				output.includes("Hook"),
 		);
 	});
 
-	it("--agents ajanları listeler", () => {
+	it("--agents lists agents", () => {
 		const output = run(["list", "--agents"]);
-		assert.ok(output.includes("Ajanlar"));
+		assert.ok(output.includes("Agents"));
 	});
 
 	it("--hooks hook'lari listeler", () => {

--- a/tests/cli.observability.test.js
+++ b/tests/cli.observability.test.js
@@ -93,7 +93,7 @@ describe("badi list --mcp", () => {
 	it("MCP kullanim bolumunu cikarir", () => {
 		const r = run(["list", "--mcp"]);
 		assert.equal(r.code, 0);
-		assert.ok(r.stdout.includes("MCP Server Kullanimi"));
+		assert.ok(r.stdout.includes("MCP Server Usage"));
 	});
 });
 

--- a/tests/cli.plugin-doctor.test.js
+++ b/tests/cli.plugin-doctor.test.js
@@ -53,7 +53,7 @@ describe("badi plugin doctor + graph (post-split)", () => {
 	it("bos pluginlerle 'doctor' sessiz cikar", () => {
 		const r = run(["plugin", "doctor"], { cwd: tmp });
 		assert.equal(r.code, 0);
-		assert.match(r.stdout, /Yuklu plugin yok/);
+		assert.match(r.stdout, /No plugins installed/);
 	});
 
 	it("apiVersion 'garbage' format taninmadi uyarisi gosterir (A2/B1)", () => {
@@ -82,6 +82,6 @@ describe("badi plugin doctor + graph (post-split)", () => {
 	it("graph topo-sort cikti uretir", () => {
 		const r = run(["plugin", "graph"], { cwd: tmp });
 		assert.equal(r.code, 0);
-		assert.match(r.stdout, /Plugin Bagimlilik Agaci/);
+		assert.match(r.stdout, /Plugin Dependency Tree/);
 	});
 });

--- a/tests/cli.plugin.test.js
+++ b/tests/cli.plugin.test.js
@@ -22,7 +22,7 @@ describe("badi plugin", () => {
 
 	it("list bos plugin listesi gosterir", () => {
 		const output = run(["plugin", "list"]);
-		assert.ok(output.includes("plugin yok") || output.includes("Plugin"));
+		assert.ok(output.includes("No plugins") || output.includes("Plugin"));
 	});
 
 	it("kaynak belirtilmeden install hata verir", () => {

--- a/tests/security-hardening.test.js
+++ b/tests/security-hardening.test.js
@@ -95,8 +95,8 @@ describe("O1 — plugin install git argument injection", () => {
 		const r = run(TMP, "plugin", "install", "--upload-pack=evil");
 		assert.ok(r.status !== 0);
 		assert.ok(
-			r.stderr.includes("Gecersiz kaynak") ||
-				r.stdout.includes("Gecersiz kaynak"),
+			r.stderr.includes("Invalid source") ||
+				r.stdout.includes("Invalid source"),
 		);
 	});
 


### PR DESCRIPTION
## Summary

Continues the English-only i18n migration (follows #220 / Phase 2o). Converts the remaining Turkish CLI output to English in:

- `lib/commands/list.js`, `lib/commands/plan.js`
- All `lib/commands/plugin/*` subcommands — `doctor`, `graph`, `help`, `index`, `install`, `list`, `remove`, `show`
- `lib/icerik-helpers.js`

Affected test assertions updated to match.

## Notes

- No user-facing Turkish strings remain in the changed files (the `icerik` domain term in function names is intentional).
- ~1:1 string swaps: 130 insertions / 126 deletions across 17 files.

## Test plan

- [x] `npm test` — **1132 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)