### PR TITLE
chore(biome): migrate config + reformat for biome 2.4.16

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/lib/commands/events.js
+++ b/lib/commands/events.js
@@ -45,9 +45,7 @@ function printHelp() {
 	console.log("");
 	console.log(chalk.bold("Diagnostics:"));
 	console.log(`  badi events path                Log file path`);
-	console.log(
-		`  badi events status              Telemetry on/off + log size`,
-	);
+	console.log(`  badi events status              Telemetry on/off + log size`);
 	console.log("");
 	console.log(
 		chalk.dim(


### PR DESCRIPTION
## Summary

Follow-up to #221 (@biomejs/biome 2.4.15 → 2.4.16). After installing the new version, `biome check .` failed on two counts — fixed here:

- **`biome.json`**: `$schema` was pinned to `2.4.15` → migrated to `2.4.16` (`biome migrate --write`).
- **`lib/commands/events.js`**: 2.4.16's formatter collapses a previously-wrapped `console.log(...)` onto a single line (`biome format --write`).

## Test plan
- [x] `npm run lint` (`biome check .`) — **passes clean** with biome 2.4.16
- [x] `npm test` — **1155 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)