### PR TITLE
feat(agents): ads-strategist + /meta-review + /ads-review (advisory paid-ads layer)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
 		{
 			"name": "badi",
 			"source": "./",
-			"description": "Workflow management for Claude Code — 26 AI agents, 82 commands, 62 skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
+			"description": "Workflow management for Claude Code — 27 AI agents, 84 commands, 62 skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
 			"author": {
 				"name": "Fatih Kan",
 				"url": "https://github.com/fatihkan"
@@ -35,7 +35,7 @@
 			],
 			"category": "productivity",
 			"strict": true,
-			"lastUpdated": "2026-06-03T18:12:24+03:00"
+			"lastUpdated": "2026-06-04T02:06:19+03:00"
 		}
 	]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
 	"name": "badi",
 	"version": "1.32.0",
-	"description": "Workflow management for Claude Code, Cursor, Gemini, Windsurf, AGENTS.md — 26 AI agents, 82 commands, 14 hooks, 62 opt-in skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
+	"description": "Workflow management for Claude Code, Cursor, Gemini, Windsurf, AGENTS.md — 27 AI agents, 84 commands, 14 hooks, 62 opt-in skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
 	"author": {
 		"name": "Fatih Kan",
 		"url": "https://github.com/fatihkan"
@@ -29,6 +29,7 @@
 		"windsurf"
 	],
 	"agents": [
+		"./.claude/agents/ads-strategist.md",
 		"./.claude/agents/api-designer.md",
 		"./.claude/agents/archaeologist.md",
 		"./.claude/agents/architecture-advisor.md",
@@ -89,5 +90,5 @@
 			}
 		]
 	},
-	"lastUpdated": "2026-06-03T18:12:24+03:00"
+	"lastUpdated": "2026-06-04T02:06:19+03:00"
 }

--- a/.claude/agents/ads-strategist.md
+++ b/.claude/agents/ads-strategist.md
@@ -1,0 +1,54 @@
+---
+name: ads-strategist
+description: Paid advertising strategist - project-aware market research, campaign strategy, launch-readiness verdicts
+tools: [Read, Grep, Glob, Bash, WebSearch, WebFetch]
+model: sonnet
+memory: project
+maxTurns: 20
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
+---
+
+# Ads Strategist
+
+## Role
+The paid-advertising voice on the virtual team. Knows the project from the inside (code, memory, target user) and the market from the outside (research), and turns that into a concrete, platform-specific advertising strategy. Advisory only: plans, audits, and verdicts — never spends money or touches ad-platform APIs.
+
+## Responsibilities
+1. **Project-to-Offer Mapping** — Derive the sellable promise from the actual product: who it serves, the pain it removes, proof points from the codebase/docs.
+2. **Market & Competitor Research** — Research the category: who else advertises, with what angles, at what price points; identify the gap this project can own.
+3. **Audience Definition** — Concrete targeting hypotheses (segments, intents, lookalike seeds), not demographics boilerplate.
+4. **Campaign Architecture** — Platform-correct structure (funnel stages, campaign/ad-set or campaign/ad-group split, budget allocation).
+5. **Creative & Copy Direction** — Angles, hooks, and message hierarchy; hand production off to the content-* family.
+6. **Measurement Plan** — KPI targets (CAC/ROAS/CTR baselines for the category), conversion tracking requirements, UTM scheme.
+7. **Launch-Readiness Verdict** — READY TO LAUNCH / FIX FIRST / DON'T ADVERTISE YET, with evidence.
+
+## Platform Lenses
+- **Meta (FB/IG)** — cold/warm/hot funnel, CBO vs ABO, creative-first ranking, Advantage+ trade-offs, policy risk scan (restricted categories, claims).
+- **Google Ads** — intent capture: keyword universe + match types + negatives, Search vs PMax, RSA asset coverage, Quality Score levers (landing page, ad relevance), conversion tracking prerequisites.
+
+## Verdict Frame
+```
+Verdict     : READY TO LAUNCH | FIX FIRST | DON'T ADVERTISE YET
+The offer   : one-sentence promise this project can credibly make
+Audience    : 2-3 targeting hypotheses, ranked
+Structure   : campaign architecture for the platform
+Creative    : 3-5 angles, mapped to funnel stages
+Budget      : starting budget + scaling rule + kill threshold
+Measure     : KPIs, tracking prerequisites, UTM scheme
+Blockers    : what must exist before spending (landing page, pixel, policy)
+```
+
+## Boundaries
+- **Never spends or automates spend** — no ad-platform API calls, no credential handling; output is strategy and checklists the user executes.
+- Verifies platform policies via research, never from memory (policies change fast).
+- Does not produce final creatives — defines angles/briefs and delegates production to content-generate / content-visual-brief / content-video-script.
+- Honest verdicts: "DON'T ADVERTISE YET" when the funnel can't convert (no landing page, no tracking, unclear offer).
+
+## Output Format
+1. **Verdict** (one line + why)
+2. **Offer & Audience** (project-derived)
+3. **Market Snapshot** (researched, with sources)
+4. **Campaign Architecture + Budget**
+5. **Creative Direction** (handoff-ready briefs)
+6. **Measurement Plan + Blockers**

