### PR TITLE
feat(i18n): English-only Phase 2q — events + mcp CLI output

### DIFF
--- a/lib/commands/events.js
+++ b/lib/commands/events.js
@@ -26,36 +26,36 @@ function printHelp() {
 	console.log(chalk.bold("Badi Self-Telemetry (Events):"));
 	console.log("");
 	console.log(
-		`  badi events list [--limit N]    ${chalk.dim("Son N olay (default 30)")}`,
+		`  badi events list [--limit N]    ${chalk.dim("Last N events (default 30)")}`,
 	);
 	console.log(
-		`  badi events stats               ${chalk.dim("Komut bazli sayim + ortalama sure")}`,
+		`  badi events stats               ${chalk.dim("Per-command count + average duration")}`,
 	);
 	console.log(
-		`  badi events tail                ${chalk.dim("list --limit 10 kisaltma")}`,
-	);
-	console.log("");
-	console.log(chalk.bold("Filtreler (list/stats):"));
-	console.log(`  --since YYYY-MM-DD              Bu tarihten itibaren`);
-	console.log(`  --until YYYY-MM-DD              Bu tarihe kadar`);
-	console.log(`  --cmd <ad>                      Sadece bu komut`);
-	console.log(
-		`  --type <event.type>             Sadece bu olay tipi (orn. badi.command.completed)`,
+		`  badi events tail                ${chalk.dim("list --limit 10 shorthand")}`,
 	);
 	console.log("");
-	console.log(chalk.bold("Diagnostik:"));
-	console.log(`  badi events path                Log dosyasi yolu`);
+	console.log(chalk.bold("Filters (list/stats):"));
+	console.log(`  --since YYYY-MM-DD              From this date onward`);
+	console.log(`  --until YYYY-MM-DD              Up to this date`);
+	console.log(`  --cmd <name>                    Only this command`);
 	console.log(
-		`  badi events status              Telemetry on/off + log boyutu`,
+		`  --type <event.type>             Only this event type (e.g. badi.command.completed)`,
+	);
+	console.log("");
+	console.log(chalk.bold("Diagnostics:"));
+	console.log(`  badi events path                Log file path`);
+	console.log(
+		`  badi events status              Telemetry on/off + log size`,
 	);
 	console.log("");
 	console.log(
 		chalk.dim(
-			"Telemetry kapatma: export BADI_TELEMETRY=off  (her cagri no-op)",
+			"Disable telemetry: export BADI_TELEMETRY=off  (every call is a no-op)",
 		),
 	);
 	console.log(
-		chalk.dim("Tum veri lokal: ~/.claude/projects/<slug>/badi-events.jsonl"),
+		chalk.dim("All data is local: ~/.claude/projects/<slug>/badi-events.jsonl"),
 	);
 }
 
