### PR TITLE
feat(i18n): English descriptions + regenerated command index + docs currency

### DIFF
--- a/.claude/agents/api-designer.md
+++ b/.claude/agents/api-designer.md
@@ -1,6 +1,6 @@
 ---
 name: api-designer
-description: API tasarim uzmani - REST/GraphQL tutarliligi, dokumantasyon, versiyon stratejisi
+description: API design expert - REST/GraphQL consistency, documentation, versioning strategy
 tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project

--- a/.claude/agents/archaeologist.md
+++ b/.claude/agents/archaeologist.md
@@ -1,6 +1,6 @@
 ---
 name: archaeologist
-description: Kod gecmisi arastirmacisi - "Neden boyle yazildi?" sorusunu cevaplar
+description: Code history researcher - answers the 'why was it written this way?' question
 tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: none

--- a/.claude/agents/architecture-advisor.md
+++ b/.claude/agents/architecture-advisor.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-advisor
-description: Mimari tasarim danismani - tasarim kaliplari, sistem tasarimi, ADR olusturma
+description: Architecture design advisor - design patterns, system design, ADR creation
 tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project

--- a/.claude/agents/auditor.md
+++ b/.claude/agents/auditor.md
@@ -1,6 +1,6 @@
 ---
 name: auditor
-description: Kalite guvence kapisi - ciktilari dogrular, tutarsizliklari tespit eder
+description: Quality assurance gate - verifies outputs, detects inconsistencies
 tools: [Read, Grep, Glob, Write, Edit, Bash]
 model: sonnet
 memory: project

--- a/.claude/agents/coach.md
+++ b/.claude/agents/coach.md
@@ -1,6 +1,6 @@
 ---
 name: coach
-description: Proaktif danisman - veri odakli kalip tespiti ve kocluk
+description: Proactive advisor - data-driven pattern detection and coaching
 tools: [Read, Grep, Glob, Write, Edit]
 model: sonnet
 memory: project

--- a/.claude/agents/code-generator.md
+++ b/.claude/agents/code-generator.md
@@ -1,6 +1,6 @@
 ---
 name: code-generator
-description: Kod iskele ve sablonlari olusturur - boilerplate, API stublari, tip tanimlari
+description: Generates code scaffolding and templates - boilerplate, API stubs, type definitions
 tools: [Read, Write, Grep, Glob, Bash]
 model: sonnet
 memory: project

--- a/.claude/agents/content-creator.md
+++ b/.claude/agents/content-creator.md
@@ -1,6 +1,6 @@
 ---
 name: content-creator
-description: Sosyal medya icerik ureticisi - post, gorsel brief, video senaryo, hikaye, reel
+description: Social media content producer - posts, visual briefs, video scripts, stories, reels
 tools: [Read, Write, Edit, Grep, Glob, Bash]
 model: sonnet
 memory: project

--- a/.claude/agents/debt-collector.md
+++ b/.claude/agents/debt-collector.md
@@ -1,6 +1,6 @@
 ---
 name: debt-collector
-description: Teknik borc tarayici ve onceliklendirme sistemi
+description: Technical debt scanner and prioritization system
 tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project

--- a/.claude/agents/error-whisperer.md
+++ b/.claude/agents/error-whisperer.md
@@ -1,6 +1,6 @@
 ---
 name: error-whisperer
-description: Hata teshis ve cozum uzman - hatalari okunabilir dile cevirir
+description: Error diagnosis and resolution expert - translates errors into readable language
 tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: none

--- a/.claude/agents/migration-pilot.md
+++ b/.claude/agents/migration-pilot.md
@@ -1,6 +1,6 @@
 ---
 name: migration-pilot
-description: Goc planlama uzmani - veritabani/framework gocleri icin risk analizi ve adim adim plan
+description: Migration planning expert - risk analysis and step-by-step plans for database/framework migrations
 tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project

--- a/.claude/agents/onboarding-sherpa.md
+++ b/.claude/agents/onboarding-sherpa.md
@@ -1,6 +1,6 @@
 ---
 name: onboarding-sherpa
-description: Kod tabani rehberi - yeni projeleri dakikalar icinde anlasilir kilar
+description: Codebase guide - makes new projects understandable within minutes
 tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project

--- a/.claude/agents/performance-profiler.md
+++ b/.claude/agents/performance-profiler.md
@@ -1,6 +1,6 @@
 ---
 name: performance-profiler
-description: Performans analiz uzmani - darbogaz, N+1, bellek sizintisi tespiti
+description: Performance analysis expert - bottleneck, N+1, memory leak detection
 tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project

--- a/.claude/agents/pr-ghostwriter.md
+++ b/.claude/agents/pr-ghostwriter.md
@@ -1,6 +1,6 @@
 ---
 name: pr-ghostwriter
-description: PR aciklamalari, commit mesajlari ve changelog girdileri olusturur
+description: Writes PR descriptions, commit messages, and changelog entries
 tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: none

--- a/.claude/agents/project-architect.md
+++ b/.claude/agents/project-architect.md
@@ -1,6 +1,6 @@
 ---
 name: project-architect
-description: Proje planlama uzmani - fikirden uygulanabilir blueprint'e 5 dokuman uretir
+description: Project planning expert - produces 5 documents from idea to actionable blueprint
 tools: [Read, Write, Edit, Grep, Glob, Bash]
 model: sonnet
 memory: project

--- a/.claude/agents/refactoring-advisor.md
+++ b/.claude/agents/refactoring-advisor.md
@@ -1,6 +1,6 @@
 ---
 name: refactoring-advisor
-description: Kod kalitesi ve refactoring uzmani - kalip tespiti, modernizasyon onerileri
+description: Code quality and refactoring expert - pattern detection, modernization suggestions
 tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project

--- a/.claude/agents/rubber-duck.md
+++ b/.claude/agents/rubber-duck.md
@@ -1,6 +1,6 @@
 ---
 name: rubber-duck
-description: Sokratik sorgulama ortagi - karmasik kararlar icin dusunce partneri
+description: Socratic questioning partner - a thinking partner for complex decisions
 tools: [Read, Grep, Glob]
 model: sonnet
 memory: none

--- a/.claude/agents/security-scanner.md
+++ b/.claude/agents/security-scanner.md
@@ -1,6 +1,6 @@
 ---
 name: security-scanner
-description: Guvenlik acigi tarayicisi - OWASP Top 10, gizli bilgi, bagimlilik analizi
+description: Security vulnerability scanner - OWASP Top 10, secrets, dependency analysis
 tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project

--- a/.claude/agents/tasarim-kurator.md
+++ b/.claude/agents/tasarim-kurator.md
@@ -1,6 +1,6 @@
 ---
 name: tasarim-kurator
-description: DESIGN.md kuratoru — marka degerleri, hedef kitle, renk psikolojisi ve tipografi karakterini sorgulayarak rationale-dolu DESIGN.md uretir. `badi tasarim init --interactive` cagrisinda devreye girer.
+description: DESIGN.md curator - produces a rationale-rich DESIGN.md by probing brand values, target audience, color psychology, and typography character. Activates on badi design init --interactive.
 tools: [Read, Write, Edit, Grep, Glob]
 model: sonnet
 memory: project

--- a/.claude/agents/test-strategist.md
+++ b/.claude/agents/test-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: test-strategist
-description: Test strateji uzmani - kapsam analizi, test planlama, test piramidi
+description: Test strategy expert - coverage analysis, test planning, test pyramid
 tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: project

--- a/.claude/agents/unsticker.md
+++ b/.claude/agents/unsticker.md
@@ -1,6 +1,6 @@
 ---
 name: unsticker
-description: Kok neden analizcisi - proje tikaniklarini teshis eder ve cozer
+description: Root-cause analyst - diagnoses and resolves project blockers
 tools: [Read, Grep, Glob, Bash]
 model: sonnet
 memory: none

--- a/.claude/agents/visual-director.md
+++ b/.claude/agents/visual-director.md
@@ -1,6 +1,6 @@
 ---
 name: visual-director
-description: Gorsel yonetmen - gorsel brief, renk paleti, kompozisyon, AI prompt olusturma
+description: Visual director - visual briefs, color palettes, composition, AI prompt creation
 tools: [Read, Write, Edit, Grep, Glob]
 model: sonnet
 memory: project

--- a/.claude/agents/yak-shave-detector.md
+++ b/.claude/agents/yak-shave-detector.md
@@ -1,6 +1,6 @@
 ---
 name: yak-shave-detector
-description: Kapsam kaymasi dedektoru - gorev rayli disina cikmayi engeller
+description: Scope-creep detector - keeps tasks from going off the rails
 tools: [Read, Grep, Glob]
 model: haiku
 memory: none

--- a/.claude/command-index.md
+++ b/.claude/command-index.md
@@ -1,93 +1,102 @@
-# Badi Komut Indeksi
+# Badi Command Index
 
-> 50 komut | 10 kategori
+> 84 commands | 3 profiles (core / dev / content) — filter with `badi commands profile <name>`
 
-## Oturum Yonetimi
-| Komut | Aciklama | Tetikleyici |
-|-------|----------|-------------|
-| `/start` | Oturumu baslat, oncelikleri belirle | Her oturum basi |
-| `/sync` | Oturum ortasinda baglam yenile | Gerektiginde |
-| `/clear` | Baglami temizle ve sifirla | Token limiti yaklastiginda |
-| `/wrap-up` | Gun sonu rituel, ozet ve yarin plani | Her oturum sonu |
+## Core — always active (session, audit, measurement) (21)
 
-## Kalite Kontrol
-| Komut | Aciklama | Tetikleyici |
-|-------|----------|-------------|
-| `/audit` | Kod kalitesi denetimi (T1-T4 seviyeleri) | Ozellik tamamlandiginda |
-| `/review` | Derinlemesine kod incelemesi | PR oncesi |
-| `/doctor` | Badi konfigurasyonunu dogrula | Ayda bir veya sorun oldugunda |
+| Command | Description |
+|---------|-------------|
+| `/ai-token` | Badi/.claude/ token usage analysis command. Categorized token counts, largest files, optimization suggestions. |
+| `/audit` | Quality audit command. Runs a systematic audit over code, structure, or process. |
+| `/clear` | Context-clearing command. Provides a seamless transition across session boundaries. Target: under 30 seconds. |
+| `/coach` | Coaching analysis command. Performs data-driven work-pattern analysis and offers personal improvement suggestions. |
+| `/dashboard` | Daily statistics panel. Presents task, audit, event, and performance data as a unified table. |
+| `/doctor` | Badi configuration validation. Checks all Badi components and produces a diagnostic report. |
+| `/drift-detect` | Configuration drift detection command. Finds inconsistencies, orphaned components, and stale content in the Badi system. |
+| `/handoff` | Handoff briefing command. Enables a smooth transition to another developer or session. |
+| `/health` | System health check. Audits dependencies, security, performance, and (if present) the production domain with a triple scan. |
+| `/memory-diff` | Memory and knowledge-base limit check + global project comparison. |
+| `/onboard` | Project onboarding command. For adapting to a new project quickly and thoroughly. |
+| `/plugin` | Plugin management command. Installs, removes, and lists plugins in the Badi system. |
+| `/prompt-test` | Regression test for slash command and agent files. Format and content validation. |
+| `/schedule` | Scheduled command reminders. Shell-based reminder system for daily/weekly recurring tasks. |
+| `/standup` | Daily standup command. Produces a quick status summary in under 30 seconds. |
+| `/start` | Badi session start command. Runs new-project onboarding or a daily kickoff. |
+| `/stats` | Usage analytics command. Badi tool usage statistics, bar charts, daily trends, habit streaks. |
+| `/sync` | Mid-session context refresh command. Keeps context fresh and consistent during work. |
+| `/system-audit` | Deep infrastructure audit command. Comprehensively audits all Badi components across 9 checkpoints. |
+| `/unstick` | Unblocking command. Finds a fast solution with a structured approach when you're stuck. |
+| `/wrap-up` | End-of-day ritual command. Prepares the day for closure and sets the stage for tomorrow. |
 
-## Dagitim ve Surum
-| Komut | Aciklama | Tetikleyici |
-|-------|----------|-------------|
-| `/release` | Surum notlari olustur | Surum oncesi |
-| `/launch` | Urun lansman plani | Yeni urun/ozellik |
-| `/deploy` | Dagitim kontrol listesi | Dagitim oncesi |
-| `/hotfix` | Acil duzeltme is akisi | Uretim sorunu |
-| `/changelog` | Git'ten degisiklik gunlugu olustur | Surum oncesi |
+## Dev — code / infra / devops (44)
 