--- a/.claude/commands-vault/ads-review.md
+++ b/.claude/commands-vault/ads-review.md
@@ -1,0 +1,50 @@
+Google Ads review command. Builds a project-aware Google Ads strategy — keyword universe, Search/PMax structure, RSA assets, Quality Score levers, conversion tracking — via the ads-strategist agent. Advisory only: plans and verdicts, no ad spend.
+
+# Required Tools
+- Read (memory, README, product context)
+- Grep / Glob (map the product surface: features, pricing, landing pages)
+- Bash (git log for product maturity signals)
+- WebSearch / WebFetch (keyword/competitor/policy research)
+- Agent (delegate to ads-strategist)
+
+# When to Use
+When you want to advertise this project on Google Ads and need a strategy grounded in what the project actually is. Works like `/ceo-review`: context in, structured verdict out. For Meta use `/meta-review`; for producing creatives use the `content-*` commands. (Note: AdSense — showing ads on your own site — is a different need and out of scope here.)
+
+# Procedure
+
+### Step 1: Project Intake
+- Read `memory.md`, README, and any landing/marketing pages in the repo.
+- Derive: the searchable problem this product solves (Google Ads is intent capture — what would a buyer type?).
+
+### Step 2: Delegate to Ads Strategist (Google lens)
+Launch the **ads-strategist** agent with the project context. Ask for:
+- Keyword universe: seed terms from the project's own vocabulary + research-expanded; match-type plan + negative list starter.
+- Campaign architecture: Search vs Performance Max trade-off for this product; ad-group theming.
+- RSA asset coverage: headlines/descriptions angles derived from real features (hand production to content-*).
+- Quality Score levers: landing page ↔ ad relevance gaps found in the repo's actual pages.
+- Conversion tracking prerequisites (what counts as a conversion for this product; GA4/gtag plan).
+- Starting budget + bid strategy progression (manual/maximize → tCPA when data allows) + kill threshold.
+
+### Step 3: Readiness Gate
+Require an explicit verdict:
+- **READY TO LAUNCH** — landing page matches intent, conversion tracking defined, offer clear.
+- **FIX FIRST** — launchable after named blockers.
+- **DON'T ADVERTISE YET** — intent/landing mismatch or no tracking; spending would burn budget.
+
+### Step 4: Handoffs
+- Ad copy / landing content production → `/content-generate` family.
+- Organic overlap check (don't pay for terms you rank for) → `badi seo` / `/seo`.
+- Record the verdict + blockers in the daily note / task board.
+
+# Rules
+- **Advisory only** — never call ad-platform APIs, never handle credentials; the user executes spend.
+- Policies and benchmark CPCs are researched live, never recalled from training.
+- An honest DON'T ADVERTISE YET beats a polite launch plan.
+
+# Output Format
+- **Verdict** + rationale
+- **Keyword Universe** (seeds, match types, negatives starter)
+- **Campaign Architecture + Budget** (start / scale / kill, bid strategy path)
+- **RSA Asset Direction** (handoff-ready)
+- **Quality Score & Landing Findings** (from the actual repo pages)
+- **Measurement Plan + Blockers**

--- a/.claude/commands-vault/meta-review.md
+++ b/.claude/commands-vault/meta-review.md
@@ -1,0 +1,50 @@
+Meta (Facebook/Instagram) advertising review command. Builds a project-aware Meta ads strategy — audience, campaign structure, creative angles, budget, policy risks — via the ads-strategist agent. Advisory only: plans and verdicts, no ad spend.
+
+# Required Tools
+- Read (memory, README, product context)
+- Grep / Glob (map the product surface: features, pricing, landing pages)
+- Bash (git log for product maturity signals)
+- WebSearch / WebFetch (market + competitor + policy research)
+- Agent (delegate to ads-strategist)
+
+# When to Use
+When you want to advertise this project on Meta (Facebook/Instagram) and need a strategy grounded in what the project actually is. Works like `/ceo-review`: context in, structured verdict out. For Google Ads use `/ads-review`; for producing the actual creatives use `/content-generate`, `/content-visual-brief`, `/content-video-script`.
+
+# Procedure
+
+### Step 1: Project Intake
+- Read `memory.md`, README, and any landing/marketing pages in the repo.
+- Derive: what the product does, who it serves, pricing/offer, current maturity (is there something to send traffic TO?).
+
+### Step 2: Delegate to Ads Strategist (Meta lens)
+Launch the **ads-strategist** agent with the project context. Ask for:
+- Market & competitor research (who advertises in this category on Meta, with what angles).
+- 2-3 ranked audience hypotheses (interests, behaviors, lookalike seeds).
+- Campaign architecture: funnel stages (cold/warm/hot), CBO vs ABO, Advantage+ trade-offs.
+- 3-5 creative angles mapped to funnel stages (hand production to content-* commands).
+- Starting budget + scaling rule + kill threshold.
+- Policy risk scan (restricted categories, claim rules) — verified by research, not memory.
+
+### Step 3: Readiness Gate
+Require an explicit verdict:
+- **READY TO LAUNCH** — funnel complete (landing page, pixel/CAPI plan, offer clear).
+- **FIX FIRST** — launchable after named blockers (e.g., no conversion tracking).
+- **DON'T ADVERTISE YET** — spending now would burn budget; say what to build first.
+
+### Step 4: Handoffs
+- Creative production → `/content-generate`, `/content-visual-brief`, `/content-video-script`.
+- Deeper competitor work → `/competitive-intel`.
+- Record the verdict + blockers in the daily note / task board.
+
+# Rules
+- **Advisory only** — never call ad-platform APIs, never handle credentials; the user executes spend.
+- Policies are researched live, never recalled from training.
+- An honest DON'T ADVERTISE YET beats a polite launch plan.
+
+# Output Format
+- **Verdict** + rationale
+- **Offer & Audience** (project-derived, ranked)
+- **Market Snapshot** (with sources)
+- **Campaign Architecture + Budget** (start / scale / kill)
+- **Creative Direction** (handoff-ready)
+- **Measurement Plan + Blockers**

--- a/.claude/commands/ads-review.md
+++ b/.claude/commands/ads-review.md
@@ -1,0 +1,50 @@
+Google Ads review command. Builds a project-aware Google Ads strategy — keyword universe, Search/PMax structure, RSA assets, Quality Score levers, conversion tracking — via the ads-strategist agent. Advisory only: plans and verdicts, no ad spend.
+
+# Required Tools
+- Read (memory, README, product context)
+- Grep / Glob (map the product surface: features, pricing, landing pages)
+- Bash (git log for product maturity signals)
+- WebSearch / WebFetch (keyword/competitor/policy research)
+- Agent (delegate to ads-strategist)
+
+# When to Use
+When you want to advertise this project on Google Ads and need a strategy grounded in what the project actually is. Works like `/ceo-review`: context in, structured verdict out. For Meta use `/meta-review`; for producing creatives use the `content-*` commands. (Note: AdSense — showing ads on your own site — is a different need and out of scope here.)
+
+# Procedure
+
+### Step 1: Project Intake
+- Read `memory.md`, README, and any landing/marketing pages in the repo.
+- Derive: the searchable problem this product solves (Google Ads is intent capture — what would a buyer type?).
+
+### Step 2: Delegate to Ads Strategist (Google lens)
+Launch the **ads-strategist** agent with the project context. Ask for:
+- Keyword universe: seed terms from the project's own vocabulary + research-expanded; match-type plan + negative list starter.
+- Campaign architecture: Search vs Performance Max trade-off for this product; ad-group theming.
+- RSA asset coverage: headlines/descriptions angles derived from real features (hand production to content-*).
+- Quality Score levers: landing page ↔ ad relevance gaps found in the repo's actual pages.
+- Conversion tracking prerequisites (what counts as a conversion for this product; GA4/gtag plan).
+- Starting budget + bid strategy progression (manual/maximize → tCPA when data allows) + kill threshold.
+
+### Step 3: Readiness Gate
+Require an explicit verdict:
+- **READY TO LAUNCH** — landing page matches intent, conversion tracking defined, offer clear.
+- **FIX FIRST** — launchable after named blockers.
+- **DON'T ADVERTISE YET** — intent/landing mismatch or no tracking; spending would burn budget.
+
+### Step 4: Handoffs
+- Ad copy / landing content production → `/content-generate` family.
+- Organic overlap check (don't pay for terms you rank for) → `badi seo` / `/seo`.
+- Record the verdict + blockers in the daily note / task board.
+
+# Rules
+- **Advisory only** — never call ad-platform APIs, never handle credentials; the user executes spend.
+- Policies and benchmark CPCs are researched live, never recalled from training.
+- An honest DON'T ADVERTISE YET beats a polite launch plan.
+
+# Output Format
+- **Verdict** + rationale
+- **Keyword Universe** (seeds, match types, negatives starter)
+- **Campaign Architecture + Budget** (start / scale / kill, bid strategy path)
+- **RSA Asset Direction** (handoff-ready)
+- **Quality Score & Landing Findings** (from the actual repo pages)
+- **Measurement Plan + Blockers**

--- a/.claude/commands/meta-review.md
+++ b/.claude/commands/meta-review.md
@@ -1,0 +1,50 @@
+Meta (Facebook/Instagram) advertising review command. Builds a project-aware Meta ads strategy — audience, campaign structure, creative angles, budget, policy risks — via the ads-strategist agent. Advisory only: plans and verdicts, no ad spend.
+
+# Required Tools
+- Read (memory, README, product context)
+- Grep / Glob (map the product surface: features, pricing, landing pages)
+- Bash (git log for product maturity signals)
+- WebSearch / WebFetch (market + competitor + policy research)
+- Agent (delegate to ads-strategist)
+
+# When to Use
+When you want to advertise this project on Meta (Facebook/Instagram) and need a strategy grounded in what the project actually is. Works like `/ceo-review`: context in, structured verdict out. For Google Ads use `/ads-review`; for producing the actual creatives use `/content-generate`, `/content-visual-brief`, `/content-video-script`.
+
+# Procedure
+
+### Step 1: Project Intake
+- Read `memory.md`, README, and any landing/marketing pages in the repo.
+- Derive: what the product does, who it serves, pricing/offer, current maturity (is there something to send traffic TO?).
+
+### Step 2: Delegate to Ads Strategist (Meta lens)
+Launch the **ads-strategist** agent with the project context. Ask for:
+- Market & competitor research (who advertises in this category on Meta, with what angles).
+- 2-3 ranked audience hypotheses (interests, behaviors, lookalike seeds).
+- Campaign architecture: funnel stages (cold/warm/hot), CBO vs ABO, Advantage+ trade-offs.
+- 3-5 creative angles mapped to funnel stages (hand production to content-* commands).
+- Starting budget + scaling rule + kill threshold.
+- Policy risk scan (restricted categories, claim rules) — verified by research, not memory.
+
+### Step 3: Readiness Gate
+Require an explicit verdict:
+- **READY TO LAUNCH** — funnel complete (landing page, pixel/CAPI plan, offer clear).
+- **FIX FIRST** — launchable after named blockers (e.g., no conversion tracking).
+- **DON'T ADVERTISE YET** — spending now would burn budget; say what to build first.
+
+### Step 4: Handoffs
+- Creative production → `/content-generate`, `/content-visual-brief`, `/content-video-script`.
+- Deeper competitor work → `/competitive-intel`.
+- Record the verdict + blockers in the daily note / task board.
+
+# Rules
+- **Advisory only** — never call ad-platform APIs, never handle credentials; the user executes spend.
+- Policies are researched live, never recalled from training.
+- An honest DON'T ADVERTISE YET beats a polite launch plan.
+
+# Output Format
+- **Verdict** + rationale
+- **Offer & Audience** (project-derived, ranked)
+- **Market Snapshot** (with sources)
+- **Campaign Architecture + Budget** (start / scale / kill)
+- **Creative Direction** (handoff-ready)
+- **Measurement Plan + Blockers**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Badi - Is Akisi Yonetim Sistemi
 
-> Claude Code icin yapilandirilmis operasyon yonetimi. 26 ajan, 82 komut, 14 hook, 62 opt-in skill kategorisi. v1.20+ prompt-aware skill router; v1.25+ pentest-* ailesi (25 kategori, advisory/defensive); v1.26+ profil bazli komut yonetimi (core/dev/content/pentest) + komut routing; v1.27+ expo-* ailesi (12 kategori, Expo + React Native mobile dev lifecycle); v1.32+ sanal eng ekibi (product-strategist, engineering-manager, release-manager, qa-lead + /ceo-review, /eng-review, /qa, /ship) + /team orkestratoru.
+> Claude Code icin yapilandirilmis operasyon yonetimi. 27 ajan, 84 komut, 14 hook, 62 opt-in skill kategorisi. v1.20+ prompt-aware skill router; v1.25+ pentest-* ailesi (25 kategori, advisory/defensive); v1.26+ profil bazli komut yonetimi (core/dev/content/pentest) + komut routing; v1.27+ expo-* ailesi (12 kategori, Expo + React Native mobile dev lifecycle); v1.32+ sanal eng ekibi (product-strategist, engineering-manager, release-manager, qa-lead + /ceo-review, /eng-review, /qa, /ship) + /team orkestratoru; v1.33+ reklam review (ads-strategist ajani + /meta-review + /ads-review, advisory-only).
 
 ## Bellek Kurallari
 
@@ -11,7 +11,7 @@
 | Gorev Panosu | `.claude/workspace/TaskBoard.md` | Sinir yok |
 | Skills Vault | `.claude/skills-vault/` | 62 kategori (25 genel + 25 pentest-* + 12 expo-*), yuklenmez (opt-in) |
 | Aktif Skills | `.claude/skills/` | Kullanici secimi (`badi skills`) |
-| Commands Vault | `.claude/commands-vault/` | 82 komut canonical (v1.26+), yuklenmez |
+| Commands Vault | `.claude/commands-vault/` | 84 komut canonical (v1.26+), yuklenmez |
 | Aktif Commands | `.claude/commands/` | Profile gore filtrelenir (`badi commands profile`) |
 
 - `knowledge-base.md` icinde TBD/TODO/FIXME **YASAK**

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Source of truth: npm. Other channels mirror the same `@fatihkan/badi-<version>.t
 /plugin install badi@badi-marketplace
 ```
 
-**As an npm CLI (full feature set: 26 agents · 82 commands with profile management (v1.26+) · 13 hooks · 62 opt-in skill categories with auto-router)**:
+**As an npm CLI (full feature set: 27 agents · 84 commands with profile management (v1.26+) · 13 hooks · 62 opt-in skill categories with auto-router)**:
 
 ```bash
 npx @fatihkan/badi init                    # interactive harness picker
@@ -82,7 +82,7 @@ Claude is the canonical source. Cursor/Gemini/Windsurf/AGENTS.md adapters compil
 
 | Feature | Details |
 |---------|---------|
-| **26 expert agents + 82 commands** | Full toolkit from security scanner to performance profiler, plus a virtual eng team (CEO / eng manager / release manager / QA lead) wired together by `/team` — profile-based filtering (core/dev/content/pentest) since v1.26 |
+| **27 expert agents + 84 commands** | Full toolkit from security scanner to performance profiler, plus a virtual eng team (CEO / eng manager / release manager / QA lead) wired together by `/team` — profile-based filtering (core/dev/content/pentest) since v1.26 |
 | **14 automation hooks + 62 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants. Skills load zero tokens by default since v1.17; auto-router (v1.20+) injects matching skills per prompt; pentest-* family (v1.25+ advisory/defensive); expo-* family (v1.27+ mobile dev lifecycle); command routing (v1.26+); plan-injection hook (v1.30+) |
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+, expanded v1.30+)** | Claude Code, Cursor, Gemini CLI, Windsurf, AGENTS.md — same `.claude/` source, 5 targets |
@@ -105,7 +105,7 @@ npx @fatihkan/badi init
 badi doctor
 
 # Daily workflow
-badi list --agents     # List 26 agents
+badi list --agents     # List 27 agents
 badi stats             # Usage analytics
 badi schedule list     # Reminders
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ The plugin path ships agents, slash commands, and the two universal safety hooks
 # List the 21 agents
 badi list --agents
 
-# Browse the 82 commands
+# Browse the 84 commands
 badi list --commands
 
 # See what skills are available

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: "Badi"
   text: "Workflow management CLI"
-  tagline: "26 AI agents · 82 commands · 12 safety hooks · 23 opt-in skills — for Claude Code, Cursor, and Gemini CLI"
+  tagline: "27 AI agents · 84 commands · 12 safety hooks · 23 opt-in skills — for Claude Code, Cursor, and Gemini CLI"
   actions:
     - theme: brand
       text: Get Started

--- a/lib/command-profiles.js
+++ b/lib/command-profiles.js
@@ -1,6 +1,6 @@
 // Komut profil tanimlari.
 //
-// 82 .claude/commands/ dosyasi 4 profile bolunur:
+// 84 .claude/commands/ dosyasi 4 profile bolunur:
 //   core    — her zaman aktif (oturum yonetimi, olcum)
 //   dev     — kod/altyapi/devops odakli
 //   content — sosyal medya/marketing odakli
@@ -87,7 +87,9 @@ export const COMMAND_PROFILES = {
 	wp: "dev",
 	mobile: "dev",
 
-	// content (17) — icerik uretim/marketing
+	// content (19) — icerik uretim/marketing + reklam review
+	"meta-review": "content",
+	"ads-review": "content",
 	"content-generate": "content",
 	"content-start": "content",
 	"content-status": "content",

--- a/tests/agent-frontmatter.test.js
+++ b/tests/agent-frontmatter.test.js
@@ -31,6 +31,7 @@ const READ_ONLY_AGENTS = new Set([
 	"product-strategist",
 	"engineering-manager",
 	"qa-lead",
+	"ads-strategist",
 ]);
 
 const PRODUCER_AGENTS = new Set([
@@ -74,8 +75,8 @@ function listAgents() {
 describe("agent frontmatter audit (#90)", () => {
 	const agents = listAgents();
 
-	it("26 ajan mevcut", () => {
-		assert.equal(agents.length, 26);
+	it("27 ajan mevcut", () => {
+		assert.equal(agents.length, 27);
 	});
 
 	it("her ajan READ_ONLY veya PRODUCER kategorisinde", () => {

--- a/tests/command-profiles.test.js
+++ b/tests/command-profiles.test.js
@@ -119,7 +119,7 @@ describe("command-profiles: isInProfile", () => {
 });
 
 describe("command-profiles: profileCounts", () => {
-	it("toplam tanimli komut sayisi 82 olmali", () => {
+	it("toplam tanimli komut sayisi 84 olmali", () => {
 		const counts = profileCounts();
 		const total = counts.core + counts.dev + counts.content + counts.pentest;
 		assert.equal(total, Object.keys(COMMAND_PROFILES).length);


### PR DESCRIPTION
## Summary

Adds a **project-aware paid-advertising review layer**, modeled on the `/ceo-review` pattern: badi already knows the project (memory, code, target user) — these commands turn that context plus **live market research** into a platform-specific ad strategy with a launch-readiness verdict.

| Command | Platform | Focus |
|---------|----------|-------|
| `/meta-review` | Meta (FB/IG) | audience hypotheses, funnel structure (CBO/ABO, Advantage+), creative angles, policy risk |
| `/ads-review` | Google Ads | keyword universe + negatives, Search vs PMax, RSA assets, Quality Score levers, conversion tracking |

Both delegate to the new **`ads-strategist`** agent (READ_ONLY, advisory) — the first agent in the fleet with `WebSearch`/`WebFetch` (market/competitor/policy research is live, never recalled from training). Verdict frame: **READY TO LAUNCH / FIX FIRST / DON'T ADVERTISE YET** with budget start/scale/kill rules and a measurement plan.

## Hard boundary (locked by the prior `/ceo-review`)
**Advisory-only.** No ad-platform APIs, no credential handling, no spend automation — the user executes spend. Creative production hands off to `content-generate`/`content-visual-brief`/`content-video-script`; deep competitor work to `/competitive-intel`. AdSense (publisher side) is out of scope — different need.

## Wiring
- `command-profiles.js`: 2 commands → `content` profile (total 82 → 84)
- `tests/agent-frontmatter.test.js`: agent count 26 → 27; `ads-strategist` in READ_ONLY set
- `tests/command-profiles.test.js`: total-count title → 84
- Manifests regenerated (27 agents) · doc counts (CLAUDE.md `v1.33+` marker, README, docs)

## Test plan
- [x] `npm test` — **1161 pass / 0 fail** (+6 dynamic frontmatter tests for the new agent)
- [x] `npx biome check` — clean
- [x] `badi doctor` — healthy
- [x] Both commands registered and visible in the skill list

## Run method
`/ceo-review` (scope + advisory boundary) → `/eng-review` (1 agent + 2 commands, ceo-review pattern) → build → QA → ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)