@@ -92,21 +92,21 @@ function applyFilters(events, flags) {
 async function cmdList(args, limitOverride) {
 	const flags = parseFlags(args);
 	if (limitOverride != null) flags.limit = limitOverride;
-	// B4 fix: filtre yoksa tail reader kullan (buyuk loglarda O(K) okuma).
-	// Filtre varsa tum dosyayi okuyup filtrelemek gerekiyor.
+	// B4 fix: use the tail reader when there are no filters (O(K) read on large logs).
+	// With filters we must read the whole file and filter it.
 	const hasFilters = !!(flags.since || flags.until || flags.cmd || flags.type);
 	const events = hasFilters
 		? await readEvents()
 		: await readEventsTail(flags.limit);
 	if (events.length === 0) {
-		console.log(chalk.dim("Olay yok. Komut calistirin, sonra tekrar deneyin."));
+		console.log(chalk.dim("No events. Run a command, then try again."));
 		return;
 	}
 	const filtered = applyFilters(events, flags);
 	const shown = filtered.slice(0, flags.limit);
 	console.log(
 		chalk.bold(
-			`Son ${shown.length} olay (toplam ${filtered.length}${filtered.length !== events.length ? `, filtreli ${events.length} olay` : ""}):`,
+			`Last ${shown.length} events (total ${filtered.length}${filtered.length !== events.length ? `, filtered from ${events.length}` : ""}):`,
 		),
 	);
 	console.log("");
@@ -134,7 +134,7 @@ async function cmdStats(args) {
 	const flags = parseFlags(args);
 	const events = await readEvents();
 	if (events.length === 0) {
-		console.log(chalk.dim("Olay yok."));
+		console.log(chalk.dim("No events."));
 		return;
 	}
 	const filtered = applyFilters(events, flags);
@@ -156,13 +156,13 @@ async function cmdStats(args) {
 
 	console.log(
 		chalk.bold(
-			`Badi Self-Telemetry — Komut Istatistikleri (${filtered.length} olay)`,
+			`Badi Self-Telemetry — Command Statistics (${filtered.length} events)`,
 		),
 	);
 	console.log("");
 
 	if (completedByCmd.size === 0 && failedByCmd.size === 0) {
-		console.log(chalk.dim("Komut olayi yok."));
+		console.log(chalk.dim("No command events."));
 		return;
 	}
 
@@ -178,7 +178,7 @@ async function cmdStats(args) {
 
 	const maxCmd = Math.max(8, ...rows.map((r) => r.cmd.length));
 	console.log(
-		`  ${chalk.bold("Komut".padEnd(maxCmd))}  ${chalk.bold("OK")}  ${chalk.bold("Fail")}  ${chalk.bold("Avg sure")}`,
+		`  ${chalk.bold("Command".padEnd(maxCmd))}  ${chalk.bold("OK")}  ${chalk.bold("Fail")}  ${chalk.bold("Avg time")}`,
 	);
 	for (const r of rows) {
 		const failColor =
@@ -191,7 +191,7 @@ async function cmdStats(args) {
 
 async function cmdPath() {
 	const p = getEventsPath();
-	console.log(p || chalk.dim("(yol cozulemedi)"));
+	console.log(p || chalk.dim("(path unresolved)"));
 }
 
 async function cmdStatus() {
@@ -201,14 +201,14 @@ async function cmdStatus() {
 	console.log(
 		`Telemetry: ${enabled ? chalk.green("on") : chalk.yellow("off (BADI_TELEMETRY=off)")}`,
 	);
-	console.log(`Log dosyasi: ${getEventsPath()}`);
+	console.log(`Log file: ${getEventsPath()}`);
 	console.log(
-		`Boyut: ${size > 0 ? `${sizeKb} KB` : chalk.dim("(bos veya yok)")}`,
+		`Size: ${size > 0 ? `${sizeKb} KB` : chalk.dim("(empty or none)")}`,
 	);
 	if (size > 5 * 1024 * 1024) {
 		console.log(
 			chalk.yellow(
-				"Uyari: log dosyasi 5MB ustunde. Kullanici manuel rotate edebilir (mv ...jsonl ...jsonl.1).",
+				"Warning: log file is over 5MB. You can rotate it manually (mv ...jsonl ...jsonl.1).",
 			),
 		);
 	}
@@ -232,7 +232,7 @@ export async function runEvents(args = []) {
 		case "status":
 			return cmdStatus();
 		default:
-			console.error(chalk.red(`Bilinmeyen events komutu: ${sub}`));
+			console.error(chalk.red(`Unknown events command: ${sub}`));
 			printHelp();
 			process.exit(1);
 	}

--- a/lib/commands/mcp.js
+++ b/lib/commands/mcp.js
@@ -1,10 +1,10 @@
-// Badi mcp komutu — Model Context Protocol server.
+// Badi mcp command — Model Context Protocol server.
 //
-// `badi mcp serve` stdio uzerinden minimal MCP server baslar. Disardaki
-// AI client'lari (Claude Code, Cursor, Continue.dev) `claude mcp add badi`
-// ile bagladiginda tools/resources Badi koprusu uzerinden cagrilabilir.
+// `badi mcp serve` starts a minimal MCP server over stdio. External AI
+// clients (Claude Code, Cursor, Continue.dev) connected via
+// `claude mcp add badi` can call tools/resources through the Badi bridge.
 //
-// Sifir disa bagimlilik: JSON-RPC over stdio elle implemente edildi.
+// Zero external dependencies: JSON-RPC over stdio implemented by hand.
 // MCP spec: https://modelcontextprotocol.io/
 
 import { existsSync, readFileSync } from "node:fs";
@@ -14,20 +14,20 @@ import { chalk, showBanner } from "../cli.js";
 const MCP_VERSION = "2024-11-05";
 const SERVER_NAME = "badi";
 
-// ─── Tool ve resource tanimlari (read-only, guvenli) ───
+// ─── Tool and resource definitions (read-only, safe) ───
 
 const TOOLS = [
 	{
 		name: "badi.skills.route",
 		description:
-			"Verilen prompt icin eslesen skill'leri puanlar (auto-router). Donus: matched skill listesi + skor.",
+			"Scores matching skills for the given prompt (auto-router). Returns: matched skill list + score.",
 		inputSchema: {
 			type: "object",
 			properties: {
-				prompt: { type: "string", description: "Kullanici prompt'u" },
+				prompt: { type: "string", description: "User prompt" },
 				top: {
 					type: "number",
-					description: "En cok N skill (default 3)",
+					description: "At most N skills (default 3)",
 					default: 3,
 				},
 			},
@@ -36,19 +36,19 @@ const TOOLS = [
 	},
 	{
 		name: "badi.skills.list",
-		description: "Aktif (opt-in) skill kategorilerini listeler.",
+		description: "Lists the active (opt-in) skill categories.",
 		inputSchema: { type: "object", properties: {} },
 	},
 	{
 		name: "badi.skills.available",
 		description:
-			"Vault'taki tum skill kategorilerini listeler (yuklu olmasa da).",
+			"Lists all skill categories in the vault (even if not installed).",
 		inputSchema: { type: "object", properties: {} },
 	},
 	{
 		name: "badi.skills.inject",
 		description:
-			"Verilen prompt icin eslesen skill'lerin SKILL.md govdesini birlestirip donderir (context injection).",
+			"Concatenates and returns the SKILL.md bodies of skills matching the given prompt (context injection).",
 		inputSchema: {
 			type: "object",
 			properties: {
@@ -63,21 +63,21 @@ const RESOURCES = [
 	{
 		uri: "badi://memory",
 		name: "memory.md",
-		description: "Oturum bellegi (kararlar, notlar, mevcut durum)",
+		description: "Session memory (decisions, notes, current state)",
 		mimeType: "text/markdown",
 		path: ".claude/memory.md",
 	},
 	{
 		uri: "badi://knowledge-base",
 		name: "knowledge-base.md",
-		description: "Proje bilgi tabani (kalici kurallar, kaliplari)",
+		description: "Project knowledge base (persistent rules, patterns)",
 		mimeType: "text/markdown",
 		path: ".claude/knowledge-base.md",
 	},
 	{
 		uri: "badi://taskboard",
 		name: "TaskBoard.md",
-		description: "Gorev panosu (acik/bekleyen isler)",
+		description: "Task board (open/pending work)",
 		mimeType: "text/markdown",
 		path: ".claude/workspace/TaskBoard.md",
 	},
@@ -97,7 +97,7 @@ function jsonRpcError(id, code, message) {
 	});
 }
 
-// ─── Tool calistirma ───
+// ─── Tool execution ───
 
 async function callTool(name, args, target) {
 	if (name === "badi.skills.route") {
@@ -147,18 +147,18 @@ async function callTool(name, args, target) {
 		const matched = routePrompt(args.prompt || "", idx);
 		const blob = buildContextInjection(matched, idx);
 		return {
-			content: [{ type: "text", text: blob || "(eslesme yok)" }],
+			content: [{ type: "text", text: blob || "(no match)" }],
 		};
 	}
 
-	throw new Error(`Bilinmeyen tool: ${name}`);
+	throw new Error(`Unknown tool: ${name}`);
 }
 
 async function readResource(uri, target) {
 	const res = RESOURCES.find((r) => r.uri === uri);
-	if (!res) throw new Error(`Bilinmeyen resource: ${uri}`);
+	if (!res) throw new Error(`Unknown resource: ${uri}`);
 	const file = join(target, res.path);
-	const text = existsSync(file) ? readFileSync(file, "utf-8") : "(dosya yok)";
+	const text = existsSync(file) ? readFileSync(file, "utf-8") : "(no file)";
 	return {
 		contents: [{ uri, mimeType: res.mimeType, text }],
 	};
@@ -211,7 +211,7 @@ async function handleRequest(req, target) {
 			return jsonRpcResponse(id, {});
 		}
 
-		// notifications (initialized vb.) cevap istemez
+		// notifications (initialized etc.) expect no response
 		if (method.startsWith("notifications/")) {
 			return null;
 		}
@@ -281,7 +281,7 @@ export async function serveMcp(target) {
 	});
 }
 
-// ─── CLI yardimcilari ───
+// ─── CLI helpers ───
 
 function manifestSnippet() {
 	return JSON.stringify(
@@ -301,15 +301,15 @@ function manifestSnippet() {
 function showHelp() {
 	console.log(`${chalk.bold("badi mcp")} — Model Context Protocol server`);
 	console.log("");
-	console.log("  serve         Stdio MCP server baslar");
-	console.log("  tools         Acik tool listesini goster");
-	console.log("  resources     Acik resource listesini goster");
-	console.log("  config        Claude Code/Cursor icin .mcp.json snippet'i");
+	console.log("  serve         Start the stdio MCP server");
+	console.log("  tools         Show the exposed tool list");
+	console.log("  resources     Show the exposed resource list");
+	console.log("  config        .mcp.json snippet for Claude Code/Cursor");
 	console.log("");
-	console.log(chalk.bold("Kurulum (Claude Code):"));
+	console.log(chalk.bold("Setup (Claude Code):"));
 	console.log("  claude mcp add badi -- npx -y @fatihkan/badi mcp serve");
 	console.log("");
-	console.log(chalk.bold("Manuel (.mcp.json):"));
+	console.log(chalk.bold("Manual (.mcp.json):"));
 	console.log(chalk.dim("  badi mcp config > .mcp.json"));
 }
 
@@ -349,7 +349,7 @@ export async function runMcp(args) {
 		return;
 	}
 
-	console.error(chalk.red(`Bilinmeyen alt komut: ${sub}`));
+	console.error(chalk.red(`Unknown subcommand: ${sub}`));
 	showHelp();
 	process.exit(1);
 }

--- a/tests/cli.events.test.js
+++ b/tests/cli.events.test.js
@@ -39,7 +39,7 @@ describe("badi events", () => {
 		const r = run(["events", "status"]);
 		assert.equal(r.code, 0);
 		assert.match(r.stdout, /Telemetry:/);
-		assert.match(r.stdout, /Log dosyasi:/);
+		assert.match(r.stdout, /Log file:/);
 	});
 
 	it("BADI_TELEMETRY=off status'ta off gosterir", () => {


### PR DESCRIPTION
## Summary

Continues the English-only i18n migration (follows #222 / Phase 2p). Translates the remaining Turkish to English in two command files:

- **`lib/commands/events.js`** — help text (filters, diagnostics, telemetry notes), `list`/`stats`/`status` output (`No events`, `Last N events`, `Command Statistics`, `Log file`, size label, 5MB rotate warning), unknown-subcommand error, and inline comments.
- **`lib/commands/mcp.js`** — header doc block, tool/resource `description` fields, help text (`serve`/`tools`/`resources`/`config`, setup), unknown tool/resource/subcommand errors, `(no match)`/`(no file)` placeholders, comments.

## Scope notes

- `icerik/sablon.js`'s remaining Turkish (`olustur`, `sil`, `sablon`, `--sablon`) are **CLI command/flag keywords** users type, not display strings — its output is already English. Renaming the grammar is a separate breaking-change effort, out of scope here.
- `bin/badi.js` (the largest remaining file) is deferred — it's mid-modularization.

## Test plan

- [x] `cli.mcp.test.js` asserts only structural names — no changes needed.
- [x] `cli.events.test.js` status assertion retargeted (`/Log dosyasi:/` → `/Log file:/`).
- [x] `npm test` — **1132 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)