-## Koordinasyon
-| Komut | Aciklama | Tetikleyici |
-|-------|----------|-------------|
-| `/standup` | Gunluk toplanti ozeti | Her sabah |
-| `/retro` | Sprint retrospektifi | Sprint sonu |
-| `/onboard` | Proje alistirma | Yeni proje/uye |
-| `/handoff` | Is teslim brifingi | Gorev devri |
+| Command | Description |
+|---------|-------------|
+| `/a11y-audit` | Web accessibility (WCAG 2.1) audit command. axe-core-based checks via PageSpeed Insights. |
+| `/adr` | Architecture Decision Record (ADR) command. Documents architectural decisions in a structured format. |
+| `/ai-review` | AI code review of the staged git diff via the Claude API. |
+| `/ai-translate` | Markdown file translation. Technical/content translation via the Claude API (without breaking markdown structure). |
+| `/api-doc` | API documentation generation. Scans route definitions and produces structured API docs. |
+| `/api-test` | HTTP API endpoint testing. Send GET/POST/PUT/DELETE requests, analyze status + response, assertions. |
+| `/architect` | Project planning command. Turns vague project ideas into 5 structured documents: specification, implementation plan, task list, brand identity, and a kickoff prompt. |
+| `/aso` | App Store Optimization command. iOS app listing analysis via the iTunes API, keyword optimization, and competitor comparison. |
+| `/brief` | Project briefing command. Turns raw project ideas into structured, actionable briefs. |
+| `/bundle-analyze` | Bundle size + framework detection + largest assets + heavy-dependency warnings. |
+| `/ceo-review` | CEO/product review command. Challenges a feature or roadmap from the top — should we build it, for whom, what does success look like — via the product-strategist agent. |
+| `/changelog` | Automatic changelog generation. Produces a structured changelog from commit history. |
+| `/changelog-gen` | CHANGELOG.md update command. Generates a changelog from git history grouped by conventional commit types. |
+| `/conv-commit` | Conventional commit helper command. Reads staged files, suggests type/scope/message, and validates. |
+| `/debt-map` | Technical debt mapping command. Systematically detects and prioritizes technical debt in the codebase. |
+| `/deploy` | Deployment checklist. Verifies all pre-deployment requirements and produces a readiness report. |
+| `/deps-update` | Safe dependency update analysis. Patch/minor/major categorization with optional automatic patch application. |
+| `/dns-audit` | DNS record audit command. Checks A/AAAA/MX/TXT/SPF/DMARC/CAA records and scores email security. |
+| `/docker-lint` | Dockerfile best-practice checks. Security, size, and reproducibility warnings. |
+| `/docs-audit` | Documentation audit command. Evaluates completeness, freshness, and quality of technical documentation. |
+| `/eng-review` | Engineering review command. Turns a green-lit goal into a locked architecture and a sequenced, shippable increment plan via the engineering-manager agent. |
+| `/env-check` | .env file validation. Detects missing, extra, empty, and placeholder values + .gitignore check. |
+| `/hotfix` | Emergency fix workflow. Manages a fast, safe patching process for production errors. |
+| `/lighthouse` | Lighthouse audit command. Performance, Accessibility, Best Practices, SEO scores and Core Web Vitals via the Google PageSpeed Insights API. |
+| `/mobile` | Mobile project management command. React Native/Flutter/Expo/Swift/Kotlin scaffolding, version sync, build and release guides. |
+| `/perf-check` | Performance profiling. Detects hot paths, bottlenecks, and optimization opportunities. |
+| `/playbook` | Workflow-to-command command. Converts repetitive manual workflows into reusable Badi commands. |
+| `/post-mortem` | Post-incident analysis (post-mortem) command. Documents root-cause analysis of production incidents and major failures. |
+| `/qa` | QA sign-off command. Verifies a change against acceptance criteria, runs the test suite, probes edge cases, and issues a ship / no-ship verdict via the qa-lead agent. |
+| `/refactor` | Refactoring command. Detects code smells and creates a safe refactoring plan. |
+| `/release` | Release notes command. Compiles changes into formats for 3 different audiences. |
+| `/report` | Professional report command. Turns raw data and findings into professional, audience-appropriate reports. |
+| `/retro` | Sprint retrospective command. Analyzes the past period and identifies improvement areas. |
+| `/review` | Deep code review command. Comprehensive code analysis across security, performance, and architecture. |
+| `/scaffold` | Code scaffolding command. Analyzes project structure and generates consistent module, component, or API skeletons. |
+| `/secret-scan` | Project-wide secret/credential scan command. AWS/GCP/GitHub/npm/Stripe/OpenAI/Anthropic keys, JWTs, database URIs, private keys. |
+| `/security-scan` | Security scan. Searches the codebase and dependencies for vulnerabilities and produces a severity-ranked report. |
+| `/seo` | SEO audit command. Website SEO analysis, meta tag checks, sitemap validation, and speed assessment. |
+| `/ship` | Ship command. Runs the pre-flight gate, decides the version bump, assembles the changelog, and opens the PR via the release-manager agent. Nothing ships unless the gate is green. |
+| `/spec-check` | Specification conformance command. Audits the current code against SPECIFICATION.md, detecting feature gaps and scope drift. |
+| `/ssl-check` | SSL certificate analysis command. Checks certificate validity, TLS version, and cipher strength for a domain. |
+| `/team` | Virtual eng team orchestrator. Runs a goal end-to-end through the whole team — strategy → plan → build → QA → ship — conducted by the engineering-manager, delegating to every specialist. One entry point that connects /ceo-review, /eng-review, /qa, and /ship. |
+| `/whois` | Domain WHOIS command. Checks registration date, expiry, registrar, and transfer lock status. |
+| `/wp` | WordPress site management command. Site status, plugin/theme management, security scan, and bulk updates. |
 
-## Analiz ve Strateji
-| Komut | Aciklama | Tetikleyici |
-|-------|----------|-------------|
-| `/debt-map` | Teknik borc haritasi | Ayda bir |
-| `/competitive-intel` | Rekabet analizi | Strateji planlamasi |
-| `/drift-detect` | Konfigurasyon sapma tespiti | Ayda bir |
-| `/system-audit` | Derin altyapi denetimi | Ayda bir |
-| `/brief` | Proje brifingi olustur | Yeni proje |
-| `/proposal` | Musteri teklifi olustur | Teklif istendiginde |
+## Content — content production / marketing / paid ads (19)
 
-## Destek ve Kocluk
-| Komut | Aciklama | Tetikleyici |
-|-------|----------|-------------|
-| `/coach` | Veri odakli is kaliplari analizi | Haftalik |
-| `/unstick` | Tikaniklik cozme | Sorun yasadiginda |
-| `/report` | Profesyonel rapor olustur | Raporlama gerektiginde |
-| `/playbook` | Is akisini komuta donustur | Tekrarlanan islemler |
-
-## Guvenlik ve Performans
-| Komut | Aciklama | Tetikleyici |
-|-------|----------|-------------|
-| `/health` | Sistem sagligi kontrolu | Hafta basi |
-| `/security-scan` | Guvenlik acigi taramas | Sprint sonu |
-| `/perf-check` | Performans profilleme | Ozellik tamamlandiginda |
-| `/api-doc` | API dokumantasyonu olustur | API degisikliginde |
-
-## Yazilim Muhendisligi
-| Komut | Aciklama | Tetikleyici |
-|-------|----------|-------------|
-| `/scaffold` | Kod iskelesi olusturma (modul, API, CRUD) | Yeni bilesen olusturulacaginda |
-| `/refactor` | Kod kokusu tespiti ve refactoring plani | Kod kalitesi iyilestirmesinde |
-| `/adr` | Mimari Karar Kaydi (ADR) olustur | Onemli teknik kararlarda |
-| `/post-mortem` | Olay sonrasi analiz raporu | Uretim olayi sonrasinda |
-| `/docs-audit` | Dokumantasyon denetimi | Ayda bir veya buyuk degisiklik sonrasi |
-| `/architect` | Proje planlama — fikirden 5 dokuman uret | Yeni proje baslatildiginda |
-| `/spec-check` | Spesifikasyon uyum kontrolu | Gelistirme sirasinda |
-
-## Icerik Uretimi ve Sosyal Medya
-| Komut | Aciklama | Tetikleyici |
-|-------|----------|-------------|
-| `/content-start` | Gunluk icerik seansini baslat | Her gun sabah |
-| `/content-plan` | Haftalik icerik planlama seansi | Haftalik (Pazar aksami) |
-| `/content-status` | Icerik uretim durumu paneli | Gunluk kontrol |
-| `/content-close` | Gun sonu icerik kapanis rituelu | Her gun aksam |
-| `/content-idea` | Yapilandirilmis icerik fikir listesi uret | Fikir tikanikligi |
-| `/content-generate` | Sosyal medya icerigi uret (post, caption, gorsel brief) | Icerik gerektiginde |
-| `/content-visual-brief` | Gorsel tasarim brifingi ve AI prompt olustur | Gorsel gerektiginde |
-| `/content-video-script` | Video senaryosu yaz (Reels, Shorts, TikTok, YouTube) | Video planlandiginda |
-| `/content-calendar` | Haftalik/aylik icerik takvimi olustur | Hafta/ay basinda |
-| `/content-brand-voice` | Marka sesi rehberi tanimla ve yonet | Ilk kurulum ve guncelleme |
-| `/content-carousel` | Karousel (coklu kare) icerik olustur | Egitici/liste icerigi icin |
-
-## Dashboard ve Plugin
-| Komut | Aciklama | Tetikleyici |
-|-------|----------|-------------|
-| `/dashboard` | Gunluk istatistik paneli | Gerektiginde |
-| `/plugin` | Plugin yukleme/kaldirma/listeleme | Plugin islemlerinde |
+| Command | Description |
+|---------|-------------|
+| `/ads-review` | Google Ads review command. Builds a project-aware Google Ads strategy — keyword universe, Search/PMax structure, RSA assets, Quality Score levers, conversion tracking — via the ads-strategist agent. Advisory only: plans and verdicts, no ad spend. |
+| `/competitive-intel` | Competitive analysis command. Analyzes the market, competitors, and opportunities with a comprehensive competitive-intelligence framework. |
+| `/content-brand-voice` | Brand voice definition and management command. Creates a brand voice guide to keep tone, style, and personality consistent across all content. |
+| `/content-calendar` | Content calendar command. Creates a weekly or monthly social media content plan with themes, platforms, and timing. |
+| `/content-carousel` | Carousel (multi-frame) content command. Produces educational or storytelling carousel content for Instagram, LinkedIn, and other platforms. |
+| `/content-close` | Content session close command. Summarizes the day's output, prepares for tomorrow, and notes learnings. |
+| `/content-generate` | Social media content generation command. Produces ready-to-use posts, captions, visual briefs, and hashtags for the given platform and type. |
+| `/content-idea` | Content idea generation command. Creates a structured idea list for a topic, theme, or platform. |
+| `/content-perf` | Content performance tracking command. Tracks likes, comments, reach, and ROI for published content. |
+| `/content-plan` | Weekly content planning session command. Sets next week's content strategy, themes, and production targets. |
+| `/content-search` | Content archive search command. Keyword search, similarity detection, and filtering across all generated content. |
+| `/content-start` | Content production session start command. Gives the daily content session a structured start, shows pending work, and sets priorities. |
+| `/content-status` | Content production status panel. Shows current output volume, pending items, calendar fit, and trend data. |
+| `/content-template` | Content template inheritance command. Custom template creation and inheritance-chain management for recurring content types. |
+| `/content-video-script` | Video script command. Scene-by-scene scripts, captions, and visualization plans for Reels, Shorts, TikTok, and YouTube. |
+| `/content-visual-brief` | Visual brief command. Detailed design instructions, color palettes, and AI image prompts for social visuals, banners, and video frames. |
+| `/launch` | Product launch plan command. Creates a comprehensive plan for a new product or feature launch. |
+| `/meta-review` | Meta (Facebook/Instagram) advertising review command. Builds a project-aware Meta ads strategy — audience, campaign structure, creative angles, budget, policy risks — via the ads-strategist agent. Advisory only: plans and verdicts, no ad spend. |
+| `/proposal` | Client proposal command. Builds a professional client proposal from project summaries. Valid for 30 days. |

--- a/.claude/commands-vault/a11y-audit.md
+++ b/.claude/commands-vault/a11y-audit.md
@@ -1,4 +1,4 @@
-Web accessibility (WCAG 2.1) denetim komutu. PageSpeed Insights uzerinden axe-core tabanli kontrol.
+Web accessibility (WCAG 2.1) audit command. axe-core-based checks via PageSpeed Insights.
 
 # Gerekli Araclar
 - Bash (badi a11y komutu cagirisi)

--- a/.claude/commands-vault/adr.md
+++ b/.claude/commands-vault/adr.md
@@ -1,4 +1,4 @@
-Mimari Karar Kaydi (ADR) olusturma komutu. Mimari kararlari yapilandirilmis formatta belgeler.
+Architecture Decision Record (ADR) command. Documents architectural decisions in a structured format.
 
 # Gerekli Araclar
 - Read (mevcut ADR'ler)

--- a/.claude/commands-vault/ai-review.md
+++ b/.claude/commands-vault/ai-review.md
@@ -1,4 +1,4 @@
-Staged git diff icin Claude API ile AI kod review.
+AI code review of the staged git diff via the Claude API.
 
 # Gerekli Araclar
 - Bash (badi ai review)

--- a/.claude/commands-vault/ai-token.md
+++ b/.claude/commands-vault/ai-token.md
@@ -1,4 +1,4 @@
-Badi/.claude/ token kullanim analiz komutu. Kategorize edilmis token sayimi, en buyuk dosyalar, optimizasyon onerileri.
+Badi/.claude/ token usage analysis command. Categorized token counts, largest files, optimization suggestions.
 
 # Gerekli Araclar
 - Bash (badi ai token)

--- a/.claude/commands-vault/ai-translate.md
+++ b/.claude/commands-vault/ai-translate.md
@@ -1,4 +1,4 @@
-Markdown dosya cevirisi. Claude API ile teknik/icerik cevirisi (markdown yapisini bozmadan).
+Markdown file translation. Technical/content translation via the Claude API (without breaking markdown structure).
 
 # Gerekli Araclar
 - Bash (badi ai translate)

--- a/.claude/commands-vault/api-doc.md
+++ b/.claude/commands-vault/api-doc.md
@@ -1,4 +1,4 @@
-API dokumantasyonu olusturma. Route tanimlarini tarar ve yapilandirilmis API belgeleri uretir.
+API documentation generation. Scans route definitions and produces structured API docs.
 
 # Gerekli Araclar
 - Bash (dosya sistemi) -- Read (kaynak kod) -- Grep (route/endpoint) -- Glob (dosya tespiti) -- Write (dok dosyasi) -- Agent (api-designer: detayli API analiz)

--- a/.claude/commands-vault/api-test.md
+++ b/.claude/commands-vault/api-test.md
@@ -1,4 +1,4 @@
-HTTP API endpoint test. GET/POST/PUT/DELETE istek gonder, status + response analiz, assertion.
+HTTP API endpoint testing. Send GET/POST/PUT/DELETE requests, analyze status + response, assertions.
 
 # Gerekli Araclar
 - Bash (badi dev api-test)

--- a/.claude/commands-vault/architect.md
+++ b/.claude/commands-vault/architect.md
@@ -1,4 +1,4 @@
-Proje planlama komutu. Belirsiz proje fikirlerini 5 yapilandirilmis dokumana donusturur: spesifikasyon, uygulama plani, gorev listesi, marka kimligi ve calistirma prompt'u.
+Project planning command. Turns vague project ideas into 5 structured documents: specification, implementation plan, task list, brand identity, and a kickoff prompt.
 
 # Gerekli Araclar
 - Read (referans dosyalari, mevcut proje bilgisi)

--- a/.claude/commands-vault/aso.md
+++ b/.claude/commands-vault/aso.md
@@ -1,4 +1,4 @@
-App Store Optimization komutu. iTunes API ile iOS app listing analizi, keyword optimizasyonu ve rakip karsilastirmasi.
+App Store Optimization command. iOS app listing analysis via the iTunes API, keyword optimization, and competitor comparison.
 
 # Gerekli Araclar
 - Bash (badi aso komutlari)

--- a/.claude/commands-vault/audit.md
+++ b/.claude/commands-vault/audit.md
@@ -1,4 +1,4 @@
-Kalite denetimi komutu. Kod, yapi veya surec uzerinde sistematik denetim yapar.
+Quality audit command. Runs a systematic audit over code, structure, or process.
 
 ## Badi CLI Komutlari (v1.6+)
 Seviye T4 (Kapsamli) denetimde su CLI araclari calistirir:

--- a/.claude/commands-vault/brief.md
+++ b/.claude/commands-vault/brief.md
@@ -1,4 +1,4 @@
-Proje brifingi komutu. Ham proje fikirlerini yapilandirilmis, uygulanabilir brifinglara donusturur.
+Project briefing command. Turns raw project ideas into structured, actionable briefs.
 
 # Gerekli Araclar
 - Read (mevcut proje bilgileri)

--- a/.claude/commands-vault/bundle-analyze.md
+++ b/.claude/commands-vault/bundle-analyze.md
@@ -1,4 +1,4 @@
-Bundle size + framework tespit + en buyuk asset'ler + agir bagimlilik uyarisi.
+Bundle size + framework detection + largest assets + heavy-dependency warnings.
 
 # Gerekli Araclar
 - Bash (badi dev bundle)

--- a/.claude/commands-vault/changelog-gen.md
+++ b/.claude/commands-vault/changelog-gen.md
@@ -1,4 +1,4 @@
-CHANGELOG.md guncelleme komutu. Git gecmisinden conventional commit tipleriyle gruplanmis changelog uretir.
+CHANGELOG.md update command. Generates a changelog from git history grouped by conventional commit types.
 
 # Gerekli Araclar
 - Bash (badi changelog komutu cagirisi)

--- a/.claude/commands-vault/changelog.md
+++ b/.claude/commands-vault/changelog.md
@@ -1,4 +1,4 @@
-Otomatik degisiklik gunlugu olusturma. Commit gecmisinden yapilandirilmis changelog uretir.
+Automatic changelog generation. Produces a structured changelog from commit history.
 
 ## Badi CLI Komutu (v1.6+)
 Hizli uretim icin:

--- a/.claude/commands-vault/clear.md
+++ b/.claude/commands-vault/clear.md
@@ -1,4 +1,4 @@
-Baglam temizleme komutu. Oturum sinirlarinda kesintisiz gecis saglar. Hedef: 30 saniye altinda tamamlanmali.
+Context-clearing command. Provides a seamless transition across session boundaries. Target: under 30 seconds.
 
 # Gerekli Araclar
 - Read (baglam dosyalari)

--- a/.claude/commands-vault/coach.md
+++ b/.claude/commands-vault/coach.md
@@ -1,4 +1,4 @@
-Kocluk analizi komutu. Veri odakli calisma kaliplari analizi yapar ve kisisel gelisim onerileri sunar.
+Coaching analysis command. Performs data-driven work-pattern analysis and offers personal improvement suggestions.
 
 # Gerekli Araclar
 - Read (bellek, gorevler, notlar, onceki kocluk raporlari)

--- a/.claude/commands-vault/competitive-intel.md
+++ b/.claude/commands-vault/competitive-intel.md
@@ -1,4 +1,4 @@
-Rekabet analizi komutu. Kapsamli rekabet istihbarati cercevesi ile pazari, rakipleri ve firsatlari analiz eder.
+Competitive analysis command. Analyzes the market, competitors, and opportunities with a comprehensive competitive-intelligence framework.
 
 # Gerekli Araclar
 - Read (mevcut veriler)

--- a/.claude/commands-vault/content-brand-voice.md
+++ b/.claude/commands-vault/content-brand-voice.md
@@ -1,4 +1,4 @@
-Marka sesi tanimlama ve yonetme komutu. Tum iceriklerde tutarli ton, stil ve kisilik saglamak icin marka sesi rehberi olusturur.
+Brand voice definition and management command. Creates a brand voice guide to keep tone, style, and personality consistent across all content.
 
 # Gerekli Araclar
 - Read (mevcut icerikler, web sitesi metinleri) -- Write (rehber) -- Grep (mevcut ton/stil analizi) -- ...

--- a/.claude/commands-vault/content-calendar.md
+++ b/.claude/commands-vault/content-calendar.md
@@ -1,4 +1,4 @@
-Icerik takvimi olusturma komutu. Haftalik veya aylik sosyal medya icerik plani, temalar, platformlar ve zamanlama ile birlikte olusturur.
+Content calendar command. Creates a weekly or monthly social media content plan with themes, platforms, and timing.
 
 # Gerekli Araclar
 - Read (marka sesi, mevcut takvim, proje baglami) -- Write (takvim dosyasi) -- Grep (onceki icerik taramasi) -- ...

--- a/.claude/commands-vault/content-carousel.md
+++ b/.claude/commands-vault/content-carousel.md
@@ -1,4 +1,4 @@
-Karousel (coklu kare) icerik olusturma komutu. Instagram, LinkedIn ve diger platformlar icin egitici veya hikaye anlatimli karousel icerikleri uretir.
+Carousel (multi-frame) content command. Produces educational or storytelling carousel content for Instagram, LinkedIn, and other platforms.
 
 # Gerekli Araclar
 - Read (marka sesi, konu, onceki icerikler) -- Write (karousel dosyasi) -- Grep (ilgili icerik) -- ...

--- a/.claude/commands-vault/content-close.md
+++ b/.claude/commands-vault/content-close.md
@@ -1,4 +1,4 @@
-Icerik uretim seansini kapanma komutu. Gun sonunda uretilenleri ozetler, yarin icin hazirlik yapar ve ogrenilenleri not eder.
+Content session close command. Summarizes the day's output, prepares for tomorrow, and notes learnings.
 
 # Gerekli Araclar
 - Read (bugunun icerikleri, notlar)

--- a/.claude/commands-vault/content-generate.md
+++ b/.claude/commands-vault/content-generate.md
@@ -1,4 +1,4 @@
-Sosyal medya icerik uretme komutu. Belirtilen platform ve tur icin hazir kullanilabilir post, caption, gorsel brief ve hashtag uretir.
+Social media content generation command. Produces ready-to-use posts, captions, visual briefs, and hashtags for the given platform and type.
 
 # Gerekli Araclar
 - Read (marka sesi, onceki icerikler, proje baglami) -- Write (icerik dosyasi) -- Grep (onceki icerik taramasi) -- ...

--- a/.claude/commands-vault/content-idea.md
+++ b/.claude/commands-vault/content-idea.md
@@ -1,4 +1,4 @@
-Icerik fikir uretme komutu. Belirli bir konu, tema veya platform icin yapilandirilmis fikir listesi olusturur.
+Content idea generation command. Creates a structured idea list for a topic, theme, or platform.
 
 # Gerekli Araclar
 - Read (marka sesi, gecmis icerikler, trend notlari)

--- a/.claude/commands-vault/content-perf.md
+++ b/.claude/commands-vault/content-perf.md
@@ -1,4 +1,4 @@
-Icerik performans takip komutu. Yayinlanan iceriklerin begeni, yorum, erisim, ROI verilerini takip eder.
+Content performance tracking command. Tracks likes, comments, reach, and ROI for published content.
 
 # Gerekli Araclar
 - Bash (badi content perf)

--- a/.claude/commands-vault/content-plan.md
+++ b/.claude/commands-vault/content-plan.md
@@ -1,4 +1,4 @@
-Haftalik icerik planlama seansi komutu. Onumuzdeki haftanin icerik stratejisini, temalarini ve uretim hedeflerini belirler.
+Weekly content planning session command. Sets next week's content strategy, themes, and production targets.
 
 # Gerekli Araclar
 - Read (marka sesi, gecmis takvim, performans)

--- a/.claude/commands-vault/content-search.md
+++ b/.claude/commands-vault/content-search.md
@@ -1,4 +1,4 @@
-Icerik arsiv arama komutu. Uretilen tum iceriklerde anahtar kelime arama, benzerlik tespiti ve filtreleme.
+Content archive search command. Keyword search, similarity detection, and filtering across all generated content.
 
 # Gerekli Araclar
 - Bash (badi content search)

--- a/.claude/commands-vault/content-start.md
+++ b/.claude/commands-vault/content-start.md
@@ -1,4 +1,4 @@
-Icerik uretim oturumu baslatma komutu. Gunluk icerik oretim seansina yapisal bir baslangic yapar, bekleyen islerti gosterir ve oncelikleri belirler.
+Content production session start command. Gives the daily content session a structured start, shows pending work, and sets priorities.
 
 # Gerekli Araclar
 - Read (marka sesi, takvim, mevcut icerikler)

--- a/.claude/commands-vault/content-status.md
+++ b/.claude/commands-vault/content-status.md
@@ -1,4 +1,4 @@
-Icerik uretim durumu paneli. Mevcut uretim hacmini, bekleyenleri, takvim uyumunu ve trend verilerini gosterir.
+Content production status panel. Shows current output volume, pending items, calendar fit, and trend data.
 
 # Gerekli Araclar
 - Read (workspace dosyalari)

--- a/.claude/commands-vault/content-template.md
+++ b/.claude/commands-vault/content-template.md
@@ -1,4 +1,4 @@
-Icerik sablon mirasi komutu. Tekrarlayan icerik turleri icin ozel sablon olusturma ve miras zinciri yonetimi.
+Content template inheritance command. Custom template creation and inheritance-chain management for recurring content types.
 
 # Gerekli Araclar
 - Bash (badi content template)

--- a/.claude/commands-vault/content-video-script.md
+++ b/.claude/commands-vault/content-video-script.md
@@ -1,4 +1,4 @@
-Video senaryo yazma komutu. Reels, Shorts, TikTok ve YouTube videolari icin sahne sahne senaryo, altyazi ve gorselleme plani olusturur.
+Video script command. Scene-by-scene scripts, captions, and visualization plans for Reels, Shorts, TikTok, and YouTube.
 
 # Gerekli Araclar
 - Read (marka sesi, onceki senaryolar, proje baglami) -- Write (senaryo dosyasi) -- Grep (trend ve referans taramasi) -- ...

--- a/.claude/commands-vault/content-visual-brief.md
+++ b/.claude/commands-vault/content-visual-brief.md
@@ -1,4 +1,4 @@
-Gorsel brief olusturma komutu. Sosyal medya gorselleri, bannerlar ve video kareleri icin detayli tasarim talimatlar, renk paletleri ve AI gorsel promptlari uretir.
+Visual brief command. Detailed design instructions, color palettes, and AI image prompts for social visuals, banners, and video frames.
 
 # Gerekli Araclar
 - Read (marka rehberi, onceki gorseller, proje baglami) -- Write (brief dosyasi) -- Grep (marka renk/font referanslari) -- ...

--- a/.claude/commands-vault/conv-commit.md
+++ b/.claude/commands-vault/conv-commit.md
@@ -1,4 +1,4 @@
-Conventional commit yardimi komutu. Staged dosyalari okur, uygun tip/scope/mesaj onerir, dogrulama yapar.
+Conventional commit helper command. Reads staged files, suggests type/scope/message, and validates.
 
 # Gerekli Araclar
 - Bash (badi commit komutu cagirisi)

--- a/.claude/commands-vault/dashboard.md
+++ b/.claude/commands-vault/dashboard.md
@@ -1,4 +1,4 @@
-Gunluk istatistik paneli. Gorev, denetim, olay ve performans verilerini birlestirilmis tablo olarak sunar.
+Daily statistics panel. Presents task, audit, event, and performance data as a unified table.
 
 # Gerekli Araclar
 - Bash (tarih hesaplama, dosya istatistikleri)

--- a/.claude/commands-vault/debt-map.md
+++ b/.claude/commands-vault/debt-map.md
@@ -1,4 +1,4 @@
-Teknik borc haritalama komutu. Kod tabanindaki teknik borcu sistematik olarak tespit eder ve onceliklendirir.
+Technical debt mapping command. Systematically detects and prioritizes technical debt in the codebase.
 
 # Gerekli Araclar
 - Grep (kod taramasi)

--- a/.claude/commands-vault/deploy.md
+++ b/.claude/commands-vault/deploy.md
@@ -1,4 +1,4 @@
-Dagitim kontrol listesi. Dagitim oncesi tum gereksinimleri dogrular ve hazirlik raporu olusturur.
+Deployment checklist. Verifies all pre-deployment requirements and produces a readiness report.
 
 ## Badi CLI Pre-Deploy Checklist (v1.6+)
 Dagitim oncesi su kontrolleri MUTLAKA calistir:

--- a/.claude/commands-vault/deps-update.md
+++ b/.claude/commands-vault/deps-update.md
@@ -1,4 +1,4 @@
-Guvenli bagimlilik guncelleme analizi. Patch/minor/major kategorizasyonu, opsiyonel otomatik patch uygulama.
+Safe dependency update analysis. Patch/minor/major categorization with optional automatic patch application.
 
 # Gerekli Araclar
 - Bash (badi dev deps)

--- a/.claude/commands-vault/dns-audit.md
+++ b/.claude/commands-vault/dns-audit.md
@@ -1,4 +1,4 @@
-DNS kayit denetimi komutu. A/AAAA/MX/TXT/SPF/DMARC/CAA kayitlari kontrol eder, email guvenlik skoru verir.
+DNS record audit command. Checks A/AAAA/MX/TXT/SPF/DMARC/CAA records and scores email security.
 
 # Gerekli Araclar
 - Bash (badi dns komutu cagirisi)

--- a/.claude/commands-vault/docker-lint.md
+++ b/.claude/commands-vault/docker-lint.md
@@ -1,4 +1,4 @@
-Dockerfile best practice kontrolu. Guvenlik, boyut, reproducibility uyarilari.
+Dockerfile best-practice checks. Security, size, and reproducibility warnings.
 
 # Gerekli Araclar
 - Bash (badi dev docker-lint)

--- a/.claude/commands-vault/docs-audit.md
+++ b/.claude/commands-vault/docs-audit.md
@@ -1,4 +1,4 @@
-Dokumantasyon denetimi komutu. Teknik dokumantasyonun tamamligini, guncelligini ve kalitesini degerlendirir.
+Documentation audit command. Evaluates completeness, freshness, and quality of technical documentation.
 
 # Gerekli Araclar
 - Read (dokumantasyon dosyalari)

--- a/.claude/commands-vault/doctor.md
+++ b/.claude/commands-vault/doctor.md
@@ -1,4 +1,4 @@
-Badi konfigur asyon dogrulamas i. Tum Badi bilesenlrini kontrol eder ve tanisal rapor olusturur.
+Badi configuration validation. Checks all Badi components and produces a diagnostic report.
 
 # Gerekli Araclar
 - Bash (dosya izinleri, dizin yapisi kontrolu)

--- a/.claude/commands-vault/drift-detect.md
+++ b/.claude/commands-vault/drift-detect.md
@@ -1,4 +1,4 @@
-Konfigurasyon sapma tespiti komutu. Badi sistemindeki tutarsizliklari, yetim bilesenleri ve eskilesmis icerigi tespit eder.
+Configuration drift detection command. Finds inconsistencies, orphaned components, and stale content in the Badi system.
 
 # Gerekli Araclar
 - Read (konfigurasyon dosyalari)

--- a/.claude/commands-vault/env-check.md
+++ b/.claude/commands-vault/env-check.md
@@ -1,4 +1,4 @@
-.env dosyasi dogrulama. Eksik, fazla, bos ve placeholder degerleri tespit + .gitignore kontrolu.
+.env file validation. Detects missing, extra, empty, and placeholder values + .gitignore check.
 
 # Gerekli Araclar
 - Bash (badi dev env-check)

--- a/.claude/commands-vault/handoff.md
+++ b/.claude/commands-vault/handoff.md
@@ -1,4 +1,4 @@
-Is teslim brifingi komutu. Baska bir gelistiriciye veya oturuma sorunsuz gecis saglar.
+Handoff briefing command. Enables a smooth transition to another developer or session.
 
 # Gerekli Araclar
 - Read (baglam, notlar, gorevler)

--- a/.claude/commands-vault/health.md
+++ b/.claude/commands-vault/health.md
@@ -1,4 +1,4 @@
-Sistem sagligi kontrolu. Bagimliliklari, guvenligi, performansi ve (varsa) production domaini uclu tarama ile denetler.
+System health check. Audits dependencies, security, performance, and (if present) the production domain with a triple scan.
 
 ## Badi CLI Komutlari
 Bu kontroller su CLI komutlarini kullanir (v1.6+):

--- a/.claude/commands-vault/hotfix.md
+++ b/.claude/commands-vault/hotfix.md
@@ -1,4 +1,4 @@
-Acil duzeltme is akisi. Produksiyon hatalari icin hizli ve guvenli yama sureci yonetir.
+Emergency fix workflow. Manages a fast, safe patching process for production errors.
 
 # Gerekli Araclar
 - Bash (git islemleri, test calistirma)

--- a/.claude/commands-vault/launch.md
+++ b/.claude/commands-vault/launch.md
@@ -1,4 +1,4 @@
-Urun lansman plani komutu. Yeni bir urun veya ozellik lansmani icin kapsamli plan olusturur.
+Product launch plan command. Creates a comprehensive plan for a new product or feature launch.
 
 # Gerekli Araclar
 - Read (proje verileri)

--- a/.claude/commands-vault/lighthouse.md
+++ b/.claude/commands-vault/lighthouse.md
@@ -1,4 +1,4 @@
-Lighthouse audit komutu. Google PageSpeed Insights API uzerinden Performance, Accessibility, Best Practices, SEO skorlari ve Core Web Vitals olcumu.
+Lighthouse audit command. Performance, Accessibility, Best Practices, SEO scores and Core Web Vitals via the Google PageSpeed Insights API.
 
 # Gerekli Araclar
 - Bash (badi lighthouse komutu cagirisi)

--- a/.claude/commands-vault/memory-diff.md
+++ b/.claude/commands-vault/memory-diff.md
@@ -1,4 +1,4 @@
-Memory ve knowledge-base limit kontrolu + global proje karsilastirmasi.
+Memory and knowledge-base limit check + global project comparison.
 
 # Gerekli Araclar
 - Bash (badi ai memory-diff)

--- a/.claude/commands-vault/mobile.md
+++ b/.claude/commands-vault/mobile.md
@@ -1,4 +1,4 @@
-Mobil proje yonetim komutu. React Native/Flutter/Expo/Swift/Kotlin proje iskelesi, version sync, build ve release rehberleri.
+Mobile project management command. React Native/Flutter/Expo/Swift/Kotlin scaffolding, version sync, build and release guides.
 
 # Gerekli Araclar
 - Bash (badi mobile komutlari)

--- a/.claude/commands-vault/onboard.md
+++ b/.claude/commands-vault/onboard.md
@@ -1,4 +1,4 @@
-Proje alistirma komutu. Yeni bir projeye hizli ve kapsamli adapte olmak icin kullanilir.
+Project onboarding command. For adapting to a new project quickly and thoroughly.
 
 # Gerekli Araclar
 - Glob (dosya yapisi taramasi)

--- a/.claude/commands-vault/perf-check.md
+++ b/.claude/commands-vault/perf-check.md
@@ -1,4 +1,4 @@
-Performans profilleme. Sicak yollari, darbogazlari ve optimizasyon firsatlarini tespit eder.
+Performance profiling. Detects hot paths, bottlenecks, and optimization opportunities.
 
 ## Badi CLI Komutlari (v1.6+)
 Production URL varsa:

--- a/.claude/commands-vault/playbook.md
+++ b/.claude/commands-vault/playbook.md
@@ -1,4 +1,4 @@
-Is akisini komuta donusturme komutu. Tekrarlayan manuel is akislarini yeniden kullanilabilir Badi komutlarina cevirir.
+Workflow-to-command command. Converts repetitive manual workflows into reusable Badi commands.
 
 # Gerekli Araclar
 - Read (mevcut komutlar) -- Write (yeni komut) -- Glob (mevcut komut listesi) -- Grep (kalip/referans)

--- a/.claude/commands-vault/plugin.md
+++ b/.claude/commands-vault/plugin.md
@@ -1,4 +1,4 @@
-Plugin yonetim komutu. Badi sistemine eklenti yukler, kaldirir ve listeler.
+Plugin management command. Installs, removes, and lists plugins in the Badi system.
 
 # Gerekli Araclar
 - Bash (git clone, npm install, dosya kopyalama)

--- a/.claude/commands-vault/post-mortem.md
+++ b/.claude/commands-vault/post-mortem.md
@@ -1,4 +1,4 @@
-Olay sonrasi analiz (post-mortem) komutu. Uretim olaylari ve onemli hatalarin kok neden analizini belgeler.
+Post-incident analysis (post-mortem) command. Documents root-cause analysis of production incidents and major failures.
 
 # Gerekli Araclar
 - Read (log dosyalari, olay kayitlari)

--- a/.claude/commands-vault/prompt-test.md
+++ b/.claude/commands-vault/prompt-test.md
@@ -1,4 +1,4 @@
-Slash komut ve ajan dosyalari icin regression test. Format ve icerik dogrulamasi.
+Regression test for slash command and agent files. Format and content validation.
 
 # Gerekli Araclar
 - Bash (badi ai prompt-test)

--- a/.claude/commands-vault/proposal.md
+++ b/.claude/commands-vault/proposal.md
@@ -1,4 +1,4 @@
-Musteri teklifi komutu. Proje ozetlerinden profesyonel musteri teklifi olusturur. 30 gun gecerli.
+Client proposal command. Builds a professional client proposal from project summaries. Valid for 30 days.
 
 # Gerekli Araclar
 - Read (proje verileri, mevcut brifing)

--- a/.claude/commands-vault/refactor.md
+++ b/.claude/commands-vault/refactor.md
@@ -1,4 +1,4 @@
-Kod yeniden duzenleme komutu. Kod kokularini tespit edip guvenli refactoring plani olusturur.
+Refactoring command. Detects code smells and creates a safe refactoring plan.
 
 # Gerekli Araclar
 - Read (kod okuma)

--- a/.claude/commands-vault/release.md
+++ b/.claude/commands-vault/release.md
@@ -1,4 +1,4 @@
-Surum notlari olusturma komutu. Degisiklikleri 3 farkli hedef kitleye uygun formatta derler.
+Release notes command. Compiles changes into formats for 3 different audiences.
 
 ## Badi CLI Workflow (v1.6+)
 Release oncesi sira:

--- a/.claude/commands-vault/report.md
+++ b/.claude/commands-vault/report.md
@@ -1,4 +1,4 @@
-Profesyonel rapor komutu. Ham veri ve bulgulari hedef kitleye uygun profesyonel raporlara donusturur.
+Professional report command. Turns raw data and findings into professional, audience-appropriate reports.
 
 # Gerekli Araclar
 - Read (veri kaynaklari)

--- a/.claude/commands-vault/retro.md
+++ b/.claude/commands-vault/retro.md
@@ -1,4 +1,4 @@
-Sprint retrospektifi komutu. Gecmis donem analizi yaparak iyilestirme alanlari belirler.
+Sprint retrospective command. Analyzes the past period and identifies improvement areas.
 
 # Gerekli Araclar
 - Read (gunluk notlar, gorev panosu, bellek)

--- a/.claude/commands-vault/review.md
+++ b/.claude/commands-vault/review.md
@@ -1,4 +1,4 @@
-Derin kod incelemesi komutu. Guvenlik, performans ve mimari boyutlariyla kapsamli kod analizi yapar.
+Deep code review command. Comprehensive code analysis across security, performance, and architecture.
 
 > **Argument formati (v1.31.0+)**: `/review [effort] [--comment] [--correctness-only]`
 > - `effort`: `low` | `medium` (default) | `high` — analiz derinligi

--- a/.claude/commands-vault/scaffold.md
+++ b/.claude/commands-vault/scaffold.md
@@ -1,4 +1,4 @@
-Kod iskelesi olusturma komutu. Proje yapisini analiz edip tutarli modul, bilesen veya API iskelesi uretir.
+Code scaffolding command. Analyzes project structure and generates consistent module, component, or API skeletons.
 
 # Gerekli Araclar
 - Read (mevcut kod kaliplari)

--- a/.claude/commands-vault/schedule.md
+++ b/.claude/commands-vault/schedule.md
@@ -1,4 +1,4 @@
-Zamanlanmis komut hatirlaticilari. Gunluk/haftalik tekrar eden gorevler icin shell bazli hatirlatma sistemi.
+Scheduled command reminders. Shell-based reminder system for daily/weekly recurring tasks.
 
 # Gerekli Araclar
 - Bash (badi schedule)

--- a/.claude/commands-vault/secret-scan.md
+++ b/.claude/commands-vault/secret-scan.md
@@ -1,4 +1,4 @@
-Proje genelinde sir/credential taramasi komutu. AWS/GCP/GitHub/npm/Stripe/OpenAI/Anthropic anahtarlari, JWT, database URI'leri, private key'ler.
+Project-wide secret/credential scan command. AWS/GCP/GitHub/npm/Stripe/OpenAI/Anthropic keys, JWTs, database URIs, private keys.
 
 > **Daha genis kapsam icin**: `badi security baseline` (secret-scan + npm audit), `/security-review` (Anthropic native AI semantic — Claude Code 2.1.140+).
 

--- a/.claude/commands-vault/security-scan.md
+++ b/.claude/commands-vault/security-scan.md
@@ -1,4 +1,4 @@
-Guvenlik taramasi. Kod tabani ve bagimliliklarda guvenlik aciklari arar ve ciddiyet siralmasili rapor olusturur.
+Security scan. Searches the codebase and dependencies for vulnerabilities and produces a severity-ranked report.
 
 > **Native komut (v1.31.0+)**: Claude Code 2.1.140+ ile `/security-review` artik **native** komut (built-in slash). Bu komut onun yaninda **deterministic baseline** (`badi security baseline`) + **post-scan triage** (`badi security triage`) saglar.
 >

--- a/.claude/commands-vault/seo.md
+++ b/.claude/commands-vault/seo.md
@@ -1,4 +1,4 @@
-SEO denetim komutu. Website SEO analizi, meta tag kontrolu, sitemap dogrulama ve hiz degerlendirmesi.
+SEO audit command. Website SEO analysis, meta tag checks, sitemap validation, and speed assessment.
 
 # Gerekli Araclar
 - Bash (badi seo komutlari)

--- a/.claude/commands-vault/spec-check.md
+++ b/.claude/commands-vault/spec-check.md
@@ -1,4 +1,4 @@
-Spesifikasyon uyum kontrolu komutu. Mevcut kodu SPECIFICATION.md'ye karsi denetler, ozellik eksiklerini ve kapsam kaymasini tespit eder.
+Specification conformance command. Audits the current code against SPECIFICATION.md, detecting feature gaps and scope drift.
 
 # Gerekli Araclar
 - Read (SPECIFICATION.md, kaynak kodlar)

--- a/.claude/commands-vault/ssl-check.md
+++ b/.claude/commands-vault/ssl-check.md
@@ -1,4 +1,4 @@
-SSL sertifika analizi komutu. Domain icin sertifika gecerliligi, TLS surumu, cipher gucu kontrolu yapar.
+SSL certificate analysis command. Checks certificate validity, TLS version, and cipher strength for a domain.
 
 # Gerekli Araclar
 - Bash (badi ssl komutu cagirisi)

--- a/.claude/commands-vault/standup.md
+++ b/.claude/commands-vault/standup.md
@@ -1,4 +1,4 @@
-Gunluk toplanti komutu. 30 saniye icinde hizli durum ozeti olusturur.
+Daily standup command. Produces a quick status summary in under 30 seconds.
 
 # Gerekli Araclar
 - Bash (git log)

--- a/.claude/commands-vault/start.md
+++ b/.claude/commands-vault/start.md
@@ -1,4 +1,4 @@
-Badi oturum baslatma komutu. Yeni proje alistirmasi veya gunluk calisma baslatmasi yapar.
+Badi session start command. Runs new-project onboarding or a daily kickoff.
 
 # Gerekli Araclar
 - Bash (dosya sistemi erisimi)

--- a/.claude/commands-vault/stats.md
+++ b/.claude/commands-vault/stats.md
@@ -1,4 +1,4 @@
-Kullanim analitikleri komutu. Badi arac kullanim istatistikleri, bar chart, gunluk trend, aliskanlik serisi.
+Usage analytics command. Badi tool usage statistics, bar charts, daily trends, habit streaks.
 
 # Gerekli Araclar
 - Bash (badi stats)

--- a/.claude/commands-vault/sync.md
+++ b/.claude/commands-vault/sync.md
@@ -1,4 +1,4 @@
-Oturum ortasi baglam yenileme komutu. Calisma sirasinda baglami taze tutar ve tutarliligi saglar.
+Mid-session context refresh command. Keeps context fresh and consistent during work.
 
 # Gerekli Araclar
 - Read (bellek ve baglam dosyalari)

--- a/.claude/commands-vault/system-audit.md
+++ b/.claude/commands-vault/system-audit.md
@@ -1,4 +1,4 @@
-Derin altyapi denetimi komutu. Badi sisteminin tum bilesenlerini 9 kontrol noktasiyla kapsamli olarak denetler.
+Deep infrastructure audit command. Comprehensively audits all Badi components across 9 checkpoints.
 
 # Gerekli Araclar
 - Read (tum konfig dosyalari) -- Grep (referans/kalip taramasi) -- Glob (dosya varlik) -- Bash (izin, JSON dogrulama, dosya bilgisi) -- Write (rapor)

--- a/.claude/commands-vault/unstick.md
+++ b/.claude/commands-vault/unstick.md
@@ -1,4 +1,4 @@
-Tikaniklik cozme komutu. Takili kaldiginda yapisal bir yaklasimla hizli cozum bulur.
+Unblocking command. Finds a fast solution with a structured approach when you're stuck.
 
 # Gerekli Araclar
 - Read (kod ve baglam okuma)

--- a/.claude/commands-vault/whois.md
+++ b/.claude/commands-vault/whois.md
@@ -1,4 +1,4 @@
-Domain WHOIS bilgisi komutu. Tescil tarihi, expire, registrar, transfer lock durumu kontrolu.
+Domain WHOIS command. Checks registration date, expiry, registrar, and transfer lock status.
 
 # Gerekli Araclar
 - Bash (badi whois komutu cagirisi)

--- a/.claude/commands-vault/wp.md
+++ b/.claude/commands-vault/wp.md
@@ -1,4 +1,4 @@
-WordPress site yonetimi komutu. Site durumu, eklenti/tema yonetimi, guvenlik taramasi ve toplu guncelleme.
+WordPress site management command. Site status, plugin/theme management, security scan, and bulk updates.
 
 # Gerekli Araclar
 - Bash (badi wp komutlari)

--- a/.claude/commands-vault/wrap-up.md
+++ b/.claude/commands-vault/wrap-up.md
@@ -1,4 +1,4 @@
-Gun sonu rituel komutu. Gunu kapanisa hazirlayarak yarin icin zemin hazirlar.
+End-of-day ritual command. Prepares the day for closure and sets the stage for tomorrow.
 
 # Gerekli Araclar
 - Read (bellek, notlar, gunlukler)

--- a/.claude/commands/a11y-audit.md
+++ b/.claude/commands/a11y-audit.md
@@ -1,4 +1,4 @@
-Web accessibility (WCAG 2.1) denetim komutu. PageSpeed Insights uzerinden axe-core tabanli kontrol.
+Web accessibility (WCAG 2.1) audit command. axe-core-based checks via PageSpeed Insights.
 
 # Gerekli Araclar
 - Bash (badi a11y komutu cagirisi)

--- a/.claude/commands/adr.md
+++ b/.claude/commands/adr.md
@@ -1,4 +1,4 @@
-Mimari Karar Kaydi (ADR) olusturma komutu. Mimari kararlari yapilandirilmis formatta belgeler.
+Architecture Decision Record (ADR) command. Documents architectural decisions in a structured format.
 
 # Gerekli Araclar
 - Read (mevcut ADR'ler)

--- a/.claude/commands/ai-review.md
+++ b/.claude/commands/ai-review.md
@@ -1,4 +1,4 @@
-Staged git diff icin Claude API ile AI kod review.
+AI code review of the staged git diff via the Claude API.
 
 # Gerekli Araclar
 - Bash (badi ai review)

--- a/.claude/commands/ai-token.md
+++ b/.claude/commands/ai-token.md
@@ -1,4 +1,4 @@
-Badi/.claude/ token kullanim analiz komutu. Kategorize edilmis token sayimi, en buyuk dosyalar, optimizasyon onerileri.
+Badi/.claude/ token usage analysis command. Categorized token counts, largest files, optimization suggestions.
 
 # Gerekli Araclar
 - Bash (badi ai token)

--- a/.claude/commands/ai-translate.md
+++ b/.claude/commands/ai-translate.md
@@ -1,4 +1,4 @@
-Markdown dosya cevirisi. Claude API ile teknik/icerik cevirisi (markdown yapisini bozmadan).
+Markdown file translation. Technical/content translation via the Claude API (without breaking markdown structure).
 
 # Gerekli Araclar
 - Bash (badi ai translate)

--- a/.claude/commands/api-doc.md
+++ b/.claude/commands/api-doc.md
@@ -1,4 +1,4 @@
-API dokumantasyonu olusturma. Route tanimlarini tarar ve yapilandirilmis API belgeleri uretir.
+API documentation generation. Scans route definitions and produces structured API docs.
 
 # Gerekli Araclar
 - Bash (dosya sistemi) -- Read (kaynak kod) -- Grep (route/endpoint) -- Glob (dosya tespiti) -- Write (dok dosyasi) -- Agent (api-designer: detayli API analiz)

--- a/.claude/commands/api-test.md
+++ b/.claude/commands/api-test.md
@@ -1,4 +1,4 @@
-HTTP API endpoint test. GET/POST/PUT/DELETE istek gonder, status + response analiz, assertion.
+HTTP API endpoint testing. Send GET/POST/PUT/DELETE requests, analyze status + response, assertions.
 
 # Gerekli Araclar
 - Bash (badi dev api-test)

--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -1,4 +1,4 @@
-Proje planlama komutu. Belirsiz proje fikirlerini 5 yapilandirilmis dokumana donusturur: spesifikasyon, uygulama plani, gorev listesi, marka kimligi ve calistirma prompt'u.
+Project planning command. Turns vague project ideas into 5 structured documents: specification, implementation plan, task list, brand identity, and a kickoff prompt.
 
 # Gerekli Araclar
 - Read (referans dosyalari, mevcut proje bilgisi)

--- a/.claude/commands/aso.md
+++ b/.claude/commands/aso.md
@@ -1,4 +1,4 @@
-App Store Optimization komutu. iTunes API ile iOS app listing analizi, keyword optimizasyonu ve rakip karsilastirmasi.
+App Store Optimization command. iOS app listing analysis via the iTunes API, keyword optimization, and competitor comparison.
 
 # Gerekli Araclar
 - Bash (badi aso komutlari)

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,4 +1,4 @@
-Kalite denetimi komutu. Kod, yapi veya surec uzerinde sistematik denetim yapar.
+Quality audit command. Runs a systematic audit over code, structure, or process.
 
 ## Badi CLI Komutlari (v1.6+)
 Seviye T4 (Kapsamli) denetimde su CLI araclari calistirir:

--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -1,4 +1,4 @@
-Proje brifingi komutu. Ham proje fikirlerini yapilandirilmis, uygulanabilir brifinglara donusturur.
+Project briefing command. Turns raw project ideas into structured, actionable briefs.
 
 # Gerekli Araclar
 - Read (mevcut proje bilgileri)

--- a/.claude/commands/bundle-analyze.md
+++ b/.claude/commands/bundle-analyze.md
@@ -1,4 +1,4 @@
-Bundle size + framework tespit + en buyuk asset'ler + agir bagimlilik uyarisi.
+Bundle size + framework detection + largest assets + heavy-dependency warnings.
 
 # Gerekli Araclar
 - Bash (badi dev bundle)

--- a/.claude/commands/changelog-gen.md
+++ b/.claude/commands/changelog-gen.md
@@ -1,4 +1,4 @@
-CHANGELOG.md guncelleme komutu. Git gecmisinden conventional commit tipleriyle gruplanmis changelog uretir.
+CHANGELOG.md update command. Generates a changelog from git history grouped by conventional commit types.
 
 # Gerekli Araclar
 - Bash (badi changelog komutu cagirisi)

--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -1,4 +1,4 @@
-Otomatik degisiklik gunlugu olusturma. Commit gecmisinden yapilandirilmis changelog uretir.
+Automatic changelog generation. Produces a structured changelog from commit history.
 
 ## Badi CLI Komutu (v1.6+)
 Hizli uretim icin:

--- a/.claude/commands/clear.md
+++ b/.claude/commands/clear.md
@@ -1,4 +1,4 @@
-Baglam temizleme komutu. Oturum sinirlarinda kesintisiz gecis saglar. Hedef: 30 saniye altinda tamamlanmali.
+Context-clearing command. Provides a seamless transition across session boundaries. Target: under 30 seconds.
 
 # Gerekli Araclar
 - Read (baglam dosyalari)

--- a/.claude/commands/coach.md
+++ b/.claude/commands/coach.md
@@ -1,4 +1,4 @@
-Kocluk analizi komutu. Veri odakli calisma kaliplari analizi yapar ve kisisel gelisim onerileri sunar.
+Coaching analysis command. Performs data-driven work-pattern analysis and offers personal improvement suggestions.
 
 # Gerekli Araclar
 - Read (bellek, gorevler, notlar, onceki kocluk raporlari)

--- a/.claude/commands/competitive-intel.md
+++ b/.claude/commands/competitive-intel.md
@@ -1,4 +1,4 @@
-Rekabet analizi komutu. Kapsamli rekabet istihbarati cercevesi ile pazari, rakipleri ve firsatlari analiz eder.
+Competitive analysis command. Analyzes the market, competitors, and opportunities with a comprehensive competitive-intelligence framework.
 
 # Gerekli Araclar
 - Read (mevcut veriler)

--- a/.claude/commands/content-brand-voice.md
+++ b/.claude/commands/content-brand-voice.md
@@ -1,4 +1,4 @@
-Marka sesi tanimlama ve yonetme komutu. Tum iceriklerde tutarli ton, stil ve kisilik saglamak icin marka sesi rehberi olusturur.
+Brand voice definition and management command. Creates a brand voice guide to keep tone, style, and personality consistent across all content.
 
 # Gerekli Araclar
 - Read (mevcut icerikler, web sitesi metinleri) -- Write (rehber) -- Grep (mevcut ton/stil analizi) -- ...

--- a/.claude/commands/content-calendar.md
+++ b/.claude/commands/content-calendar.md
@@ -1,4 +1,4 @@
-Icerik takvimi olusturma komutu. Haftalik veya aylik sosyal medya icerik plani, temalar, platformlar ve zamanlama ile birlikte olusturur.
+Content calendar command. Creates a weekly or monthly social media content plan with themes, platforms, and timing.
 
 # Gerekli Araclar
 - Read (marka sesi, mevcut takvim, proje baglami) -- Write (takvim dosyasi) -- Grep (onceki icerik taramasi) -- ...

--- a/.claude/commands/content-carousel.md
+++ b/.claude/commands/content-carousel.md
@@ -1,4 +1,4 @@
-Karousel (coklu kare) icerik olusturma komutu. Instagram, LinkedIn ve diger platformlar icin egitici veya hikaye anlatimli karousel icerikleri uretir.
+Carousel (multi-frame) content command. Produces educational or storytelling carousel content for Instagram, LinkedIn, and other platforms.
 
 # Gerekli Araclar
 - Read (marka sesi, konu, onceki icerikler) -- Write (karousel dosyasi) -- Grep (ilgili icerik) -- ...

--- a/.claude/commands/content-close.md
+++ b/.claude/commands/content-close.md
@@ -1,4 +1,4 @@
-Icerik uretim seansini kapanma komutu. Gun sonunda uretilenleri ozetler, yarin icin hazirlik yapar ve ogrenilenleri not eder.
+Content session close command. Summarizes the day's output, prepares for tomorrow, and notes learnings.
 
 # Gerekli Araclar
 - Read (bugunun icerikleri, notlar)

--- a/.claude/commands/content-generate.md
+++ b/.claude/commands/content-generate.md
@@ -1,4 +1,4 @@
-Sosyal medya icerik uretme komutu. Belirtilen platform ve tur icin hazir kullanilabilir post, caption, gorsel brief ve hashtag uretir.
+Social media content generation command. Produces ready-to-use posts, captions, visual briefs, and hashtags for the given platform and type.
 
 # Gerekli Araclar
 - Read (marka sesi, onceki icerikler, proje baglami) -- Write (icerik dosyasi) -- Grep (onceki icerik taramasi) -- ...

--- a/.claude/commands/content-idea.md
+++ b/.claude/commands/content-idea.md
@@ -1,4 +1,4 @@
-Icerik fikir uretme komutu. Belirli bir konu, tema veya platform icin yapilandirilmis fikir listesi olusturur.
+Content idea generation command. Creates a structured idea list for a topic, theme, or platform.
 
 # Gerekli Araclar
 - Read (marka sesi, gecmis icerikler, trend notlari)

--- a/.claude/commands/content-perf.md
+++ b/.claude/commands/content-perf.md
@@ -1,4 +1,4 @@
-Icerik performans takip komutu. Yayinlanan iceriklerin begeni, yorum, erisim, ROI verilerini takip eder.
+Content performance tracking command. Tracks likes, comments, reach, and ROI for published content.
 
 # Gerekli Araclar
 - Bash (badi content perf)

--- a/.claude/commands/content-plan.md
+++ b/.claude/commands/content-plan.md
@@ -1,4 +1,4 @@
-Haftalik icerik planlama seansi komutu. Onumuzdeki haftanin icerik stratejisini, temalarini ve uretim hedeflerini belirler.
+Weekly content planning session command. Sets next week's content strategy, themes, and production targets.
 
 # Gerekli Araclar
 - Read (marka sesi, gecmis takvim, performans)

--- a/.claude/commands/content-search.md
+++ b/.claude/commands/content-search.md
@@ -1,4 +1,4 @@
-Icerik arsiv arama komutu. Uretilen tum iceriklerde anahtar kelime arama, benzerlik tespiti ve filtreleme.
+Content archive search command. Keyword search, similarity detection, and filtering across all generated content.
 
 # Gerekli Araclar
 - Bash (badi content search)

--- a/.claude/commands/content-start.md
+++ b/.claude/commands/content-start.md
@@ -1,4 +1,4 @@
-Icerik uretim oturumu baslatma komutu. Gunluk icerik oretim seansina yapisal bir baslangic yapar, bekleyen islerti gosterir ve oncelikleri belirler.
+Content production session start command. Gives the daily content session a structured start, shows pending work, and sets priorities.
 
 # Gerekli Araclar
 - Read (marka sesi, takvim, mevcut icerikler)

--- a/.claude/commands/content-status.md
+++ b/.claude/commands/content-status.md
@@ -1,4 +1,4 @@
-Icerik uretim durumu paneli. Mevcut uretim hacmini, bekleyenleri, takvim uyumunu ve trend verilerini gosterir.
+Content production status panel. Shows current output volume, pending items, calendar fit, and trend data.
 
 # Gerekli Araclar
 - Read (workspace dosyalari)

--- a/.claude/commands/content-template.md
+++ b/.claude/commands/content-template.md
@@ -1,4 +1,4 @@
-Icerik sablon mirasi komutu. Tekrarlayan icerik turleri icin ozel sablon olusturma ve miras zinciri yonetimi.
+Content template inheritance command. Custom template creation and inheritance-chain management for recurring content types.
 
 # Gerekli Araclar
 - Bash (badi content template)

--- a/.claude/commands/content-video-script.md
+++ b/.claude/commands/content-video-script.md
@@ -1,4 +1,4 @@
-Video senaryo yazma komutu. Reels, Shorts, TikTok ve YouTube videolari icin sahne sahne senaryo, altyazi ve gorselleme plani olusturur.
+Video script command. Scene-by-scene scripts, captions, and visualization plans for Reels, Shorts, TikTok, and YouTube.
 
 # Gerekli Araclar
 - Read (marka sesi, onceki senaryolar, proje baglami) -- Write (senaryo dosyasi) -- Grep (trend ve referans taramasi) -- ...

--- a/.claude/commands/content-visual-brief.md
+++ b/.claude/commands/content-visual-brief.md
@@ -1,4 +1,4 @@
-Gorsel brief olusturma komutu. Sosyal medya gorselleri, bannerlar ve video kareleri icin detayli tasarim talimatlar, renk paletleri ve AI gorsel promptlari uretir.
+Visual brief command. Detailed design instructions, color palettes, and AI image prompts for social visuals, banners, and video frames.
 
 # Gerekli Araclar
 - Read (marka rehberi, onceki gorseller, proje baglami) -- Write (brief dosyasi) -- Grep (marka renk/font referanslari) -- ...

--- a/.claude/commands/conv-commit.md
+++ b/.claude/commands/conv-commit.md
@@ -1,4 +1,4 @@
-Conventional commit yardimi komutu. Staged dosyalari okur, uygun tip/scope/mesaj onerir, dogrulama yapar.
+Conventional commit helper command. Reads staged files, suggests type/scope/message, and validates.
 
 # Gerekli Araclar
 - Bash (badi commit komutu cagirisi)

--- a/.claude/commands/dashboard.md
+++ b/.claude/commands/dashboard.md
@@ -1,4 +1,4 @@
-Gunluk istatistik paneli. Gorev, denetim, olay ve performans verilerini birlestirilmis tablo olarak sunar.
+Daily statistics panel. Presents task, audit, event, and performance data as a unified table.
 
 # Gerekli Araclar
 - Bash (tarih hesaplama, dosya istatistikleri)

--- a/.claude/commands/debt-map.md
+++ b/.claude/commands/debt-map.md
@@ -1,4 +1,4 @@
-Teknik borc haritalama komutu. Kod tabanindaki teknik borcu sistematik olarak tespit eder ve onceliklendirir.
+Technical debt mapping command. Systematically detects and prioritizes technical debt in the codebase.
 
 # Gerekli Araclar
 - Grep (kod taramasi)

--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,4 +1,4 @@
-Dagitim kontrol listesi. Dagitim oncesi tum gereksinimleri dogrular ve hazirlik raporu olusturur.
+Deployment checklist. Verifies all pre-deployment requirements and produces a readiness report.
 
 ## Badi CLI Pre-Deploy Checklist (v1.6+)
 Dagitim oncesi su kontrolleri MUTLAKA calistir:

--- a/.claude/commands/deps-update.md
+++ b/.claude/commands/deps-update.md
@@ -1,4 +1,4 @@
-Guvenli bagimlilik guncelleme analizi. Patch/minor/major kategorizasyonu, opsiyonel otomatik patch uygulama.
+Safe dependency update analysis. Patch/minor/major categorization with optional automatic patch application.
 
 # Gerekli Araclar
 - Bash (badi dev deps)

--- a/.claude/commands/dns-audit.md
+++ b/.claude/commands/dns-audit.md
@@ -1,4 +1,4 @@
-DNS kayit denetimi komutu. A/AAAA/MX/TXT/SPF/DMARC/CAA kayitlari kontrol eder, email guvenlik skoru verir.
+DNS record audit command. Checks A/AAAA/MX/TXT/SPF/DMARC/CAA records and scores email security.
 
 # Gerekli Araclar
 - Bash (badi dns komutu cagirisi)

--- a/.claude/commands/docker-lint.md
+++ b/.claude/commands/docker-lint.md
@@ -1,4 +1,4 @@
-Dockerfile best practice kontrolu. Guvenlik, boyut, reproducibility uyarilari.
+Dockerfile best-practice checks. Security, size, and reproducibility warnings.
 
 # Gerekli Araclar
 - Bash (badi dev docker-lint)

--- a/.claude/commands/docs-audit.md
+++ b/.claude/commands/docs-audit.md
@@ -1,4 +1,4 @@
-Dokumantasyon denetimi komutu. Teknik dokumantasyonun tamamligini, guncelligini ve kalitesini degerlendirir.
+Documentation audit command. Evaluates completeness, freshness, and quality of technical documentation.
 
 # Gerekli Araclar
 - Read (dokumantasyon dosyalari)

--- a/.claude/commands/doctor.md
+++ b/.claude/commands/doctor.md
@@ -1,4 +1,4 @@
-Badi konfigur asyon dogrulamas i. Tum Badi bilesenlrini kontrol eder ve tanisal rapor olusturur.
+Badi configuration validation. Checks all Badi components and produces a diagnostic report.
 
 # Gerekli Araclar
 - Bash (dosya izinleri, dizin yapisi kontrolu)

--- a/.claude/commands/drift-detect.md
+++ b/.claude/commands/drift-detect.md
@@ -1,4 +1,4 @@
-Konfigurasyon sapma tespiti komutu. Badi sistemindeki tutarsizliklari, yetim bilesenleri ve eskilesmis icerigi tespit eder.
+Configuration drift detection command. Finds inconsistencies, orphaned components, and stale content in the Badi system.
 
 # Gerekli Araclar
 - Read (konfigurasyon dosyalari)

--- a/.claude/commands/env-check.md
+++ b/.claude/commands/env-check.md
@@ -1,4 +1,4 @@
-.env dosyasi dogrulama. Eksik, fazla, bos ve placeholder degerleri tespit + .gitignore kontrolu.
+.env file validation. Detects missing, extra, empty, and placeholder values + .gitignore check.
 
 # Gerekli Araclar
 - Bash (badi dev env-check)

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,4 +1,4 @@
-Is teslim brifingi komutu. Baska bir gelistiriciye veya oturuma sorunsuz gecis saglar.
+Handoff briefing command. Enables a smooth transition to another developer or session.
 
 # Gerekli Araclar
 - Read (baglam, notlar, gorevler)

--- a/.claude/commands/health.md
+++ b/.claude/commands/health.md
@@ -1,4 +1,4 @@
-Sistem sagligi kontrolu. Bagimliliklari, guvenligi, performansi ve (varsa) production domaini uclu tarama ile denetler.
+System health check. Audits dependencies, security, performance, and (if present) the production domain with a triple scan.
 
 ## Badi CLI Komutlari
 Bu kontroller su CLI komutlarini kullanir (v1.6+):

--- a/.claude/commands/hotfix.md
+++ b/.claude/commands/hotfix.md
@@ -1,4 +1,4 @@
-Acil duzeltme is akisi. Produksiyon hatalari icin hizli ve guvenli yama sureci yonetir.
+Emergency fix workflow. Manages a fast, safe patching process for production errors.
 
 # Gerekli Araclar
 - Bash (git islemleri, test calistirma)

--- a/.claude/commands/launch.md
+++ b/.claude/commands/launch.md
@@ -1,4 +1,4 @@
-Urun lansman plani komutu. Yeni bir urun veya ozellik lansmani icin kapsamli plan olusturur.
+Product launch plan command. Creates a comprehensive plan for a new product or feature launch.
 
 # Gerekli Araclar
 - Read (proje verileri)

--- a/.claude/commands/lighthouse.md
+++ b/.claude/commands/lighthouse.md
@@ -1,4 +1,4 @@
-Lighthouse audit komutu. Google PageSpeed Insights API uzerinden Performance, Accessibility, Best Practices, SEO skorlari ve Core Web Vitals olcumu.
+Lighthouse audit command. Performance, Accessibility, Best Practices, SEO scores and Core Web Vitals via the Google PageSpeed Insights API.
 
 # Gerekli Araclar
 - Bash (badi lighthouse komutu cagirisi)

--- a/.claude/commands/memory-diff.md
+++ b/.claude/commands/memory-diff.md
@@ -1,4 +1,4 @@
-Memory ve knowledge-base limit kontrolu + global proje karsilastirmasi.
+Memory and knowledge-base limit check + global project comparison.
 
 # Gerekli Araclar
 - Bash (badi ai memory-diff)

--- a/.claude/commands/mobile.md
+++ b/.claude/commands/mobile.md
@@ -1,4 +1,4 @@
-Mobil proje yonetim komutu. React Native/Flutter/Expo/Swift/Kotlin proje iskelesi, version sync, build ve release rehberleri.
+Mobile project management command. React Native/Flutter/Expo/Swift/Kotlin scaffolding, version sync, build and release guides.
 
 # Gerekli Araclar
 - Bash (badi mobile komutlari)

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -1,4 +1,4 @@
-Proje alistirma komutu. Yeni bir projeye hizli ve kapsamli adapte olmak icin kullanilir.
+Project onboarding command. For adapting to a new project quickly and thoroughly.
 
 # Gerekli Araclar
 - Glob (dosya yapisi taramasi)

--- a/.claude/commands/perf-check.md
+++ b/.claude/commands/perf-check.md
@@ -1,4 +1,4 @@
-Performans profilleme. Sicak yollari, darbogazlari ve optimizasyon firsatlarini tespit eder.
+Performance profiling. Detects hot paths, bottlenecks, and optimization opportunities.
 
 ## Badi CLI Komutlari (v1.6+)
 Production URL varsa:

--- a/.claude/commands/playbook.md
+++ b/.claude/commands/playbook.md
@@ -1,4 +1,4 @@
-Is akisini komuta donusturme komutu. Tekrarlayan manuel is akislarini yeniden kullanilabilir Badi komutlarina cevirir.
+Workflow-to-command command. Converts repetitive manual workflows into reusable Badi commands.
 
 # Gerekli Araclar
 - Read (mevcut komutlar) -- Write (yeni komut) -- Glob (mevcut komut listesi) -- Grep (kalip/referans)

--- a/.claude/commands/plugin.md
+++ b/.claude/commands/plugin.md
@@ -1,4 +1,4 @@
-Plugin yonetim komutu. Badi sistemine eklenti yukler, kaldirir ve listeler.
+Plugin management command. Installs, removes, and lists plugins in the Badi system.
 
 # Gerekli Araclar
 - Bash (git clone, npm install, dosya kopyalama)

--- a/.claude/commands/post-mortem.md
+++ b/.claude/commands/post-mortem.md
@@ -1,4 +1,4 @@
-Olay sonrasi analiz (post-mortem) komutu. Uretim olaylari ve onemli hatalarin kok neden analizini belgeler.
+Post-incident analysis (post-mortem) command. Documents root-cause analysis of production incidents and major failures.
 
 # Gerekli Araclar
 - Read (log dosyalari, olay kayitlari)

--- a/.claude/commands/prompt-test.md
+++ b/.claude/commands/prompt-test.md
@@ -1,4 +1,4 @@
-Slash komut ve ajan dosyalari icin regression test. Format ve icerik dogrulamasi.
+Regression test for slash command and agent files. Format and content validation.
 
 # Gerekli Araclar
 - Bash (badi ai prompt-test)

--- a/.claude/commands/proposal.md
+++ b/.claude/commands/proposal.md
@@ -1,4 +1,4 @@
-Musteri teklifi komutu. Proje ozetlerinden profesyonel musteri teklifi olusturur. 30 gun gecerli.
+Client proposal command. Builds a professional client proposal from project summaries. Valid for 30 days.
 
 # Gerekli Araclar
 - Read (proje verileri, mevcut brifing)

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -1,4 +1,4 @@
-Kod yeniden duzenleme komutu. Kod kokularini tespit edip guvenli refactoring plani olusturur.
+Refactoring command. Detects code smells and creates a safe refactoring plan.
 
 # Gerekli Araclar
 - Read (kod okuma)

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,4 +1,4 @@
-Surum notlari olusturma komutu. Degisiklikleri 3 farkli hedef kitleye uygun formatta derler.
+Release notes command. Compiles changes into formats for 3 different audiences.
 
 ## Badi CLI Workflow (v1.6+)
 Release oncesi sira:

--- a/.claude/commands/report.md
+++ b/.claude/commands/report.md
@@ -1,4 +1,4 @@
-Profesyonel rapor komutu. Ham veri ve bulgulari hedef kitleye uygun profesyonel raporlara donusturur.
+Professional report command. Turns raw data and findings into professional, audience-appropriate reports.
 
 # Gerekli Araclar
 - Read (veri kaynaklari)

--- a/.claude/commands/retro.md
+++ b/.claude/commands/retro.md
@@ -1,4 +1,4 @@
-Sprint retrospektifi komutu. Gecmis donem analizi yaparak iyilestirme alanlari belirler.
+Sprint retrospective command. Analyzes the past period and identifies improvement areas.
 
 # Gerekli Araclar
 - Read (gunluk notlar, gorev panosu, bellek)

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,4 +1,4 @@
-Derin kod incelemesi komutu. Guvenlik, performans ve mimari boyutlariyla kapsamli kod analizi yapar.
+Deep code review command. Comprehensive code analysis across security, performance, and architecture.
 
 > **Argument formati (v1.31.0+)**: `/review [effort] [--comment] [--correctness-only]`
 > - `effort`: `low` | `medium` (default) | `high` — analiz derinligi

--- a/.claude/commands/scaffold.md
+++ b/.claude/commands/scaffold.md
@@ -1,4 +1,4 @@
-Kod iskelesi olusturma komutu. Proje yapisini analiz edip tutarli modul, bilesen veya API iskelesi uretir.
+Code scaffolding command. Analyzes project structure and generates consistent module, component, or API skeletons.
 
 # Gerekli Araclar
 - Read (mevcut kod kaliplari)

--- a/.claude/commands/schedule.md
+++ b/.claude/commands/schedule.md
@@ -1,4 +1,4 @@
-Zamanlanmis komut hatirlaticilari. Gunluk/haftalik tekrar eden gorevler icin shell bazli hatirlatma sistemi.
+Scheduled command reminders. Shell-based reminder system for daily/weekly recurring tasks.
 
 # Gerekli Araclar
 - Bash (badi schedule)

--- a/.claude/commands/secret-scan.md
+++ b/.claude/commands/secret-scan.md
@@ -1,4 +1,4 @@
-Proje genelinde sir/credential taramasi komutu. AWS/GCP/GitHub/npm/Stripe/OpenAI/Anthropic anahtarlari, JWT, database URI'leri, private key'ler.
+Project-wide secret/credential scan command. AWS/GCP/GitHub/npm/Stripe/OpenAI/Anthropic keys, JWTs, database URIs, private keys.
 
 > **Daha genis kapsam icin**: `badi security baseline` (secret-scan + npm audit), `/security-review` (Anthropic native AI semantic — Claude Code 2.1.140+).
 

--- a/.claude/commands/security-scan.md
+++ b/.claude/commands/security-scan.md
@@ -1,4 +1,4 @@
-Guvenlik taramasi. Kod tabani ve bagimliliklarda guvenlik aciklari arar ve ciddiyet siralmasili rapor olusturur.
+Security scan. Searches the codebase and dependencies for vulnerabilities and produces a severity-ranked report.
 
 > **Native komut (v1.31.0+)**: Claude Code 2.1.140+ ile `/security-review` artik **native** komut (built-in slash). Bu komut onun yaninda **deterministic baseline** (`badi security baseline`) + **post-scan triage** (`badi security triage`) saglar.
 >

--- a/.claude/commands/seo.md
+++ b/.claude/commands/seo.md
@@ -1,4 +1,4 @@
-SEO denetim komutu. Website SEO analizi, meta tag kontrolu, sitemap dogrulama ve hiz degerlendirmesi.
+SEO audit command. Website SEO analysis, meta tag checks, sitemap validation, and speed assessment.
 
 # Gerekli Araclar
 - Bash (badi seo komutlari)

--- a/.claude/commands/spec-check.md
+++ b/.claude/commands/spec-check.md
@@ -1,4 +1,4 @@
-Spesifikasyon uyum kontrolu komutu. Mevcut kodu SPECIFICATION.md'ye karsi denetler, ozellik eksiklerini ve kapsam kaymasini tespit eder.
+Specification conformance command. Audits the current code against SPECIFICATION.md, detecting feature gaps and scope drift.
 
 # Gerekli Araclar
 - Read (SPECIFICATION.md, kaynak kodlar)

--- a/.claude/commands/ssl-check.md
+++ b/.claude/commands/ssl-check.md
@@ -1,4 +1,4 @@
-SSL sertifika analizi komutu. Domain icin sertifika gecerliligi, TLS surumu, cipher gucu kontrolu yapar.
+SSL certificate analysis command. Checks certificate validity, TLS version, and cipher strength for a domain.
 
 # Gerekli Araclar
 - Bash (badi ssl komutu cagirisi)

--- a/.claude/commands/standup.md
+++ b/.claude/commands/standup.md
@@ -1,4 +1,4 @@
-Gunluk toplanti komutu. 30 saniye icinde hizli durum ozeti olusturur.
+Daily standup command. Produces a quick status summary in under 30 seconds.
 
 # Gerekli Araclar
 - Bash (git log)

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -1,4 +1,4 @@
-Badi oturum baslatma komutu. Yeni proje alistirmasi veya gunluk calisma baslatmasi yapar.
+Badi session start command. Runs new-project onboarding or a daily kickoff.
 
 # Gerekli Araclar
 - Bash (dosya sistemi erisimi)

--- a/.claude/commands/stats.md
+++ b/.claude/commands/stats.md
@@ -1,4 +1,4 @@
-Kullanim analitikleri komutu. Badi arac kullanim istatistikleri, bar chart, gunluk trend, aliskanlik serisi.
+Usage analytics command. Badi tool usage statistics, bar charts, daily trends, habit streaks.
 
 # Gerekli Araclar
 - Bash (badi stats)

--- a/.claude/commands/sync.md
+++ b/.claude/commands/sync.md
@@ -1,4 +1,4 @@
-Oturum ortasi baglam yenileme komutu. Calisma sirasinda baglami taze tutar ve tutarliligi saglar.
+Mid-session context refresh command. Keeps context fresh and consistent during work.
 
 # Gerekli Araclar
 - Read (bellek ve baglam dosyalari)

--- a/.claude/commands/system-audit.md
+++ b/.claude/commands/system-audit.md
@@ -1,4 +1,4 @@
-Derin altyapi denetimi komutu. Badi sisteminin tum bilesenlerini 9 kontrol noktasiyla kapsamli olarak denetler.
+Deep infrastructure audit command. Comprehensively audits all Badi components across 9 checkpoints.
 
 # Gerekli Araclar
 - Read (tum konfig dosyalari) -- Grep (referans/kalip taramasi) -- Glob (dosya varlik) -- Bash (izin, JSON dogrulama, dosya bilgisi) -- Write (rapor)

--- a/.claude/commands/unstick.md
+++ b/.claude/commands/unstick.md
@@ -1,4 +1,4 @@
-Tikaniklik cozme komutu. Takili kaldiginda yapisal bir yaklasimla hizli cozum bulur.
+Unblocking command. Finds a fast solution with a structured approach when you're stuck.
 
 # Gerekli Araclar
 - Read (kod ve baglam okuma)

--- a/.claude/commands/whois.md
+++ b/.claude/commands/whois.md
@@ -1,4 +1,4 @@
-Domain WHOIS bilgisi komutu. Tescil tarihi, expire, registrar, transfer lock durumu kontrolu.
+Domain WHOIS command. Checks registration date, expiry, registrar, and transfer lock status.
 
 # Gerekli Araclar
 - Bash (badi whois komutu cagirisi)

--- a/.claude/commands/wp.md
+++ b/.claude/commands/wp.md
@@ -1,4 +1,4 @@
-WordPress site yonetimi komutu. Site durumu, eklenti/tema yonetimi, guvenlik taramasi ve toplu guncelleme.
+WordPress site management command. Site status, plugin/theme management, security scan, and bulk updates.
 
 # Gerekli Araclar
 - Bash (badi wp komutlari)

--- a/.claude/commands/wrap-up.md
+++ b/.claude/commands/wrap-up.md
@@ -1,4 +1,4 @@
-Gun sonu rituel komutu. Gunu kapanisa hazirlayarak yarin icin zemin hazirlar.
+End-of-day ritual command. Prepares the day for closure and sets the stage for tomorrow.
 
 # Gerekli Araclar
 - Read (bellek, notlar, gunlukler)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Added — ads-strategist agent + /meta-review + /ads-review (advisory paid-ads layer)
+
+Project-aware paid advertising review, modeled on the /ceo-review pattern: badi knows the project (memory, code, target user) and turns that context plus live market research into a platform-specific ad strategy with a launch-readiness verdict (READY TO LAUNCH / FIX FIRST / DON'T ADVERTISE YET).
+
+- New agent `ads-strategist` (READ_ONLY, advisory; first agent with WebSearch/WebFetch).
+- `/meta-review` (Meta: audiences, CBO/ABO funnel, creative angles, policy risk) and `/ads-review` (Google Ads: keyword universe, Search/PMax, RSA assets, Quality Score, conversion tracking) — both in the `content` profile.
+- Hard boundary: advisory-only — no ad-platform APIs, no credentials, no spend automation. Fleet: 26 → 27 agents, 82 → 84 commands.
+
+### Changed — English command/agent descriptions + regenerated command index
+
+- All 84 slash-command description lines and all 27 agent `description:` fields are now English (the slash-menu surface matches the v1.32 English-only migration).
+- `.claude/command-index.md` regenerated from the vault: was stale at 50 Turkish entries; now 84 English entries grouped by profile, including `/team`, `/ceo-review`, `/eng-review`, `/qa`, `/ship`, `/meta-review`, `/ads-review`.
+- README/docs currency: hero counts 22/77 → 27/84, tests badge 915 → 1161, harness table, and the stale "CLI output is Turkish" note replaced with the English-only statement.
+
 ## [1.32.0] - 2026-06-03
 
 > **English-only migration completed + virtual engineering team.** The entire user-facing CLI surface — command output, command grammar, and Claude Code slash commands — is now English. A managerial agent layer (`/ceo-review`, `/eng-review`, `/qa`, `/ship`, `/team`) was added, inspired by the "virtual eng team" pattern.

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,20 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+### Eklenen — ads-strategist ajani + /meta-review + /ads-review (advisory paid-ads katmani)
+
+Proje-farkindali reklam stratejisi review'u (/ceo-review deseni): badi projeyi taniyor; bu baglami + canli pazar arastirmasini platforma ozel reklam stratejisine ve lansman-hazirlik verdiktine cevirir (READY TO LAUNCH / FIX FIRST / DON'T ADVERTISE YET).
+
+- Yeni ajan `ads-strategist` (READ_ONLY, advisory; WebSearch/WebFetch'li ilk ajan).
+- `/meta-review` (Meta: kitle, CBO/ABO funnel, creative acilari, policy riski) ve `/ads-review` (Google Ads: keyword evreni, Search/PMax, RSA, Quality Score, conversion tracking) — content profili.
+- Kesin sinir: advisory-only — reklam API'si yok, kimlik bilgisi yok, harcama otomasyonu yok. Filo: 26 → 27 ajan, 82 → 84 komut.
+
+### Degisen — Ingilizce komut/ajan aciklamalari + komut indeksi yeniden uretildi
+
+- 84 slash-komut aciklama satiri + 27 ajan `description:` alani artik Ingilizce (slash-menu yuzeyi v1.32 English-only gocuyle hizalandi).
+- `.claude/command-index.md` vault'tan yeniden uretildi: 50 Turkce girdide bayatti; simdi 84 Ingilizce girdi, profil gruplu, yeni komutlar (`/team`, `/ceo-review`, `/eng-review`, `/qa`, `/ship`, `/meta-review`, `/ads-review`) dahil.
+- README/docs guncellik: sayimlar 22/77 → 27/84, test rozeti 915 → 1161, harness tablosu, bayat "CLI ciktisi Turkce" notu English-only ifadesiyle degistirildi.
+
 ## [1.32.0] - 2026-06-03
 
 > **English-only goc tamamlandi + sanal muhendislik ekibi.** Kullanicinin gordugu/yazdigi tum CLI yuzeyi — komut ciktisi, komut grammar'i ve Claude Code slash komutlari — artik Ingilizce. "Sanal eng ekibi" ilhamiyla yonetimsel bir ajan katmani (`/ceo-review`, `/eng-review`, `/qa`, `/ship`, `/team`) eklendi.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
   <img src="https://img.shields.io/npm/dm/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm downloads per month" />
   <img src="https://img.shields.io/npm/dt/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm total downloads" />
   <img src="https://img.shields.io/npm/l/@fatihkan/badi?color=00d4ff&style=flat-square" alt="license" />
-  <img src="https://img.shields.io/badge/tests-915%20passing-00d4ff?style=flat-square" alt="tests" />
+  <img src="https://img.shields.io/badge/tests-1161%20passing-00d4ff?style=flat-square" alt="tests" />
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **22 AI subagents**, **77 slash commands** (profile-based core/dev/content/pentest management since v1.26), **13 automation hooks**, and **62 opt-in skill categories** (25 general + 25 pentest-* advisory/defensive since v1.25 + 12 expo-* mobile dev lifecycle since v1.27) with **prompt-aware auto-routing** for both skills and commands (v1.20+ / v1.26+). OWASP Top 10 scans, code review, content production, mobile/web SEO, App Store market research with `wishlist` + `gaps` analysis. Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
+**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **27 AI subagents** (incl. a virtual eng team + ads strategist), **84 slash commands** (profile-based core/dev/content/pentest management since v1.26), **13 automation hooks**, and **62 opt-in skill categories** (25 general + 25 pentest-* advisory/defensive since v1.25 + 12 expo-* mobile dev lifecycle since v1.27) with **prompt-aware auto-routing** for both skills and commands (v1.20+ / v1.26+). OWASP Top 10 scans, code review, content production, mobile/web SEO, App Store market research with `wishlist` + `gaps` analysis. Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
 
 ## Demo
 
@@ -70,8 +70,8 @@ For Turkish/UTF-8 output in cmd, run `chcp 65001` once or use Windows Terminal /
 
 | Harness | Rules | Commands | MCP | Subagents | Hooks | Skills |
 |---------|:-----:|:--------:|:---:|:---------:|:-----:|:------:|
-| Claude Code | `CLAUDE.md` | 77 | `.mcp.json` | 22 | 14 | 62 |
-| Cursor | `.cursor/rules/badi-main.mdc` | 77 | `.cursor/mcp.json` | — | — | — |
+| Claude Code | `CLAUDE.md` | 84 | `.mcp.json` | 27 | 14 | 62 |
+| Cursor | `.cursor/rules/badi-main.mdc` | 84 | `.cursor/mcp.json` | — | — | — |
 | Gemini CLI | `GEMINI.md` (merged) | inline | `.gemini/settings.json` | — | — | — |
 | Windsurf (v1.30+) | `.windsurfrules` (merged) | inline | — | — | — | — |
 | AGENTS.md (v1.30+) | `AGENTS.md` (merged) | inline | — | — | — | — |
@@ -82,18 +82,18 @@ Claude is the canonical source. Cursor/Gemini/Windsurf/AGENTS.md adapters compil
 
 | Feature | Details |
 |---------|---------|
-| **27 expert agents + 84 commands** | Full toolkit from security scanner to performance profiler, plus a virtual eng team (CEO / eng manager / release manager / QA lead) wired together by `/team` — profile-based filtering (core/dev/content/pentest) since v1.26 |
+| **27 expert agents + 84 commands** | Full toolkit from security scanner to performance profiler, plus a virtual eng team (CEO / eng manager / release manager / QA lead) wired together by `/team`, and an ads strategist (`/meta-review`, `/ads-review`) — profile-based filtering (core/dev/content/pentest) since v1.26 |
 | **14 automation hooks + 62 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants. Skills load zero tokens by default since v1.17; auto-router (v1.20+) injects matching skills per prompt; pentest-* family (v1.25+ advisory/defensive); expo-* family (v1.27+ mobile dev lifecycle); command routing (v1.26+); plan-injection hook (v1.30+) |
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+, expanded v1.30+)** | Claude Code, Cursor, Gemini CLI, Windsurf, AGENTS.md — same `.claude/` source, 5 targets |
 | **Observability (v1.29+) + self-telemetry (v1.30+)** | Read Claude Code transcripts (`badi stats --session/--models/--cost`, `badi search`, `badi session`) + emit own command events (`badi events list/stats`, BADI_TELEMETRY=off to disable) |
-| **1021 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, tasarim, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter |
-| **TR/EN content engine** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
+| **1161 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, tasarim, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter |
+| **Content engine (English)** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
 | **Modular architecture** | 22 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
 | **Open source (MIT)** | Community-first, transparent licensing |
 
-> Note on CLI language: most CLI output text is currently Turkish (backward-compatible). Docs are English-first; full CLI i18n is on the v1.10 roadmap.
+> CLI language: all output, command grammar, and slash commands are English as of v1.32 (English-only migration complete).
 
 ## Quick Start
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,7 +37,7 @@ The plugin path ships agents, slash commands, and the two universal safety hooks
 ## First steps
 
 ```bash
-# List the 21 agents
+# List the 27 agents
 badi list --agents
 
 # Browse the 84 commands

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: "Badi"
   text: "Workflow management CLI"
-  tagline: "27 AI agents · 84 commands · 12 safety hooks · 23 opt-in skills — for Claude Code, Cursor, and Gemini CLI"
+  tagline: "27 AI agents · 84 commands · 14 hooks · 62 opt-in skills — for Claude Code, Cursor, and Gemini CLI"
   actions:
     - theme: brand
       text: Get Started


### PR DESCRIPTION
## Summary

Closes the last **user-visible** Turkish surface (the slash-menu descriptions) and brings README/CHANGELOG/command-index current — the new commands (`/team`, `/ceo-review`, `/eng-review`, `/qa`, `/ship`, `/meta-review`, `/ads-review`) were invisible in the index and docs.

### Changes
- **84 command description lines → English** (vault + active, 154 files): the line-1 description every user sees in the slash menu.
- **27 agent `description:` fields → English** (22 translated; 5 were already EN).
- **`command-index.md` regenerated from the vault** — was stale at *50 Turkish entries*; now 84 English entries grouped by profile, all new commands included.
- **README currency**: hero counts 22/77→27/84 (+ virtual eng team & ads strategist), tests badge 915→1161, harness table, `1021 passing tests`→1161, `TR/EN content engine`→English, and the stale *"CLI output is currently Turkish"* note replaced with the English-only statement.
- **docs**: getting-started "21 agents"→27; index tagline hooks/skills 12/23→14/62.
- **CHANGELOG (en+tr) `[Unreleased]`**: ads-strategist feature (#232) + this sweep.

### Scope note
Command/agent **bodies** (the procedures, still Turkish in the 70 older commands) are deliberately out — that's a much larger translation phase. This PR makes every *visible* surface (menu, index, README) consistent.

## Test plan
- [x] `npm test` — **1161 pass / 0 fail**
- [x] `npx biome check` — clean · `badi doctor` — healthy
- [x] Zero Turkish in description lines (broad scan) and in the regenerated index
- [x] All 7 new commands present in `command-index.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)