### PR TITLE
feat(i18n): Phase 3b — English core command bodies (21 commands)

### DIFF
--- a/.claude/commands-vault/ai-token.md
+++ b/.claude/commands-vault/ai-token.md
@@ -1,45 +1,45 @@
 Badi/.claude/ token usage analysis command. Categorized token counts, largest files, optimization suggestions.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi ai token)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Calistir
+### Step 1: Run
 ```bash
 badi ai token
 ```
 
-### Adim 2: Sonuclari Yorumla
+### Step 2: Interpret the Results
 
-Kategori bazli dokum:
-- **agents** — Ajan tanimlari
-- **commands** — Slash komutlar
-- **hooks** — Shell hook'lari
-- **skills** — Beceri kutuphanesi (genelde en buyuk)
-- **references** — Proje rehberleri
-- **memory/workspace** — Proje notlari
+Category breakdown:
+- **agents** — Agent definitions
+- **commands** — Slash commands
+- **hooks** — Shell hooks
+- **skills** — Skill library (usually the largest)
+- **references** — Project guides
+- **memory/workspace** — Project notes
 
-Toplam token esigi:
-- `< 80K` — Saglikli
-- `80-150K` — Izleme gerekli
-- `> 150K` — Optimizasyon zorunlu
+Total token thresholds:
+- `< 80K` — Healthy
+- `80-150K` — Needs monitoring
+- `> 150K` — Optimization mandatory
 
-### Adim 3: Optimizasyon Onerileri
+### Step 3: Optimization Suggestions
 
-Toplam yuksekse:
-1. **Buyuk SKILL.md'leri bol** — `references/` alt dizinine cekme
-2. **Unused commandlari kaldir** — Kullanilmayan slash komut
-3. **CLAUDE.md minimize** — 1.2KB hedef
-4. **Log rotation** — .claude/logs/ otomatik sinir
+If the total is high:
+1. **Split large SKILL.md files** — move into a `references/` subdirectory
+2. **Remove unused commands** — slash commands nobody invokes
+3. **Minimize CLAUDE.md** — 1.2KB target
+4. **Log rotation** — automatic cap on .claude/logs/
 
-### Adim 4: Takip
+### Step 4: Follow-up
 
-Haftalik kontrol:
-- `/ai-token` her Pazartesi sabahi
-- Trendi izle (her hafta 10%+ artis varsa inceleme)
+Weekly check:
+- `/ai-token` every Monday morning
+- Watch the trend (investigate on 10%+ weekly growth)
 
-# Ornek
+# Example
 
 ```
 /ai-token

--- a/.claude/commands-vault/audit.md
+++ b/.claude/commands-vault/audit.md
@@ -1,114 +1,114 @@
 Quality audit command. Runs a systematic audit over code, structure, or process.
 
-## Badi CLI Komutlari (v1.6+)
-Seviye T4 (Kapsamli) denetimde su CLI araclari calistirir:
-- `badi secret-scan --git` — Sir taramasi + git history
+## Badi CLI Commands (v1.6+)
+A Level T4 (Comprehensive) audit runs these CLI tools:
+- `badi secret-scan --git` — Secret scan + git history
 - `badi lighthouse [url]` — Performance + Core Web Vitals
 - `badi a11y [url]` — Accessibility (WCAG 2.1)
-- `badi ssl/dns/whois [domain]` — Domain saglik (uretim varsa)
-- `badi commit --check` — Son commit conventional format
+- `badi ssl/dns/whois [domain]` — Domain health (if production exists)
+- `badi commit --check` — Last commit conventional format
 
-# Gerekli Araclar
-- Read (dosya okuma)
-- Grep (kod taramasi)
-- Glob (dosya bulma)
-- Bash (analiz araclari)
-- Write (rapor yazimi)
+# Required Tools
+- Read (file reading)
+- Grep (code scan)
+- Glob (file discovery)
+- Bash (analysis tools)
+- Write (report writing)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Kapsam Belirle
-Kullaniciya sor: "Denetim kapsamini secin:"
-- **Dosya/Dizin:** Belirli bir dosya veya klasor
-- **Modul:** Tum bir modul veya ozellik
-- **Proje Geneli:** Tum kod tabani
-- **Surec:** CI/CD, test, deploy surecleri
+### Step 1: Define the Scope
+Ask the user: "Pick the audit scope:"
+- **File/Directory:** A specific file or folder
+- **Module:** A whole module or feature
+- **Project-Wide:** The entire codebase
+- **Process:** CI/CD, test, deploy processes
 
-### Adim 2: Denetim Seviyesi Sec (T1-T4)
+### Step 2: Pick the Audit Level (T1-T4)
 
-**T1 - Hizli Tarama (2-5 dk)**
-- Sozdizimi ve format kontrolleri
-- Bariz guvenlik sorunlari (hardcoded secrets, SQL injection)
-- Eksik dosyalar veya kirik importlar
-- Lint kurali ihlalleri
+**T1 - Quick Scan (2-5 min)**
+- Syntax and format checks
+- Obvious security issues (hardcoded secrets, SQL injection)
+- Missing files or broken imports
+- Lint rule violations
 
-**T2 - Standart Denetim (5-15 dk)**
-- T1 + kod kalite metrikleri
-- Tekrarlanan kod (DRY ihlalleri)
-- Isimlendirme tutarliligi
-- Yorum ve dokumantasyon eksiklikleri
-- Test kapsami analizi
+**T2 - Standard Audit (5-15 min)**
+- T1 + code quality metrics
+- Duplicated code (DRY violations)
+- Naming consistency
+- Comment and documentation gaps
+- Test coverage analysis
 
-**T3 - Derin Denetim (15-30 dk)**
-- T2 + mimari uyum analizi
-- Bagimlilik grafigi incelemesi
-- Performans darbogazlari
-- Hata yonetimi kaliplari
-- Erisim kontrol ve yetkilendirme
+**T3 - Deep Audit (15-30 min)**
+- T2 + architectural fit analysis
+- Dependency graph review
+- Performance bottlenecks
+- Error handling patterns
+- Access control and authorization
 
-**T4 - Kapsamli Denetim (30+ dk)**
-- T3 + guvenlik taramasi (OWASP Top 10)
-- Olceklenebilirlik degerlendirmesi
-- Felaket kurtarma hazirlik durumu
-- Uyumluluk kontrolleri (lisans, KVKK vb.)
-- Teknik borc envanteri
-- **Badi CLI Ekstralari**:
-  - `badi secret-scan --git` — Sir + git history
-  - `badi lighthouse [url]` — Performans + SEO + A11y + Best Practices
-  - `badi a11y [url]` — WCAG 2.1 detay
-  - `badi ssl/dns/whois [domain]` — Uretim domain saglik
-  - `badi commit --check` — Commit format uyumu
+**T4 - Comprehensive Audit (30+ min)**
+- T3 + security scan (OWASP Top 10)
+- Scalability assessment
+- Disaster recovery readiness
+- Compliance checks (licenses, GDPR/KVKK, etc.)
+- Technical debt inventory
+- **Badi CLI Extras**:
+  - `badi secret-scan --git` — Secrets + git history
+  - `badi lighthouse [url]` — Performance + SEO + A11y + Best Practices
+  - `badi a11y [url]` — WCAG 2.1 detail
+  - `badi ssl/dns/whois [domain]` — Production domain health
+  - `badi commit --check` — Commit format compliance
 
-### Adim 3: Denetim Ajani Devret
-Secilen seviyeye gore denetimi baslat:
-- Her kontrol maddesi icin GECTI / KALDI / UYARI durumu belirle
-- Bulgulari topla ve siniflandir
-- Kanit (kod satirlari, dosya yollari) ekle
+### Step 3: Delegate to the Audit Agent
+Start the audit at the chosen level:
+- Mark every check item PASS / FAIL / WARN
+- Collect and classify the findings
+- Attach evidence (code lines, file paths)
 
-### Adim 4: Sonuclari Isle
-Bulgulari siniflandir:
-- **KRITIK:** Hemen mudahale gerekli (guvenlik acigi, veri kaybi riski)
-- **YUKSEK:** Kisa vadede cozulmeli (performans, hata yonetimi)
-- **ORTA:** Planlanan sprintte ele alinmali (kod kalitesi)
-- **DUSUK:** Iyilestirme firsati (refactoring, dokumantasyon)
+### Step 4: Process the Results
+Classify the findings:
+- **CRITICAL:** Immediate intervention required (security hole, data-loss risk)
+- **HIGH:** Resolve in the short term (performance, error handling)
+- **MEDIUM:** Handle in a planned sprint (code quality)
+- **LOW:** Improvement opportunity (refactoring, documentation)
 
-### Adim 5: Gunlukleri Guncelle
-- Denetim sonuclarini gunluk nota ekle
-- Tespit edilen gorevleri gorev panosuna ekle
-- `memory.md` dosyasina onemli bulgulari kaydet
+### Step 5: Update the Logs
+- Add the audit results to the daily note
+- Add detected tasks to the task board
+- Record important findings in `memory.md`
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI DENETIM RAPORU ===
-Tarih: [tarih]
-Kapsam: [belirtilen kapsam]
-Seviye: T[1-4]
-Sure: [gecen sure]
+=== BADI AUDIT REPORT ===
+Date: [date]
+Scope: [specified scope]
+Level: T[1-4]
+Duration: [elapsed]
 
-## Ozet
-- Toplam Kontrol: [sayi]
-- Gecti: [sayi] | Kaldi: [sayi] | Uyari: [sayi]
-- Genel Skor: [yuzde]%
+## Summary
+- Total Checks: [count]
+- Passed: [count] | Failed: [count] | Warnings: [count]
+- Overall Score: [percent]%
 
-## Kritik Bulgular
-[varsa listele]
+## Critical Findings
+[list if any]
 
-## Yuksek Oncelikli Bulgular
-[listele]
+## High-Priority Findings
+[list]
 
-## Orta Oncelikli Bulgular
-[listele]
+## Medium-Priority Findings
+[list]
 
-## Dusuk Oncelikli / Iyilestirme
-[listele]
+## Low Priority / Improvements
+[list]
 
-## Onerilen Aksiyonlar
-1. [aksiyon]
-2. [aksiyon]
+## Suggested Actions
+1. [action]
+2. [action]
 ...
 
-## Sonraki Denetim Onerisi
-Tarih: [onerilen tarih]
-Kapsam: [onerilen kapsam]
+## Next Audit Suggestion
+Date: [suggested date]
+Scope: [suggested scope]
 =============================
 ```

--- a/.claude/commands-vault/clear.md
+++ b/.claude/commands-vault/clear.md
@@ -1,88 +1,88 @@
 Context-clearing command. Provides a seamless transition across session boundaries. Target: under 30 seconds.
 
-# Gerekli Araclar
-- Read (baglam dosyalari)
-- Write (devir notu ve bellek guncelleme)
+# Required Tools
+- Read (context files)
+- Write (handoff note and memory update)
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-### Adim 1: Kapilari Sifirla
-- Aktif dosya izleme listesini temizle
-- Gecici analiz sonuclarini sifirla
-- Acik kalan paralel isleri kapat
-- Oturum ici degiskenleri temizle
+### Step 1: Reset the Gates
+- Clear the active file-watch list
+- Reset temporary analysis results
+- Close any open parallel work
+- Clear in-session variables
 
-### Adim 2: Oturumu Ozetle (7 Bilesen)
-Su 7 bileseni iceren bir ozet olustur:
+### Step 2: Summarize the Session (7 Components)
+Build a summary covering these 7 components:
 
-1. **Aktif Gorev:** Su an uzerinde calisilan gorev nedir?
-2. **Durum:** Hangi asamada? (baslangic/orta/tamamlandi/bloke)
-3. **Son Eylem:** En son yapilan is neydi?
-4. **Sonraki Adim:** Hemen yapilmasi gereken sey nedir?
-5. **Acik Sorular:** Cevap bekleyen sorular var mi?
-6. **Degisen Dosyalar:** Bu oturumda degistirilen dosyalar
-7. **Onemli Baglam:** Sonraki oturumun bilmesi gereken kritik bilgi
+1. **Active Task:** What task is being worked on right now?
+2. **Status:** What stage? (start/middle/done/blocked)
+3. **Last Action:** What was the most recent work?
+4. **Next Step:** What needs to happen immediately?
+5. **Open Questions:** Any questions awaiting answers?
+6. **Changed Files:** Files modified this session
+7. **Key Context:** Critical information the next session must know
 
-### Adim 3: Devir Notu Yaz
-`handoffs/handoff-[GGAAYY-SSDD].md` dosyasini olustur:
+### Step 3: Write the Handoff Note
+Create `handoffs/handoff-[DDMMYY-HHMM].md`:
 ```markdown
-# Devir Notu - [tarih saat]
+# Handoff Note - [date time]
 
-## Aktif Gorev
-[gorev aciklamasi]
+## Active Task
+[task description]
 
-## Mevcut Durum
-[durum detayi]
+## Current Status
+[status detail]
 
-## Son Eylemler
-- [eylem listesi]
+## Recent Actions
+- [action list]
 
-## Sonraki Adimlar
-1. [adim]
-2. [adim]
+## Next Steps
+1. [step]
+2. [step]
 
-## Acik Sorular
-- [sorular]
+## Open Questions
+- [questions]
 
-## Degisen Dosyalar
-- [dosya listesi]
+## Changed Files
+- [file list]
 
-## Kritik Baglam
-[kaybedilmemesi gereken bilgi]
+## Critical Context
+[information that must not be lost]
 ```
 
-### Adim 4: Bellegi Guncelle
-`memory.md` dosyasinda:
-- Son gorev durumunu guncelle
-- Devir notu referansini ekle
-- Zaman damgasini guncelle
+### Step 4: Update Memory
+In `memory.md`:
+- Update the latest task status
+- Add the handoff note reference
+- Update the timestamp
 
-### Adim 5: Ogrenimleri Tasi
-Bu oturumda kazanilan ogrenimleri `knowledge-base.md` dosyasina aktar:
-- Teknik bilgiler
-- Proje kararlari
-- Surec notlari
+### Step 5: Move Learnings
+Transfer this session's learnings into `knowledge-base.md`:
+- Technical knowledge
+- Project decisions
+- Process notes
 
-### Adim 6: Otomatik Devam
-Sonraki oturumun baslangiç komutu icin hazirlık yap:
-- Devir notunun yolunu belirt
-- Oncelikli eylemleri vurgula
-- Baslama onerisini sun
+### Step 6: Auto-Continue
+Prepare for the next session's start command:
+- Point to the handoff note path
+- Highlight the priority actions
+- Offer a starting suggestion
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI BAGLAM TEMIZLEME ===
-Sure: [saniye]s
-Devir Notu: handoffs/handoff-[tarih].md
-Bellek: GUNCELLENDI
-Ogrenimler: [sayi] madde aktarildi
+=== BADI CONTEXT CLEAR ===
+Duration: [seconds]s
+Handoff Note: handoffs/handoff-[date].md
+Memory: UPDATED
+Learnings: [count] items transferred
 
-Sonraki Oturum Icin:
-> [tek satirlik baslama onerisi]
+For the Next Session:
+> [one-line starting suggestion]
 ===============================
 ```
 
-# Performans Hedefi
-- Tum islem 30 saniye altinda tamamlanmali
-- Bellek dosyasi 500 satiri gecmemeli
-- Devir notu ozlu ve net olmali (gereksiz detay yok)
+# Performance Target
+- The whole operation must finish in under 30 seconds
+- The memory file must not exceed 500 lines
+- The handoff note must be concise and clear (no needless detail)

--- a/.claude/commands-vault/coach.md
+++ b/.claude/commands-vault/coach.md
@@ -1,142 +1,142 @@
 Coaching analysis command. Performs data-driven work-pattern analysis and offers personal improvement suggestions.
 
-# Gerekli Araclar
-- Read (bellek, gorevler, notlar, onceki kocluk raporlari)
-- Write (kocluk raporu)
-- Grep (kalip taramasi)
-- Glob (veri kaynaklari bulma)
-- Bash (git istatistikleri)
+# Required Tools
+- Read (memory, tasks, notes, previous coaching reports)
+- Write (coaching report)
+- Grep (pattern scan)
+- Glob (finding data sources)
+- Bash (git statistics)
 
-# Opsiyonel Zaman Dilimi
-Kullaniciya sor: "Hangi doenemi analiz edelim?"
-- **Haftalik:** Son 7 gun
-- **Aylik:** Son 30 gun
-- **Tum Veri:** Mevcut tum kayitlar
+# Optional Time Window
+Ask the user: "Which period shall we analyze?"
+- **Weekly:** Last 7 days
+- **Monthly:** Last 30 days
+- **All Data:** Every existing record
 
-# Prosedur (4 Bolum)
+# Procedure (4 Sections)
 
-### Bolum 0: Veri Toplama
-Analiz icin veri kaynaklarini topla:
-- `memory.md` dosyasini oku
-- Gorev panosunu incele (tamamlanan, devam eden, ertelenen)
-- Gunluk notlari tara (belirtilen donem icin)
-- Git istatistiklerini topla (commit sikligi, degisiklik hacmi)
-- Onceki kocluk gozlemlerini oku (varsa)
-- Devir notlarini incele
-- Retrospektif raporlarini kontrol et
+### Section 0: Data Collection
+Gather the data sources for analysis:
+- Read `memory.md`
+- Review the task board (completed, in progress, deferred)
+- Scan the daily notes (for the chosen period)
+- Collect git statistics (commit frequency, change volume)
+- Read previous coaching observations (if any)
+- Review the handoff notes
+- Check the retrospective reports
 
-### Bolum 1: Uretkenlik Analizi
+### Section 1: Productivity Analysis
 
-**Metrikler:**
-- Gorev tamamlama orani (tamamlanan / planlanan)
-- Gunluk ortalama commit sayisi
-- Uretken gun sayisi ve oruntuleri
-- Gorev basina harcanan ortalama sure
-- Zaman dagilimi analizi (gelistirme / toplanti / yonetim / arastirma)
-- En verimli saat ve gun analizi
-- Darbogazlar ve bekleme sureleri
+**Metrics:**
+- Task completion rate (completed / planned)
+- Average daily commit count
+- Productive day count and patterns
+- Average time spent per task
+- Time distribution analysis (development / meetings / management / research)
+- Most productive hour and day analysis
+- Bottlenecks and waiting times
 
-**Degerllendirme:**
-- Ust duzey performans alanlari
-- Iyilestirme gerektiren alanlar
-- Verimlilik trendi (artis/azalis/sabit)
+**Assessment:**
+- Top-performance areas
+- Areas needing improvement
+- Productivity trend (rising/falling/flat)
 
-### Bolum 2: Buyume Analizi
+### Section 2: Growth Analysis
 
-**Metrikler:**
-- Yeni ogrenilen teknoloji ve araclar
-- Icerik uretim sikligi (blog, dokumantasyon, vb.)
-- Karmasiklik seviyesi artan gorevler (zorluk ilerlesmesi)
-- Problem cozme hizi degisimi
-- Kanal cesitliligi (gelistirme, tasarim, is gelistirme, vb.)
-- Teknik derinlik gostergesi
+**Metrics:**
+- Newly learned technologies and tools
+- Content production frequency (blog, documentation, etc.)
+- Tasks with rising complexity (difficulty progression)
+- Change in problem-solving speed
+- Channel diversity (development, design, business development, etc.)
+- Technical depth indicator
 
-**Degerllendirme:**
-- Beceri gelistirme alanlari
-- Konfor bolgesinden cikmis mi?
-- Yeni zorluklar aranmis mi?
+**Assessment:**
+- Skill development areas
+- Did they step out of the comfort zone?
+- Were new challenges sought?
 
-### Bolum 3: Surdurulebilirlik Analizi
+### Section 3: Sustainability Analysis
 
-**Sinyaller:**
-- Tukenmislik belirtileri:
-  - Hafta sonu calisma sikligi
-  - Asiri uzun oturumlar (4+ saat arasiiz)
-  - Gece gelistirme aktivitesi
-  - Artan hata orani
-- Engel yogunlugu (ne siklikta bloke olunuyor?)
-- Tekrarlayan sorunlar (ayni sey kac kez sorun oldu?)
-- Mola kalipleri (yeterli ara veriliyor mu?)
-- Is/yasam dengesi gostergeleri
+**Signals:**
+- Burnout symptoms:
+  - Weekend work frequency
+  - Excessively long sessions (4+ hours uninterrupted)
+  - Late-night development activity
+  - Rising error rate
+- Blocker density (how often blocked?)
+- Recurring problems (how many times did the same thing break?)
+- Break patterns (enough breaks taken?)
+- Work/life balance indicators
 
-**Degerllendirme:**
-- Mevcut tempo surdurulebilir mi?
-- Risk sinyalleri var mi?
-- Iyilestirme onerileri
+**Assessment:**
+- Is the current pace sustainable?
+- Any risk signals?
+- Improvement suggestions
 
-### Bolum 4: Firsat Analizi
+### Section 4: Opportunity Analysis
 
-**Kacirilmis Firsatlar:**
-- Tamamlanmamis ama degerli isler
-- Tekrarlayan manuel islemler (otomasyon adayi)
-- Kullanilmayan arac veya skill'ler
-- Delegasyon firsatlari
-- Paralellestirilebilir is akislari
+**Missed Opportunities:**
+- Valuable but unfinished work
+- Repetitive manual operations (automation candidates)
+- Unused tools or skills
+- Delegation opportunities
+- Parallelizable workflows
 
-**Yeni Firsatlar:**
-- Trend olan teknolojiler ve araclar
-- Mevcut becerileri genisletme alanlari
-- Verimlilik kazanimi potansiyeli
-- Strateji degisikligi firsatlari
+**New Opportunities:**
+- Trending technologies and tools
+- Areas to extend existing skills
+- Efficiency-gain potential
+- Strategy-change opportunities
 
-### Takip Kontrolu
-- Onceki kocluk onerilerinin uygulanma durumunu kontrol et
-- Uygulanan onerilerin etkisini degerlendir
-- 3 haftadan eski uygulanmamis onerileri gozden gecir:
-  - Hala gecerli mi? Yeniden onceliklendirdir
-  - Artik gecerli degil mi? Kaldir ve nedenini not et
+### Follow-up Check
+- Check the status of previous coaching suggestions
+- Assess the impact of applied suggestions
+- Review unapplied suggestions older than 3 weeks:
+  - Still valid? Reprioritize
+  - No longer valid? Remove and note why
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI KOCLUK RAPORU ===
-Donem: [baslangic] - [bitis]
-Tarih: [tarih]
+=== BADI COACHING REPORT ===
+Period: [start] - [end]
+Date: [date]
 
-## Veri Ozeti
-- Analiz Edilen Gun: [sayi]
-- Toplam Commit: [sayi]
-- Tamamlanan Gorev: [sayi]
-- Gorev Tamamlama Orani: [yuzde]%
+## Data Summary
+- Days Analyzed: [count]
+- Total Commits: [count]
+- Completed Tasks: [count]
+- Task Completion Rate: [percent]%
 
-## Guclu Yonler (2-3 Madde)
-1. [guclu yon ve kanit]
-2. [guclu yon ve kanit]
-3. [guclu yon ve kanit]
+## Strengths (2-3 Items)
+1. [strength and evidence]
+2. [strength and evidence]
+3. [strength and evidence]
 
-## Uyarilar
-- [dikkat gerektiren alan ve neden]
+## Warnings
+- [area needing attention and why]
 
-## Firsatlar
-- [firsat ve nasil degererlendirileegi]
+## Opportunities
+- [opportunity and how to use it]
 
-## Surdurulebilirlik Notu
-[tukenmislik riski degerllendirmesi]
+## Sustainability Note
+[burnout risk assessment]
 
-## Tek Oncelik
-> Bu hafta odaklanilmasi gereken tek sey:
-> [net, uygulanabilir oneri]
+## Single Priority
+> The one thing to focus on this week:
+> [clear, actionable suggestion]
 
-## Onceki Onerilerin Takibi
-| Oneri | Durum | Etki |
-|-------|-------|------|
-| [oneri] | Uygulandi/Bekliyor/Iptal | [degerllendirme] |
+## Previous Suggestion Follow-up
+| Suggestion | Status | Impact |
+|------------|--------|--------|
+| [suggestion] | Applied/Pending/Cancelled | [assessment] |
 
-## Motivasyon Notu
-[kisisel, ozgun bir motivasyon mesaji]
+## Motivation Note
+[a personal, genuine motivational message]
 =============================
 ```
 
-# Not
-- Kocluk raporu `memory.md` dosyasina kaydedilir
-- Haftalik kocluk wrap-up komutu ile entegre calisir (Cuma analizi)
-- Ton: destekleyici, veri odakli, motivasyon verici
+# Notes
+- The coaching report is saved into `memory.md`
+- Integrates with the weekly wrap-up command (Friday analysis)
+- Tone: supportive, data-driven, motivating

--- a/.claude/commands-vault/dashboard.md
+++ b/.claude/commands-vault/dashboard.md
@@ -1,116 +1,116 @@
 Daily statistics panel. Presents task, audit, event, and performance data as a unified table.
 
-# Gerekli Araclar
-- Bash (tarih hesaplama, dosya istatistikleri)
-- Read (TaskBoard.md, audit-trail.md, incident-log.md, failure-log.md, gunluk notlar)
-- Grep (veri cikartma ve sayma)
+# Required Tools
+- Bash (date calculations, file statistics)
+- Read (TaskBoard.md, audit-trail.md, incident-log.md, failure-log.md, daily notes)
+- Grep (data extraction and counting)
 - ...
 
-# Veri Kaynaklari
-Bu komut asagidaki dosyalardan veri toplar:
-- `TaskBoard.md` - Gorev durumu bilgileri
-- `audit-trail.md` - Denetim izi kayitlari
-- `incident-log.md` - Olay kayitlari
-- ...
-
----
-
-## Bolum 1: Gorev Istatistikleri
-
-### Adim 1: TaskBoard Verilerini Oku
-- `TaskBoard.md` dosyasini oku
-- Gorev durumlarini say:
-  - Tamamlandi (DONE/BITTI)
-  - Devam Ediyor (IN_PROGRESS/DEVAM)
-  - Bekliyor (TODO/BEKLIYOR)
-  - Engelli (BLOCKED/ENGELLI)
-
-### Adim 2: Bugunun Gorev Hareketi
-- Bugun tamamlanan gorevleri filtrele
-- Bugun olusturulan yeni gorevleri tespit et
-- Durumu degisen gorevleri listele
+# Data Sources
+This command collects data from the following files:
+- `TaskBoard.md` - Task status information
+- `audit-trail.md` - Audit trail records
+- `incident-log.md` - Incident records
 - ...
 
 ---
 
-## Bolum 2: Degisiklik Istatistikleri
+## Section 1: Task Statistics
 
-### Adim 3: Audit Trail Analizi
-- `audit-trail.md` dosyasini oku
-- Bugunun tarihiyle eslesen girisleri filtrele
-- Degisen dosya sayisini cikar
-- ...
+### Step 1: Read the TaskBoard Data
+- Read `TaskBoard.md`
+- Count the task states:
+  - Done (DONE)
+  - In Progress (IN_PROGRESS)
+  - Waiting (TODO)
+  - Blocked (BLOCKED)
 
-### Adim 4: Git Istatistikleri
-- `git log --since="today" --format="%H" | wc -l` ile bugunun commit sayisini al
-- `git diff --stat HEAD~[sayi]` ile degisiklik boyutunu hesapla
-- Eklenen ve silinen satir sayisini raporla
-
----
-
-## Bolum 3: Olay ve Hata Istatistikleri
-
-### Adim 5: Olay Kayitlarini Incele
-- `incident-log.md` dosyasini oku (mevcutsa)
-- Bugunun olaylarini filtrele
-- Ciddiyet dagilimini cikar:
-  - KRITIK: Produksiyon etkileyen
-  - YUKSEK: Onemli islevsellik etkileyen
-  - ORTA: Sinirli etki
-  - DUSUK: Kozmetik veya kucuk sorunlar
-
-### Adim 6: Hata Kayitlarini Incele
-- `failure-log.md` dosyasini oku (mevcutsa)
-- Bugunun hatalarini filtrele
-- Tekrarlayan hata kaliplarini tespit et
+### Step 2: Today's Task Movement
+- Filter tasks completed today
+- Detect new tasks created today
+- List tasks whose status changed
 - ...
 
 ---
 
-## Bolum 4: Oturum Suresi Tahmini
+## Section 2: Change Statistics
 
-### Adim 7: Sure Hesaplama
-- audit-trail.md veya gunluk notlardan ilk girisi bul (oturum baslangici)
-- Son girisi bul (simdiki zaman veya son aktivite)
-- Aradaki farki hesapla
+### Step 3: Audit Trail Analysis
+- Read `audit-trail.md`
+- Filter entries matching today's date
+- Extract the changed file count
+- ...
+
+### Step 4: Git Statistics
+- Get today's commit count with `git log --since="today" --format="%H" | wc -l`
+- Compute the change size with `git diff --stat HEAD~[count]`
+- Report added and removed line counts
+
+---
+
+## Section 3: Incident and Failure Statistics
+
+### Step 5: Review the Incident Records
+- Read `incident-log.md` (if present)
+- Filter today's incidents
+- Extract the severity distribution:
+  - CRITICAL: production-impacting
+  - HIGH: affects important functionality
+  - MEDIUM: limited impact
+  - LOW: cosmetic or small issues
+
+### Step 6: Review the Failure Records
+- Read `failure-log.md` (if present)
+- Filter today's failures
+- Detect recurring failure patterns
 - ...
 
 ---
 
-## Bolum 5: Haftalik Karsilastirma
+## Section 4: Session Length Estimate
 
-### Adim 8: Gecen Hafta Verilerini Topla
-- Gecen haftanin ayni gunundeki istatistikleri bul (mevcutsa)
-- Karsilastirma metrikleri:
-  - Tamamlanan gorev sayisi
-  - Commit sayisi
-  - Olay/hata sayisi
-  - Calisma suresi
-
-### Adim 9: Trend Hesaplama
-- Her metrik icin degisim yuzdesi hesapla
-- Trend yonu belirle:
-  - YUKARI (artis, pozitif metrikler icin iyi)
-  - ASAGI (azalis)
-  - AYNI (+-5% icinde sabit)
-- Gorev tamamlama icin YUKARI iyi, olay sayisi icin ASAGI iyi
+### Step 7: Duration Calculation
+- Find the first entry in audit-trail.md or the daily notes (session start)
+- Find the last entry (now or the latest activity)
+- Compute the difference
+- ...
 
 ---
 
-## Cikti: Turkce Formatli Tablo
+## Section 5: Weekly Comparison
 
-### Adim 10: Dashboard Olustur
+### Step 8: Collect Last Week's Data
+- Find last week's same-day statistics (if available)
+- Comparison metrics:
+  - Completed task count
+  - Commit count
+  - Incident/failure count
+  - Work duration
+
+### Step 9: Trend Calculation
+- Compute the percent change for each metric
+- Determine the trend direction:
+  - UP (increase; good for positive metrics)
+  - DOWN (decrease)
+  - FLAT (stable within +-5%)
+- UP is good for task completion; DOWN is good for incident counts
+
+---
+
+## Output: Formatted Table
+
+### Step 10: Build the Dashboard
 ```
-[kisaltildi]
+[abridged]
 ```
 
-### Trend Ok Aciklamalari
-- Yukari ok: Deger artmis (gorevler icin olumlu, hatalar icin olumsuz)
-- Asagi ok: Deger azalmis
-- Yatay ok: Deger sabit (+-%5 icinde)
+### Trend Arrow Legend
+- Up arrow: value increased (positive for tasks, negative for failures)
+- Down arrow: value decreased
+- Flat arrow: value stable (within +-5%)
 - ...
 
-### Adim 11: Gunluk Ozet Yorumu
-- Genel uretkenlik degerlendirmesi (1 cumle)
-- En dikkat cekici metrik veya trend
-- Yarni icin oneri (eger belirgin bir kalip varsa)
+### Step 11: Daily Summary Comment
+- Overall productivity assessment (1 sentence)
+- The most notable metric or trend
+- A suggestion for tomorrow (if a clear pattern exists)

--- a/.claude/commands-vault/doctor.md
+++ b/.claude/commands-vault/doctor.md
@@ -1,108 +1,108 @@
 Badi configuration validation. Checks all Badi components and produces a diagnostic report.
 
-# Gerekli Araclar
-- Bash (dosya izinleri, dizin yapisi kontrolu)
-- Read (konfigur asyon ve manifest dosyalari)
-- Glob (dosya var lk taramasi)
+# Required Tools
+- Bash (file permissions, directory structure checks)
+- Read (configuration and manifest files)
+- Glob (file existence scan)
 - ...
 
-# Amac
-Bu komut Badi sisteminin dogru yapilandirildigini dogrular.
-Yeni kurulum sonrasi veya sorun yasandiginda calistirilmasi onerilir.
+# Purpose
+This command verifies that the Badi system is configured correctly.
+Recommended after a fresh install or whenever problems occur.
 
 ---
 
-## Kontrol 1: Hook Scriptleri
+## Check 1: Hook Scripts
 
-### Adim 1: Hook Dosya Varligi
-- `.claude/hooks/` dizinini tara
-- Tum `.sh` ve `.js` dosyalarini listele
-- Beklenen hook'larin mevcut oldugunu dogrula:
+### Step 1: Hook File Presence
+- Scan the `.claude/hooks/` directory
+- List all `.sh` and `.js` files
+- Verify the expected hooks exist:
   - Pre-commit hook
   - Post-commit hook
-  - Pre-push hook (varsa)
-  - Ozel Badi hooklari
+  - Pre-push hook (if any)
+  - Custom Badi hooks
 
-### Adim 2: Calistirma Izinleri
-- Her hook dosyasinin calistirma iznini kontrol et (`chmod +x`)
-- Izni olmayan dosyalar icin UYARI ver
-- Shebang satiri (`#!/bin/bash` veya `#!/usr/bin/env node`) kontrolu yap
+### Step 2: Execute Permissions
+- Check the execute permission of every hook file (`chmod +x`)
+- Give a WARNING for files lacking permission
+- Check the shebang line (`#!/bin/bash` or `#!/usr/bin/env node`)
 - ...
 
 ---
 
-## Kontrol 2: Settings.json Dogrulamas i
+## Check 2: settings.json Validation
 
-### Adim 3: Dosya Varligi ve Format
-- `.claude/settings.json` dosyasinin varligini kontrol et
-- JSON formatinin gecerli oldugunu dogrula (parse edilebilir mi)
-- Bos veya eksik dosya icin BASARISIZ ver
+### Step 3: File Presence and Format
+- Check that `.claude/settings.json` exists
+- Verify the JSON format is valid (parseable)
+- FAIL on an empty or missing file
 
-### Adim 4: Hook Referanslari
-- settings.json icindeki hook tanimlarini oku
-- Her referans edilen hook dosyasinin fiziksel olarak var oldugunu dogrula
-- Kirik referanslar (dosyasi olmayan hook tanimlari) icin BASARISIZ ver
+### Step 4: Hook References
+- Read the hook definitions inside settings.json
+- Verify every referenced hook file physically exists
+- FAIL on broken references (hook entries without files)
 - ...
 
 ---
 
-## Kontrol 3: Agent Dosyalari
+## Check 3: Agent Files
 
-### Adim 5: Agent Dizini Taramasi
-- `.claude/agents/` dizinini tara
-- Tum `.md` dosyalarini listele
+### Step 5: Agent Directory Scan
+- Scan the `.claude/agents/` directory
+- List all `.md` files
 
-### Adim 6: Frontmatter Dogrulamas i
-Her agent dosyasi icin:
-- Dosyanin basinda gecerli frontmatter olup olmadigini kontrol et
-- Gerekli alanlar: `name`, `description` (veya ilk satir aciklama)
-- Arac (tools) tanimlarinin gecerli formatta oldugunu dogrula
+### Step 6: Frontmatter Validation
+For each agent file:
+- Check whether valid frontmatter exists at the top
+- Required fields: `name`, `description` (or a first-line description)
+- Verify tool definitions are in a valid format
 - ...
 
 ---
 
-## Kontrol 4: Command-Index Referanslari
+## Check 4: Command-Index References
 
-### Adim 7: Index Dosyasini Oku
-- `command-index.md` dosyasini bul ve oku
-- Index'te listelenen tum komut referanslarini cikar
+### Step 7: Read the Index File
+- Find and read `command-index.md`
+- Extract all command references listed in the index
 
-### Adim 8: Referans Eslestirme
-- Her index girisinin `.claude/commands/` altinda karsilik gelen dosyasi var mi kontrol et
-- commands/ altinda olan ama index'te olmayan dosyalari tespit et
-- Index'te olan ama dosyasi olmayan kayiplari BASARISIZ olarak isaretl
+### Step 8: Reference Matching
+- Check that every index entry has a corresponding file under `.claude/commands/`
+- Detect files under commands/ that are missing from the index
+- Mark index entries without files as FAILED
 - ...
 
 ---
 
-## Kontrol 5: Bellek Dosyalari
+## Check 5: Memory Files
 
-### Adim 9: Bellek Dosya Boyutlari
-- `memory.md` dosyasinin varligini kontrol et
-- Dosya boyutunu olc
-- Boyut limiti asiliyor mu kontrol et (oner: 50KB uzeri icin UYARI)
+### Step 9: Memory File Sizes
+- Check that `memory.md` exists
+- Measure the file size
+- Check whether the size limit is exceeded (suggested: WARN above 50KB)
 - ...
 
-### Adim 10: Bellek Icerigi Kontrolu
-- memory.md icinde zorunlu bolumlerin varligini dogrula
-- Bos veya yapilandirilmamis bellek dosyasi icin UYARI ver
-- Sonuc: GECTI / UYARI / BASARISIZ
+### Step 10: Memory Content Check
+- Verify the mandatory sections exist inside memory.md
+- WARN on an empty or unstructured memory file
+- Result: PASS / WARN / FAIL
 
 ---
 
-## Kontrol 6: Skill Dizin Yapisi
+## Check 6: Skill Directory Structure
 
-### Adim 11: Skills Dizini
-- `.claude/skills/` dizinini kontrol et (mevcutsa)
-- `INDEX.md` dosyasinin var oldugunu dogrula
-- Her skill dosyasinin gecerli formatta oldugunu kontrol et
+### Step 11: Skills Directory
+- Check the `.claude/skills/` directory (if present)
+- Verify the `INDEX.md` file exists
+- Check that every skill file is in a valid format
 - ...
 
 ---
 
-## Tanisal Rapor
+## Diagnostic Report
 
-### Adim 12: Birlestirilmis Rapor Olustur
+### Step 12: Build the Combined Report
 ```
-[kisaltildi]
+[abridged]
 ```

--- a/.claude/commands-vault/drift-detect.md
+++ b/.claude/commands-vault/drift-detect.md
@@ -1,127 +1,127 @@
 Configuration drift detection command. Finds inconsistencies, orphaned components, and stale content in the Badi system.
 
-# Gerekli Araclar
-- Read (konfigurasyon dosyalari)
-- Grep (referans taramasi)
-- Glob (dosya varlik kontrolu)
-- Bash (dosya bilgileri, JSON dogrulama)
+# Required Tools
+- Read (configuration files)
+- Grep (reference scan)
+- Glob (file existence check)
+- Bash (file info, JSON validation)
 
-# Denetlenecek Dosyalar
-- `CLAUDE.md` (ana talimatlar)
-- `.claude/memory.md` (bellek katmani)
-- `.claude/knowledge-base.md` (bilgi tabani)
-- `.claude/settings.json` (ayarlar)
-- `.claude/commands/` (tum komut dosyalari)
-- `.claude/command-index.md` (komut dizini)
-- `.claude/agents/` (ajan dosyalari, varsa)
+# Files to Audit
+- `CLAUDE.md` (main instructions)
+- `.claude/memory.md` (memory layer)
+- `.claude/knowledge-base.md` (knowledge base)
+- `.claude/settings.json` (settings)
+- `.claude/commands/` (all command files)
+- `.claude/command-index.md` (command index)
+- `.claude/agents/` (agent files, if any)
 
-# Prosedur (5 Kontrol)
+# Procedure (5 Checks)
 
-### Kontrol 1: Celiski Tespiti
-Dosyalar arasi tutarsizliklari ara:
+### Check 1: Contradiction Detection
+Look for inconsistencies across files:
 
-**CLAUDE.md Celiskileri:**
-- Birbiriyle celisen talimatlar var mi?
-- Ayni konu hakkinda farkli yonlendirmeler var mi?
-- Eski ve yeni talimatlar arasinda catisma var mi?
+**CLAUDE.md Contradictions:**
+- Are there instructions that contradict each other?
+- Different directions about the same topic?
+- Conflicts between old and new instructions?
 
-**memory.md - Gerceklik Uyumu:**
-- Bellekteki proje durumu gercegi yansitiyor mu?
-- Artik gecerli olmayan bilgiler var mi?
-- Teknoloji yigini bilgisi guncel mi?
-- Dosya yollari hala dogru mu?
+**memory.md - Reality Alignment:**
+- Does the project state in memory reflect reality?
+- Any information no longer valid?
+- Is the tech stack info current?
+- Are the file paths still correct?
 
-**knowledge-base.md Tutarliligi:**
-- Ic celiskiler var mi?
-- memory.md ile catisan bilgiler var mi?
-- CLAUDE.md ile uyumsuz icgörüler var mi?
+**knowledge-base.md Consistency:**
+- Any internal contradictions?
+- Information conflicting with memory.md?
+- Insights inconsistent with CLAUDE.md?
 
-**settings.json Dogrulamasi:**
-- JSON formati gecerli mi?
-- Referans edilen dosya yollari mevcut mu?
-- Hook tanimlamalari dogru formatli mi?
+**settings.json Validation:**
+- Is the JSON format valid?
+- Do the referenced file paths exist?
+- Are the hook definitions correctly formatted?
 
-### Kontrol 2: Yetim Bilesen Tespiti
-Baglantisiz bilesenleri bul:
+### Check 2: Orphaned Component Detection
+Find disconnected components:
 
-- **Cagrilmayan Komutlar:** `commands/` dizininde olup hicbir yerde referans edilmeyen dosyalar
-- **Kullanilmayan Ajanlar:** `agents/` dizininde olup hicbir yerde cagrilmayan ajanlar
-- **Kirik Referanslar:** Mevcut olmayan dosyalara yapilan atiflar
-- **Baglantisiz Hooklar:** settings.json'da tanimli ama dosyasi olmayan hooklar
-- **Indekste Olmayan Komutlar:** `command-index.md` ile `commands/` dizini uyumsuzlugu
-- **Gereksiz Dosyalar:** Eski, artik kullanilmayan konfigurasyon dosyalari
+- **Uninvoked Commands:** Files in `commands/` referenced nowhere
+- **Unused Agents:** Agents in `agents/` never invoked anywhere
+- **Broken References:** Citations to files that do not exist
+- **Disconnected Hooks:** Hooks defined in settings.json without files
+- **Commands Missing from the Index:** Mismatch between `command-index.md` and `commands/`
+- **Redundant Files:** Old configuration files no longer in use
 
-### Kontrol 3: Eskime Kontrolleri
-Icerik tazeligi degerlendir:
+### Check 3: Staleness Checks
+Assess content freshness:
 
-- **memory.md Girdileri:** 3 gunden eski girdileri isaretle
-- **Gunluk Notlar:** 7 gunden eski islenMEmis notlar
-- **Devir Notlari:** 14 gunden eski devir notlari
-- **Gorev Panosu:** 30 gunden eski acik gorevler
-- **knowledge-base.md:** Dogrulanmasi gereken eski bilgiler
-- **Arac Referanslari:** Artik mevcut olmayan araclara atiflar
-- **Arsiv Notlari:** 30 gunden eski arsiv dosyalari (temizlik adayi)
-- **Takilan Gorevler:** Ilerleme kaydetmeyen gorevler
+- **memory.md Entries:** Flag entries older than 3 days
+- **Daily Notes:** Unprocessed notes older than 7 days
+- **Handoff Notes:** Handoffs older than 14 days
+- **Task Board:** Open tasks older than 30 days
+- **knowledge-base.md:** Old information needing re-verification
+- **Tool References:** Citations to tools that no longer exist
+- **Archive Notes:** Archive files older than 30 days (cleanup candidates)
+- **Stuck Tasks:** Tasks making no progress
 
-### Kontrol 4: Konfigurasyon Sagligi
-Teknik saglik kontrolleri:
+### Check 4: Configuration Health
+Technical health checks:
 
-- **JSON Dogrulama:** Tum JSON dosyalarinin gecerliligi
-- **Dosya Boyutu Esikleri:**
-  - memory.md: 500 satirdan fazla mi? (UYARI)
-  - knowledge-base.md: 1000 satirdan fazla mi? (UYARI)
-  - Gunluk notlar: 200 satirdan fazla mi? (BILGI)
-- **Hook Calistirilabilirlik:** Hook dosyalari icin izin kontrolu
-- **Markdown Formati:** Kirik baslantsilar, kapanmamis kod bloklari
-- **Karakter Kodlamasi:** UTF-8 uyumluluk kontrolu
+- **JSON Validation:** Validity of every JSON file
+- **File Size Thresholds:**
+  - memory.md: over 500 lines? (WARN)
+  - knowledge-base.md: over 1000 lines? (WARN)
+  - Daily notes: over 200 lines? (INFO)
+- **Hook Executability:** Permission check for hook files
+- **Markdown Format:** Broken links, unclosed code blocks
+- **Character Encoding:** UTF-8 compatibility check
 
-### Kontrol 5: Capraz Tutarlilik
-Tum sistem genelinde tutarlilik:
+### Check 5: Cross-Consistency
+Consistency across the whole system:
 
-- CLAUDE.md'deki kurallar settings.json ile uyumlu mu?
-- Komut dosyalarindaki arac referanslari geerli mi?
-- Ajan tanimlarindaki bagimlliklar karsilaniyor mu?
-- Tum dosya referanslari cift yonlu mu? (A -> B ise B -> A da var mi?)
+- Are the rules in CLAUDE.md consistent with settings.json?
+- Are tool references in command files valid?
+- Are the dependencies in agent definitions satisfied?
+- Are all file references bidirectional? (if A -> B, does B -> A exist too?)
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI SAPMA TESPITI ===
-Tarih: [tarih]
-Durum: TEMIZ | UYARI | SORUN
+=== BADI DRIFT DETECTION ===
+Date: [date]
+Status: CLEAN | WARNING | PROBLEM
 
-## Celiski Bulgulari
-- Bulunan: [sayi]
-[varsa detaylar]
+## Contradiction Findings
+- Found: [count]
+[details if any]
 
-## Yetim Bilesenler
-- Bulunan: [sayi]
-[varsa detaylar]
+## Orphaned Components
+- Found: [count]
+[details if any]
 
-## Eskilesmis Icerik
-- Bulunan: [sayi]
-[varsa detaylar]
+## Stale Content
+- Found: [count]
+[details if any]
 
-## Konfigurasyon Sagligi
-- JSON: GECERLI / HATALI
-- Boyutlar: NORMAL / ASIRI
-- Izinler: DOGRU / HATALI
+## Configuration Health
+- JSON: VALID / BROKEN
+- Sizes: NORMAL / EXCESSIVE
+- Permissions: CORRECT / BROKEN
 
-## Capraz Tutarlilik
-- Durum: TUTARLI / UYUMSUZ
-[varsa detaylar]
+## Cross-Consistency
+- Status: CONSISTENT / MISMATCHED
+[details if any]
 
-## Duzeltme Onerileri
-1. [ACIL] [oneri]
-2. [ONEMLI] [oneri]
-3. [ONERILEN] [oneri]
+## Remediation Suggestions
+1. [URGENT] [suggestion]
+2. [IMPORTANT] [suggestion]
+3. [SUGGESTED] [suggestion]
 
-## Sonraki Tarama
-Onerilen: [tarih]
+## Next Scan
+Suggested: [date]
 ============================
 ```
 
-# Tetikleyici
-- Ayda bir rutin tarama
-- Sistem davranisi anormal gorundigunde
-- Buyuk konfigur asyon degisikligi sonrasinda
-- Yeni komut veya ajan eklenmesinden sonra
+# Triggers
+- Monthly routine scan
+- When system behavior looks abnormal
+- After a large configuration change
+- After adding a new command or agent

--- a/.claude/commands-vault/handoff.md
+++ b/.claude/commands-vault/handoff.md
@@ -1,101 +1,101 @@
 Handoff briefing command. Enables a smooth transition to another developer or session.
 
-# Gerekli Araclar
-- Read (baglam, notlar, gorevler)
-- Bash (git durumu)
-- Write (teslim dosyasi)
+# Required Tools
+- Read (context, notes, tasks)
+- Bash (git status)
+- Write (handoff file)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Baglam Toplama
-Mevcut durumun tam resmini cikar:
-- `memory.md` dosyasini oku
-- Gunluk notlari incele
-- Git durumunu kontrol et (branch, commit edilmemis degisiklikler)
-- Gorev panosunu oku
-- Onceki devir notlarini kontrol et
+### Step 1: Gather Context
+Build the full picture of the current state:
+- Read `memory.md`
+- Review the daily notes
+- Check the git status (branch, uncommitted changes)
+- Read the task board
+- Check previous handoff notes
 
-### Adim 2: Basarilari Belgele
-Bu donemde tamamlanan isleri listele:
-- Tamamlanan ozellikler ve iyilestirmeler
-- Cozulen hatalar
-- Tamamlanan arastirma veya analizler
-- Alinan mimari kararlar ve gerekceleri
-- Yapilan refactoring veya temizlik isleri
+### Step 2: Document Achievements
+List the work completed in this period:
+- Completed features and improvements
+- Fixed bugs
+- Completed research or analyses
+- Architectural decisions taken and their rationale
+- Refactoring or cleanup work done
 
-### Adim 3: On Kosullari Belirle
-Alici icin gerekli bilgileri hazirla:
-- Gelistirme ortami gereksinimleri
-- Ozel konfigur asyon veya erisim ihtiyaclari
-- Calistirilmasi gereken migration veya scriptler
-- Ortam degiskenleri
-- Ucuncu parti servis erisim bilgileri (sirlar haric)
+### Step 3: Identify Prerequisites
+Prepare what the recipient needs:
+- Development environment requirements
+- Special configuration or access needs
+- Migrations or scripts that must be run
+- Environment variables
+- Third-party service access details (excluding secrets)
 
-### Adim 4: Alici Baglami Olustur
-Devralan kisinin hemen ise baslamasi icin:
-- Mevcut branch durumu ve nereye merge edilecegi
-- Acik gorevler oncelik sirasina gore
-- Bilinen sorunlar ve gecici cozumler (workaround)
-- Bloke olan isler ve beklentiler
-- Test durumu (gecen/kalan testler)
-- Kritik son tarihler
+### Step 4: Build the Recipient Context
+So the person taking over can start immediately:
+- Current branch state and where it merges
+- Open tasks in priority order
+- Known issues and workarounds
+- Blocked work and what it waits on
+- Test status (passing/failing tests)
+- Critical deadlines
 
-### Adim 5: Teslim Dosyasi Olustur
-`handoffs/handoff-[GGAAYY].md` dosyasini olustur:
+### Step 5: Create the Handoff File
+Create `handoffs/handoff-[DDMMYY].md`:
 
 ```markdown
-# Is Teslim Brifingi - [tarih]
+# Handoff Briefing - [date]
 
-## Proje Ozeti
-[projenin mevcut hali, 2-3 cumle]
+## Project Summary
+[the project's current state, 2-3 sentences]
 
-## Donem Ozeti
-**Baslangic:** [tarih]
-**Bitis:** [tarih]
-**Odak Alani:** [ana calisma alani]
+## Period Summary
+**Start:** [date]
+**End:** [date]
+**Focus Area:** [main work area]
 
-## Basarilar
-- [tamamlanan isler listesi]
+## Achievements
+- [list of completed work]
 
-## Mevcut Durum
+## Current State
 
-### Branch Durumu
-- Aktif Branch: [branch adi]
-- Base: [hedef branch]
-- Commit Edilmemis Degisiklik: [var/yok]
-- CI Durumu: [gecti/kaldi/bekliyor]
+### Branch Status
+- Active Branch: [branch name]
+- Base: [target branch]
+- Uncommitted Changes: [yes/no]
+- CI Status: [passed/failed/pending]
 
-### Acik Gorevler (Oncelik Sirasina Gore)
-1. **[YUKSEK]** [gorev aciklamasi]
-   - Durum: [durum]
-   - Sonraki adim: [adim]
-2. **[ORTA]** [gorev aciklamasi]
+### Open Tasks (In Priority Order)
+1. **[HIGH]** [task description]
+   - Status: [status]
+   - Next step: [step]
+2. **[MEDIUM]** [task description]
    ...
 
-### Bilinen Sorunlar
-- [sorun]: [gecici cozum veya plan]
+### Known Issues
+- [issue]: [workaround or plan]
 
-### Bloke Olan Isler
-- [is]: [neden bloke, kimden/neden bekleniyor]
+### Blocked Work
+- [work]: [why blocked, waiting on whom/what]
 
-## On Kosullar
-- [ortam gereksinimleri]
-- [konfigur asyon adimlari]
+## Prerequisites
+- [environment requirements]
+- [configuration steps]
 
-## Kritik Tarihler
-- [tarih]: [ne icin]
+## Critical Dates
+- [date]: [for what]
 
-## Onemli Dosyalar
-- [dosya yolu]: [neden onemli]
+## Important Files
+- [file path]: [why it matters]
 
-## Notlar ve Uyarilar
-[dikkat edilmesi gereken ozel durumlar]
+## Notes and Warnings
+[special situations to watch]
 
-## Iletisim
-[sorular icin iletisim bilgisi]
+## Contact
+[contact info for questions]
 ```
 
-# Cikti Formati
-- `handoffs/handoff-[GGAAYY].md` dosyasi
-- Guncellenmis `memory.md` (teslim referansi)
-- Terminal ozeti (teslim edilenlerin kisa listesi)
+# Output Format
+- The `handoffs/handoff-[DDMMYY].md` file
+- Updated `memory.md` (handoff reference)
+- Terminal summary (short list of what was handed off)

--- a/.claude/commands-vault/health.md
+++ b/.claude/commands-vault/health.md
@@ -1,120 +1,120 @@
 System health check. Audits dependencies, security, performance, and (if present) the production domain with a triple scan.
 
-## Badi CLI Komutlari
-Bu kontroller su CLI komutlarini kullanir (v1.6+):
-- `badi doctor` — Badi kurulum dogrulamasi
-- `badi secret-scan` — Sir/credential taramasi (17 pattern)
-- `badi ssl [domain]` — Production SSL sertifika (varsa)
-- `badi dns [domain]` — Email guvenlik (SPF/DMARC/CAA)
+## Badi CLI Commands
+These checks use the following CLI commands (v1.6+):
+- `badi doctor` — Badi installation validation
+- `badi secret-scan` — Secret/credential scan (17 patterns)
+- `badi ssl [domain]` — Production SSL certificate (if any)
+- `badi dns [domain]` — Email security (SPF/DMARC/CAA)
 - `badi lighthouse [url]` — Core Web Vitals
-- `badi a11y [url]` — WCAG 2.1 uyum
+- `badi a11y [url]` — WCAG 2.1 compliance
 
-# Gerekli Araclar
-- Bash (npm audit, sistem komutlari)
-- Read (konfigur asyon dosyalari)
-- Glob (proje dosya taramasi)
-- Grep (kalip arama)
-- Agent (security-scanner: guvenlik taramasi, performance-profiler: performans analizi)
+# Required Tools
+- Bash (npm audit, system commands)
+- Read (configuration files)
+- Glob (project file scan)
+- Grep (pattern search)
+- Agent (security-scanner: security scan, performance-profiler: performance analysis)
 
-# Calisma Zamanlamas i
-Bu komut ozellikle Pazartesi sabahlarinda `/start` sonrasinda calistirilmasi onerilir.
-Haftalik rutin olarak saglik kontrolu yapilmasi projeyi saglkli tutar.
-
----
-
-## Kontrol 1: Bagimlilik Denetimi
-
-### Adim 1: Paket Yoneticisini Tespit Et
-- `package.json` varsa npm/yarn/pnpm kullan
-- `Cargo.toml` varsa cargo kullan
-- `pyproject.toml` veya `requirements.txt` varsa pip kullan
-
-### Adim 2: Audit Taramas i Calistir
-- npm projelerinde `npm audit --json` calistir
-- Ek olarak `badi secret-scan` calistir — 17 pattern ile sir taramasi (working tree)
-- Sonuclari ciddiyet seviyesine gore siniflandir (critical, high, moderate, low)
-- Guncellenmesi gereken paketleri listele
-
-### Adim 3: Bagimlilik Durum Degerlendirmesi
-- YESIL: Kritik veya yuksek seviye acik yok
-- SARI: Sadece moderate seviye aciklar var
-- KIRMIZI: Critical veya high seviye aciklar mevcut
+# Scheduling
+Running this command is especially recommended after `/start` on Monday mornings.
+A weekly health-check routine keeps the project healthy.
 
 ---
 
-## Kontrol 2: Guvenlik Taramasi
+## Check 1: Dependency Audit
 
-### Adim 4: Security-Scanner Ajanini Cagir
-Agent aracini kullanarak security-scanner ajanini calistir:
-- Sabit kodlu sirlar icin kod taramasi yap (.env, API anahtarlari, tokenlar)
-- Guvenlik basliklarini kontrol et (CORS, CSP, X-Frame-Options)
-- Auth konfigurasyonunu incele
-- Bilinen guvenlik acigi kaliplarini ara (SQL injection, XSS vektorleri)
+### Step 1: Detect the Package Manager
+- If `package.json` exists, use npm/yarn/pnpm
+- If `Cargo.toml` exists, use cargo
+- If `pyproject.toml` or `requirements.txt` exists, use pip
 
-### Adim 5: Guvenlik Durum Degerlendirmesi
-- YESIL: Bilinen guvenlik sorunu yok
-- SARI: Dusuk riskli bulgular veya iyilestirme onerileri var
-- KIRMIZI: Kritik guvenlik acigi tespit edildi
+### Step 2: Run the Audit Scan
+- Run `npm audit --json` on npm projects
+- Additionally run `badi secret-scan` — 17-pattern secret scan (working tree)
+- Classify results by severity (critical, high, moderate, low)
+- List packages that need updating
+
+### Step 3: Dependency Status Assessment
+- GREEN: No critical or high severity issues
+- YELLOW: Only moderate severity issues
+- RED: Critical or high severity issues present
 
 ---
 
-## Kontrol 3: Performans Analizi
+## Check 2: Security Scan
 
-### Adim 6: Performance-Profiler Ajanini Cagir
-Agent aracini kullanarak performance-profiler ajanini calistir:
-- Build/paket boyutlarini olc
-- Karmasik fonksiyonlari tespit et (yuksek siklomatik karmasiklik)
-- Gereksiz bagimliliklari bul
-- Onbellek stratejilerini degerlendir
+### Step 4: Invoke the Security-Scanner Agent
+Run the security-scanner agent via the Agent tool:
+- Scan code for hardcoded secrets (.env, API keys, tokens)
+- Check security headers (CORS, CSP, X-Frame-Options)
+- Review the auth configuration
+- Look for known vulnerability patterns (SQL injection, XSS vectors)
 
-**Production URL varsa ek kontroller:**
+### Step 5: Security Status Assessment
+- GREEN: No known security issues
+- YELLOW: Low-risk findings or improvement suggestions
+- RED: Critical vulnerability detected
+
+---
+
+## Check 3: Performance Analysis
+
+### Step 6: Invoke the Performance-Profiler Agent
+Run the performance-profiler agent via the Agent tool:
+- Measure build/bundle sizes
+- Detect complex functions (high cyclomatic complexity)
+- Find unnecessary dependencies
+- Evaluate caching strategies
+
+**Extra checks when a production URL exists:**
 - `badi lighthouse [url]` — Core Web Vitals (FCP, LCP, TBT, CLS)
-- `badi a11y [url]` — Accessibility skoru
-Kullaniciya sor: "Bir production URL'iniz var mi? Varsa lighthouse + a11y de calistirabilirim."
+- `badi a11y [url]` — Accessibility score
+Ask the user: "Do you have a production URL? If so I can also run lighthouse + a11y."
 
-### Adim 7: Performans Durum Degerlendirmesi
-- YESIL: Performans metrikleri kabul edilebilir sinirlar icinde
-- SARI: Iyilestirme firsatlari mevcut ama kritik degil
-- KIRMIZI: Ciddi performans sorunlari tespit edildi
+### Step 7: Performance Status Assessment
+- GREEN: Performance metrics within acceptable bounds
+- YELLOW: Improvement opportunities exist but not critical
+- RED: Serious performance problems detected
 
 ---
 
-## Birlestirmis Saglik Rapor Karti
+## Combined Health Report Card
 
-### Adim 8: Rapor Olustur
-Asagidaki formatta birlestirilmis rapor sun:
+### Step 8: Build the Report
+Present the combined report in this format:
 
 ```
 ╔══════════════════════════════════════════╗
-║        BADI SISTEM SAGLIK RAPORU         ║
-║        Tarih: [GG.AA.YYYY]              ║
+║        BADI SYSTEM HEALTH REPORT          ║
+║        Date: [DD.MM.YYYY]                ║
 ╠══════════════════════════════════════════╣
 ║                                          ║
-║  Bagimlilik Denetimi:  [YESIL/SARI/KIR] ║
-║  > [kisa aciklama]                       ║
+║  Dependency Audit:     [GREEN/YEL/RED]  ║
+║  > [short note]                          ║
 ║                                          ║
-║  Guvenlik Taramasi:    [YESIL/SARI/KIR] ║
-║  > [kisa aciklama]                       ║
+║  Security Scan:        [GREEN/YEL/RED]  ║
+║  > [short note]                          ║
 ║                                          ║
-║  Performans Analizi:   [YESIL/SARI/KIR] ║
-║  > [kisa aciklama]                       ║
+║  Performance Analysis: [GREEN/YEL/RED]  ║
+║  > [short note]                          ║
 ║                                          ║
 ╠══════════════════════════════════════════╣
-║  Genel Durum: [SAGLIKLI / DIKKAT / ACIL]║
+║  Overall: [HEALTHY / ATTENTION / URGENT]║
 ║                                          ║
-║  Onerilen Aksiyonlar:                    ║
-║  1. [varsa en onemli aksiyon]            ║
-║  2. [varsa ikinci aksiyon]               ║
-║  3. [varsa ucuncu aksiyon]               ║
+║  Suggested Actions:                      ║
+║  1. [most important action, if any]      ║
+║  2. [second action, if any]              ║
+║  3. [third action, if any]               ║
 ╚══════════════════════════════════════════╝
 ```
 
-### Adim 9: Genel Durum Belirleme
-- SAGLIKLI: Tum kategoriler YESIL
-- DIKKAT: En az bir kategori SARI, hicbiri KIRMIZI degil
-- ACIL: En az bir kategori KIRMIZI
+### Step 9: Determine the Overall State
+- HEALTHY: All categories GREEN
+- ATTENTION: At least one category YELLOW, none RED
+- URGENT: At least one category RED
 
-### Adim 10: Takip Onerileri
-- KIRMIZI durumlar icin acil gorev olusturmayi oner
-- SARI durumlar icin haftalik plana eklemeyi oner
-- Bir sonraki saglik kontrolu tarihini hatrlat
+### Step 10: Follow-up Suggestions
+- Suggest creating urgent tasks for RED states
+- Suggest adding YELLOW states to the weekly plan
+- Remind about the next health-check date

--- a/.claude/commands-vault/memory-diff.md
+++ b/.claude/commands-vault/memory-diff.md
@@ -1,49 +1,49 @@
 Memory and knowledge-base limit check + global project comparison.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi ai memory-diff)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Calistir
+### Step 1: Run
 ```bash
 badi ai memory-diff
 ```
 
-### Adim 2: Sonuclari Yorumla
+### Step 2: Interpret the Results
 
-Uc bolum:
-1. **memory.md** — Oturum bellek, 100 satir limiti
-2. **knowledge-base.md** — Bilgi tabani, 200 satir limiti + TBD yasak
-3. **Global projects** — Baska projelerdeki MEMORY.md karsilastirmasi
+Three sections:
+1. **memory.md** — Session memory, 100-line limit
+2. **knowledge-base.md** — Knowledge base, 200-line limit + TBD forbidden
+3. **Global projects** — MEMORY.md comparison across other projects
 
-### Adim 3: Eylemler
+### Step 3: Actions
 
-**memory.md > 80 satir:**
-- `/clear` ile sifirla + onemlileri knowledge-base'e tasi
+**memory.md > 80 lines:**
+- Reset with `/clear` + move the important parts to the knowledge base
 
-**knowledge-base.md'de TBD/TODO:**
-- YASAK (CLAUDE.md kurali)
-- Iceriği tamamla veya kaldir
-- Kaynak eklenmediyse `[Kaynak: ...]` zorunlu
+**TBD/TODO in knowledge-base.md:**
+- FORBIDDEN (CLAUDE.md rule)
+- Complete the content or remove it
+- `[Kaynak: ...]` source tag is mandatory if missing
 
-**knowledge-base.md > 200 satir:**
-- Auditor onayiyla konsolidasyon
-- Eski/alakasiz kisimlari archive/knowledge-archive.md'ye tasi
+**knowledge-base.md > 200 lines:**
+- Consolidation with Auditor approval
+- Move old/irrelevant parts to archive/knowledge-archive.md
 
-### Adim 4: Haftalik Rutin
+### Step 4: Weekly Routine
 
-Her Pazartesi `/ai-memory-diff` calistir, memory sagliguni kontrol et.
+Run `/ai-memory-diff` every Monday and check memory health.
 
-# Bellek Kurallari (CLAUDE.md)
+# Memory Rules (CLAUDE.md)
 
-| Katman | Sinir | Aksiyon |
-|--------|-------|---------|
-| memory.md | 100 satir | /clear |
-| knowledge-base.md | 200 satir | Auditor onayi |
-| TaskBoard.md | Sinirsiz | - |
+| Layer | Limit | Action |
+|-------|-------|--------|
+| memory.md | 100 lines | /clear |
+| knowledge-base.md | 200 lines | Auditor approval |
+| TaskBoard.md | Unlimited | - |
 
-# Ornek
+# Example
 
 ```
 /memory-diff

--- a/.claude/commands-vault/onboard.md
+++ b/.claude/commands-vault/onboard.md
@@ -1,119 +1,119 @@
 Project onboarding command. For adapting to a new project quickly and thoroughly.
 
-# Gerekli Araclar
-- Glob (dosya yapisi taramasi)
-- Read (dosya okuma)
-- Grep (kod arama)
-- Bash (git gecmisi, bagimliliklar)
-- Write (alistirma raporu)
+# Required Tools
+- Glob (file structure scan)
+- Read (file reading)
+- Grep (code search)
+- Bash (git history, dependencies)
+- Write (onboarding report)
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-### Adim 1: Proje Dogrulama
-- Proje kok dizinini dogrula
-- `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md` var mi kontrol et
-- Lisans dosyasini kontrol et
-- `.gitignore` ve `.editorconfig` incele
+### Step 1: Project Verification
+- Verify the project root directory
+- Check for `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`
+- Check the license file
+- Review `.gitignore` and `.editorconfig`
 
-### Adim 2: 3 Paralel Tarama
+### Step 2: 3 Parallel Scans
 
-**Tarama A: Yapi Analizi**
-- Dizin agacini cikar (2 seviye derinlik)
-- Kaynak kod dizinlerini belirle (src, lib, app, vb.)
-- Test dizinlerini bul (test, __tests__, spec, vb.)
-- Konfigur asyon dosyalarini listele
-- CI/CD dosyalarini bul (.github, .gitlab-ci, Jenkinsfile, vb.)
-- Docker dosyalarini tespit et
+**Scan A: Structure Analysis**
+- Extract the directory tree (2 levels deep)
+- Identify the source directories (src, lib, app, etc.)
+- Find the test directories (test, __tests__, spec, etc.)
+- List the configuration files
+- Find CI/CD files (.github, .gitlab-ci, Jenkinsfile, etc.)
+- Detect Docker files
 
-**Tarama B: Teknoloji Tespiti**
-- Manifest dosyalarini oku (package.json, Cargo.toml, pyproject.toml, go.mod, vb.)
-- Framework ve kutuphaneleri listele
-- Versiyon bilgilerini topla
-- Gelistirme araclarini belirle (linter, formatter, bundler)
-- Veritabani teknolojisini tespit et (migration dosyalari, ORM konfigurasyon)
+**Scan B: Technology Detection**
+- Read the manifest files (package.json, Cargo.toml, pyproject.toml, go.mod, etc.)
+- List frameworks and libraries
+- Collect version information
+- Identify the dev tooling (linter, formatter, bundler)
+- Detect the database technology (migration files, ORM configuration)
 
-**Tarama C: Dokumantasyon Taramasi**
-- Tum markdown dosyalarini bul
-- API dokumantasyonunu ara (OpenAPI, Swagger, vb.)
-- Yorum yogunlugu analizi (JSDoc, docstring, vb.)
-- Ortam degiskeni dokumantasyonu (.env.example)
-- Mimari karar kayitlari (ADR) var mi?
+**Scan C: Documentation Scan**
+- Find all markdown files
+- Look for API documentation (OpenAPI, Swagger, etc.)
+- Comment density analysis (JSDoc, docstrings, etc.)
+- Environment variable documentation (.env.example)
+- Are there Architecture Decision Records (ADRs)?
 
-### Adim 3: Bagimlilik Analizi
-- Dogrudan bagimliliklari listele
-- Gelistirme bagimliliklerini ayir
-- Guncelligini yitirmis bagimliliklari tespit et
-- Guvenlik uyarilari kontrol et (npm audit, cargo audit, vb.)
-- Bagimlilik grafigi cikart (ana moduller arasi iliskiler)
+### Step 3: Dependency Analysis
+- List direct dependencies
+- Separate the dev dependencies
+- Detect outdated dependencies
+- Check security advisories (npm audit, cargo audit, etc.)
+- Sketch the dependency graph (relationships between main modules)
 
-### Adim 4: Kod Kaliplari
-Kullanilan kaliplari tespit et:
-- Mimari kalip (MVC, MVVM, Clean Architecture, Hexagonal, vb.)
-- Hata yonetimi yaklasimlari (try-catch kaliplari, Result tipi, vb.)
-- Loglama stratejisi
-- Test stratejisi (unit, integration, e2e oranlari)
-- Isimlendirme konvansiyonlari
-- Import/export kaliplari
-- State yonetimi yaklasimlari
+### Step 4: Code Patterns
+Detect the patterns in use:
+- Architectural pattern (MVC, MVVM, Clean Architecture, Hexagonal, etc.)
+- Error-handling approaches (try-catch patterns, Result types, etc.)
+- Logging strategy
+- Test strategy (unit, integration, e2e ratios)
+- Naming conventions
+- Import/export patterns
+- State-management approaches
 
-### Adim 5: Git Arkeolojisi
-- En cok degisen dosyalari bul (son 3 ay)
-- Ana katkilcilari belirle
-- Branch stratejisini analiz et (main, develop, feature, vb.)
-- Commit mesaj formatini tespit et (conventional commits, vb.)
-- Son release tarihini ve versiyonu bul
-- Merge/rebase stratejisini belirle
+### Step 5: Git Archaeology
+- Find the most-changed files (last 3 months)
+- Identify the main contributors
+- Analyze the branch strategy (main, develop, feature, etc.)
+- Detect the commit message format (conventional commits, etc.)
+- Find the last release date and version
+- Determine the merge/rebase strategy
 
-### Adim 6: ONBOARDING.md Olustur
+### Step 6: Create ONBOARDING.md
 ```markdown
-# Proje Alistirma Kilavuzu
+# Project Onboarding Guide
 
-## Proje Ozeti
-[projenin ne yaptigi, 2-3 cumle]
+## Project Summary
+[what the project does, 2-3 sentences]
 
-## Teknoloji Yigini
-| Kategori | Teknoloji | Versiyon |
-|----------|-----------|----------|
-| Dil | ... | ... |
+## Tech Stack
+| Category | Technology | Version |
+|----------|------------|---------|
+| Language | ... | ... |
 | Framework | ... | ... |
-| Veritabani | ... | ... |
+| Database | ... | ... |
 | Test | ... | ... |
 
-## Dizin Yapisi
+## Directory Structure
 ```
-[agac gorunumu]
+[tree view]
 ```
 
-## Baslangic Komutlari
+## Getting Started
 ```bash
-# Kurulum
-[kurulum komutlari]
+# Install
+[install commands]
 
-# Calistirma
-[calistirma komutlari]
+# Run
+[run commands]
 
 # Test
-[test komutlari]
+[test commands]
 ```
 
-## Onemli Dosyalar
-- [dosya]: [aciklama]
-- [dosya]: [aciklama]
+## Important Files
+- [file]: [description]
+- [file]: [description]
 
-## Mimari Notlar
-[mimari kaliplar ve kararlar]
+## Architecture Notes
+[architectural patterns and decisions]
 
-## Kod Konvansiyonlari
-[isimlendirme, format, commit mesaji kurallari]
+## Code Conventions
+[naming, format, commit message rules]
 
-## Bilinen Sorunlar / Teknik Borc
-[tespit edilen sorunlar]
+## Known Issues / Technical Debt
+[detected problems]
 
-## Bagimlilik Notlari
-[dikkat edilmesi gereken bagimliliklar]
+## Dependency Notes
+[dependencies that need attention]
 ```
 
-# Cikti Formati
-- `ONBOARDING.md` dosyasi (detayli alistirma kilavuzu)
-- Guncellenmis `memory.md` (proje bilgileri)
-- Terminal ozeti (temel bulgular)
+# Output Format
+- The `ONBOARDING.md` file (detailed onboarding guide)
+- Updated `memory.md` (project information)
+- Terminal summary (key findings)

--- a/.claude/commands-vault/plugin.md
+++ b/.claude/commands-vault/plugin.md
@@ -1,115 +1,115 @@
 Plugin management command. Installs, removes, and lists plugins in the Badi system.
 
-# Gerekli Araclar
-- Bash (git clone, npm install, dosya kopyalama)
-- Read (manifest dosyalari, mevcut konfigur asyon)
-- Write (konfigur asyon guncelleme, dosya olusturma)
+# Required Tools
+- Bash (git clone, npm install, file copy)
+- Read (manifest files, current configuration)
+- Write (configuration updates, file creation)
 - ...
 
-# Alt Komutlar
-Bu komut uc alt komut icerir:
-- `install <kaynak>` - Yeni plugin yukle
-- `remove <isim>` - Plugin kaldir
-- `list` - Yuklu pluginleri listele
+# Subcommands
+This command has three subcommands:
+- `install <source>` - Install a new plugin
+- `remove <name>` - Remove a plugin
+- `list` - List installed plugins
 
-Kullanici alt komutu belirtmediyse hangisini istedigini sor.
+If the user did not specify a subcommand, ask which one they want.
 
 ---
 
-## Alt Komut: install <kaynak>
+## Subcommand: install <source>
 
-### Adim 1: Kaynak Tipi Tespiti
-- Git URL ise (`.git` ile bitiyor veya `github.com` iceriyor): Git kaynak
-- npm paket adi ise: npm kaynak
-- Yerel dizin yolu ise: Yerel kaynak
+### Step 1: Source Type Detection
+- If a git URL (ends with `.git` or contains `github.com`): git source
+- If an npm package name: npm source
+- If a local directory path: local source
 - ...
 
-### Adim 2: Plugin Indirme
-**Git kaynagi icin:**
-- Gecici dizine `git clone [URL]` yap
-- `badi-plugin.json` manifest dosyasini kontrol et
-- Manifest yoksa HATA ver ve dur
+### Step 2: Download the Plugin
+**For a git source:**
+- `git clone [URL]` into a temporary directory
+- Check the `badi-plugin.json` manifest file
+- If there is no manifest, ERROR and stop
 
-**npm kaynagi icin:**
-- `npm pack [paket]` ile paketi indir
-- Paketi gecici dizine ac
-- `badi-plugin.json` manifest dosyasini kontrol et
+**For an npm source:**
+- Download the package with `npm pack [package]`
+- Extract into a temporary directory
+- Check the `badi-plugin.json` manifest file
 
-**Yerel kaynak icin:**
-- Belirtilen dizinde `badi-plugin.json` varligini dogrula
+**For a local source:**
+- Verify `badi-plugin.json` exists in the given directory
 
-### Adim 3: Manifest Okuma ve Dogrulama
-`badi-plugin.json` dosyasini oku ve dogrula:
+### Step 3: Read and Validate the Manifest
+Read and validate `badi-plugin.json`:
 ```
-[kisaltildi]
+[abridged]
 ```
-Zorunlu alanlar: `name`, `version`
-Gecersiz manifest icin HATA ver ve dur.
+Required fields: `name`, `version`
+ERROR and stop on an invalid manifest.
 
-### Adim 4: Catisma Kontrolu
-- Ayni isimde yuklu plugin var mi kontrol et
-- Eklenen komutlarin mevcut komutlarla catisip catismadigini dogrula
-- Agent isim catismalarini kontrol et
+### Step 4: Conflict Check
+- Check whether a plugin with the same name is installed
+- Verify added commands do not collide with existing commands
+- Check agent name collisions
 - ...
 
-### Adim 5: Dosyalari Kopyala
-- `.claude/plugins/[plugin-adi]/` dizinini olustur
-- Manifest dosyasini kopyala
-- Agent dosyalarini `.claude/agents/` altina kopyala
+### Step 5: Copy the Files
+- Create the `.claude/plugins/[plugin-name]/` directory
+- Copy the manifest file
+- Copy agent files under `.claude/agents/`
 - ...
 
-### Adim 6: Index Guncelleme
-- `command-index.md` dosyasina yeni komutlari `[Plugin]` etiketi ile ekle
-- Ornek format: `| /plugin-komut | Aciklama [Plugin: plugin-adi] |`
-- settings.json'a yeni hook referanslarini ekle (gerekirse)
+### Step 6: Index Update
+- Add the new commands to `command-index.md` with a `[Plugin]` tag
+- Example format: `| /plugin-command | Description [Plugin: plugin-name] |`
+- Add new hook references to settings.json (if needed)
 
-### Adim 7: Kurulum Dogrulama
-- Tum dosyalarin basariyla kopyalandigini dogrula
-- `/doctor` calistirmayi oner
-- Kurulum ozeti goster
+### Step 7: Install Verification
+- Verify all files copied successfully
+- Suggest running `/doctor`
+- Show an install summary
 
 ---
 
-## Alt Komut: remove <isim>
+## Subcommand: remove <name>
 
-### Adim 8: Plugin Tespiti
-- `.claude/plugins/[isim]/` dizininin var oldugunu dogrula
-- `badi-plugin.json` manifestini oku
-- Plugin yoksa HATA ver
+### Step 8: Plugin Detection
+- Verify the `.claude/plugins/[name]/` directory exists
+- Read the `badi-plugin.json` manifest
+- ERROR if the plugin does not exist
 
-### Adim 9: Kaldirilacak Dosyalari Belirle
-- Manifeste gore hangi dosyalarin plugin tarafindan ekledigini tespit et
-- Diger pluginlerle paylasilan dosyalari KORUMA (kaldirma)
-- Kullaniciya kaldirilacak dosya listesini goster ve onay iste
+### Step 9: Determine Files to Remove
+- From the manifest, identify which files the plugin added
+- PROTECT files shared with other plugins (do not remove)
+- Show the user the removal list and ask for confirmation
 
-### Adim 10: Dosyalari Kaldir
-- Plugin agent dosyalarini sil
-- Plugin komut dosyalarini sil
-- Plugin skill dosyalarini sil
+### Step 10: Remove the Files
+- Delete the plugin agent files
+- Delete the plugin command files
+- Delete the plugin skill files
 - ...
 
-### Adim 11: Kaldirma Dogrulama
-- Tum dosyalarin basariyla silindgini dogrula
-- Kirik referans birakilmadigini kontrol et
-- Kaldirma ozeti goster
+### Step 11: Removal Verification
+- Verify all files were deleted successfully
+- Check no broken references remain
+- Show a removal summary
 
 ---
 
-## Alt Komut: list
+## Subcommand: list
 
-### Adim 12: Yuklu Pluginleri Tara
-- `.claude/plugins/` dizinini tara
-- Her alt dizindeki `badi-plugin.json` dosyasini oku
+### Step 12: Scan Installed Plugins
+- Scan the `.claude/plugins/` directory
+- Read `badi-plugin.json` in each subdirectory
 
-### Adim 13: Plugin Listesi Olustur
+### Step 13: Build the Plugin List
 ```
-[kisaltildi]
+[abridged]
 ```
 
-### Adim 14: Plugin Yoksa
-- `.claude/plugins/` dizini yoksa veya bossa bilgilendir
-- Plugin yukleme komutu ornegi goster:
+### Step 14: When There Are No Plugins
+- Inform the user if `.claude/plugins/` is missing or empty
+- Show an install example:
   ```
-  /plugin install https://github.com/user/badi-plugin-ornek.git
-  /plugin install badi-plugin-ornek
+  /plugin install https://github.com/user/badi-plugin-example.git
+  /plugin install badi-plugin-example
   ```

--- a/.claude/commands-vault/prompt-test.md
+++ b/.claude/commands-vault/prompt-test.md
@@ -1,46 +1,46 @@
 Regression test for slash command and agent files. Format and content validation.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi ai prompt-test)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Calistir
+### Step 1: Run
 ```bash
 badi ai prompt-test
 ```
 
-### Adim 2: Kontroller
+### Step 2: Checks
 
-Her `.claude/commands/*.md` ve `.claude/agents/*.md` icin:
+For every `.claude/commands/*.md` and `.claude/agents/*.md`:
 
-1. **Bos/cok kisa dosya** — 50 karakter altinda uyari
-2. **Ajan frontmatter** — `---` + `name:` + `description:` zorunlu
-3. **TODO/FIXME/TBD** — production icin isaret
-4. **Uzun satir** — 500+ karakter formatting bozulmasi
+1. **Empty/too-short file** — warning under 50 characters
+2. **Agent frontmatter** — `---` + `name:` + `description:` mandatory
+3. **TODO/FIXME/TBD** — flagged for production
+4. **Long lines** — 500+ characters break formatting
 
-### Adim 3: Aksiyonlar
+### Step 3: Actions
 
-Bulgularina gore:
-- Bos dosya: icerik ekle veya sil
-- Frontmatter eksik: ekle
-- TODO: tamamla veya sil
-- Uzun satir: yeniden format
+Based on the findings:
+- Empty file: add content or delete
+- Missing frontmatter: add it
+- TODO: complete or remove
+- Long line: reformat
 
-### Adim 4: CI Entegrasyonu
+### Step 4: CI Integration
 
-GitHub Actions'a ekle:
+Add to GitHub Actions:
 ```yaml
 - name: Prompt Regression
   run: badi ai prompt-test
 ```
 
-Exit code olmadigindan asagidaki ile zorla:
+Since there is no exit code, enforce with:
 ```bash
-badi ai prompt-test | grep -q "temiz" || exit 1
+badi ai prompt-test | grep -q "clean" || exit 1
 ```
 
-# Ornek
+# Example
 
 ```
 /prompt-test

--- a/.claude/commands-vault/schedule.md
+++ b/.claude/commands-vault/schedule.md
@@ -1,74 +1,74 @@
 Scheduled command reminders. Shell-based reminder system for daily/weekly recurring tasks.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi schedule)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Mevcut Hatirlaticilar
+### Step 1: Existing Reminders
 
 ```bash
 badi schedule list
 ```
 
-### Adim 2: Yeni Hatirlatici Ekle
+### Step 2: Add a New Reminder
 
 ```bash
-# Is gunu her sabah
-badi schedule add "icerik basla" --at "09:00" --days "mon-fri"
+# Every workday morning
+badi schedule add "content start" --at "09:00" --days "mon-fri"
 
-# Haftalik (Pazar aksam)
-badi schedule add "icerik plan" --at "20:00" --days "sun"
+# Weekly (Sunday evening)
+badi schedule add "content plan" --at "20:00" --days "sun"
 
-# Gunluk
+# Daily
 badi schedule add "wrap-up" --at "18:00" --days "daily"
 ```
 
-Gun araligi: pzt/sal/car/per/cum/cts/paz (TR) veya mon/tue/wed/thu/fri/sat/sun (EN).
-Wrap-around destekli: sat-sun, fri-mon.
+Day ranges: pzt/sal/car/per/cum/cts/paz (TR) or mon/tue/wed/thu/fri/sat/sun (EN).
+Wrap-around supported: sat-sun, fri-mon.
 
-### Adim 3: Shell Entegrasyonu (ilk kurulum)
+### Step 3: Shell Integration (first setup)
 
-`~/.zshrc` veya `~/.bashrc`'ye ekle:
+Add to `~/.zshrc` or `~/.bashrc`:
 ```bash
 command -v badi &>/dev/null && badi schedule check 2>/dev/null
 ```
 
-Her shell baslangicinda zamani gelen hatirlaticilari gosterir (60dk toleransli).
+Shows due reminders at every shell start (60-minute tolerance).
 
-### Adim 4: Silme
+### Step 4: Removal
 
 ```bash
-badi schedule list            # ID'leri gor
-badi schedule remove [id]     # Sil
+badi schedule list            # See the IDs
+badi schedule remove [id]     # Remove
 ```
 
-### Adim 5: Kontrol
+### Step 5: Check
 
 ```bash
-badi schedule check           # Zamani gelenleri goster
+badi schedule check           # Show what is due
 ```
 
-# Ornek Rutinler
+# Example Routines
 
 ```bash
-# Is gunu sabahlari (09:00): icerik uretim oturumu
-badi schedule add "icerik basla" --at "09:00" --days "mon-fri"
+# Workday mornings (09:00): content production session
+badi schedule add "content start" --at "09:00" --days "mon-fri"
 
-# Hafta sonu disi 18:00: gun sonu ozeti
+# Weekdays 18:00: end-of-day summary
 badi schedule add "wrap-up" --at "18:00" --days "mon-fri"
 
-# Haftalik: Pazar aksam icerik planlama
-badi schedule add "icerik plan" --at "20:00" --days "sun"
+# Weekly: Sunday evening content planning
+badi schedule add "content plan" --at "20:00" --days "sun"
 
-# Her Pazartesi: haftalik saglik
+# Every Monday: weekly health
 badi schedule add "health" --at "09:30" --days "mon"
 
-# Her ay baslangici: denetim
+# Start of each month: audit
 badi schedule add "audit" --at "10:00" --days "mon"
 ```
 
-# Ornek Kullanim
+# Example Usage
 
 ```
 /schedule list

--- a/.claude/commands-vault/standup.md
+++ b/.claude/commands-vault/standup.md
@@ -1,60 +1,60 @@
 Daily standup command. Produces a quick status summary in under 30 seconds.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (git log)
-- Read (gorev panosu, notlar)
-- Grep (aktivite taramasi)
+- Read (task board, notes)
+- Grep (activity scan)
 
-# Prosedur (Hedef: 30 saniye)
+# Procedure (Target: 30 seconds)
 
-### Adim 1: Git Aktivitesi (Paralel)
-- Son is gununun commitlerini al: `git log --oneline --since="yesterday"`
-- Degisen dosya sayisini hesapla
-- Branch durumunu kontrol et
+### Step 1: Git Activity (Parallel)
+- Get the last working day's commits: `git log --oneline --since="yesterday"`
+- Count the changed files
+- Check the branch status
 
-### Adim 2: Gorev Panosu (Paralel)
-- Aktif gorevleri oku
-- Tamamlananlari say
-- Bloke olanlari tespit et
-- Yeni eklenen gorevleri belirle
+### Step 2: Task Board (Parallel)
+- Read the active tasks
+- Count the completed ones
+- Detect blocked tasks
+- Identify newly added tasks
 
-### Adim 3: Onceki Notlar (Paralel)
-- Son gunluk notu oku
-- Devir notu varsa kontrol et
-- "Yarinki isler" bolumunu bul
+### Step 3: Previous Notes (Parallel)
+- Read the latest daily note
+- Check the handoff note if one exists
+- Find the "tomorrow's work" section
 
-### Adim 4: Mevcut Odak
-- Bugunun onceliklerini belirle
-- Bagimliliklari kontrol et
-- Risk veya engel var mi?
+### Step 4: Current Focus
+- Determine today's priorities
+- Check dependencies
+- Any risks or blockers?
 
-# Cikti Formati
+# Output Format
 ```
 === BADI STANDUP ===
-Tarih: [tarih]
+Date: [date]
 
-DUN:
-- [yapilan isler - git commitlerden ve notlardan]
-- [tamamlanan gorevler]
+YESTERDAY:
+- [work done - from git commits and notes]
+- [completed tasks]
 
-BUGUN:
-- [planlanmis isler - oncelik sirasina gore]
-- [devam eden gorevler]
+TODAY:
+- [planned work - in priority order]
+- [in-progress tasks]
 
-ENGELLEYICILER:
-- [varsa engeller ve beklentiler]
-- [yoksa: "Engel yok, yol acik."]
+BLOCKERS:
+- [blockers and expectations, if any]
+- [otherwise: "No blockers, road clear."]
 
-METRIKLER:
-- Commitler (dun): [sayi]
-- Acik Gorevler: [sayi]
-- Tamamlanan (dun): [sayi]
+METRICS:
+- Commits (yesterday): [count]
+- Open Tasks: [count]
+- Completed (yesterday): [count]
 ====================
 ```
 
-# Kurallar
-- Kisa ve oz tut, maksimum 15 satir cikti
-- Her madde bir satirda
-- Engelleyicileri vurgula (varsa)
-- Metrikleri her zaman ekle
-- 30 saniyeyi gecme
+# Rules
+- Keep it short and tight, 15 lines of output max
+- One line per item
+- Highlight blockers (if any)
+- Always include the metrics
+- Do not exceed 30 seconds

--- a/.claude/commands-vault/start.md
+++ b/.claude/commands-vault/start.md
@@ -1,111 +1,111 @@
 Badi session start command. Runs new-project onboarding or a daily kickoff.
 
-# Gerekli Araclar
-- Bash (dosya sistemi erisimi)
-- Read (bellek ve baglam dosyalari)
-- Glob (proje yapisi taramasi)
-- Grep (kod arama)
-- Write (gunluk not olusturma)
+# Required Tools
+- Bash (filesystem access)
+- Read (memory and context files)
+- Glob (project structure scan)
+- Grep (code search)
+- Write (daily note creation)
 
-# Mod Secimi
+# Mode Selection
 
-Kullaniciya sor: "Yeni proje alistirmasi mi, gunluk baslatma mi?"
-
----
-
-## A) Yeni Proje Alistirmasi
-
-### Adim 1: Proje Yapi Taramasi
-- Kok dizindeki tum dosya ve klasorleri tara
-- `package.json`, `Cargo.toml`, `pyproject.toml`, `go.mod` gibi manifest dosyalarini bul
-- `.env.example`, `docker-compose.yml`, `Makefile` gibi altyapi dosyalarini tespit et
-
-### Adim 2: Teknoloji Yigini Tespiti
-- Programlama dilleri ve versiyonlari
-- Framework ve kutuphaneler
-- Veritabani ve dis servisler
-- CI/CD ve deploy altyapisi
-- Test araclari
-
-### Adim 3: Baglam Sorulari (4 Soru)
-Kullaniciya su sorulari yonelt:
-1. "Bu projenin temel amaci ve hedef kullanicisi kim?"
-2. "Su anki en onemli onceliginiz nedir?"
-3. "Bilmem gereken teknik kisitlamalar veya kararlar var mi?"
-4. "Calisma tarzinizla ilgili tercihleriniz nelerdir? (commit stili, branch stratejisi, test beklentileri)"
-
-### Adim 4: Bellek Olusturma
-Toplanan bilgilerle `memory.md` dosyasini olustur veya guncelle:
-- Proje ozeti
-- Teknoloji yigini
-- Kullanici tercihleri
-- Onemli dosya yollari
-- Mimari notlar
-
-### Adim 5: Skill Onerisi
-Projeye uygun Badi komutlarini oner:
-- Hangi komutlar bu proje icin en faydali olacak
-- Onerilen gunluk is akisi
-- Ozel komut ihtiyaclari varsa belirt
+Ask the user: "New-project onboarding or a daily kickoff?"
 
 ---
 
-## B) Gunluk Baslatma
+## A) New-Project Onboarding
 
-### Adim 1: Tarih Al
-- Bugunku tarihi `GGAAYY` formatinda belirle (ornek: 090426)
+### Step 1: Project Structure Scan
+- Scan all files and folders in the root directory
+- Find manifest files like `package.json`, `Cargo.toml`, `pyproject.toml`, `go.mod`
+- Detect infrastructure files like `.env.example`, `docker-compose.yml`, `Makefile`
 
-### Adim 2: Baglam Yukle
-- `memory.md` dosyasini oku
-- `knowledge-base.md` varsa oku
-- Son oturum notlarini kontrol et
+### Step 2: Tech Stack Detection
+- Programming languages and versions
+- Frameworks and libraries
+- Databases and external services
+- CI/CD and deploy infrastructure
+- Test tooling
 
-### Adim 3: Gunluk Not Olustur
-`daily-notes/GGAAYY.md` dosyasini olustur:
+### Step 3: Context Questions (4 Questions)
+Ask the user:
+1. "What is the core purpose of this project and who is its target user?"
+2. "What is your most important priority right now?"
+3. "Any technical constraints or decisions I should know about?"
+4. "What are your working-style preferences? (commit style, branch strategy, test expectations)"
+
+### Step 4: Memory Creation
+Create or update `memory.md` with what was gathered:
+- Project summary
+- Tech stack
+- User preferences
+- Important file paths
+- Architecture notes
+
+### Step 5: Skill Suggestions
+Suggest the Badi commands that fit the project:
+- Which commands will be most useful for this project
+- A suggested daily workflow
+- Note any custom command needs
+
+---
+
+## B) Daily Kickoff
+
+### Step 1: Get the Date
+- Determine today's date in `DDMMYY` format (example: 090426)
+
+### Step 2: Load Context
+- Read `memory.md`
+- Read `knowledge-base.md` if it exists
+- Check the latest session notes
+
+### Step 3: Create the Daily Note
+Create `daily-notes/DDMMYY.md`:
 ```markdown
-# Gunluk Not - [GG.AA.YYYY]
+# Daily Note - [DD.MM.YYYY]
 
-## Odak Alanlari
+## Focus Areas
 - [ ] ...
 
-## Notlar
+## Notes
 ...
 
-## Kararlar
+## Decisions
 ...
 
-## Yarinki Isler
+## Tomorrow's Work
 ...
 ```
 
-### Adim 4: Gorev Panosu Incele
-- Acik gorevleri listele
-- Gecen oturumdan kalan isleri kontrol et
-- Tamamlanmis ama kapatilmamis gorevleri tespit et
+### Step 4: Review the Task Board
+- List the open tasks
+- Check work left from the previous session
+- Detect completed-but-not-closed tasks
 
-### Adim 5: Arka Plan Watcher Ozeti (v1.13+)
-- `badi agent status --since 24h` calistir (varsa; hata dondurse sessiz gec)
-- Cikti `!! N uyari` iceriyorsa brifing'e "Watcher uyarilari" bolumu ekle
-- Kullaniciya sor: "Bu uyarilara bakalim mi?"
+### Step 5: Background Watcher Summary (v1.13+)
+- Run `badi agent status --since 24h` (if available; pass silently on error)
+- If the output includes `!! N warnings`, add a "Watcher warnings" section to the briefing
+- Ask the user: "Shall we look at these warnings?"
 
-### Adim 6: Oncelikleri Dogrula
-Kullaniciya sor:
-- "Bugunku oncelikler dogru mu?"
-- "Degisiklik veya ekleme var mi?"
+### Step 6: Confirm Priorities
+Ask the user:
+- "Are today's priorities correct?"
+- "Any changes or additions?"
 
-### Adim 7: Brifing
-Kisa bir ozet sun:
+### Step 7: Briefing
+Present a short summary:
 ```
-=== BADI GUNLUK BRIFING ===
-Tarih: [tarih]
-Acik Gorevler: [sayi]
-Bugunku Odak: [oncelikler]
-Devam Eden: [onceki oturumdan kalanlar]
-Watcher: [24h icinde N uyari | hepsi OK | watcher yok]
-Dikkat: [onemli notlar veya uyarilar]
+=== BADI DAILY BRIEFING ===
+Date: [date]
+Open Tasks: [count]
+Today's Focus: [priorities]
+In Progress: [carried over from the previous session]
+Watcher: [N warnings in 24h | all OK | no watcher]
+Attention: [important notes or warnings]
 ===========================
 ```
 
-# Cikti Formati
-- Mod A: Proje profili + bellek dosyasi + skill onerileri
-- Mod B: Gunluk brifing + not dosyasi + oncelik listesi
+# Output Format
+- Mode A: Project profile + memory file + skill suggestions
+- Mode B: Daily briefing + note file + priority list

--- a/.claude/commands-vault/stats.md
+++ b/.claude/commands-vault/stats.md
@@ -1,41 +1,41 @@
 Usage analytics command. Badi tool usage statistics, bar charts, daily trends, habit streaks.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi stats)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Donem Belirle
-
-```bash
-badi stats                    # Son 7 gun (varsayilan)
-badi stats --week             # Son 7 gun
-badi stats --month            # Son 30 gun
-badi stats --all              # Tum zamanlar
-```
-
-### Adim 2: Filtre ve Detay
+### Step 1: Pick a Period
 
 ```bash
-badi stats --command Bash     # Sadece Bash kullanimi
-badi stats --habits           # Aliskanlik serisi (streak)
-badi stats --export csv       # CSV olarak disa aktar
+badi stats                    # Last 7 days (default)
+badi stats --week             # Last 7 days
+badi stats --month            # Last 30 days
+badi stats --all              # All time
 ```
 
-### Adim 3: Yorumla
+### Step 2: Filter and Detail
 
-Ciktiya gore kullaniciya:
-- **Yuksek Bash kullanimi**: Komut kisayollari onerilebilir
-- **Streak kirildi**: Haftalik/gunluk rutin hatirlaticisi
-- **Az kullanilan arac**: Rehberlik teklif
+```bash
+badi stats --command Bash     # Bash usage only
+badi stats --habits           # Habit streaks
+badi stats --export csv       # Export as CSV
+```
 
-### Adim 4: Gorsel Rapor
+### Step 3: Interpret
 
-Bar chart, gunluk trend ve habit streak'lari ozetle.
+Based on the output, tell the user:
+- **High Bash usage**: command shortcuts could be suggested
+- **Broken streak**: weekly/daily routine reminder
+- **Rarely used tool**: offer guidance
 
-# Ornek
+### Step 4: Visual Report
+
+Summarize bar charts, daily trends, and habit streaks.
+
+# Example
 ```
 /stats --habits
 /stats --month --command Bash
-/stats --export csv > usage-rapor.csv
+/stats --export csv > usage-report.csv
 ```

--- a/.claude/commands-vault/sync.md
+++ b/.claude/commands-vault/sync.md
@@ -1,76 +1,76 @@
 Mid-session context refresh command. Keeps context fresh and consistent during work.
 
-# Gerekli Araclar
-- Read (bellek ve baglam dosyalari)
-- Write (guncelleme yazimi)
-- Grep (degisiklik taramasi)
-- Bash (git durumu)
+# Required Tools
+- Read (memory and context files)
+- Write (writing updates)
+- Grep (change scan)
+- Bash (git status)
 
-# Prosedur (9 Adim)
+# Procedure (9 Steps)
 
-### Adim 1: Baglam Oku
-- `memory.md` dosyasini oku
-- `knowledge-base.md` dosyasini oku
-- Aktif gunluk notu (`daily-notes/GGAAYY.md`) oku
-- Son `handoffs/` notunu kontrol et
+### Step 1: Read Context
+- Read `memory.md`
+- Read `knowledge-base.md`
+- Read the active daily note (`daily-notes/DDMMYY.md`)
+- Check the latest `handoffs/` note
 
-### Adim 2: Notlari Isle
-- Bu oturumda alinan kararlari listele
-- Yeni ogrenimleri tespit et
-- Degisen gereksinimleri not et
-- Cozulen ve yeni ortaya cikan sorunlari kaydet
+### Step 2: Process Notes
+- List the decisions made this session
+- Identify new learnings
+- Note changed requirements
+- Record solved and newly surfaced problems
 
-### Adim 3: Gorevleri Yonet
-- Tamamlanan gorevleri "bitti" olarak isaretle
-- Yeni ortaya cikan gorevleri ekle
-- Oncelikleri yeniden degerllendir
-- Bagimliliklari kontrol et
+### Step 3: Manage Tasks
+- Mark completed tasks as "done"
+- Add newly surfaced tasks
+- Re-evaluate priorities
+- Check dependencies
 
-### Adim 4: Baglamsal Oz-Sorgulama
-Su sorulari ic kontrol olarak degerlendir:
-- "Mevcut calisma hedefle uyumlu mu?"
-- "Kapsam kaymasi (scope creep) belirtisi var mi?"
-- "Atlanan veya ertelenen bir sey var mi?"
-- "Kullanicinin son talepleriyle tutarli miyim?"
+### Step 4: Contextual Self-Check
+Evaluate these questions as an internal check:
+- "Is the current work aligned with the goal?"
+- "Any signs of scope creep?"
+- "Anything skipped or postponed?"
+- "Am I consistent with the user's latest requests?"
 
-### Adim 5: Boyd Kurali Kontrolu (OODA)
-- **Gozlem (Observe):** Mevcut durum nedir?
-- **Yonelim (Orient):** Bu bilgiyi nasil yorumluyorum?
-- **Karar (Decide):** Sonraki adim ne olmali?
-- **Eylem (Act):** Hangi eylemi onerecegim?
+### Step 5: Boyd Loop Check (OODA)
+- **Observe:** What is the current state?
+- **Orient:** How do I interpret this information?
+- **Decide:** What should the next step be?
+- **Act:** What action will I propose?
 
-### Adim 6: Bellek Guncelle
-- `memory.md` dosyasina yeni bilgileri ekle
-- Eskimis bilgileri guncelle veya kaldir
-- Celiski varsa coz ve not et
+### Step 6: Update Memory
+- Add new information to `memory.md`
+- Update or remove stale information
+- Resolve and note any contradictions
 
-### Adim 7: Olay Gunlugu Incele
-- Son degisiklikleri tara (git log, dosya degisiklikleri)
-- Beklenmeyen degisiklik varsa uyar
-- Onemli olaylari kronolojik sirala
+### Step 7: Review the Event Log
+- Scan recent changes (git log, file changes)
+- Warn about unexpected changes
+- Order important events chronologically
 
-### Adim 8: Koc Icegorusu
-Kisa bir degerllendirme sun:
-- Uretkenlik akisi nasil gidiyor?
-- Dikkat dagilmasi veya bloklama var mi?
-- Mola onerisi gerekli mi?
+### Step 8: Coach Insight
+Offer a brief assessment:
+- How is the productivity flow going?
+- Any distraction or blocking?
+- Is a break recommended?
 
-### Adim 9: Durum Raporu
+### Step 9: Status Report
 ```
-=== BADI SENKRONIZASYON ===
-Zaman: [saat]
-Oturum Suresi: [tahmini]
-Tamamlanan: [son senkrondan beri]
-Devam Eden: [aktif isler]
-Yeni Gorevler: [eklenenler]
-Bellek Durumu: GUNCEL / UYARI
-Boyd Analizi: [ozet]
-Koc Notu: [icegorusu]
+=== BADI SYNC ===
+Time: [time]
+Session Length: [estimate]
+Completed: [since the last sync]
+In Progress: [active work]
+New Tasks: [added]
+Memory State: CURRENT / WARNING
+Boyd Analysis: [summary]
+Coach Note: [insight]
 ============================
 ```
 
-# Cikti Formati
-- Guncellenmis bellek dosyasi
-- Gunluk nota eklenen yeni bilgiler
-- Durum raporu (yukaridaki format)
-- Gerekirse oneri veya uyari listesi
+# Output Format
+- Updated memory file
+- New information added to the daily note
+- Status report (format above)
+- Suggestion or warning list when needed

--- a/.claude/commands-vault/system-audit.md
+++ b/.claude/commands-vault/system-audit.md
@@ -1,89 +1,89 @@
 Deep infrastructure audit command. Comprehensively audits all Badi components across 9 checkpoints.
 
-# Gerekli Araclar
-- Read (tum konfig dosyalari) -- Grep (referans/kalip taramasi) -- Glob (dosya varlik) -- Bash (izin, JSON dogrulama, dosya bilgisi) -- Write (rapor)
+# Required Tools
+- Read (all config files) -- Grep (reference/pattern scan) -- Glob (file existence) -- Bash (permissions, JSON validation, file info) -- Write (report)
 
-# Prosedur (9 Kontrol)
+# Procedure (9 Checks)
 
-## Kontrol 1: Ajan Sagligi
-- `.claude/agents/` dosyalarini listele
-- Her ajan: YAML frontmatter formati -- gerekli alanlar (isim, aciklama, araclar) -- referans araclar gecerli mi -- cozulmemis `{{...}}` -- talimat tutarliligi
-- Ajan sayisi ve durum ozeti
+## Check 1: Agent Health
+- List the `.claude/agents/` files
+- Each agent: YAML frontmatter format -- required fields (name, description, tools) -- are referenced tools valid -- unresolved `{{...}}` -- instruction consistency
+- Agent count and status summary
 
-## Kontrol 2: Komut Sagligi
-- `.claude/commands/` dosyalarini listele
-- Her komut: aciklama satiri -- arac gereksinimi -- prosedur adimlari -- cikti formati -- markdown gecerli
-- `command-index.md` capraz referans: indekste olup dosyasi olmayan -- dosyasi olup indekste olmayan -- aciklama uyumsuzlugu
+## Check 2: Command Health
+- List the `.claude/commands/` files
+- Each command: description line -- tool requirements -- procedure steps -- output format -- valid markdown
+- `command-index.md` cross-reference: in the index but no file -- file exists but not in the index -- description mismatch
 
-## Kontrol 3: Hook Sagligi
-- `settings.json` JSON dogrula
-- Her hook: dosya mevcut mu -- calistirilabilir izin -- kuru calistirma (syntax) -- tetikleyici dogru
-- Calisma sirasi/oncelik -- carpisan/celisen hooklar
+## Check 3: Hook Health
+- Validate `settings.json` JSON
+- Each hook: does the file exist -- executable permission -- dry run (syntax) -- correct trigger
+- Run order/priority -- colliding/conflicting hooks
 
-## Kontrol 4: Bellek Katmani
-- `memory.md`: boyut (500 satir limiti) -- tazelik (son guncelleme) -- ic tutarlilik (celisen bilgi) -- kaynak atfisi
-- `knowledge-base.md`: boyut (1000 satir limiti) -- kategorizasyon -- dogrulanmamis bilgi -- atif/referans
+## Check 4: Memory Layer
+- `memory.md`: size (500-line limit) -- freshness (last update) -- internal consistency (contradicting info) -- source attribution
+- `knowledge-base.md`: size (1000-line limit) -- categorization -- unverified information -- citation/reference
 
-## Kontrol 5: Gunluk Sagligi
-- Dizinler: `daily-notes/`, `handoffs/` boyut/sayi -- denetim iz dosyalari (audit-trail.md, incident-log.md, failure-log.md)
-- Her gunluk: boyut siniri -- format tutarliligi -- tarih dogrulugu
-- JSONL (verdicts.jsonl): her satir gecerli JSON -- sema tutarliligi
+## Check 5: Log Health
+- Directories: `daily-notes/`, `handoffs/` size/count -- audit trail files (audit-trail.md, incident-log.md, failure-log.md)
+- Each log: size limit -- format consistency -- date accuracy
+- JSONL (verdicts.jsonl): each line valid JSON -- schema consistency
 
-## Kontrol 6: Izin/Konfigurasyon
-- Hook dosya izinleri -- settings.json icindeki referanslar mevcut mu -- ortam degiskeni bagimliliklari (kullanilan ama tanimsiz) -- dizin yapisi -- `.gitignore` ile hassas dosya kontrolu
+## Check 6: Permissions/Configuration
+- Hook file permissions -- do references inside settings.json exist -- environment variable dependencies (used but undefined) -- directory structure -- sensitive-file check against `.gitignore`
 
-## Kontrol 7: Capraz Tutarlilik
-- A → B atif yapiyorsa B mevcut mu -- dongusel bagimlilik -- yetim referans (baglanmayan dosya) -- CLAUDE.md ↔ komut/ajan davranis uyumu -- isimlendirme konvansiyonu
+## Check 7: Cross-Consistency
+- If A references B, does B exist -- circular dependencies -- orphan references (unlinked files) -- CLAUDE.md ↔ command/agent behavior alignment -- naming conventions
 
-## Kontrol 8: Yedekleme/Depolama
-- Toplam `.claude/` boyutu -- en buyuk 5 dosya -- 30 gunden eski (arsiv adayi) -- otomatik temizlik mekanizmasi -- gecici dosyalar -- yedekleme stratejisi guncel mi
+## Check 8: Backup/Storage
+- Total `.claude/` size -- 5 largest files -- older than 30 days (archive candidates) -- automatic cleanup mechanism -- temporary files -- is the backup strategy current
 
-## Kontrol 9: Via Negativa
-Gereksiz karmasik tespit: kullanilmayan bilesen (komut/ajan/hook) -- tekrarlayan/carpisan islev -- gereksiz bagimlilik zinciri -- asiri karmasik konfig -- olmeyen workaround -- kaldirildiginda sistemi iyilestirecek ogeler
+## Check 9: Via Negativa
+Detect needless complexity: unused components (command/agent/hook) -- duplicated/colliding functionality -- needless dependency chains -- overly complex config -- undying workarounds -- items whose removal would improve the system
 
-# Derecelendirme
-- **A:** Tum alt kontroller gecti, iyilestirme gerektirmiyor
-- **B:** Kucuk uyarilar, acil mudahale yok
-- **C:** Duzeltilmesi gereken sorunlar, planli sprintte
-- **D:** Ciddi sorunlar, hemen ele alinmali
-- **F:** Kritik basarisizlik, acil mudahale
+# Grading
+- **A:** All sub-checks passed, no improvement needed
+- **B:** Minor warnings, no urgent intervention
+- **C:** Issues to fix, in a planned sprint
+- **D:** Serious issues, address immediately
+- **F:** Critical failure, urgent intervention
 
-**Genel Derece:** en dusuk bireysel veya agirlikli ortalama.
+**Overall Grade:** the lowest individual grade or a weighted average.
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI SISTEM DENETIMI ===
-Tarih: [tarih]
-Genel Derece: [A-F]
+=== BADI SYSTEM AUDIT ===
+Date: [date]
+Overall Grade: [A-F]
 
-## Kontrol Sonuclari
-| # | Kontrol | Derece | Bulgu |
-|---|---------|--------|-------|
-| 1 | Ajan Sagligi | [A-F] | [ozet] |
-| 2 | Komut Sagligi | [A-F] | [ozet] |
-| 3 | Hook Sagligi | [A-F] | [ozet] |
-| 4 | Bellek Katmani | [A-F] | [ozet] |
-| 5 | Gunluk Sagligi | [A-F] | [ozet] |
-| 6 | Izin/Konfigurasyon | [A-F] | [ozet] |
-| 7 | Capraz Tutarlilik | [A-F] | [ozet] |
-| 8 | Yedekleme/Depolama | [A-F] | [ozet] |
-| 9 | Via Negativa | [A-F] | [ozet] |
+## Check Results
+| # | Check | Grade | Finding |
+|---|-------|-------|---------|
+| 1 | Agent Health | [A-F] | [summary] |
+| 2 | Command Health | [A-F] | [summary] |
+| 3 | Hook Health | [A-F] | [summary] |
+| 4 | Memory Layer | [A-F] | [summary] |
+| 5 | Log Health | [A-F] | [summary] |
+| 6 | Permissions/Config | [A-F] | [summary] |
+| 7 | Cross-Consistency | [A-F] | [summary] |
+| 8 | Backup/Storage | [A-F] | [summary] |
+| 9 | Via Negativa | [A-F] | [summary] |
 
-## Kritik Bulgular (D ve F)
-[detaylar ve acil aksiyonlar]
+## Critical Findings (D and F)
+[details and urgent actions]
 
-## Uyarilar (C)
-[detaylar ve planlanmis aksiyonlar]
+## Warnings (C)
+[details and planned actions]
 
-## Iyilestirme Onerileri (A ve B)
-[opsiyonel iyilestirmeler]
+## Improvement Suggestions (A and B)
+[optional improvements]
 
-## Duzeltme Plani
-1. [ACIL] [aksiyon] - Hedef: [tarih]
-2. [PLANLI] [aksiyon] - Hedef: [tarih]
-3. [ONERILEN] [aksiyon] - Hedef: [tarih]
+## Remediation Plan
+1. [URGENT] [action] - Target: [date]
+2. [PLANNED] [action] - Target: [date]
+3. [SUGGESTED] [action] - Target: [date]
 
-## Sonraki Denetim
-Onerilen: [tarih] (aylik veya buyuk degisiklik sonrasi)
+## Next Audit
+Suggested: [date] (monthly or after major changes)
 ==============================
 ```

--- a/.claude/commands-vault/unstick.md
+++ b/.claude/commands-vault/unstick.md
@@ -1,120 +1,120 @@
 Unblocking command. Finds a fast solution with a structured approach when you're stuck.
 
-# Gerekli Araclar
-- Read (kod ve baglam okuma)
-- Grep (hata ve kalip arama)
-- Glob (dosya bulma)
-- Bash (test calistirma, hata ayiklama)
+# Required Tools
+- Read (code and context reading)
+- Grep (error and pattern search)
+- Glob (file discovery)
+- Bash (running tests, debugging)
 
-# Baslangic Formati
-Kullanicidan: "[Y] nedeniyle [X]'de takildim"
-Ornek: "CORS hatasi nedeniyle API entegrasyonunda takildim"
+# Starting Format
+From the user: "I'm stuck on [X] because of [Y]"
+Example: "I'm stuck on the API integration because of a CORS error"
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Engeli Yakala
-Kullanicidan su bilgileri topla:
-- **Ne:** Hangi gorevde/islemde takili? (X)
-- **Neden:** Engelin dograsi/sebebi nedir? (Y)
-- **Denenenler:** Simdiye kadar ne denendi?
-- **Hata Mesaji:** Varsa gercek hata ciktisi
-- **Beklenen Sonuc:** Ne olmasini bekliyordu?
-- **Gerceklesen:** Bunun yerine ne oldu?
-- **Ortam:** Hangi ortamda? (yerel, staging, production)
+### Step 1: Capture the Blocker
+Collect from the user:
+- **What:** Which task/operation is stuck? (X)
+- **Why:** What is the nature/cause of the blocker? (Y)
+- **Tried:** What has been attempted so far?
+- **Error Message:** The actual error output, if any
+- **Expected:** What did they expect to happen?
+- **Actual:** What happened instead?
+- **Environment:** Which environment? (local, staging, production)
 
-### Adim 2: Siniflandir
-Engeli 5 kategoriden birine ata:
+### Step 2: Classify
+Assign the blocker to one of 5 categories:
 
-**A) Bilgi Eksikligi**
-- Eksik veri, dokumantasyon veya API bilgisi
-- Cozum: Ilgili kaynakllari bul ve incele
-- Araclar: Grep, Read, dokumantasyon taramasi
+**A) Missing Information**
+- Missing data, documentation, or API knowledge
+- Fix: Find and review the relevant sources
+- Tools: Grep, Read, documentation scan
 
-**B) Karar Felci**
-- Birden fazla secenek arasinda takili kalma
-- Cozum: Secenekleri karsilastirmali analiz et, artilari/eksileri listele
-- Yaklasim: "Geri donulebilir mi?" sorusuyla basla, geri donulebilirce en basitini sec
+**B) Decision Paralysis**
+- Stuck between multiple options
+- Fix: Comparative analysis of the options; list pros/cons
+- Approach: Start with "is it reversible?"; if reversible, pick the simplest
 
-**C) Dongusel Hata Ayiklama**
-- Ayni hataya tekrar tekrar dusme
-- Cozum: Varsayimlari sorgula, sorun alanini daralt
-- Yaklasim: Ikili arama (binary search) - sorunun nerede oldugunu sistematik daralt
+**C) Circular Debugging**
+- Hitting the same error repeatedly
+- Fix: Question the assumptions, narrow the problem area
+- Approach: Binary search — systematically narrow where the problem lives
 
-**D) Kapsam Karisikligi**
-- Ne yapilacagi belirsiz, gereksinimler muglak
-- Cozum: Gereksinimleri netlestir, en kucuk ise yarar parcayi belirle
-- Yaklasim: "Yapilabilecek en kucuk sey nedir?" sorusu
+**D) Scope Confusion**
+- Unclear what to do, vague requirements
+- Fix: Clarify requirements, define the smallest useful piece
+- Approach: the question "what is the smallest thing that could work?"
 
-**E) Ortam Sorunlari**
-- Yapilandirma, bagimlilik, erisim, versiyon uyumsuzlugu
-- Cozum: Ortam kontrolu, bagimlilik dogrulamasi
-- Yaklasim: Temiz ortamda tekrarlama, izolasyon testi
+**E) Environment Issues**
+- Configuration, dependencies, access, version mismatch
+- Fix: Environment check, dependency verification
+- Approach: Reproduce in a clean environment, isolation test
 
-### Adim 3: Analizci Ajanini Etkinlestir
-Siniflandirmaya gore analiz baslat:
+### Step 3: Activate the Analyst
+Start the analysis per the classification:
 
-**Bilgi toplama:**
-- Ilgili kodu oku ve baglamini anla
-- Hata mesajini arastir
-- Benzer sorunlarin cozumlerini ara
-- Dokumantasyonu kontrol et
+**Information gathering:**
+- Read the relevant code and understand its context
+- Research the error message
+- Search for solutions to similar problems
+- Check the documentation
 
-**Kok neden analizi:**
-- 5 Neden teknigini uygula (Why-Why-Why)
-- Varsayim listesi cikar ve her birini dogrula
-- Sorun alanini en dar hale getir
-- Yeniden uretilip uretilemeyecigini kontrol et
+**Root cause analysis:**
+- Apply the 5 Whys technique
+- List the assumptions and verify each one
+- Narrow the problem area as much as possible
+- Check whether it can be reproduced
 
-**Cozum uretimi:**
-- En az 2, en fazla 4 cozum onerisi sun
-- Her oneri icin: ne yapilacak, risk seviyesi, tahmini sure
-- En hizli sonuc verecek oneriyi isaretle (quick win)
+**Solution generation:**
+- Offer at least 2, at most 4 solution proposals
+- For each: what to do, risk level, estimated time
+- Mark the one likely to deliver fastest (quick win)
 
-### Adim 4: Oneriyi Uygula
-En uygun oneriyi sec ve hemen uygula:
-- Oneriyi adim adim yap
-- Her adimda sonucu dogrula
-- Islemezse sonraki oneriye gec
-- Tum oneriler basarisiz olursa, yeni bilgiyle Adim 3'e don
+### Step 4: Apply the Proposal
+Pick the best proposal and apply it immediately:
+- Execute the proposal step by step
+- Verify the result at each step
+- If it does not work, move to the next proposal
+- If all proposals fail, return to Step 3 with the new information
 
-### Adim 5: Cozumu Belgele
-Cozumu kalici hale getir:
+### Step 5: Document the Solution
+Make the fix durable:
 
-**Gunluk Nota Ekle:**
+**Add to the daily note:**
 ```markdown
-## Tikaniklik Cozumu - [saat]
-- **Engel:** [X] - [Y]
-- **Kategori:** [A-E]
-- **Kok Neden:** [gercek sebep]
-- **Cozum:** [uygulanan cozum]
-- **Sure:** [harcanan sure]
-- **Ogrenin:** [cikarilan ders]
+## Unblock Solution - [time]
+- **Blocker:** [X] - [Y]
+- **Category:** [A-E]
+- **Root Cause:** [real reason]
+- **Solution:** [applied solution]
+- **Duration:** [time spent]
+- **Learning:** [lesson learned]
 ```
 
-**Tekrar Kontrolu:**
-- Bu sorun daha once yasandi mi? (tekrarlayan kalip kontrolu)
-- Tekrarliyorsa, kalici cozum icin `knowledge-base.md`'ye ekle
-- Otomasyon firsati var mi? (hook veya script ile onlenebilir mi?)
+**Recurrence check:**
+- Has this problem happened before? (recurring pattern check)
+- If recurring, add a durable fix to `knowledge-base.md`
+- Any automation opportunity? (preventable via a hook or script?)
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI TIKANIKLIK COZUMU ===
-Engel: [X] - [Y]
-Kategori: [A-E]: [kategori adi]
-Sure: [cozum suresi]
+=== BADI UNBLOCK ===
+Blocker: [X] - [Y]
+Category: [A-E]: [category name]
+Duration: [time to solve]
 
-Kok Neden: [aciklama]
-Uygulanan Cozum: [ne yapildi]
-Sonuc: COZULDU / KISMI / DEVAM EDIYOR
+Root Cause: [explanation]
+Applied Solution: [what was done]
+Result: SOLVED / PARTIAL / ONGOING
 
-Ogrenin: [cikarilan ders]
-Tekrar Riski: DUSUK / ORTA / YUKSEK
-[Yuksekse: Kalici cozum onerisi]
+Learning: [lesson learned]
+Recurrence Risk: LOW / MEDIUM / HIGH
+[If high: durable fix suggestion]
 ===============================
 ```
 
-# Hizli Ipuclari
-- Bazi tikanikliklar 5 dakika mola ile cozulur - bunu da oner
-- "Geri donulebilir mi?" sorusu karar felcini kirder
-- Hata mesajini kelimesi kelimesine aramak cogu zaman cozumu bulur
-- Sorunu baskasina aciklamak (rubber duck debugging) tek basina cozebilir
+# Quick Tips
+- Some blockers dissolve after a 5-minute break — suggest that too
+- The "is it reversible?" question breaks decision paralysis
+- Searching the error message verbatim often finds the fix
+- Explaining the problem to someone (rubber duck debugging) can solve it on its own

--- a/.claude/commands-vault/wrap-up.md
+++ b/.claude/commands-vault/wrap-up.md
@@ -1,116 +1,116 @@
 End-of-day ritual command. Prepares the day for closure and sets the stage for tomorrow.
 
-# Gerekli Araclar
-- Read (bellek, notlar, gunlukler)
-- Write (guncelleme ve rapor yazimi)
-- Bash (git durumu, gorev kontrolu)
-- Grep (olay taramasi)
+# Required Tools
+- Read (memory, notes, logs)
+- Write (updates and report writing)
+- Bash (git status, task checks)
+- Grep (event scan)
 
-# Prosedur (11 Adim)
+# Procedure (11 Steps)
 
-### Adim 1: Durum Oku
-- `memory.md` dosyasini oku
-- Gunluk notu (`daily-notes/GGAAYY.md`) oku
-- Gorev panosunu kontrol et
-- Git durumunu incele (commit edilmemis degisiklikler)
+### Step 1: Read the State
+- Read `memory.md`
+- Read the daily note (`daily-notes/DDMMYY.md`)
+- Check the task board
+- Review the git status (uncommitted changes)
 
-### Adim 2: Defteri Isle
-Gunun olaylarini derle:
-- Yapilan commitler ve degisiklikler
-- Alinan kararlar ve gerekceleri
-- Karsilasilan sorunlar ve cozumleri
-- Kullanicinin verdigi yonlendirmeler
+### Step 2: Process the Ledger
+Compile the day's events:
+- Commits and changes made
+- Decisions taken and their rationale
+- Problems hit and their solutions
+- Directions given by the user
 
-### Adim 3: Bellegi Senkronize Et
-`memory.md` dosyasini guncelle:
-- Yeni ogrenimleri ekle
-- Eskimis bilgileri kaldir
-- Proje durumunu guncelle
-- Onemli kararlari kaydet
+### Step 3: Synchronize Memory
+Update `memory.md`:
+- Add new learnings
+- Remove stale information
+- Update the project state
+- Record important decisions
 
-### Adim 4: Tamamlanan Gorevleri Tasi
-- Biten gorevleri "tamamlandi" olarak isaretle
-- Tamamlanma tarihini ekle
-- Kismen biten gorevlerin durumunu guncelle
-- Bloke olan gorevleri ve nedenlerini belirt
+### Step 4: Move Completed Tasks
+- Mark finished tasks as "completed"
+- Add the completion date
+- Update the status of partially finished tasks
+- Note blocked tasks and their reasons
 
-### Adim 5: Ogrenimleri Disariya Aktar
-Bugunden cikarilan dersleri kaydet:
-- Teknik ogrenimler (yeni API, kalip, arac)
-- Surec ogrenimleri (neyin ise yaradigi/yaramadigi)
-- Proje icegoruleri
-- `knowledge-base.md` dosyasina ekle
+### Step 5: Export Learnings
+Record today's lessons:
+- Technical learnings (new APIs, patterns, tools)
+- Process learnings (what worked / what did not)
+- Project insights
+- Add them to `knowledge-base.md`
 
-### Adim 6: Denetci Calistir
-Hizli bir T1 denetim yap:
-- Commit edilmemis degisiklik var mi?
-- Kirik test var mi?
-- Gecici dosya veya debug kodu kalmis mi?
-- Guvenlik riski tasiyan bir sey var mi?
+### Step 6: Run the Auditor
+Do a quick T1 audit:
+- Any uncommitted changes?
+- Any broken tests?
+- Any temp files or debug code left behind?
+- Anything carrying a security risk?
 
-### Adim 7: Olay Gunlugu Incele
-- Gunun onemli olaylarini kronolojik sirala
-- Anormal veya dikkat gerektiren durumlar var mi?
-- Takip gerektiren konulari isaretle
+### Step 7: Review the Event Log
+- Order the day's important events chronologically
+- Anything abnormal or needing attention?
+- Flag topics that need follow-up
 
-### Adim 8: Yarini Onizle
-- Yarin icin oncelikli gorevleri belirle
-- Bagimliliklari kontrol et (baskasini bekleyen isler)
-- Takvim etkinlikleri veya son tarihler var mi?
-- Onerilen odak alanlarini listele
+### Step 8: Preview Tomorrow
+- Determine tomorrow's priority tasks
+- Check dependencies (work waiting on someone else)
+- Any calendar events or deadlines?
+- List the suggested focus areas
 
-### Adim 9: Gunluk Notlari Guncelle
-`daily-notes/GGAAYY.md` dosyasini tamamla:
+### Step 9: Update the Daily Notes
+Complete the `daily-notes/DDMMYY.md` file:
 ```markdown
-## Gun Sonu Ozeti
-- Tamamlanan: [liste]
-- Devam Eden: [liste]
-- Ertelenen: [liste]
-- Yarinki Oncelik: [liste]
+## End-of-Day Summary
+- Completed: [list]
+- In Progress: [list]
+- Deferred: [list]
+- Tomorrow's Priority: [list]
 
-## Ogrenimler
-- [ogrenimler]
+## Learnings
+- [learnings]
 
-## Kararlar
-- [kararlar ve gerekceleri]
+## Decisions
+- [decisions and their rationale]
 ```
 
-### Adim 10: Koc Analizi (Cumalari)
-Eger gun Cuma ise, haftalik kocluk analizi yap:
-- Haftalik uretkenlik ozeti
-- Hedeflere ilerleme durumu
-- Enerji ve odak kaliplari
-- Gelecek hafta icin oneriler
-- Kutlanacak basarilar
+### Step 10: Coach Analysis (Fridays)
+If it is Friday, run the weekly coaching analysis:
+- Weekly productivity summary
+- Progress toward goals
+- Energy and focus patterns
+- Suggestions for next week
+- Wins to celebrate
 
-### Adim 11: Cikis Ozeti
+### Step 11: Exit Summary
 ```
-=== BADI GUN SONU ===
-Tarih: [tarih]
-Oturum Suresi: [tahmini]
+=== BADI END OF DAY ===
+Date: [date]
+Session Length: [estimate]
 
-Tamamlanan Gorevler: [sayi]
-Commitler: [sayi]
-Satir Degisikligi: +[eklenen] / -[silinen]
+Completed Tasks: [count]
+Commits: [count]
+Line Changes: +[added] / -[removed]
 
-Devam Eden: [sayi] gorev
-Bloke: [sayi] gorev
+In Progress: [count] tasks
+Blocked: [count] tasks
 
-Yarinki Oncelikler:
-1. [oncelik]
-2. [oncelik]
-3. [oncelik]
+Tomorrow's Priorities:
+1. [priority]
+2. [priority]
+3. [priority]
 
-Denetim Durumu: TEMIZ / [sorun sayisi] UYARI
-Bellek: SENKRONIZE
+Audit Status: CLEAN / [issue count] WARNINGS
+Memory: SYNCHRONIZED
 
-[Cuma ise: Haftalik Koc Notu]
+[If Friday: Weekly Coach Note]
 =========================
 ```
 
-# Cikti Formati
-- Guncellenmis `memory.md`
-- Tamamlanmis gunluk not
-- `knowledge-base.md` guncellemesi
-- Gun sonu ozet raporu
-- (Cumalari) Haftalik kocluk raporu
+# Output Format
+- Updated `memory.md`
+- Completed daily note
+- `knowledge-base.md` update
+- End-of-day summary report
+- (Fridays) Weekly coaching report

--- a/.claude/commands/ai-token.md
+++ b/.claude/commands/ai-token.md
@@ -1,45 +1,45 @@
 Badi/.claude/ token usage analysis command. Categorized token counts, largest files, optimization suggestions.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi ai token)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Calistir
+### Step 1: Run
 ```bash
 badi ai token
 ```
 
-### Adim 2: Sonuclari Yorumla
+### Step 2: Interpret the Results
 
-Kategori bazli dokum:
-- **agents** — Ajan tanimlari
-- **commands** — Slash komutlar
-- **hooks** — Shell hook'lari
-- **skills** — Beceri kutuphanesi (genelde en buyuk)
-- **references** — Proje rehberleri
-- **memory/workspace** — Proje notlari
+Category breakdown:
+- **agents** — Agent definitions
+- **commands** — Slash commands
+- **hooks** — Shell hooks
+- **skills** — Skill library (usually the largest)
+- **references** — Project guides
+- **memory/workspace** — Project notes
 
-Toplam token esigi:
-- `< 80K` — Saglikli
-- `80-150K` — Izleme gerekli
-- `> 150K` — Optimizasyon zorunlu
+Total token thresholds:
+- `< 80K` — Healthy
+- `80-150K` — Needs monitoring
+- `> 150K` — Optimization mandatory
 
-### Adim 3: Optimizasyon Onerileri
+### Step 3: Optimization Suggestions
 
-Toplam yuksekse:
-1. **Buyuk SKILL.md'leri bol** — `references/` alt dizinine cekme
-2. **Unused commandlari kaldir** — Kullanilmayan slash komut
-3. **CLAUDE.md minimize** — 1.2KB hedef
-4. **Log rotation** — .claude/logs/ otomatik sinir
+If the total is high:
+1. **Split large SKILL.md files** — move into a `references/` subdirectory
+2. **Remove unused commands** — slash commands nobody invokes
+3. **Minimize CLAUDE.md** — 1.2KB target
+4. **Log rotation** — automatic cap on .claude/logs/
 
-### Adim 4: Takip
+### Step 4: Follow-up
 
-Haftalik kontrol:
-- `/ai-token` her Pazartesi sabahi
-- Trendi izle (her hafta 10%+ artis varsa inceleme)
+Weekly check:
+- `/ai-token` every Monday morning
+- Watch the trend (investigate on 10%+ weekly growth)
 
-# Ornek
+# Example
 
 ```
 /ai-token

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,114 +1,114 @@
 Quality audit command. Runs a systematic audit over code, structure, or process.
 
-## Badi CLI Komutlari (v1.6+)
-Seviye T4 (Kapsamli) denetimde su CLI araclari calistirir:
-- `badi secret-scan --git` — Sir taramasi + git history
+## Badi CLI Commands (v1.6+)
+A Level T4 (Comprehensive) audit runs these CLI tools:
+- `badi secret-scan --git` — Secret scan + git history
 - `badi lighthouse [url]` — Performance + Core Web Vitals
 - `badi a11y [url]` — Accessibility (WCAG 2.1)
-- `badi ssl/dns/whois [domain]` — Domain saglik (uretim varsa)
-- `badi commit --check` — Son commit conventional format
+- `badi ssl/dns/whois [domain]` — Domain health (if production exists)
+- `badi commit --check` — Last commit conventional format
 
-# Gerekli Araclar
-- Read (dosya okuma)
-- Grep (kod taramasi)
-- Glob (dosya bulma)
-- Bash (analiz araclari)
-- Write (rapor yazimi)
+# Required Tools
+- Read (file reading)
+- Grep (code scan)
+- Glob (file discovery)
+- Bash (analysis tools)
+- Write (report writing)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Kapsam Belirle
-Kullaniciya sor: "Denetim kapsamini secin:"
-- **Dosya/Dizin:** Belirli bir dosya veya klasor
-- **Modul:** Tum bir modul veya ozellik
-- **Proje Geneli:** Tum kod tabani
-- **Surec:** CI/CD, test, deploy surecleri
+### Step 1: Define the Scope
+Ask the user: "Pick the audit scope:"
+- **File/Directory:** A specific file or folder
+- **Module:** A whole module or feature
+- **Project-Wide:** The entire codebase
+- **Process:** CI/CD, test, deploy processes
 
-### Adim 2: Denetim Seviyesi Sec (T1-T4)
+### Step 2: Pick the Audit Level (T1-T4)
 
-**T1 - Hizli Tarama (2-5 dk)**
-- Sozdizimi ve format kontrolleri
-- Bariz guvenlik sorunlari (hardcoded secrets, SQL injection)
-- Eksik dosyalar veya kirik importlar
-- Lint kurali ihlalleri
+**T1 - Quick Scan (2-5 min)**
+- Syntax and format checks
+- Obvious security issues (hardcoded secrets, SQL injection)
+- Missing files or broken imports
+- Lint rule violations
 
-**T2 - Standart Denetim (5-15 dk)**
-- T1 + kod kalite metrikleri
-- Tekrarlanan kod (DRY ihlalleri)
-- Isimlendirme tutarliligi
-- Yorum ve dokumantasyon eksiklikleri
-- Test kapsami analizi
+**T2 - Standard Audit (5-15 min)**
+- T1 + code quality metrics
+- Duplicated code (DRY violations)
+- Naming consistency
+- Comment and documentation gaps
+- Test coverage analysis
 
-**T3 - Derin Denetim (15-30 dk)**
-- T2 + mimari uyum analizi
-- Bagimlilik grafigi incelemesi
-- Performans darbogazlari
-- Hata yonetimi kaliplari
-- Erisim kontrol ve yetkilendirme
+**T3 - Deep Audit (15-30 min)**
+- T2 + architectural fit analysis
+- Dependency graph review
+- Performance bottlenecks
+- Error handling patterns
+- Access control and authorization
 
-**T4 - Kapsamli Denetim (30+ dk)**
-- T3 + guvenlik taramasi (OWASP Top 10)
-- Olceklenebilirlik degerlendirmesi
-- Felaket kurtarma hazirlik durumu
-- Uyumluluk kontrolleri (lisans, KVKK vb.)
-- Teknik borc envanteri
-- **Badi CLI Ekstralari**:
-  - `badi secret-scan --git` — Sir + git history
-  - `badi lighthouse [url]` — Performans + SEO + A11y + Best Practices
-  - `badi a11y [url]` — WCAG 2.1 detay
-  - `badi ssl/dns/whois [domain]` — Uretim domain saglik
-  - `badi commit --check` — Commit format uyumu
+**T4 - Comprehensive Audit (30+ min)**
+- T3 + security scan (OWASP Top 10)
+- Scalability assessment
+- Disaster recovery readiness
+- Compliance checks (licenses, GDPR/KVKK, etc.)
+- Technical debt inventory
+- **Badi CLI Extras**:
+  - `badi secret-scan --git` — Secrets + git history
+  - `badi lighthouse [url]` — Performance + SEO + A11y + Best Practices
+  - `badi a11y [url]` — WCAG 2.1 detail
+  - `badi ssl/dns/whois [domain]` — Production domain health
+  - `badi commit --check` — Commit format compliance
 
-### Adim 3: Denetim Ajani Devret
-Secilen seviyeye gore denetimi baslat:
-- Her kontrol maddesi icin GECTI / KALDI / UYARI durumu belirle
-- Bulgulari topla ve siniflandir
-- Kanit (kod satirlari, dosya yollari) ekle
+### Step 3: Delegate to the Audit Agent
+Start the audit at the chosen level:
+- Mark every check item PASS / FAIL / WARN
+- Collect and classify the findings
+- Attach evidence (code lines, file paths)
 
-### Adim 4: Sonuclari Isle
-Bulgulari siniflandir:
-- **KRITIK:** Hemen mudahale gerekli (guvenlik acigi, veri kaybi riski)
-- **YUKSEK:** Kisa vadede cozulmeli (performans, hata yonetimi)
-- **ORTA:** Planlanan sprintte ele alinmali (kod kalitesi)
-- **DUSUK:** Iyilestirme firsati (refactoring, dokumantasyon)
+### Step 4: Process the Results
+Classify the findings:
+- **CRITICAL:** Immediate intervention required (security hole, data-loss risk)
+- **HIGH:** Resolve in the short term (performance, error handling)
+- **MEDIUM:** Handle in a planned sprint (code quality)
+- **LOW:** Improvement opportunity (refactoring, documentation)
 
-### Adim 5: Gunlukleri Guncelle
-- Denetim sonuclarini gunluk nota ekle
-- Tespit edilen gorevleri gorev panosuna ekle
-- `memory.md` dosyasina onemli bulgulari kaydet
+### Step 5: Update the Logs
+- Add the audit results to the daily note
+- Add detected tasks to the task board
+- Record important findings in `memory.md`
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI DENETIM RAPORU ===
-Tarih: [tarih]
-Kapsam: [belirtilen kapsam]
-Seviye: T[1-4]
-Sure: [gecen sure]
+=== BADI AUDIT REPORT ===
+Date: [date]
+Scope: [specified scope]
+Level: T[1-4]
+Duration: [elapsed]
 
-## Ozet
-- Toplam Kontrol: [sayi]
-- Gecti: [sayi] | Kaldi: [sayi] | Uyari: [sayi]
-- Genel Skor: [yuzde]%
+## Summary
+- Total Checks: [count]
+- Passed: [count] | Failed: [count] | Warnings: [count]
+- Overall Score: [percent]%
 
-## Kritik Bulgular
-[varsa listele]
+## Critical Findings
+[list if any]
 
-## Yuksek Oncelikli Bulgular
-[listele]
+## High-Priority Findings
+[list]
 
-## Orta Oncelikli Bulgular
-[listele]
+## Medium-Priority Findings
+[list]
 
-## Dusuk Oncelikli / Iyilestirme
-[listele]
+## Low Priority / Improvements
+[list]
 
-## Onerilen Aksiyonlar
-1. [aksiyon]
-2. [aksiyon]
+## Suggested Actions
+1. [action]
+2. [action]
 ...
 
-## Sonraki Denetim Onerisi
-Tarih: [onerilen tarih]
-Kapsam: [onerilen kapsam]
+## Next Audit Suggestion
+Date: [suggested date]
+Scope: [suggested scope]
 =============================
 ```

--- a/.claude/commands/clear.md
+++ b/.claude/commands/clear.md
@@ -1,88 +1,88 @@
 Context-clearing command. Provides a seamless transition across session boundaries. Target: under 30 seconds.
 
-# Gerekli Araclar
-- Read (baglam dosyalari)
-- Write (devir notu ve bellek guncelleme)
+# Required Tools
+- Read (context files)
+- Write (handoff note and memory update)
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-### Adim 1: Kapilari Sifirla
-- Aktif dosya izleme listesini temizle
-- Gecici analiz sonuclarini sifirla
-- Acik kalan paralel isleri kapat
-- Oturum ici degiskenleri temizle
+### Step 1: Reset the Gates
+- Clear the active file-watch list
+- Reset temporary analysis results
+- Close any open parallel work
+- Clear in-session variables
 
-### Adim 2: Oturumu Ozetle (7 Bilesen)
-Su 7 bileseni iceren bir ozet olustur:
+### Step 2: Summarize the Session (7 Components)
+Build a summary covering these 7 components:
 
-1. **Aktif Gorev:** Su an uzerinde calisilan gorev nedir?
-2. **Durum:** Hangi asamada? (baslangic/orta/tamamlandi/bloke)
-3. **Son Eylem:** En son yapilan is neydi?
-4. **Sonraki Adim:** Hemen yapilmasi gereken sey nedir?
-5. **Acik Sorular:** Cevap bekleyen sorular var mi?
-6. **Degisen Dosyalar:** Bu oturumda degistirilen dosyalar
-7. **Onemli Baglam:** Sonraki oturumun bilmesi gereken kritik bilgi
+1. **Active Task:** What task is being worked on right now?
+2. **Status:** What stage? (start/middle/done/blocked)
+3. **Last Action:** What was the most recent work?
+4. **Next Step:** What needs to happen immediately?
+5. **Open Questions:** Any questions awaiting answers?
+6. **Changed Files:** Files modified this session
+7. **Key Context:** Critical information the next session must know
 
-### Adim 3: Devir Notu Yaz
-`handoffs/handoff-[GGAAYY-SSDD].md` dosyasini olustur:
+### Step 3: Write the Handoff Note
+Create `handoffs/handoff-[DDMMYY-HHMM].md`:
 ```markdown
-# Devir Notu - [tarih saat]
+# Handoff Note - [date time]
 
-## Aktif Gorev
-[gorev aciklamasi]
+## Active Task
+[task description]
 
-## Mevcut Durum
-[durum detayi]
+## Current Status
+[status detail]
 
-## Son Eylemler
-- [eylem listesi]
+## Recent Actions
+- [action list]
 
-## Sonraki Adimlar
-1. [adim]
-2. [adim]
+## Next Steps
+1. [step]
+2. [step]
 
-## Acik Sorular
-- [sorular]
+## Open Questions
+- [questions]
 
-## Degisen Dosyalar
-- [dosya listesi]
+## Changed Files
+- [file list]
 
-## Kritik Baglam
-[kaybedilmemesi gereken bilgi]
+## Critical Context
+[information that must not be lost]
 ```
 
-### Adim 4: Bellegi Guncelle
-`memory.md` dosyasinda:
-- Son gorev durumunu guncelle
-- Devir notu referansini ekle
-- Zaman damgasini guncelle
+### Step 4: Update Memory
+In `memory.md`:
+- Update the latest task status
+- Add the handoff note reference
+- Update the timestamp
 
-### Adim 5: Ogrenimleri Tasi
-Bu oturumda kazanilan ogrenimleri `knowledge-base.md` dosyasina aktar:
-- Teknik bilgiler
-- Proje kararlari
-- Surec notlari
+### Step 5: Move Learnings
+Transfer this session's learnings into `knowledge-base.md`:
+- Technical knowledge
+- Project decisions
+- Process notes
 
-### Adim 6: Otomatik Devam
-Sonraki oturumun baslangiç komutu icin hazirlık yap:
-- Devir notunun yolunu belirt
-- Oncelikli eylemleri vurgula
-- Baslama onerisini sun
+### Step 6: Auto-Continue
+Prepare for the next session's start command:
+- Point to the handoff note path
+- Highlight the priority actions
+- Offer a starting suggestion
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI BAGLAM TEMIZLEME ===
-Sure: [saniye]s
-Devir Notu: handoffs/handoff-[tarih].md
-Bellek: GUNCELLENDI
-Ogrenimler: [sayi] madde aktarildi
+=== BADI CONTEXT CLEAR ===
+Duration: [seconds]s
+Handoff Note: handoffs/handoff-[date].md
+Memory: UPDATED
+Learnings: [count] items transferred
 
-Sonraki Oturum Icin:
-> [tek satirlik baslama onerisi]
+For the Next Session:
+> [one-line starting suggestion]
 ===============================
 ```
 
-# Performans Hedefi
-- Tum islem 30 saniye altinda tamamlanmali
-- Bellek dosyasi 500 satiri gecmemeli
-- Devir notu ozlu ve net olmali (gereksiz detay yok)
+# Performance Target
+- The whole operation must finish in under 30 seconds
+- The memory file must not exceed 500 lines
+- The handoff note must be concise and clear (no needless detail)

--- a/.claude/commands/coach.md
+++ b/.claude/commands/coach.md
@@ -1,142 +1,142 @@
 Coaching analysis command. Performs data-driven work-pattern analysis and offers personal improvement suggestions.
 
-# Gerekli Araclar
-- Read (bellek, gorevler, notlar, onceki kocluk raporlari)
-- Write (kocluk raporu)
-- Grep (kalip taramasi)
-- Glob (veri kaynaklari bulma)
-- Bash (git istatistikleri)
+# Required Tools
+- Read (memory, tasks, notes, previous coaching reports)
+- Write (coaching report)
+- Grep (pattern scan)
+- Glob (finding data sources)
+- Bash (git statistics)
 
-# Opsiyonel Zaman Dilimi
-Kullaniciya sor: "Hangi doenemi analiz edelim?"
-- **Haftalik:** Son 7 gun
-- **Aylik:** Son 30 gun
-- **Tum Veri:** Mevcut tum kayitlar
+# Optional Time Window
+Ask the user: "Which period shall we analyze?"
+- **Weekly:** Last 7 days
+- **Monthly:** Last 30 days
+- **All Data:** Every existing record
 
-# Prosedur (4 Bolum)
+# Procedure (4 Sections)
 
-### Bolum 0: Veri Toplama
-Analiz icin veri kaynaklarini topla:
-- `memory.md` dosyasini oku
-- Gorev panosunu incele (tamamlanan, devam eden, ertelenen)
-- Gunluk notlari tara (belirtilen donem icin)
-- Git istatistiklerini topla (commit sikligi, degisiklik hacmi)
-- Onceki kocluk gozlemlerini oku (varsa)
-- Devir notlarini incele
-- Retrospektif raporlarini kontrol et
+### Section 0: Data Collection
+Gather the data sources for analysis:
+- Read `memory.md`
+- Review the task board (completed, in progress, deferred)
+- Scan the daily notes (for the chosen period)
+- Collect git statistics (commit frequency, change volume)
+- Read previous coaching observations (if any)
+- Review the handoff notes
+- Check the retrospective reports
 
-### Bolum 1: Uretkenlik Analizi
+### Section 1: Productivity Analysis
 
-**Metrikler:**
-- Gorev tamamlama orani (tamamlanan / planlanan)
-- Gunluk ortalama commit sayisi
-- Uretken gun sayisi ve oruntuleri
-- Gorev basina harcanan ortalama sure
-- Zaman dagilimi analizi (gelistirme / toplanti / yonetim / arastirma)
-- En verimli saat ve gun analizi
-- Darbogazlar ve bekleme sureleri
+**Metrics:**
+- Task completion rate (completed / planned)
+- Average daily commit count
+- Productive day count and patterns
+- Average time spent per task
+- Time distribution analysis (development / meetings / management / research)
+- Most productive hour and day analysis
+- Bottlenecks and waiting times
 
-**Degerllendirme:**
-- Ust duzey performans alanlari
-- Iyilestirme gerektiren alanlar
-- Verimlilik trendi (artis/azalis/sabit)
+**Assessment:**
+- Top-performance areas
+- Areas needing improvement
+- Productivity trend (rising/falling/flat)
 
-### Bolum 2: Buyume Analizi
+### Section 2: Growth Analysis
 
-**Metrikler:**
-- Yeni ogrenilen teknoloji ve araclar
-- Icerik uretim sikligi (blog, dokumantasyon, vb.)
-- Karmasiklik seviyesi artan gorevler (zorluk ilerlesmesi)
-- Problem cozme hizi degisimi
-- Kanal cesitliligi (gelistirme, tasarim, is gelistirme, vb.)
-- Teknik derinlik gostergesi
+**Metrics:**
+- Newly learned technologies and tools
+- Content production frequency (blog, documentation, etc.)
+- Tasks with rising complexity (difficulty progression)
+- Change in problem-solving speed
+- Channel diversity (development, design, business development, etc.)
+- Technical depth indicator
 
-**Degerllendirme:**
-- Beceri gelistirme alanlari
-- Konfor bolgesinden cikmis mi?
-- Yeni zorluklar aranmis mi?
+**Assessment:**
+- Skill development areas
+- Did they step out of the comfort zone?
+- Were new challenges sought?
 
-### Bolum 3: Surdurulebilirlik Analizi
+### Section 3: Sustainability Analysis
 
-**Sinyaller:**
-- Tukenmislik belirtileri:
-  - Hafta sonu calisma sikligi
-  - Asiri uzun oturumlar (4+ saat arasiiz)
-  - Gece gelistirme aktivitesi
-  - Artan hata orani
-- Engel yogunlugu (ne siklikta bloke olunuyor?)
-- Tekrarlayan sorunlar (ayni sey kac kez sorun oldu?)
-- Mola kalipleri (yeterli ara veriliyor mu?)
-- Is/yasam dengesi gostergeleri
+**Signals:**
+- Burnout symptoms:
+  - Weekend work frequency
+  - Excessively long sessions (4+ hours uninterrupted)
+  - Late-night development activity
+  - Rising error rate
+- Blocker density (how often blocked?)
+- Recurring problems (how many times did the same thing break?)
+- Break patterns (enough breaks taken?)
+- Work/life balance indicators
 
-**Degerllendirme:**
-- Mevcut tempo surdurulebilir mi?
-- Risk sinyalleri var mi?
-- Iyilestirme onerileri
+**Assessment:**
+- Is the current pace sustainable?
+- Any risk signals?
+- Improvement suggestions
 
-### Bolum 4: Firsat Analizi
+### Section 4: Opportunity Analysis
 
-**Kacirilmis Firsatlar:**
-- Tamamlanmamis ama degerli isler
-- Tekrarlayan manuel islemler (otomasyon adayi)
-- Kullanilmayan arac veya skill'ler
-- Delegasyon firsatlari
-- Paralellestirilebilir is akislari
+**Missed Opportunities:**
+- Valuable but unfinished work
+- Repetitive manual operations (automation candidates)
+- Unused tools or skills
+- Delegation opportunities
+- Parallelizable workflows
 
-**Yeni Firsatlar:**
-- Trend olan teknolojiler ve araclar
-- Mevcut becerileri genisletme alanlari
-- Verimlilik kazanimi potansiyeli
-- Strateji degisikligi firsatlari
+**New Opportunities:**
+- Trending technologies and tools
+- Areas to extend existing skills
+- Efficiency-gain potential
+- Strategy-change opportunities
 
-### Takip Kontrolu
-- Onceki kocluk onerilerinin uygulanma durumunu kontrol et
-- Uygulanan onerilerin etkisini degerlendir
-- 3 haftadan eski uygulanmamis onerileri gozden gecir:
-  - Hala gecerli mi? Yeniden onceliklendirdir
-  - Artik gecerli degil mi? Kaldir ve nedenini not et
+### Follow-up Check
+- Check the status of previous coaching suggestions
+- Assess the impact of applied suggestions
+- Review unapplied suggestions older than 3 weeks:
+  - Still valid? Reprioritize
+  - No longer valid? Remove and note why
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI KOCLUK RAPORU ===
-Donem: [baslangic] - [bitis]
-Tarih: [tarih]
+=== BADI COACHING REPORT ===
+Period: [start] - [end]
+Date: [date]
 
-## Veri Ozeti
-- Analiz Edilen Gun: [sayi]
-- Toplam Commit: [sayi]
-- Tamamlanan Gorev: [sayi]
-- Gorev Tamamlama Orani: [yuzde]%
+## Data Summary
+- Days Analyzed: [count]
+- Total Commits: [count]
+- Completed Tasks: [count]
+- Task Completion Rate: [percent]%
 
-## Guclu Yonler (2-3 Madde)
-1. [guclu yon ve kanit]
-2. [guclu yon ve kanit]
-3. [guclu yon ve kanit]
+## Strengths (2-3 Items)
+1. [strength and evidence]
+2. [strength and evidence]
+3. [strength and evidence]
 
-## Uyarilar
-- [dikkat gerektiren alan ve neden]
+## Warnings
+- [area needing attention and why]
 
-## Firsatlar
-- [firsat ve nasil degererlendirileegi]
+## Opportunities
+- [opportunity and how to use it]
 
-## Surdurulebilirlik Notu
-[tukenmislik riski degerllendirmesi]
+## Sustainability Note
+[burnout risk assessment]
 
-## Tek Oncelik
-> Bu hafta odaklanilmasi gereken tek sey:
-> [net, uygulanabilir oneri]
+## Single Priority
+> The one thing to focus on this week:
+> [clear, actionable suggestion]
 
-## Onceki Onerilerin Takibi
-| Oneri | Durum | Etki |
-|-------|-------|------|
-| [oneri] | Uygulandi/Bekliyor/Iptal | [degerllendirme] |
+## Previous Suggestion Follow-up
+| Suggestion | Status | Impact |
+|------------|--------|--------|
+| [suggestion] | Applied/Pending/Cancelled | [assessment] |
 
-## Motivasyon Notu
-[kisisel, ozgun bir motivasyon mesaji]
+## Motivation Note
+[a personal, genuine motivational message]
 =============================
 ```
 
-# Not
-- Kocluk raporu `memory.md` dosyasina kaydedilir
-- Haftalik kocluk wrap-up komutu ile entegre calisir (Cuma analizi)
-- Ton: destekleyici, veri odakli, motivasyon verici
+# Notes
+- The coaching report is saved into `memory.md`
+- Integrates with the weekly wrap-up command (Friday analysis)
+- Tone: supportive, data-driven, motivating

--- a/.claude/commands/dashboard.md
+++ b/.claude/commands/dashboard.md
@@ -1,116 +1,116 @@
 Daily statistics panel. Presents task, audit, event, and performance data as a unified table.
 
-# Gerekli Araclar
-- Bash (tarih hesaplama, dosya istatistikleri)
-- Read (TaskBoard.md, audit-trail.md, incident-log.md, failure-log.md, gunluk notlar)
-- Grep (veri cikartma ve sayma)
+# Required Tools
+- Bash (date calculations, file statistics)
+- Read (TaskBoard.md, audit-trail.md, incident-log.md, failure-log.md, daily notes)
+- Grep (data extraction and counting)
 - ...
 
-# Veri Kaynaklari
-Bu komut asagidaki dosyalardan veri toplar:
-- `TaskBoard.md` - Gorev durumu bilgileri
-- `audit-trail.md` - Denetim izi kayitlari
-- `incident-log.md` - Olay kayitlari
-- ...
-
----
-
-## Bolum 1: Gorev Istatistikleri
-
-### Adim 1: TaskBoard Verilerini Oku
-- `TaskBoard.md` dosyasini oku
-- Gorev durumlarini say:
-  - Tamamlandi (DONE/BITTI)
-  - Devam Ediyor (IN_PROGRESS/DEVAM)
-  - Bekliyor (TODO/BEKLIYOR)
-  - Engelli (BLOCKED/ENGELLI)
-
-### Adim 2: Bugunun Gorev Hareketi
-- Bugun tamamlanan gorevleri filtrele
-- Bugun olusturulan yeni gorevleri tespit et
-- Durumu degisen gorevleri listele
+# Data Sources
+This command collects data from the following files:
+- `TaskBoard.md` - Task status information
+- `audit-trail.md` - Audit trail records
+- `incident-log.md` - Incident records
 - ...
 
 ---
 
-## Bolum 2: Degisiklik Istatistikleri
+## Section 1: Task Statistics
 
-### Adim 3: Audit Trail Analizi
-- `audit-trail.md` dosyasini oku
-- Bugunun tarihiyle eslesen girisleri filtrele
-- Degisen dosya sayisini cikar
-- ...
+### Step 1: Read the TaskBoard Data
+- Read `TaskBoard.md`
+- Count the task states:
+  - Done (DONE)
+  - In Progress (IN_PROGRESS)
+  - Waiting (TODO)
+  - Blocked (BLOCKED)
 
-### Adim 4: Git Istatistikleri
-- `git log --since="today" --format="%H" | wc -l` ile bugunun commit sayisini al
-- `git diff --stat HEAD~[sayi]` ile degisiklik boyutunu hesapla
-- Eklenen ve silinen satir sayisini raporla
-
----
-
-## Bolum 3: Olay ve Hata Istatistikleri
-
-### Adim 5: Olay Kayitlarini Incele
-- `incident-log.md` dosyasini oku (mevcutsa)
-- Bugunun olaylarini filtrele
-- Ciddiyet dagilimini cikar:
-  - KRITIK: Produksiyon etkileyen
-  - YUKSEK: Onemli islevsellik etkileyen
-  - ORTA: Sinirli etki
-  - DUSUK: Kozmetik veya kucuk sorunlar
-
-### Adim 6: Hata Kayitlarini Incele
-- `failure-log.md` dosyasini oku (mevcutsa)
-- Bugunun hatalarini filtrele
-- Tekrarlayan hata kaliplarini tespit et
+### Step 2: Today's Task Movement
+- Filter tasks completed today
+- Detect new tasks created today
+- List tasks whose status changed
 - ...
 
 ---
 
-## Bolum 4: Oturum Suresi Tahmini
+## Section 2: Change Statistics
 
-### Adim 7: Sure Hesaplama
-- audit-trail.md veya gunluk notlardan ilk girisi bul (oturum baslangici)
-- Son girisi bul (simdiki zaman veya son aktivite)
-- Aradaki farki hesapla
+### Step 3: Audit Trail Analysis
+- Read `audit-trail.md`
+- Filter entries matching today's date
+- Extract the changed file count
+- ...
+
+### Step 4: Git Statistics
+- Get today's commit count with `git log --since="today" --format="%H" | wc -l`
+- Compute the change size with `git diff --stat HEAD~[count]`
+- Report added and removed line counts
+
+---
+
+## Section 3: Incident and Failure Statistics
+
+### Step 5: Review the Incident Records
+- Read `incident-log.md` (if present)
+- Filter today's incidents
+- Extract the severity distribution:
+  - CRITICAL: production-impacting
+  - HIGH: affects important functionality
+  - MEDIUM: limited impact
+  - LOW: cosmetic or small issues
+
+### Step 6: Review the Failure Records
+- Read `failure-log.md` (if present)
+- Filter today's failures
+- Detect recurring failure patterns
 - ...
 
 ---
 
-## Bolum 5: Haftalik Karsilastirma
+## Section 4: Session Length Estimate
 
-### Adim 8: Gecen Hafta Verilerini Topla
-- Gecen haftanin ayni gunundeki istatistikleri bul (mevcutsa)
-- Karsilastirma metrikleri:
-  - Tamamlanan gorev sayisi
-  - Commit sayisi
-  - Olay/hata sayisi
-  - Calisma suresi
-
-### Adim 9: Trend Hesaplama
-- Her metrik icin degisim yuzdesi hesapla
-- Trend yonu belirle:
-  - YUKARI (artis, pozitif metrikler icin iyi)
-  - ASAGI (azalis)
-  - AYNI (+-5% icinde sabit)
-- Gorev tamamlama icin YUKARI iyi, olay sayisi icin ASAGI iyi
+### Step 7: Duration Calculation
+- Find the first entry in audit-trail.md or the daily notes (session start)
+- Find the last entry (now or the latest activity)
+- Compute the difference
+- ...
 
 ---
 
-## Cikti: Turkce Formatli Tablo
+## Section 5: Weekly Comparison
 
-### Adim 10: Dashboard Olustur
+### Step 8: Collect Last Week's Data
+- Find last week's same-day statistics (if available)
+- Comparison metrics:
+  - Completed task count
+  - Commit count
+  - Incident/failure count
+  - Work duration
+
+### Step 9: Trend Calculation
+- Compute the percent change for each metric
+- Determine the trend direction:
+  - UP (increase; good for positive metrics)
+  - DOWN (decrease)
+  - FLAT (stable within +-5%)
+- UP is good for task completion; DOWN is good for incident counts
+
+---
+
+## Output: Formatted Table
+
+### Step 10: Build the Dashboard
 ```
-[kisaltildi]
+[abridged]
 ```
 
-### Trend Ok Aciklamalari
-- Yukari ok: Deger artmis (gorevler icin olumlu, hatalar icin olumsuz)
-- Asagi ok: Deger azalmis
-- Yatay ok: Deger sabit (+-%5 icinde)
+### Trend Arrow Legend
+- Up arrow: value increased (positive for tasks, negative for failures)
+- Down arrow: value decreased
+- Flat arrow: value stable (within +-5%)
 - ...
 
-### Adim 11: Gunluk Ozet Yorumu
-- Genel uretkenlik degerlendirmesi (1 cumle)
-- En dikkat cekici metrik veya trend
-- Yarni icin oneri (eger belirgin bir kalip varsa)
+### Step 11: Daily Summary Comment
+- Overall productivity assessment (1 sentence)
+- The most notable metric or trend
+- A suggestion for tomorrow (if a clear pattern exists)

--- a/.claude/commands/doctor.md
+++ b/.claude/commands/doctor.md
@@ -1,108 +1,108 @@
 Badi configuration validation. Checks all Badi components and produces a diagnostic report.
 
-# Gerekli Araclar
-- Bash (dosya izinleri, dizin yapisi kontrolu)
-- Read (konfigur asyon ve manifest dosyalari)
-- Glob (dosya var lk taramasi)
+# Required Tools
+- Bash (file permissions, directory structure checks)
+- Read (configuration and manifest files)
+- Glob (file existence scan)
 - ...
 
-# Amac
-Bu komut Badi sisteminin dogru yapilandirildigini dogrular.
-Yeni kurulum sonrasi veya sorun yasandiginda calistirilmasi onerilir.
+# Purpose
+This command verifies that the Badi system is configured correctly.
+Recommended after a fresh install or whenever problems occur.
 
 ---
 
-## Kontrol 1: Hook Scriptleri
+## Check 1: Hook Scripts
 
-### Adim 1: Hook Dosya Varligi
-- `.claude/hooks/` dizinini tara
-- Tum `.sh` ve `.js` dosyalarini listele
-- Beklenen hook'larin mevcut oldugunu dogrula:
+### Step 1: Hook File Presence
+- Scan the `.claude/hooks/` directory
+- List all `.sh` and `.js` files
+- Verify the expected hooks exist:
   - Pre-commit hook
   - Post-commit hook
-  - Pre-push hook (varsa)
-  - Ozel Badi hooklari
+  - Pre-push hook (if any)
+  - Custom Badi hooks
 
-### Adim 2: Calistirma Izinleri
-- Her hook dosyasinin calistirma iznini kontrol et (`chmod +x`)
-- Izni olmayan dosyalar icin UYARI ver
-- Shebang satiri (`#!/bin/bash` veya `#!/usr/bin/env node`) kontrolu yap
+### Step 2: Execute Permissions
+- Check the execute permission of every hook file (`chmod +x`)
+- Give a WARNING for files lacking permission
+- Check the shebang line (`#!/bin/bash` or `#!/usr/bin/env node`)
 - ...
 
 ---
 
-## Kontrol 2: Settings.json Dogrulamas i
+## Check 2: settings.json Validation
 
-### Adim 3: Dosya Varligi ve Format
-- `.claude/settings.json` dosyasinin varligini kontrol et
-- JSON formatinin gecerli oldugunu dogrula (parse edilebilir mi)
-- Bos veya eksik dosya icin BASARISIZ ver
+### Step 3: File Presence and Format
+- Check that `.claude/settings.json` exists
+- Verify the JSON format is valid (parseable)
+- FAIL on an empty or missing file
 
-### Adim 4: Hook Referanslari
-- settings.json icindeki hook tanimlarini oku
-- Her referans edilen hook dosyasinin fiziksel olarak var oldugunu dogrula
-- Kirik referanslar (dosyasi olmayan hook tanimlari) icin BASARISIZ ver
+### Step 4: Hook References
+- Read the hook definitions inside settings.json
+- Verify every referenced hook file physically exists
+- FAIL on broken references (hook entries without files)
 - ...
 
 ---
 
-## Kontrol 3: Agent Dosyalari
+## Check 3: Agent Files
 
-### Adim 5: Agent Dizini Taramasi
-- `.claude/agents/` dizinini tara
-- Tum `.md` dosyalarini listele
+### Step 5: Agent Directory Scan
+- Scan the `.claude/agents/` directory
+- List all `.md` files
 
-### Adim 6: Frontmatter Dogrulamas i
-Her agent dosyasi icin:
-- Dosyanin basinda gecerli frontmatter olup olmadigini kontrol et
-- Gerekli alanlar: `name`, `description` (veya ilk satir aciklama)
-- Arac (tools) tanimlarinin gecerli formatta oldugunu dogrula
+### Step 6: Frontmatter Validation
+For each agent file:
+- Check whether valid frontmatter exists at the top
+- Required fields: `name`, `description` (or a first-line description)
+- Verify tool definitions are in a valid format
 - ...
 
 ---
 
-## Kontrol 4: Command-Index Referanslari
+## Check 4: Command-Index References
 
-### Adim 7: Index Dosyasini Oku
-- `command-index.md` dosyasini bul ve oku
-- Index'te listelenen tum komut referanslarini cikar
+### Step 7: Read the Index File
+- Find and read `command-index.md`
+- Extract all command references listed in the index
 
-### Adim 8: Referans Eslestirme
-- Her index girisinin `.claude/commands/` altinda karsilik gelen dosyasi var mi kontrol et
-- commands/ altinda olan ama index'te olmayan dosyalari tespit et
-- Index'te olan ama dosyasi olmayan kayiplari BASARISIZ olarak isaretl
+### Step 8: Reference Matching
+- Check that every index entry has a corresponding file under `.claude/commands/`
+- Detect files under commands/ that are missing from the index
+- Mark index entries without files as FAILED
 - ...
 
 ---
 
-## Kontrol 5: Bellek Dosyalari
+## Check 5: Memory Files
 
-### Adim 9: Bellek Dosya Boyutlari
-- `memory.md` dosyasinin varligini kontrol et
-- Dosya boyutunu olc
-- Boyut limiti asiliyor mu kontrol et (oner: 50KB uzeri icin UYARI)
+### Step 9: Memory File Sizes
+- Check that `memory.md` exists
+- Measure the file size
+- Check whether the size limit is exceeded (suggested: WARN above 50KB)
 - ...
 
-### Adim 10: Bellek Icerigi Kontrolu
-- memory.md icinde zorunlu bolumlerin varligini dogrula
-- Bos veya yapilandirilmamis bellek dosyasi icin UYARI ver
-- Sonuc: GECTI / UYARI / BASARISIZ
+### Step 10: Memory Content Check
+- Verify the mandatory sections exist inside memory.md
+- WARN on an empty or unstructured memory file
+- Result: PASS / WARN / FAIL
 
 ---
 
-## Kontrol 6: Skill Dizin Yapisi
+## Check 6: Skill Directory Structure
 
-### Adim 11: Skills Dizini
-- `.claude/skills/` dizinini kontrol et (mevcutsa)
-- `INDEX.md` dosyasinin var oldugunu dogrula
-- Her skill dosyasinin gecerli formatta oldugunu kontrol et
+### Step 11: Skills Directory
+- Check the `.claude/skills/` directory (if present)
+- Verify the `INDEX.md` file exists
+- Check that every skill file is in a valid format
 - ...
 
 ---
 
-## Tanisal Rapor
+## Diagnostic Report
 
-### Adim 12: Birlestirilmis Rapor Olustur
+### Step 12: Build the Combined Report
 ```
-[kisaltildi]
+[abridged]
 ```

--- a/.claude/commands/drift-detect.md
+++ b/.claude/commands/drift-detect.md
@@ -1,127 +1,127 @@
 Configuration drift detection command. Finds inconsistencies, orphaned components, and stale content in the Badi system.
 
-# Gerekli Araclar
-- Read (konfigurasyon dosyalari)
-- Grep (referans taramasi)
-- Glob (dosya varlik kontrolu)
-- Bash (dosya bilgileri, JSON dogrulama)
+# Required Tools
+- Read (configuration files)
+- Grep (reference scan)
+- Glob (file existence check)
+- Bash (file info, JSON validation)
 
-# Denetlenecek Dosyalar
-- `CLAUDE.md` (ana talimatlar)
-- `.claude/memory.md` (bellek katmani)
-- `.claude/knowledge-base.md` (bilgi tabani)
-- `.claude/settings.json` (ayarlar)
-- `.claude/commands/` (tum komut dosyalari)
-- `.claude/command-index.md` (komut dizini)
-- `.claude/agents/` (ajan dosyalari, varsa)
+# Files to Audit
+- `CLAUDE.md` (main instructions)
+- `.claude/memory.md` (memory layer)
+- `.claude/knowledge-base.md` (knowledge base)
+- `.claude/settings.json` (settings)
+- `.claude/commands/` (all command files)
+- `.claude/command-index.md` (command index)
+- `.claude/agents/` (agent files, if any)
 
-# Prosedur (5 Kontrol)
+# Procedure (5 Checks)
 
-### Kontrol 1: Celiski Tespiti
-Dosyalar arasi tutarsizliklari ara:
+### Check 1: Contradiction Detection
+Look for inconsistencies across files:
 
-**CLAUDE.md Celiskileri:**
-- Birbiriyle celisen talimatlar var mi?
-- Ayni konu hakkinda farkli yonlendirmeler var mi?
-- Eski ve yeni talimatlar arasinda catisma var mi?
+**CLAUDE.md Contradictions:**
+- Are there instructions that contradict each other?
+- Different directions about the same topic?
+- Conflicts between old and new instructions?
 
-**memory.md - Gerceklik Uyumu:**
-- Bellekteki proje durumu gercegi yansitiyor mu?
-- Artik gecerli olmayan bilgiler var mi?
-- Teknoloji yigini bilgisi guncel mi?
-- Dosya yollari hala dogru mu?
+**memory.md - Reality Alignment:**
+- Does the project state in memory reflect reality?
+- Any information no longer valid?
+- Is the tech stack info current?
+- Are the file paths still correct?
 
-**knowledge-base.md Tutarliligi:**
-- Ic celiskiler var mi?
-- memory.md ile catisan bilgiler var mi?
-- CLAUDE.md ile uyumsuz icgörüler var mi?
+**knowledge-base.md Consistency:**
+- Any internal contradictions?
+- Information conflicting with memory.md?
+- Insights inconsistent with CLAUDE.md?
 
-**settings.json Dogrulamasi:**
-- JSON formati gecerli mi?
-- Referans edilen dosya yollari mevcut mu?
-- Hook tanimlamalari dogru formatli mi?
+**settings.json Validation:**
+- Is the JSON format valid?
+- Do the referenced file paths exist?
+- Are the hook definitions correctly formatted?
 
-### Kontrol 2: Yetim Bilesen Tespiti
-Baglantisiz bilesenleri bul:
+### Check 2: Orphaned Component Detection
+Find disconnected components:
 
-- **Cagrilmayan Komutlar:** `commands/` dizininde olup hicbir yerde referans edilmeyen dosyalar
-- **Kullanilmayan Ajanlar:** `agents/` dizininde olup hicbir yerde cagrilmayan ajanlar
-- **Kirik Referanslar:** Mevcut olmayan dosyalara yapilan atiflar
-- **Baglantisiz Hooklar:** settings.json'da tanimli ama dosyasi olmayan hooklar
-- **Indekste Olmayan Komutlar:** `command-index.md` ile `commands/` dizini uyumsuzlugu
-- **Gereksiz Dosyalar:** Eski, artik kullanilmayan konfigurasyon dosyalari
+- **Uninvoked Commands:** Files in `commands/` referenced nowhere
+- **Unused Agents:** Agents in `agents/` never invoked anywhere
+- **Broken References:** Citations to files that do not exist
+- **Disconnected Hooks:** Hooks defined in settings.json without files
+- **Commands Missing from the Index:** Mismatch between `command-index.md` and `commands/`
+- **Redundant Files:** Old configuration files no longer in use
 
-### Kontrol 3: Eskime Kontrolleri
-Icerik tazeligi degerlendir:
+### Check 3: Staleness Checks
+Assess content freshness:
 
-- **memory.md Girdileri:** 3 gunden eski girdileri isaretle
-- **Gunluk Notlar:** 7 gunden eski islenMEmis notlar
-- **Devir Notlari:** 14 gunden eski devir notlari
-- **Gorev Panosu:** 30 gunden eski acik gorevler
-- **knowledge-base.md:** Dogrulanmasi gereken eski bilgiler
-- **Arac Referanslari:** Artik mevcut olmayan araclara atiflar
-- **Arsiv Notlari:** 30 gunden eski arsiv dosyalari (temizlik adayi)
-- **Takilan Gorevler:** Ilerleme kaydetmeyen gorevler
+- **memory.md Entries:** Flag entries older than 3 days
+- **Daily Notes:** Unprocessed notes older than 7 days
+- **Handoff Notes:** Handoffs older than 14 days
+- **Task Board:** Open tasks older than 30 days
+- **knowledge-base.md:** Old information needing re-verification
+- **Tool References:** Citations to tools that no longer exist
+- **Archive Notes:** Archive files older than 30 days (cleanup candidates)
+- **Stuck Tasks:** Tasks making no progress
 
-### Kontrol 4: Konfigurasyon Sagligi
-Teknik saglik kontrolleri:
+### Check 4: Configuration Health
+Technical health checks:
 
-- **JSON Dogrulama:** Tum JSON dosyalarinin gecerliligi
-- **Dosya Boyutu Esikleri:**
-  - memory.md: 500 satirdan fazla mi? (UYARI)
-  - knowledge-base.md: 1000 satirdan fazla mi? (UYARI)
-  - Gunluk notlar: 200 satirdan fazla mi? (BILGI)
-- **Hook Calistirilabilirlik:** Hook dosyalari icin izin kontrolu
-- **Markdown Formati:** Kirik baslantsilar, kapanmamis kod bloklari
-- **Karakter Kodlamasi:** UTF-8 uyumluluk kontrolu
+- **JSON Validation:** Validity of every JSON file
+- **File Size Thresholds:**
+  - memory.md: over 500 lines? (WARN)
+  - knowledge-base.md: over 1000 lines? (WARN)
+  - Daily notes: over 200 lines? (INFO)
+- **Hook Executability:** Permission check for hook files
+- **Markdown Format:** Broken links, unclosed code blocks
+- **Character Encoding:** UTF-8 compatibility check
 
-### Kontrol 5: Capraz Tutarlilik
-Tum sistem genelinde tutarlilik:
+### Check 5: Cross-Consistency
+Consistency across the whole system:
 
-- CLAUDE.md'deki kurallar settings.json ile uyumlu mu?
-- Komut dosyalarindaki arac referanslari geerli mi?
-- Ajan tanimlarindaki bagimlliklar karsilaniyor mu?
-- Tum dosya referanslari cift yonlu mu? (A -> B ise B -> A da var mi?)
+- Are the rules in CLAUDE.md consistent with settings.json?
+- Are tool references in command files valid?
+- Are the dependencies in agent definitions satisfied?
+- Are all file references bidirectional? (if A -> B, does B -> A exist too?)
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI SAPMA TESPITI ===
-Tarih: [tarih]
-Durum: TEMIZ | UYARI | SORUN
+=== BADI DRIFT DETECTION ===
+Date: [date]
+Status: CLEAN | WARNING | PROBLEM
 
-## Celiski Bulgulari
-- Bulunan: [sayi]
-[varsa detaylar]
+## Contradiction Findings
+- Found: [count]
+[details if any]
 
-## Yetim Bilesenler
-- Bulunan: [sayi]
-[varsa detaylar]
+## Orphaned Components
+- Found: [count]
+[details if any]
 
-## Eskilesmis Icerik
-- Bulunan: [sayi]
-[varsa detaylar]
+## Stale Content
+- Found: [count]
+[details if any]
 
-## Konfigurasyon Sagligi
-- JSON: GECERLI / HATALI
-- Boyutlar: NORMAL / ASIRI
-- Izinler: DOGRU / HATALI
+## Configuration Health
+- JSON: VALID / BROKEN
+- Sizes: NORMAL / EXCESSIVE
+- Permissions: CORRECT / BROKEN
 
-## Capraz Tutarlilik
-- Durum: TUTARLI / UYUMSUZ
-[varsa detaylar]
+## Cross-Consistency
+- Status: CONSISTENT / MISMATCHED
+[details if any]
 
-## Duzeltme Onerileri
-1. [ACIL] [oneri]
-2. [ONEMLI] [oneri]
-3. [ONERILEN] [oneri]
+## Remediation Suggestions
+1. [URGENT] [suggestion]
+2. [IMPORTANT] [suggestion]
+3. [SUGGESTED] [suggestion]
 
-## Sonraki Tarama
-Onerilen: [tarih]
+## Next Scan
+Suggested: [date]
 ============================
 ```
 
-# Tetikleyici
-- Ayda bir rutin tarama
-- Sistem davranisi anormal gorundigunde
-- Buyuk konfigur asyon degisikligi sonrasinda
-- Yeni komut veya ajan eklenmesinden sonra
+# Triggers
+- Monthly routine scan
+- When system behavior looks abnormal
+- After a large configuration change
+- After adding a new command or agent

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,101 +1,101 @@
 Handoff briefing command. Enables a smooth transition to another developer or session.
 
-# Gerekli Araclar
-- Read (baglam, notlar, gorevler)
-- Bash (git durumu)
-- Write (teslim dosyasi)
+# Required Tools
+- Read (context, notes, tasks)
+- Bash (git status)
+- Write (handoff file)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Baglam Toplama
-Mevcut durumun tam resmini cikar:
-- `memory.md` dosyasini oku
-- Gunluk notlari incele
-- Git durumunu kontrol et (branch, commit edilmemis degisiklikler)
-- Gorev panosunu oku
-- Onceki devir notlarini kontrol et
+### Step 1: Gather Context
+Build the full picture of the current state:
+- Read `memory.md`
+- Review the daily notes
+- Check the git status (branch, uncommitted changes)
+- Read the task board
+- Check previous handoff notes
 
-### Adim 2: Basarilari Belgele
-Bu donemde tamamlanan isleri listele:
-- Tamamlanan ozellikler ve iyilestirmeler
-- Cozulen hatalar
-- Tamamlanan arastirma veya analizler
-- Alinan mimari kararlar ve gerekceleri
-- Yapilan refactoring veya temizlik isleri
+### Step 2: Document Achievements
+List the work completed in this period:
+- Completed features and improvements
+- Fixed bugs
+- Completed research or analyses
+- Architectural decisions taken and their rationale
+- Refactoring or cleanup work done
 
-### Adim 3: On Kosullari Belirle
-Alici icin gerekli bilgileri hazirla:
-- Gelistirme ortami gereksinimleri
-- Ozel konfigur asyon veya erisim ihtiyaclari
-- Calistirilmasi gereken migration veya scriptler
-- Ortam degiskenleri
-- Ucuncu parti servis erisim bilgileri (sirlar haric)
+### Step 3: Identify Prerequisites
+Prepare what the recipient needs:
+- Development environment requirements
+- Special configuration or access needs
+- Migrations or scripts that must be run
+- Environment variables
+- Third-party service access details (excluding secrets)
 
-### Adim 4: Alici Baglami Olustur
-Devralan kisinin hemen ise baslamasi icin:
-- Mevcut branch durumu ve nereye merge edilecegi
-- Acik gorevler oncelik sirasina gore
-- Bilinen sorunlar ve gecici cozumler (workaround)
-- Bloke olan isler ve beklentiler
-- Test durumu (gecen/kalan testler)
-- Kritik son tarihler
+### Step 4: Build the Recipient Context
+So the person taking over can start immediately:
+- Current branch state and where it merges
+- Open tasks in priority order
+- Known issues and workarounds
+- Blocked work and what it waits on
+- Test status (passing/failing tests)
+- Critical deadlines
 
-### Adim 5: Teslim Dosyasi Olustur
-`handoffs/handoff-[GGAAYY].md` dosyasini olustur:
+### Step 5: Create the Handoff File
+Create `handoffs/handoff-[DDMMYY].md`:
 
 ```markdown
-# Is Teslim Brifingi - [tarih]
+# Handoff Briefing - [date]
 
-## Proje Ozeti
-[projenin mevcut hali, 2-3 cumle]
+## Project Summary
+[the project's current state, 2-3 sentences]
 
-## Donem Ozeti
-**Baslangic:** [tarih]
-**Bitis:** [tarih]
-**Odak Alani:** [ana calisma alani]
+## Period Summary
+**Start:** [date]
+**End:** [date]
+**Focus Area:** [main work area]
 
-## Basarilar
-- [tamamlanan isler listesi]
+## Achievements
+- [list of completed work]
 
-## Mevcut Durum
+## Current State
 
-### Branch Durumu
-- Aktif Branch: [branch adi]
-- Base: [hedef branch]
-- Commit Edilmemis Degisiklik: [var/yok]
-- CI Durumu: [gecti/kaldi/bekliyor]
+### Branch Status
+- Active Branch: [branch name]
+- Base: [target branch]
+- Uncommitted Changes: [yes/no]
+- CI Status: [passed/failed/pending]
 
-### Acik Gorevler (Oncelik Sirasina Gore)
-1. **[YUKSEK]** [gorev aciklamasi]
-   - Durum: [durum]
-   - Sonraki adim: [adim]
-2. **[ORTA]** [gorev aciklamasi]
+### Open Tasks (In Priority Order)
+1. **[HIGH]** [task description]
+   - Status: [status]
+   - Next step: [step]
+2. **[MEDIUM]** [task description]
    ...
 
-### Bilinen Sorunlar
-- [sorun]: [gecici cozum veya plan]
+### Known Issues
+- [issue]: [workaround or plan]
 
-### Bloke Olan Isler
-- [is]: [neden bloke, kimden/neden bekleniyor]
+### Blocked Work
+- [work]: [why blocked, waiting on whom/what]
 
-## On Kosullar
-- [ortam gereksinimleri]
-- [konfigur asyon adimlari]
+## Prerequisites
+- [environment requirements]
+- [configuration steps]
 
-## Kritik Tarihler
-- [tarih]: [ne icin]
+## Critical Dates
+- [date]: [for what]
 
-## Onemli Dosyalar
-- [dosya yolu]: [neden onemli]
+## Important Files
+- [file path]: [why it matters]
 
-## Notlar ve Uyarilar
-[dikkat edilmesi gereken ozel durumlar]
+## Notes and Warnings
+[special situations to watch]
 
-## Iletisim
-[sorular icin iletisim bilgisi]
+## Contact
+[contact info for questions]
 ```
 
-# Cikti Formati
-- `handoffs/handoff-[GGAAYY].md` dosyasi
-- Guncellenmis `memory.md` (teslim referansi)
-- Terminal ozeti (teslim edilenlerin kisa listesi)
+# Output Format
+- The `handoffs/handoff-[DDMMYY].md` file
+- Updated `memory.md` (handoff reference)
+- Terminal summary (short list of what was handed off)

--- a/.claude/commands/health.md
+++ b/.claude/commands/health.md
@@ -1,120 +1,120 @@
 System health check. Audits dependencies, security, performance, and (if present) the production domain with a triple scan.
 
-## Badi CLI Komutlari
-Bu kontroller su CLI komutlarini kullanir (v1.6+):
-- `badi doctor` — Badi kurulum dogrulamasi
-- `badi secret-scan` — Sir/credential taramasi (17 pattern)
-- `badi ssl [domain]` — Production SSL sertifika (varsa)
-- `badi dns [domain]` — Email guvenlik (SPF/DMARC/CAA)
+## Badi CLI Commands
+These checks use the following CLI commands (v1.6+):
+- `badi doctor` — Badi installation validation
+- `badi secret-scan` — Secret/credential scan (17 patterns)
+- `badi ssl [domain]` — Production SSL certificate (if any)
+- `badi dns [domain]` — Email security (SPF/DMARC/CAA)
 - `badi lighthouse [url]` — Core Web Vitals
-- `badi a11y [url]` — WCAG 2.1 uyum
+- `badi a11y [url]` — WCAG 2.1 compliance
 
-# Gerekli Araclar
-- Bash (npm audit, sistem komutlari)
-- Read (konfigur asyon dosyalari)
-- Glob (proje dosya taramasi)
-- Grep (kalip arama)
-- Agent (security-scanner: guvenlik taramasi, performance-profiler: performans analizi)
+# Required Tools
+- Bash (npm audit, system commands)
+- Read (configuration files)
+- Glob (project file scan)
+- Grep (pattern search)
+- Agent (security-scanner: security scan, performance-profiler: performance analysis)
 
-# Calisma Zamanlamas i
-Bu komut ozellikle Pazartesi sabahlarinda `/start` sonrasinda calistirilmasi onerilir.
-Haftalik rutin olarak saglik kontrolu yapilmasi projeyi saglkli tutar.
-
----
-
-## Kontrol 1: Bagimlilik Denetimi
-
-### Adim 1: Paket Yoneticisini Tespit Et
-- `package.json` varsa npm/yarn/pnpm kullan
-- `Cargo.toml` varsa cargo kullan
-- `pyproject.toml` veya `requirements.txt` varsa pip kullan
-
-### Adim 2: Audit Taramas i Calistir
-- npm projelerinde `npm audit --json` calistir
-- Ek olarak `badi secret-scan` calistir — 17 pattern ile sir taramasi (working tree)
-- Sonuclari ciddiyet seviyesine gore siniflandir (critical, high, moderate, low)
-- Guncellenmesi gereken paketleri listele
-
-### Adim 3: Bagimlilik Durum Degerlendirmesi
-- YESIL: Kritik veya yuksek seviye acik yok
-- SARI: Sadece moderate seviye aciklar var
-- KIRMIZI: Critical veya high seviye aciklar mevcut
+# Scheduling
+Running this command is especially recommended after `/start` on Monday mornings.
+A weekly health-check routine keeps the project healthy.
 
 ---
 
-## Kontrol 2: Guvenlik Taramasi
+## Check 1: Dependency Audit
 
-### Adim 4: Security-Scanner Ajanini Cagir
-Agent aracini kullanarak security-scanner ajanini calistir:
-- Sabit kodlu sirlar icin kod taramasi yap (.env, API anahtarlari, tokenlar)
-- Guvenlik basliklarini kontrol et (CORS, CSP, X-Frame-Options)
-- Auth konfigurasyonunu incele
-- Bilinen guvenlik acigi kaliplarini ara (SQL injection, XSS vektorleri)
+### Step 1: Detect the Package Manager
+- If `package.json` exists, use npm/yarn/pnpm
+- If `Cargo.toml` exists, use cargo
+- If `pyproject.toml` or `requirements.txt` exists, use pip
 
-### Adim 5: Guvenlik Durum Degerlendirmesi
-- YESIL: Bilinen guvenlik sorunu yok
-- SARI: Dusuk riskli bulgular veya iyilestirme onerileri var
-- KIRMIZI: Kritik guvenlik acigi tespit edildi
+### Step 2: Run the Audit Scan
+- Run `npm audit --json` on npm projects
+- Additionally run `badi secret-scan` — 17-pattern secret scan (working tree)
+- Classify results by severity (critical, high, moderate, low)
+- List packages that need updating
+
+### Step 3: Dependency Status Assessment
+- GREEN: No critical or high severity issues
+- YELLOW: Only moderate severity issues
+- RED: Critical or high severity issues present
 
 ---
 
-## Kontrol 3: Performans Analizi
+## Check 2: Security Scan
 
-### Adim 6: Performance-Profiler Ajanini Cagir
-Agent aracini kullanarak performance-profiler ajanini calistir:
-- Build/paket boyutlarini olc
-- Karmasik fonksiyonlari tespit et (yuksek siklomatik karmasiklik)
-- Gereksiz bagimliliklari bul
-- Onbellek stratejilerini degerlendir
+### Step 4: Invoke the Security-Scanner Agent
+Run the security-scanner agent via the Agent tool:
+- Scan code for hardcoded secrets (.env, API keys, tokens)
+- Check security headers (CORS, CSP, X-Frame-Options)
+- Review the auth configuration
+- Look for known vulnerability patterns (SQL injection, XSS vectors)
 
-**Production URL varsa ek kontroller:**
+### Step 5: Security Status Assessment
+- GREEN: No known security issues
+- YELLOW: Low-risk findings or improvement suggestions
+- RED: Critical vulnerability detected
+
+---
+
+## Check 3: Performance Analysis
+
+### Step 6: Invoke the Performance-Profiler Agent
+Run the performance-profiler agent via the Agent tool:
+- Measure build/bundle sizes
+- Detect complex functions (high cyclomatic complexity)
+- Find unnecessary dependencies
+- Evaluate caching strategies
+
+**Extra checks when a production URL exists:**
 - `badi lighthouse [url]` — Core Web Vitals (FCP, LCP, TBT, CLS)
-- `badi a11y [url]` — Accessibility skoru
-Kullaniciya sor: "Bir production URL'iniz var mi? Varsa lighthouse + a11y de calistirabilirim."
+- `badi a11y [url]` — Accessibility score
+Ask the user: "Do you have a production URL? If so I can also run lighthouse + a11y."
 
-### Adim 7: Performans Durum Degerlendirmesi
-- YESIL: Performans metrikleri kabul edilebilir sinirlar icinde
-- SARI: Iyilestirme firsatlari mevcut ama kritik degil
-- KIRMIZI: Ciddi performans sorunlari tespit edildi
+### Step 7: Performance Status Assessment
+- GREEN: Performance metrics within acceptable bounds
+- YELLOW: Improvement opportunities exist but not critical
+- RED: Serious performance problems detected
 
 ---
 
-## Birlestirmis Saglik Rapor Karti
+## Combined Health Report Card
 
-### Adim 8: Rapor Olustur
-Asagidaki formatta birlestirilmis rapor sun:
+### Step 8: Build the Report
+Present the combined report in this format:
 
 ```
 ╔══════════════════════════════════════════╗
-║        BADI SISTEM SAGLIK RAPORU         ║
-║        Tarih: [GG.AA.YYYY]              ║
+║        BADI SYSTEM HEALTH REPORT          ║
+║        Date: [DD.MM.YYYY]                ║
 ╠══════════════════════════════════════════╣
 ║                                          ║
-║  Bagimlilik Denetimi:  [YESIL/SARI/KIR] ║
-║  > [kisa aciklama]                       ║
+║  Dependency Audit:     [GREEN/YEL/RED]  ║
+║  > [short note]                          ║
 ║                                          ║
-║  Guvenlik Taramasi:    [YESIL/SARI/KIR] ║
-║  > [kisa aciklama]                       ║
+║  Security Scan:        [GREEN/YEL/RED]  ║
+║  > [short note]                          ║
 ║                                          ║
-║  Performans Analizi:   [YESIL/SARI/KIR] ║
-║  > [kisa aciklama]                       ║
+║  Performance Analysis: [GREEN/YEL/RED]  ║
+║  > [short note]                          ║
 ║                                          ║
 ╠══════════════════════════════════════════╣
-║  Genel Durum: [SAGLIKLI / DIKKAT / ACIL]║
+║  Overall: [HEALTHY / ATTENTION / URGENT]║
 ║                                          ║
-║  Onerilen Aksiyonlar:                    ║
-║  1. [varsa en onemli aksiyon]            ║
-║  2. [varsa ikinci aksiyon]               ║
-║  3. [varsa ucuncu aksiyon]               ║
+║  Suggested Actions:                      ║
+║  1. [most important action, if any]      ║
+║  2. [second action, if any]              ║
+║  3. [third action, if any]               ║
 ╚══════════════════════════════════════════╝
 ```
 
-### Adim 9: Genel Durum Belirleme
-- SAGLIKLI: Tum kategoriler YESIL
-- DIKKAT: En az bir kategori SARI, hicbiri KIRMIZI degil
-- ACIL: En az bir kategori KIRMIZI
+### Step 9: Determine the Overall State
+- HEALTHY: All categories GREEN
+- ATTENTION: At least one category YELLOW, none RED
+- URGENT: At least one category RED
 
-### Adim 10: Takip Onerileri
-- KIRMIZI durumlar icin acil gorev olusturmayi oner
-- SARI durumlar icin haftalik plana eklemeyi oner
-- Bir sonraki saglik kontrolu tarihini hatrlat
+### Step 10: Follow-up Suggestions
+- Suggest creating urgent tasks for RED states
+- Suggest adding YELLOW states to the weekly plan
+- Remind about the next health-check date

--- a/.claude/commands/memory-diff.md
+++ b/.claude/commands/memory-diff.md
@@ -1,49 +1,49 @@
 Memory and knowledge-base limit check + global project comparison.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi ai memory-diff)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Calistir
+### Step 1: Run
 ```bash
 badi ai memory-diff
 ```
 
-### Adim 2: Sonuclari Yorumla
+### Step 2: Interpret the Results
 
-Uc bolum:
-1. **memory.md** — Oturum bellek, 100 satir limiti
-2. **knowledge-base.md** — Bilgi tabani, 200 satir limiti + TBD yasak
-3. **Global projects** — Baska projelerdeki MEMORY.md karsilastirmasi
+Three sections:
+1. **memory.md** — Session memory, 100-line limit
+2. **knowledge-base.md** — Knowledge base, 200-line limit + TBD forbidden
+3. **Global projects** — MEMORY.md comparison across other projects
 
-### Adim 3: Eylemler
+### Step 3: Actions
 
-**memory.md > 80 satir:**
-- `/clear` ile sifirla + onemlileri knowledge-base'e tasi
+**memory.md > 80 lines:**
+- Reset with `/clear` + move the important parts to the knowledge base
 
-**knowledge-base.md'de TBD/TODO:**
-- YASAK (CLAUDE.md kurali)
-- Iceriği tamamla veya kaldir
-- Kaynak eklenmediyse `[Kaynak: ...]` zorunlu
+**TBD/TODO in knowledge-base.md:**
+- FORBIDDEN (CLAUDE.md rule)
+- Complete the content or remove it
+- `[Kaynak: ...]` source tag is mandatory if missing
 
-**knowledge-base.md > 200 satir:**
-- Auditor onayiyla konsolidasyon
-- Eski/alakasiz kisimlari archive/knowledge-archive.md'ye tasi
+**knowledge-base.md > 200 lines:**
+- Consolidation with Auditor approval
+- Move old/irrelevant parts to archive/knowledge-archive.md
 
-### Adim 4: Haftalik Rutin
+### Step 4: Weekly Routine
 
-Her Pazartesi `/ai-memory-diff` calistir, memory sagliguni kontrol et.
+Run `/ai-memory-diff` every Monday and check memory health.
 
-# Bellek Kurallari (CLAUDE.md)
+# Memory Rules (CLAUDE.md)
 
-| Katman | Sinir | Aksiyon |
-|--------|-------|---------|
-| memory.md | 100 satir | /clear |
-| knowledge-base.md | 200 satir | Auditor onayi |
-| TaskBoard.md | Sinirsiz | - |
+| Layer | Limit | Action |
+|-------|-------|--------|
+| memory.md | 100 lines | /clear |
+| knowledge-base.md | 200 lines | Auditor approval |
+| TaskBoard.md | Unlimited | - |
 
-# Ornek
+# Example
 
 ```
 /memory-diff

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -1,119 +1,119 @@
 Project onboarding command. For adapting to a new project quickly and thoroughly.
 
-# Gerekli Araclar
-- Glob (dosya yapisi taramasi)
-- Read (dosya okuma)
-- Grep (kod arama)
-- Bash (git gecmisi, bagimliliklar)
-- Write (alistirma raporu)
+# Required Tools
+- Glob (file structure scan)
+- Read (file reading)
+- Grep (code search)
+- Bash (git history, dependencies)
+- Write (onboarding report)
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-### Adim 1: Proje Dogrulama
-- Proje kok dizinini dogrula
-- `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md` var mi kontrol et
-- Lisans dosyasini kontrol et
-- `.gitignore` ve `.editorconfig` incele
+### Step 1: Project Verification
+- Verify the project root directory
+- Check for `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`
+- Check the license file
+- Review `.gitignore` and `.editorconfig`
 
-### Adim 2: 3 Paralel Tarama
+### Step 2: 3 Parallel Scans
 
-**Tarama A: Yapi Analizi**
-- Dizin agacini cikar (2 seviye derinlik)
-- Kaynak kod dizinlerini belirle (src, lib, app, vb.)
-- Test dizinlerini bul (test, __tests__, spec, vb.)
-- Konfigur asyon dosyalarini listele
-- CI/CD dosyalarini bul (.github, .gitlab-ci, Jenkinsfile, vb.)
-- Docker dosyalarini tespit et
+**Scan A: Structure Analysis**
+- Extract the directory tree (2 levels deep)
+- Identify the source directories (src, lib, app, etc.)
+- Find the test directories (test, __tests__, spec, etc.)
+- List the configuration files
+- Find CI/CD files (.github, .gitlab-ci, Jenkinsfile, etc.)
+- Detect Docker files
 
-**Tarama B: Teknoloji Tespiti**
-- Manifest dosyalarini oku (package.json, Cargo.toml, pyproject.toml, go.mod, vb.)
-- Framework ve kutuphaneleri listele
-- Versiyon bilgilerini topla
-- Gelistirme araclarini belirle (linter, formatter, bundler)
-- Veritabani teknolojisini tespit et (migration dosyalari, ORM konfigurasyon)
+**Scan B: Technology Detection**
+- Read the manifest files (package.json, Cargo.toml, pyproject.toml, go.mod, etc.)
+- List frameworks and libraries
+- Collect version information
+- Identify the dev tooling (linter, formatter, bundler)
+- Detect the database technology (migration files, ORM configuration)
 
-**Tarama C: Dokumantasyon Taramasi**
-- Tum markdown dosyalarini bul
-- API dokumantasyonunu ara (OpenAPI, Swagger, vb.)
-- Yorum yogunlugu analizi (JSDoc, docstring, vb.)
-- Ortam degiskeni dokumantasyonu (.env.example)
-- Mimari karar kayitlari (ADR) var mi?
+**Scan C: Documentation Scan**
+- Find all markdown files
+- Look for API documentation (OpenAPI, Swagger, etc.)
+- Comment density analysis (JSDoc, docstrings, etc.)
+- Environment variable documentation (.env.example)
+- Are there Architecture Decision Records (ADRs)?
 
-### Adim 3: Bagimlilik Analizi
-- Dogrudan bagimliliklari listele
-- Gelistirme bagimliliklerini ayir
-- Guncelligini yitirmis bagimliliklari tespit et
-- Guvenlik uyarilari kontrol et (npm audit, cargo audit, vb.)
-- Bagimlilik grafigi cikart (ana moduller arasi iliskiler)
+### Step 3: Dependency Analysis
+- List direct dependencies
+- Separate the dev dependencies
+- Detect outdated dependencies
+- Check security advisories (npm audit, cargo audit, etc.)
+- Sketch the dependency graph (relationships between main modules)
 
-### Adim 4: Kod Kaliplari
-Kullanilan kaliplari tespit et:
-- Mimari kalip (MVC, MVVM, Clean Architecture, Hexagonal, vb.)
-- Hata yonetimi yaklasimlari (try-catch kaliplari, Result tipi, vb.)
-- Loglama stratejisi
-- Test stratejisi (unit, integration, e2e oranlari)
-- Isimlendirme konvansiyonlari
-- Import/export kaliplari
-- State yonetimi yaklasimlari
+### Step 4: Code Patterns
+Detect the patterns in use:
+- Architectural pattern (MVC, MVVM, Clean Architecture, Hexagonal, etc.)
+- Error-handling approaches (try-catch patterns, Result types, etc.)
+- Logging strategy
+- Test strategy (unit, integration, e2e ratios)
+- Naming conventions
+- Import/export patterns
+- State-management approaches
 
-### Adim 5: Git Arkeolojisi
-- En cok degisen dosyalari bul (son 3 ay)
-- Ana katkilcilari belirle
-- Branch stratejisini analiz et (main, develop, feature, vb.)
-- Commit mesaj formatini tespit et (conventional commits, vb.)
-- Son release tarihini ve versiyonu bul
-- Merge/rebase stratejisini belirle
+### Step 5: Git Archaeology
+- Find the most-changed files (last 3 months)
+- Identify the main contributors
+- Analyze the branch strategy (main, develop, feature, etc.)
+- Detect the commit message format (conventional commits, etc.)
+- Find the last release date and version
+- Determine the merge/rebase strategy
 
-### Adim 6: ONBOARDING.md Olustur
+### Step 6: Create ONBOARDING.md
 ```markdown
-# Proje Alistirma Kilavuzu
+# Project Onboarding Guide
 
-## Proje Ozeti
-[projenin ne yaptigi, 2-3 cumle]
+## Project Summary
+[what the project does, 2-3 sentences]
 
-## Teknoloji Yigini
-| Kategori | Teknoloji | Versiyon |
-|----------|-----------|----------|
-| Dil | ... | ... |
+## Tech Stack
+| Category | Technology | Version |
+|----------|------------|---------|
+| Language | ... | ... |
 | Framework | ... | ... |
-| Veritabani | ... | ... |
+| Database | ... | ... |
 | Test | ... | ... |
 
-## Dizin Yapisi
+## Directory Structure
 ```
-[agac gorunumu]
+[tree view]
 ```
 
-## Baslangic Komutlari
+## Getting Started
 ```bash
-# Kurulum
-[kurulum komutlari]
+# Install
+[install commands]
 
-# Calistirma
-[calistirma komutlari]
+# Run
+[run commands]
 
 # Test
-[test komutlari]
+[test commands]
 ```
 
-## Onemli Dosyalar
-- [dosya]: [aciklama]
-- [dosya]: [aciklama]
+## Important Files
+- [file]: [description]
+- [file]: [description]
 
-## Mimari Notlar
-[mimari kaliplar ve kararlar]
+## Architecture Notes
+[architectural patterns and decisions]
 
-## Kod Konvansiyonlari
-[isimlendirme, format, commit mesaji kurallari]
+## Code Conventions
+[naming, format, commit message rules]
 
-## Bilinen Sorunlar / Teknik Borc
-[tespit edilen sorunlar]
+## Known Issues / Technical Debt
+[detected problems]
 
-## Bagimlilik Notlari
-[dikkat edilmesi gereken bagimliliklar]
+## Dependency Notes
+[dependencies that need attention]
 ```
 
-# Cikti Formati
-- `ONBOARDING.md` dosyasi (detayli alistirma kilavuzu)
-- Guncellenmis `memory.md` (proje bilgileri)
-- Terminal ozeti (temel bulgular)
+# Output Format
+- The `ONBOARDING.md` file (detailed onboarding guide)
+- Updated `memory.md` (project information)
+- Terminal summary (key findings)

--- a/.claude/commands/plugin.md
+++ b/.claude/commands/plugin.md
@@ -1,115 +1,115 @@
 Plugin management command. Installs, removes, and lists plugins in the Badi system.
 
-# Gerekli Araclar
-- Bash (git clone, npm install, dosya kopyalama)
-- Read (manifest dosyalari, mevcut konfigur asyon)
-- Write (konfigur asyon guncelleme, dosya olusturma)
+# Required Tools
+- Bash (git clone, npm install, file copy)
+- Read (manifest files, current configuration)
+- Write (configuration updates, file creation)
 - ...
 
-# Alt Komutlar
-Bu komut uc alt komut icerir:
-- `install <kaynak>` - Yeni plugin yukle
-- `remove <isim>` - Plugin kaldir
-- `list` - Yuklu pluginleri listele
+# Subcommands
+This command has three subcommands:
+- `install <source>` - Install a new plugin
+- `remove <name>` - Remove a plugin
+- `list` - List installed plugins
 
-Kullanici alt komutu belirtmediyse hangisini istedigini sor.
+If the user did not specify a subcommand, ask which one they want.
 
 ---
 
-## Alt Komut: install <kaynak>
+## Subcommand: install <source>
 
-### Adim 1: Kaynak Tipi Tespiti
-- Git URL ise (`.git` ile bitiyor veya `github.com` iceriyor): Git kaynak
-- npm paket adi ise: npm kaynak
-- Yerel dizin yolu ise: Yerel kaynak
+### Step 1: Source Type Detection
+- If a git URL (ends with `.git` or contains `github.com`): git source
+- If an npm package name: npm source
+- If a local directory path: local source
 - ...
 
-### Adim 2: Plugin Indirme
-**Git kaynagi icin:**
-- Gecici dizine `git clone [URL]` yap
-- `badi-plugin.json` manifest dosyasini kontrol et
-- Manifest yoksa HATA ver ve dur
+### Step 2: Download the Plugin
+**For a git source:**
+- `git clone [URL]` into a temporary directory
+- Check the `badi-plugin.json` manifest file
+- If there is no manifest, ERROR and stop
 
-**npm kaynagi icin:**
-- `npm pack [paket]` ile paketi indir
-- Paketi gecici dizine ac
-- `badi-plugin.json` manifest dosyasini kontrol et
+**For an npm source:**
+- Download the package with `npm pack [package]`
+- Extract into a temporary directory
+- Check the `badi-plugin.json` manifest file
 
-**Yerel kaynak icin:**
-- Belirtilen dizinde `badi-plugin.json` varligini dogrula
+**For a local source:**
+- Verify `badi-plugin.json` exists in the given directory
 
-### Adim 3: Manifest Okuma ve Dogrulama
-`badi-plugin.json` dosyasini oku ve dogrula:
+### Step 3: Read and Validate the Manifest
+Read and validate `badi-plugin.json`:
 ```
-[kisaltildi]
+[abridged]
 ```
-Zorunlu alanlar: `name`, `version`
-Gecersiz manifest icin HATA ver ve dur.
+Required fields: `name`, `version`
+ERROR and stop on an invalid manifest.
 
-### Adim 4: Catisma Kontrolu
-- Ayni isimde yuklu plugin var mi kontrol et
-- Eklenen komutlarin mevcut komutlarla catisip catismadigini dogrula
-- Agent isim catismalarini kontrol et
+### Step 4: Conflict Check
+- Check whether a plugin with the same name is installed
+- Verify added commands do not collide with existing commands
+- Check agent name collisions
 - ...
 
-### Adim 5: Dosyalari Kopyala
-- `.claude/plugins/[plugin-adi]/` dizinini olustur
-- Manifest dosyasini kopyala
-- Agent dosyalarini `.claude/agents/` altina kopyala
+### Step 5: Copy the Files
+- Create the `.claude/plugins/[plugin-name]/` directory
+- Copy the manifest file
+- Copy agent files under `.claude/agents/`
 - ...
 
-### Adim 6: Index Guncelleme
-- `command-index.md` dosyasina yeni komutlari `[Plugin]` etiketi ile ekle
-- Ornek format: `| /plugin-komut | Aciklama [Plugin: plugin-adi] |`
-- settings.json'a yeni hook referanslarini ekle (gerekirse)
+### Step 6: Index Update
+- Add the new commands to `command-index.md` with a `[Plugin]` tag
+- Example format: `| /plugin-command | Description [Plugin: plugin-name] |`
+- Add new hook references to settings.json (if needed)
 
-### Adim 7: Kurulum Dogrulama
-- Tum dosyalarin basariyla kopyalandigini dogrula
-- `/doctor` calistirmayi oner
-- Kurulum ozeti goster
+### Step 7: Install Verification
+- Verify all files copied successfully
+- Suggest running `/doctor`
+- Show an install summary
 
 ---
 
-## Alt Komut: remove <isim>
+## Subcommand: remove <name>
 
-### Adim 8: Plugin Tespiti
-- `.claude/plugins/[isim]/` dizininin var oldugunu dogrula
-- `badi-plugin.json` manifestini oku
-- Plugin yoksa HATA ver
+### Step 8: Plugin Detection
+- Verify the `.claude/plugins/[name]/` directory exists
+- Read the `badi-plugin.json` manifest
+- ERROR if the plugin does not exist
 
-### Adim 9: Kaldirilacak Dosyalari Belirle
-- Manifeste gore hangi dosyalarin plugin tarafindan ekledigini tespit et
-- Diger pluginlerle paylasilan dosyalari KORUMA (kaldirma)
-- Kullaniciya kaldirilacak dosya listesini goster ve onay iste
+### Step 9: Determine Files to Remove
+- From the manifest, identify which files the plugin added
+- PROTECT files shared with other plugins (do not remove)
+- Show the user the removal list and ask for confirmation
 
-### Adim 10: Dosyalari Kaldir
-- Plugin agent dosyalarini sil
-- Plugin komut dosyalarini sil
-- Plugin skill dosyalarini sil
+### Step 10: Remove the Files
+- Delete the plugin agent files
+- Delete the plugin command files
+- Delete the plugin skill files
 - ...
 
-### Adim 11: Kaldirma Dogrulama
-- Tum dosyalarin basariyla silindgini dogrula
-- Kirik referans birakilmadigini kontrol et
-- Kaldirma ozeti goster
+### Step 11: Removal Verification
+- Verify all files were deleted successfully
+- Check no broken references remain
+- Show a removal summary
 
 ---
 
-## Alt Komut: list
+## Subcommand: list
 
-### Adim 12: Yuklu Pluginleri Tara
-- `.claude/plugins/` dizinini tara
-- Her alt dizindeki `badi-plugin.json` dosyasini oku
+### Step 12: Scan Installed Plugins
+- Scan the `.claude/plugins/` directory
+- Read `badi-plugin.json` in each subdirectory
 
-### Adim 13: Plugin Listesi Olustur
+### Step 13: Build the Plugin List
 ```
-[kisaltildi]
+[abridged]
 ```
 
-### Adim 14: Plugin Yoksa
-- `.claude/plugins/` dizini yoksa veya bossa bilgilendir
-- Plugin yukleme komutu ornegi goster:
+### Step 14: When There Are No Plugins
+- Inform the user if `.claude/plugins/` is missing or empty
+- Show an install example:
   ```
-  /plugin install https://github.com/user/badi-plugin-ornek.git
-  /plugin install badi-plugin-ornek
+  /plugin install https://github.com/user/badi-plugin-example.git
+  /plugin install badi-plugin-example
   ```

--- a/.claude/commands/prompt-test.md
+++ b/.claude/commands/prompt-test.md
@@ -1,46 +1,46 @@
 Regression test for slash command and agent files. Format and content validation.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi ai prompt-test)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Calistir
+### Step 1: Run
 ```bash
 badi ai prompt-test
 ```
 
-### Adim 2: Kontroller
+### Step 2: Checks
 
-Her `.claude/commands/*.md` ve `.claude/agents/*.md` icin:
+For every `.claude/commands/*.md` and `.claude/agents/*.md`:
 
-1. **Bos/cok kisa dosya** — 50 karakter altinda uyari
-2. **Ajan frontmatter** — `---` + `name:` + `description:` zorunlu
-3. **TODO/FIXME/TBD** — production icin isaret
-4. **Uzun satir** — 500+ karakter formatting bozulmasi
+1. **Empty/too-short file** — warning under 50 characters
+2. **Agent frontmatter** — `---` + `name:` + `description:` mandatory
+3. **TODO/FIXME/TBD** — flagged for production
+4. **Long lines** — 500+ characters break formatting
 
-### Adim 3: Aksiyonlar
+### Step 3: Actions
 
-Bulgularina gore:
-- Bos dosya: icerik ekle veya sil
-- Frontmatter eksik: ekle
-- TODO: tamamla veya sil
-- Uzun satir: yeniden format
+Based on the findings:
+- Empty file: add content or delete
+- Missing frontmatter: add it
+- TODO: complete or remove
+- Long line: reformat
 
-### Adim 4: CI Entegrasyonu
+### Step 4: CI Integration
 
-GitHub Actions'a ekle:
+Add to GitHub Actions:
 ```yaml
 - name: Prompt Regression
   run: badi ai prompt-test
 ```
 
-Exit code olmadigindan asagidaki ile zorla:
+Since there is no exit code, enforce with:
 ```bash
-badi ai prompt-test | grep -q "temiz" || exit 1
+badi ai prompt-test | grep -q "clean" || exit 1
 ```
 
-# Ornek
+# Example
 
 ```
 /prompt-test

--- a/.claude/commands/schedule.md
+++ b/.claude/commands/schedule.md
@@ -1,74 +1,74 @@
 Scheduled command reminders. Shell-based reminder system for daily/weekly recurring tasks.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi schedule)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Mevcut Hatirlaticilar
+### Step 1: Existing Reminders
 
 ```bash
 badi schedule list
 ```
 
-### Adim 2: Yeni Hatirlatici Ekle
+### Step 2: Add a New Reminder
 
 ```bash
-# Is gunu her sabah
-badi schedule add "icerik basla" --at "09:00" --days "mon-fri"
+# Every workday morning
+badi schedule add "content start" --at "09:00" --days "mon-fri"
 
-# Haftalik (Pazar aksam)
-badi schedule add "icerik plan" --at "20:00" --days "sun"
+# Weekly (Sunday evening)
+badi schedule add "content plan" --at "20:00" --days "sun"
 
-# Gunluk
+# Daily
 badi schedule add "wrap-up" --at "18:00" --days "daily"
 ```
 
-Gun araligi: pzt/sal/car/per/cum/cts/paz (TR) veya mon/tue/wed/thu/fri/sat/sun (EN).
-Wrap-around destekli: sat-sun, fri-mon.
+Day ranges: pzt/sal/car/per/cum/cts/paz (TR) or mon/tue/wed/thu/fri/sat/sun (EN).
+Wrap-around supported: sat-sun, fri-mon.
 
-### Adim 3: Shell Entegrasyonu (ilk kurulum)
+### Step 3: Shell Integration (first setup)
 
-`~/.zshrc` veya `~/.bashrc`'ye ekle:
+Add to `~/.zshrc` or `~/.bashrc`:
 ```bash
 command -v badi &>/dev/null && badi schedule check 2>/dev/null
 ```
 
-Her shell baslangicinda zamani gelen hatirlaticilari gosterir (60dk toleransli).
+Shows due reminders at every shell start (60-minute tolerance).
 
-### Adim 4: Silme
+### Step 4: Removal
 
 ```bash
-badi schedule list            # ID'leri gor
-badi schedule remove [id]     # Sil
+badi schedule list            # See the IDs
+badi schedule remove [id]     # Remove
 ```
 
-### Adim 5: Kontrol
+### Step 5: Check
 
 ```bash
-badi schedule check           # Zamani gelenleri goster
+badi schedule check           # Show what is due
 ```
 
-# Ornek Rutinler
+# Example Routines
 
 ```bash
-# Is gunu sabahlari (09:00): icerik uretim oturumu
-badi schedule add "icerik basla" --at "09:00" --days "mon-fri"
+# Workday mornings (09:00): content production session
+badi schedule add "content start" --at "09:00" --days "mon-fri"
 
-# Hafta sonu disi 18:00: gun sonu ozeti
+# Weekdays 18:00: end-of-day summary
 badi schedule add "wrap-up" --at "18:00" --days "mon-fri"
 
-# Haftalik: Pazar aksam icerik planlama
-badi schedule add "icerik plan" --at "20:00" --days "sun"
+# Weekly: Sunday evening content planning
+badi schedule add "content plan" --at "20:00" --days "sun"
 
-# Her Pazartesi: haftalik saglik
+# Every Monday: weekly health
 badi schedule add "health" --at "09:30" --days "mon"
 
-# Her ay baslangici: denetim
+# Start of each month: audit
 badi schedule add "audit" --at "10:00" --days "mon"
 ```
 
-# Ornek Kullanim
+# Example Usage
 
 ```
 /schedule list

--- a/.claude/commands/standup.md
+++ b/.claude/commands/standup.md
@@ -1,60 +1,60 @@
 Daily standup command. Produces a quick status summary in under 30 seconds.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (git log)
-- Read (gorev panosu, notlar)
-- Grep (aktivite taramasi)
+- Read (task board, notes)
+- Grep (activity scan)
 
-# Prosedur (Hedef: 30 saniye)
+# Procedure (Target: 30 seconds)
 
-### Adim 1: Git Aktivitesi (Paralel)
-- Son is gununun commitlerini al: `git log --oneline --since="yesterday"`
-- Degisen dosya sayisini hesapla
-- Branch durumunu kontrol et
+### Step 1: Git Activity (Parallel)
+- Get the last working day's commits: `git log --oneline --since="yesterday"`
+- Count the changed files
+- Check the branch status
 
-### Adim 2: Gorev Panosu (Paralel)
-- Aktif gorevleri oku
-- Tamamlananlari say
-- Bloke olanlari tespit et
-- Yeni eklenen gorevleri belirle
+### Step 2: Task Board (Parallel)
+- Read the active tasks
+- Count the completed ones
+- Detect blocked tasks
+- Identify newly added tasks
 
-### Adim 3: Onceki Notlar (Paralel)
-- Son gunluk notu oku
-- Devir notu varsa kontrol et
-- "Yarinki isler" bolumunu bul
+### Step 3: Previous Notes (Parallel)
+- Read the latest daily note
+- Check the handoff note if one exists
+- Find the "tomorrow's work" section
 
-### Adim 4: Mevcut Odak
-- Bugunun onceliklerini belirle
-- Bagimliliklari kontrol et
-- Risk veya engel var mi?
+### Step 4: Current Focus
+- Determine today's priorities
+- Check dependencies
+- Any risks or blockers?
 
-# Cikti Formati
+# Output Format
 ```
 === BADI STANDUP ===
-Tarih: [tarih]
+Date: [date]
 
-DUN:
-- [yapilan isler - git commitlerden ve notlardan]
-- [tamamlanan gorevler]
+YESTERDAY:
+- [work done - from git commits and notes]
+- [completed tasks]
 
-BUGUN:
-- [planlanmis isler - oncelik sirasina gore]
-- [devam eden gorevler]
+TODAY:
+- [planned work - in priority order]
+- [in-progress tasks]
 
-ENGELLEYICILER:
-- [varsa engeller ve beklentiler]
-- [yoksa: "Engel yok, yol acik."]
+BLOCKERS:
+- [blockers and expectations, if any]
+- [otherwise: "No blockers, road clear."]
 
-METRIKLER:
-- Commitler (dun): [sayi]
-- Acik Gorevler: [sayi]
-- Tamamlanan (dun): [sayi]
+METRICS:
+- Commits (yesterday): [count]
+- Open Tasks: [count]
+- Completed (yesterday): [count]
 ====================
 ```
 
-# Kurallar
-- Kisa ve oz tut, maksimum 15 satir cikti
-- Her madde bir satirda
-- Engelleyicileri vurgula (varsa)
-- Metrikleri her zaman ekle
-- 30 saniyeyi gecme
+# Rules
+- Keep it short and tight, 15 lines of output max
+- One line per item
+- Highlight blockers (if any)
+- Always include the metrics
+- Do not exceed 30 seconds

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -1,111 +1,111 @@
 Badi session start command. Runs new-project onboarding or a daily kickoff.
 
-# Gerekli Araclar
-- Bash (dosya sistemi erisimi)
-- Read (bellek ve baglam dosyalari)
-- Glob (proje yapisi taramasi)
-- Grep (kod arama)
-- Write (gunluk not olusturma)
+# Required Tools
+- Bash (filesystem access)
+- Read (memory and context files)
+- Glob (project structure scan)
+- Grep (code search)
+- Write (daily note creation)
 
-# Mod Secimi
+# Mode Selection
 
-Kullaniciya sor: "Yeni proje alistirmasi mi, gunluk baslatma mi?"
-
----
-
-## A) Yeni Proje Alistirmasi
-
-### Adim 1: Proje Yapi Taramasi
-- Kok dizindeki tum dosya ve klasorleri tara
-- `package.json`, `Cargo.toml`, `pyproject.toml`, `go.mod` gibi manifest dosyalarini bul
-- `.env.example`, `docker-compose.yml`, `Makefile` gibi altyapi dosyalarini tespit et
-
-### Adim 2: Teknoloji Yigini Tespiti
-- Programlama dilleri ve versiyonlari
-- Framework ve kutuphaneler
-- Veritabani ve dis servisler
-- CI/CD ve deploy altyapisi
-- Test araclari
-
-### Adim 3: Baglam Sorulari (4 Soru)
-Kullaniciya su sorulari yonelt:
-1. "Bu projenin temel amaci ve hedef kullanicisi kim?"
-2. "Su anki en onemli onceliginiz nedir?"
-3. "Bilmem gereken teknik kisitlamalar veya kararlar var mi?"
-4. "Calisma tarzinizla ilgili tercihleriniz nelerdir? (commit stili, branch stratejisi, test beklentileri)"
-
-### Adim 4: Bellek Olusturma
-Toplanan bilgilerle `memory.md` dosyasini olustur veya guncelle:
-- Proje ozeti
-- Teknoloji yigini
-- Kullanici tercihleri
-- Onemli dosya yollari
-- Mimari notlar
-
-### Adim 5: Skill Onerisi
-Projeye uygun Badi komutlarini oner:
-- Hangi komutlar bu proje icin en faydali olacak
-- Onerilen gunluk is akisi
-- Ozel komut ihtiyaclari varsa belirt
+Ask the user: "New-project onboarding or a daily kickoff?"
 
 ---
 
-## B) Gunluk Baslatma
+## A) New-Project Onboarding
 
-### Adim 1: Tarih Al
-- Bugunku tarihi `GGAAYY` formatinda belirle (ornek: 090426)
+### Step 1: Project Structure Scan
+- Scan all files and folders in the root directory
+- Find manifest files like `package.json`, `Cargo.toml`, `pyproject.toml`, `go.mod`
+- Detect infrastructure files like `.env.example`, `docker-compose.yml`, `Makefile`
 
-### Adim 2: Baglam Yukle
-- `memory.md` dosyasini oku
-- `knowledge-base.md` varsa oku
-- Son oturum notlarini kontrol et
+### Step 2: Tech Stack Detection
+- Programming languages and versions
+- Frameworks and libraries
+- Databases and external services
+- CI/CD and deploy infrastructure
+- Test tooling
 
-### Adim 3: Gunluk Not Olustur
-`daily-notes/GGAAYY.md` dosyasini olustur:
+### Step 3: Context Questions (4 Questions)
+Ask the user:
+1. "What is the core purpose of this project and who is its target user?"
+2. "What is your most important priority right now?"
+3. "Any technical constraints or decisions I should know about?"
+4. "What are your working-style preferences? (commit style, branch strategy, test expectations)"
+
+### Step 4: Memory Creation
+Create or update `memory.md` with what was gathered:
+- Project summary
+- Tech stack
+- User preferences
+- Important file paths
+- Architecture notes
+
+### Step 5: Skill Suggestions
+Suggest the Badi commands that fit the project:
+- Which commands will be most useful for this project
+- A suggested daily workflow
+- Note any custom command needs
+
+---
+
+## B) Daily Kickoff
+
+### Step 1: Get the Date
+- Determine today's date in `DDMMYY` format (example: 090426)
+
+### Step 2: Load Context
+- Read `memory.md`
+- Read `knowledge-base.md` if it exists
+- Check the latest session notes
+
+### Step 3: Create the Daily Note
+Create `daily-notes/DDMMYY.md`:
 ```markdown
-# Gunluk Not - [GG.AA.YYYY]
+# Daily Note - [DD.MM.YYYY]
 
-## Odak Alanlari
+## Focus Areas
 - [ ] ...
 
-## Notlar
+## Notes
 ...
 
-## Kararlar
+## Decisions
 ...
 
-## Yarinki Isler
+## Tomorrow's Work
 ...
 ```
 
-### Adim 4: Gorev Panosu Incele
-- Acik gorevleri listele
-- Gecen oturumdan kalan isleri kontrol et
-- Tamamlanmis ama kapatilmamis gorevleri tespit et
+### Step 4: Review the Task Board
+- List the open tasks
+- Check work left from the previous session
+- Detect completed-but-not-closed tasks
 
-### Adim 5: Arka Plan Watcher Ozeti (v1.13+)
-- `badi agent status --since 24h` calistir (varsa; hata dondurse sessiz gec)
-- Cikti `!! N uyari` iceriyorsa brifing'e "Watcher uyarilari" bolumu ekle
-- Kullaniciya sor: "Bu uyarilara bakalim mi?"
+### Step 5: Background Watcher Summary (v1.13+)
+- Run `badi agent status --since 24h` (if available; pass silently on error)
+- If the output includes `!! N warnings`, add a "Watcher warnings" section to the briefing
+- Ask the user: "Shall we look at these warnings?"
 
-### Adim 6: Oncelikleri Dogrula
-Kullaniciya sor:
-- "Bugunku oncelikler dogru mu?"
-- "Degisiklik veya ekleme var mi?"
+### Step 6: Confirm Priorities
+Ask the user:
+- "Are today's priorities correct?"
+- "Any changes or additions?"
 
-### Adim 7: Brifing
-Kisa bir ozet sun:
+### Step 7: Briefing
+Present a short summary:
 ```
-=== BADI GUNLUK BRIFING ===
-Tarih: [tarih]
-Acik Gorevler: [sayi]
-Bugunku Odak: [oncelikler]
-Devam Eden: [onceki oturumdan kalanlar]
-Watcher: [24h icinde N uyari | hepsi OK | watcher yok]
-Dikkat: [onemli notlar veya uyarilar]
+=== BADI DAILY BRIEFING ===
+Date: [date]
+Open Tasks: [count]
+Today's Focus: [priorities]
+In Progress: [carried over from the previous session]
+Watcher: [N warnings in 24h | all OK | no watcher]
+Attention: [important notes or warnings]
 ===========================
 ```
 
-# Cikti Formati
-- Mod A: Proje profili + bellek dosyasi + skill onerileri
-- Mod B: Gunluk brifing + not dosyasi + oncelik listesi
+# Output Format
+- Mode A: Project profile + memory file + skill suggestions
+- Mode B: Daily briefing + note file + priority list

--- a/.claude/commands/stats.md
+++ b/.claude/commands/stats.md
@@ -1,41 +1,41 @@
 Usage analytics command. Badi tool usage statistics, bar charts, daily trends, habit streaks.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi stats)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Donem Belirle
-
-```bash
-badi stats                    # Son 7 gun (varsayilan)
-badi stats --week             # Son 7 gun
-badi stats --month            # Son 30 gun
-badi stats --all              # Tum zamanlar
-```
-
-### Adim 2: Filtre ve Detay
+### Step 1: Pick a Period
 
 ```bash
-badi stats --command Bash     # Sadece Bash kullanimi
-badi stats --habits           # Aliskanlik serisi (streak)
-badi stats --export csv       # CSV olarak disa aktar
+badi stats                    # Last 7 days (default)
+badi stats --week             # Last 7 days
+badi stats --month            # Last 30 days
+badi stats --all              # All time
 ```
 
-### Adim 3: Yorumla
+### Step 2: Filter and Detail
 
-Ciktiya gore kullaniciya:
-- **Yuksek Bash kullanimi**: Komut kisayollari onerilebilir
-- **Streak kirildi**: Haftalik/gunluk rutin hatirlaticisi
-- **Az kullanilan arac**: Rehberlik teklif
+```bash
+badi stats --command Bash     # Bash usage only
+badi stats --habits           # Habit streaks
+badi stats --export csv       # Export as CSV
+```
 
-### Adim 4: Gorsel Rapor
+### Step 3: Interpret
 
-Bar chart, gunluk trend ve habit streak'lari ozetle.
+Based on the output, tell the user:
+- **High Bash usage**: command shortcuts could be suggested
+- **Broken streak**: weekly/daily routine reminder
+- **Rarely used tool**: offer guidance
 
-# Ornek
+### Step 4: Visual Report
+
+Summarize bar charts, daily trends, and habit streaks.
+
+# Example
 ```
 /stats --habits
 /stats --month --command Bash
-/stats --export csv > usage-rapor.csv
+/stats --export csv > usage-report.csv
 ```

--- a/.claude/commands/sync.md
+++ b/.claude/commands/sync.md
@@ -1,76 +1,76 @@
 Mid-session context refresh command. Keeps context fresh and consistent during work.
 
-# Gerekli Araclar
-- Read (bellek ve baglam dosyalari)
-- Write (guncelleme yazimi)
-- Grep (degisiklik taramasi)
-- Bash (git durumu)
+# Required Tools
+- Read (memory and context files)
+- Write (writing updates)
+- Grep (change scan)
+- Bash (git status)
 
-# Prosedur (9 Adim)
+# Procedure (9 Steps)
 
-### Adim 1: Baglam Oku
-- `memory.md` dosyasini oku
-- `knowledge-base.md` dosyasini oku
-- Aktif gunluk notu (`daily-notes/GGAAYY.md`) oku
-- Son `handoffs/` notunu kontrol et
+### Step 1: Read Context
+- Read `memory.md`
+- Read `knowledge-base.md`
+- Read the active daily note (`daily-notes/DDMMYY.md`)
+- Check the latest `handoffs/` note
 
-### Adim 2: Notlari Isle
-- Bu oturumda alinan kararlari listele
-- Yeni ogrenimleri tespit et
-- Degisen gereksinimleri not et
-- Cozulen ve yeni ortaya cikan sorunlari kaydet
+### Step 2: Process Notes
+- List the decisions made this session
+- Identify new learnings
+- Note changed requirements
+- Record solved and newly surfaced problems
 
-### Adim 3: Gorevleri Yonet
-- Tamamlanan gorevleri "bitti" olarak isaretle
-- Yeni ortaya cikan gorevleri ekle
-- Oncelikleri yeniden degerllendir
-- Bagimliliklari kontrol et
+### Step 3: Manage Tasks
+- Mark completed tasks as "done"
+- Add newly surfaced tasks
+- Re-evaluate priorities
+- Check dependencies
 
-### Adim 4: Baglamsal Oz-Sorgulama
-Su sorulari ic kontrol olarak degerlendir:
-- "Mevcut calisma hedefle uyumlu mu?"
-- "Kapsam kaymasi (scope creep) belirtisi var mi?"
-- "Atlanan veya ertelenen bir sey var mi?"
-- "Kullanicinin son talepleriyle tutarli miyim?"
+### Step 4: Contextual Self-Check
+Evaluate these questions as an internal check:
+- "Is the current work aligned with the goal?"
+- "Any signs of scope creep?"
+- "Anything skipped or postponed?"
+- "Am I consistent with the user's latest requests?"
 
-### Adim 5: Boyd Kurali Kontrolu (OODA)
-- **Gozlem (Observe):** Mevcut durum nedir?
-- **Yonelim (Orient):** Bu bilgiyi nasil yorumluyorum?
-- **Karar (Decide):** Sonraki adim ne olmali?
-- **Eylem (Act):** Hangi eylemi onerecegim?
+### Step 5: Boyd Loop Check (OODA)
+- **Observe:** What is the current state?
+- **Orient:** How do I interpret this information?
+- **Decide:** What should the next step be?
+- **Act:** What action will I propose?
 
-### Adim 6: Bellek Guncelle
-- `memory.md` dosyasina yeni bilgileri ekle
-- Eskimis bilgileri guncelle veya kaldir
-- Celiski varsa coz ve not et
+### Step 6: Update Memory
+- Add new information to `memory.md`
+- Update or remove stale information
+- Resolve and note any contradictions
 
-### Adim 7: Olay Gunlugu Incele
-- Son degisiklikleri tara (git log, dosya degisiklikleri)
-- Beklenmeyen degisiklik varsa uyar
-- Onemli olaylari kronolojik sirala
+### Step 7: Review the Event Log
+- Scan recent changes (git log, file changes)
+- Warn about unexpected changes
+- Order important events chronologically
 
-### Adim 8: Koc Icegorusu
-Kisa bir degerllendirme sun:
-- Uretkenlik akisi nasil gidiyor?
-- Dikkat dagilmasi veya bloklama var mi?
-- Mola onerisi gerekli mi?
+### Step 8: Coach Insight
+Offer a brief assessment:
+- How is the productivity flow going?
+- Any distraction or blocking?
+- Is a break recommended?
 
-### Adim 9: Durum Raporu
+### Step 9: Status Report
 ```
-=== BADI SENKRONIZASYON ===
-Zaman: [saat]
-Oturum Suresi: [tahmini]
-Tamamlanan: [son senkrondan beri]
-Devam Eden: [aktif isler]
-Yeni Gorevler: [eklenenler]
-Bellek Durumu: GUNCEL / UYARI
-Boyd Analizi: [ozet]
-Koc Notu: [icegorusu]
+=== BADI SYNC ===
+Time: [time]
+Session Length: [estimate]
+Completed: [since the last sync]
+In Progress: [active work]
+New Tasks: [added]
+Memory State: CURRENT / WARNING
+Boyd Analysis: [summary]
+Coach Note: [insight]
 ============================
 ```
 
-# Cikti Formati
-- Guncellenmis bellek dosyasi
-- Gunluk nota eklenen yeni bilgiler
-- Durum raporu (yukaridaki format)
-- Gerekirse oneri veya uyari listesi
+# Output Format
+- Updated memory file
+- New information added to the daily note
+- Status report (format above)
+- Suggestion or warning list when needed

--- a/.claude/commands/system-audit.md
+++ b/.claude/commands/system-audit.md
@@ -1,89 +1,89 @@
 Deep infrastructure audit command. Comprehensively audits all Badi components across 9 checkpoints.
 
-# Gerekli Araclar
-- Read (tum konfig dosyalari) -- Grep (referans/kalip taramasi) -- Glob (dosya varlik) -- Bash (izin, JSON dogrulama, dosya bilgisi) -- Write (rapor)
+# Required Tools
+- Read (all config files) -- Grep (reference/pattern scan) -- Glob (file existence) -- Bash (permissions, JSON validation, file info) -- Write (report)
 
-# Prosedur (9 Kontrol)
+# Procedure (9 Checks)
 
-## Kontrol 1: Ajan Sagligi
-- `.claude/agents/` dosyalarini listele
-- Her ajan: YAML frontmatter formati -- gerekli alanlar (isim, aciklama, araclar) -- referans araclar gecerli mi -- cozulmemis `{{...}}` -- talimat tutarliligi
-- Ajan sayisi ve durum ozeti
+## Check 1: Agent Health
+- List the `.claude/agents/` files
+- Each agent: YAML frontmatter format -- required fields (name, description, tools) -- are referenced tools valid -- unresolved `{{...}}` -- instruction consistency
+- Agent count and status summary
 
-## Kontrol 2: Komut Sagligi
-- `.claude/commands/` dosyalarini listele
-- Her komut: aciklama satiri -- arac gereksinimi -- prosedur adimlari -- cikti formati -- markdown gecerli
-- `command-index.md` capraz referans: indekste olup dosyasi olmayan -- dosyasi olup indekste olmayan -- aciklama uyumsuzlugu
+## Check 2: Command Health
+- List the `.claude/commands/` files
+- Each command: description line -- tool requirements -- procedure steps -- output format -- valid markdown
+- `command-index.md` cross-reference: in the index but no file -- file exists but not in the index -- description mismatch
 
-## Kontrol 3: Hook Sagligi
-- `settings.json` JSON dogrula
-- Her hook: dosya mevcut mu -- calistirilabilir izin -- kuru calistirma (syntax) -- tetikleyici dogru
-- Calisma sirasi/oncelik -- carpisan/celisen hooklar
+## Check 3: Hook Health
+- Validate `settings.json` JSON
+- Each hook: does the file exist -- executable permission -- dry run (syntax) -- correct trigger
+- Run order/priority -- colliding/conflicting hooks
 
-## Kontrol 4: Bellek Katmani
-- `memory.md`: boyut (500 satir limiti) -- tazelik (son guncelleme) -- ic tutarlilik (celisen bilgi) -- kaynak atfisi
-- `knowledge-base.md`: boyut (1000 satir limiti) -- kategorizasyon -- dogrulanmamis bilgi -- atif/referans
+## Check 4: Memory Layer
+- `memory.md`: size (500-line limit) -- freshness (last update) -- internal consistency (contradicting info) -- source attribution
+- `knowledge-base.md`: size (1000-line limit) -- categorization -- unverified information -- citation/reference
 
-## Kontrol 5: Gunluk Sagligi
-- Dizinler: `daily-notes/`, `handoffs/` boyut/sayi -- denetim iz dosyalari (audit-trail.md, incident-log.md, failure-log.md)
-- Her gunluk: boyut siniri -- format tutarliligi -- tarih dogrulugu
-- JSONL (verdicts.jsonl): her satir gecerli JSON -- sema tutarliligi
+## Check 5: Log Health
+- Directories: `daily-notes/`, `handoffs/` size/count -- audit trail files (audit-trail.md, incident-log.md, failure-log.md)
+- Each log: size limit -- format consistency -- date accuracy
+- JSONL (verdicts.jsonl): each line valid JSON -- schema consistency
 
-## Kontrol 6: Izin/Konfigurasyon
-- Hook dosya izinleri -- settings.json icindeki referanslar mevcut mu -- ortam degiskeni bagimliliklari (kullanilan ama tanimsiz) -- dizin yapisi -- `.gitignore` ile hassas dosya kontrolu
+## Check 6: Permissions/Configuration
+- Hook file permissions -- do references inside settings.json exist -- environment variable dependencies (used but undefined) -- directory structure -- sensitive-file check against `.gitignore`
 
-## Kontrol 7: Capraz Tutarlilik
-- A → B atif yapiyorsa B mevcut mu -- dongusel bagimlilik -- yetim referans (baglanmayan dosya) -- CLAUDE.md ↔ komut/ajan davranis uyumu -- isimlendirme konvansiyonu
+## Check 7: Cross-Consistency
+- If A references B, does B exist -- circular dependencies -- orphan references (unlinked files) -- CLAUDE.md ↔ command/agent behavior alignment -- naming conventions
 
-## Kontrol 8: Yedekleme/Depolama
-- Toplam `.claude/` boyutu -- en buyuk 5 dosya -- 30 gunden eski (arsiv adayi) -- otomatik temizlik mekanizmasi -- gecici dosyalar -- yedekleme stratejisi guncel mi
+## Check 8: Backup/Storage
+- Total `.claude/` size -- 5 largest files -- older than 30 days (archive candidates) -- automatic cleanup mechanism -- temporary files -- is the backup strategy current
 
-## Kontrol 9: Via Negativa
-Gereksiz karmasik tespit: kullanilmayan bilesen (komut/ajan/hook) -- tekrarlayan/carpisan islev -- gereksiz bagimlilik zinciri -- asiri karmasik konfig -- olmeyen workaround -- kaldirildiginda sistemi iyilestirecek ogeler
+## Check 9: Via Negativa
+Detect needless complexity: unused components (command/agent/hook) -- duplicated/colliding functionality -- needless dependency chains -- overly complex config -- undying workarounds -- items whose removal would improve the system
 
-# Derecelendirme
-- **A:** Tum alt kontroller gecti, iyilestirme gerektirmiyor
-- **B:** Kucuk uyarilar, acil mudahale yok
-- **C:** Duzeltilmesi gereken sorunlar, planli sprintte
-- **D:** Ciddi sorunlar, hemen ele alinmali
-- **F:** Kritik basarisizlik, acil mudahale
+# Grading
+- **A:** All sub-checks passed, no improvement needed
+- **B:** Minor warnings, no urgent intervention
+- **C:** Issues to fix, in a planned sprint
+- **D:** Serious issues, address immediately
+- **F:** Critical failure, urgent intervention
 
-**Genel Derece:** en dusuk bireysel veya agirlikli ortalama.
+**Overall Grade:** the lowest individual grade or a weighted average.
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI SISTEM DENETIMI ===
-Tarih: [tarih]
-Genel Derece: [A-F]
+=== BADI SYSTEM AUDIT ===
+Date: [date]
+Overall Grade: [A-F]
 
-## Kontrol Sonuclari
-| # | Kontrol | Derece | Bulgu |
-|---|---------|--------|-------|
-| 1 | Ajan Sagligi | [A-F] | [ozet] |
-| 2 | Komut Sagligi | [A-F] | [ozet] |
-| 3 | Hook Sagligi | [A-F] | [ozet] |
-| 4 | Bellek Katmani | [A-F] | [ozet] |
-| 5 | Gunluk Sagligi | [A-F] | [ozet] |
-| 6 | Izin/Konfigurasyon | [A-F] | [ozet] |
-| 7 | Capraz Tutarlilik | [A-F] | [ozet] |
-| 8 | Yedekleme/Depolama | [A-F] | [ozet] |
-| 9 | Via Negativa | [A-F] | [ozet] |
+## Check Results
+| # | Check | Grade | Finding |
+|---|-------|-------|---------|
+| 1 | Agent Health | [A-F] | [summary] |
+| 2 | Command Health | [A-F] | [summary] |
+| 3 | Hook Health | [A-F] | [summary] |
+| 4 | Memory Layer | [A-F] | [summary] |
+| 5 | Log Health | [A-F] | [summary] |
+| 6 | Permissions/Config | [A-F] | [summary] |
+| 7 | Cross-Consistency | [A-F] | [summary] |
+| 8 | Backup/Storage | [A-F] | [summary] |
+| 9 | Via Negativa | [A-F] | [summary] |
 
-## Kritik Bulgular (D ve F)
-[detaylar ve acil aksiyonlar]
+## Critical Findings (D and F)
+[details and urgent actions]
 
-## Uyarilar (C)
-[detaylar ve planlanmis aksiyonlar]
+## Warnings (C)
+[details and planned actions]
 
-## Iyilestirme Onerileri (A ve B)
-[opsiyonel iyilestirmeler]
+## Improvement Suggestions (A and B)
+[optional improvements]
 
-## Duzeltme Plani
-1. [ACIL] [aksiyon] - Hedef: [tarih]
-2. [PLANLI] [aksiyon] - Hedef: [tarih]
-3. [ONERILEN] [aksiyon] - Hedef: [tarih]
+## Remediation Plan
+1. [URGENT] [action] - Target: [date]
+2. [PLANNED] [action] - Target: [date]
+3. [SUGGESTED] [action] - Target: [date]
 
-## Sonraki Denetim
-Onerilen: [tarih] (aylik veya buyuk degisiklik sonrasi)
+## Next Audit
+Suggested: [date] (monthly or after major changes)
 ==============================
 ```

--- a/.claude/commands/unstick.md
+++ b/.claude/commands/unstick.md
@@ -1,120 +1,120 @@
 Unblocking command. Finds a fast solution with a structured approach when you're stuck.
 
-# Gerekli Araclar
-- Read (kod ve baglam okuma)
-- Grep (hata ve kalip arama)
-- Glob (dosya bulma)
-- Bash (test calistirma, hata ayiklama)
+# Required Tools
+- Read (code and context reading)
+- Grep (error and pattern search)
+- Glob (file discovery)
+- Bash (running tests, debugging)
 
-# Baslangic Formati
-Kullanicidan: "[Y] nedeniyle [X]'de takildim"
-Ornek: "CORS hatasi nedeniyle API entegrasyonunda takildim"
+# Starting Format
+From the user: "I'm stuck on [X] because of [Y]"
+Example: "I'm stuck on the API integration because of a CORS error"
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Engeli Yakala
-Kullanicidan su bilgileri topla:
-- **Ne:** Hangi gorevde/islemde takili? (X)
-- **Neden:** Engelin dograsi/sebebi nedir? (Y)
-- **Denenenler:** Simdiye kadar ne denendi?
-- **Hata Mesaji:** Varsa gercek hata ciktisi
-- **Beklenen Sonuc:** Ne olmasini bekliyordu?
-- **Gerceklesen:** Bunun yerine ne oldu?
-- **Ortam:** Hangi ortamda? (yerel, staging, production)
+### Step 1: Capture the Blocker
+Collect from the user:
+- **What:** Which task/operation is stuck? (X)
+- **Why:** What is the nature/cause of the blocker? (Y)
+- **Tried:** What has been attempted so far?
+- **Error Message:** The actual error output, if any
+- **Expected:** What did they expect to happen?
+- **Actual:** What happened instead?
+- **Environment:** Which environment? (local, staging, production)
 
-### Adim 2: Siniflandir
-Engeli 5 kategoriden birine ata:
+### Step 2: Classify
+Assign the blocker to one of 5 categories:
 
-**A) Bilgi Eksikligi**
-- Eksik veri, dokumantasyon veya API bilgisi
-- Cozum: Ilgili kaynakllari bul ve incele
-- Araclar: Grep, Read, dokumantasyon taramasi
+**A) Missing Information**
+- Missing data, documentation, or API knowledge
+- Fix: Find and review the relevant sources
+- Tools: Grep, Read, documentation scan
 
-**B) Karar Felci**
-- Birden fazla secenek arasinda takili kalma
-- Cozum: Secenekleri karsilastirmali analiz et, artilari/eksileri listele
-- Yaklasim: "Geri donulebilir mi?" sorusuyla basla, geri donulebilirce en basitini sec
+**B) Decision Paralysis**
+- Stuck between multiple options
+- Fix: Comparative analysis of the options; list pros/cons
+- Approach: Start with "is it reversible?"; if reversible, pick the simplest
 
-**C) Dongusel Hata Ayiklama**
-- Ayni hataya tekrar tekrar dusme
-- Cozum: Varsayimlari sorgula, sorun alanini daralt
-- Yaklasim: Ikili arama (binary search) - sorunun nerede oldugunu sistematik daralt
+**C) Circular Debugging**
+- Hitting the same error repeatedly
+- Fix: Question the assumptions, narrow the problem area
+- Approach: Binary search — systematically narrow where the problem lives
 
-**D) Kapsam Karisikligi**
-- Ne yapilacagi belirsiz, gereksinimler muglak
-- Cozum: Gereksinimleri netlestir, en kucuk ise yarar parcayi belirle
-- Yaklasim: "Yapilabilecek en kucuk sey nedir?" sorusu
+**D) Scope Confusion**
+- Unclear what to do, vague requirements
+- Fix: Clarify requirements, define the smallest useful piece
+- Approach: the question "what is the smallest thing that could work?"
 
-**E) Ortam Sorunlari**
-- Yapilandirma, bagimlilik, erisim, versiyon uyumsuzlugu
-- Cozum: Ortam kontrolu, bagimlilik dogrulamasi
-- Yaklasim: Temiz ortamda tekrarlama, izolasyon testi
+**E) Environment Issues**
+- Configuration, dependencies, access, version mismatch
+- Fix: Environment check, dependency verification
+- Approach: Reproduce in a clean environment, isolation test
 
-### Adim 3: Analizci Ajanini Etkinlestir
-Siniflandirmaya gore analiz baslat:
+### Step 3: Activate the Analyst
+Start the analysis per the classification:
 
-**Bilgi toplama:**
-- Ilgili kodu oku ve baglamini anla
-- Hata mesajini arastir
-- Benzer sorunlarin cozumlerini ara
-- Dokumantasyonu kontrol et
+**Information gathering:**
+- Read the relevant code and understand its context
+- Research the error message
+- Search for solutions to similar problems
+- Check the documentation
 
-**Kok neden analizi:**
-- 5 Neden teknigini uygula (Why-Why-Why)
-- Varsayim listesi cikar ve her birini dogrula
-- Sorun alanini en dar hale getir
-- Yeniden uretilip uretilemeyecigini kontrol et
+**Root cause analysis:**
+- Apply the 5 Whys technique
+- List the assumptions and verify each one
+- Narrow the problem area as much as possible
+- Check whether it can be reproduced
 
-**Cozum uretimi:**
-- En az 2, en fazla 4 cozum onerisi sun
-- Her oneri icin: ne yapilacak, risk seviyesi, tahmini sure
-- En hizli sonuc verecek oneriyi isaretle (quick win)
+**Solution generation:**
+- Offer at least 2, at most 4 solution proposals
+- For each: what to do, risk level, estimated time
+- Mark the one likely to deliver fastest (quick win)
 
-### Adim 4: Oneriyi Uygula
-En uygun oneriyi sec ve hemen uygula:
-- Oneriyi adim adim yap
-- Her adimda sonucu dogrula
-- Islemezse sonraki oneriye gec
-- Tum oneriler basarisiz olursa, yeni bilgiyle Adim 3'e don
+### Step 4: Apply the Proposal
+Pick the best proposal and apply it immediately:
+- Execute the proposal step by step
+- Verify the result at each step
+- If it does not work, move to the next proposal
+- If all proposals fail, return to Step 3 with the new information
 
-### Adim 5: Cozumu Belgele
-Cozumu kalici hale getir:
+### Step 5: Document the Solution
+Make the fix durable:
 
-**Gunluk Nota Ekle:**
+**Add to the daily note:**
 ```markdown
-## Tikaniklik Cozumu - [saat]
-- **Engel:** [X] - [Y]
-- **Kategori:** [A-E]
-- **Kok Neden:** [gercek sebep]
-- **Cozum:** [uygulanan cozum]
-- **Sure:** [harcanan sure]
-- **Ogrenin:** [cikarilan ders]
+## Unblock Solution - [time]
+- **Blocker:** [X] - [Y]
+- **Category:** [A-E]
+- **Root Cause:** [real reason]
+- **Solution:** [applied solution]
+- **Duration:** [time spent]
+- **Learning:** [lesson learned]
 ```
 
-**Tekrar Kontrolu:**
-- Bu sorun daha once yasandi mi? (tekrarlayan kalip kontrolu)
-- Tekrarliyorsa, kalici cozum icin `knowledge-base.md`'ye ekle
-- Otomasyon firsati var mi? (hook veya script ile onlenebilir mi?)
+**Recurrence check:**
+- Has this problem happened before? (recurring pattern check)
+- If recurring, add a durable fix to `knowledge-base.md`
+- Any automation opportunity? (preventable via a hook or script?)
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI TIKANIKLIK COZUMU ===
-Engel: [X] - [Y]
-Kategori: [A-E]: [kategori adi]
-Sure: [cozum suresi]
+=== BADI UNBLOCK ===
+Blocker: [X] - [Y]
+Category: [A-E]: [category name]
+Duration: [time to solve]
 
-Kok Neden: [aciklama]
-Uygulanan Cozum: [ne yapildi]
-Sonuc: COZULDU / KISMI / DEVAM EDIYOR
+Root Cause: [explanation]
+Applied Solution: [what was done]
+Result: SOLVED / PARTIAL / ONGOING
 
-Ogrenin: [cikarilan ders]
-Tekrar Riski: DUSUK / ORTA / YUKSEK
-[Yuksekse: Kalici cozum onerisi]
+Learning: [lesson learned]
+Recurrence Risk: LOW / MEDIUM / HIGH
+[If high: durable fix suggestion]
 ===============================
 ```
 
-# Hizli Ipuclari
-- Bazi tikanikliklar 5 dakika mola ile cozulur - bunu da oner
-- "Geri donulebilir mi?" sorusu karar felcini kirder
-- Hata mesajini kelimesi kelimesine aramak cogu zaman cozumu bulur
-- Sorunu baskasina aciklamak (rubber duck debugging) tek basina cozebilir
+# Quick Tips
+- Some blockers dissolve after a 5-minute break — suggest that too
+- The "is it reversible?" question breaks decision paralysis
+- Searching the error message verbatim often finds the fix
+- Explaining the problem to someone (rubber duck debugging) can solve it on its own

--- a/.claude/commands/wrap-up.md
+++ b/.claude/commands/wrap-up.md
@@ -1,116 +1,116 @@
 End-of-day ritual command. Prepares the day for closure and sets the stage for tomorrow.
 
-# Gerekli Araclar
-- Read (bellek, notlar, gunlukler)
-- Write (guncelleme ve rapor yazimi)
-- Bash (git durumu, gorev kontrolu)
-- Grep (olay taramasi)
+# Required Tools
+- Read (memory, notes, logs)
+- Write (updates and report writing)
+- Bash (git status, task checks)
+- Grep (event scan)
 
-# Prosedur (11 Adim)
+# Procedure (11 Steps)
 
-### Adim 1: Durum Oku
-- `memory.md` dosyasini oku
-- Gunluk notu (`daily-notes/GGAAYY.md`) oku
-- Gorev panosunu kontrol et
-- Git durumunu incele (commit edilmemis degisiklikler)
+### Step 1: Read the State
+- Read `memory.md`
+- Read the daily note (`daily-notes/DDMMYY.md`)
+- Check the task board
+- Review the git status (uncommitted changes)
 
-### Adim 2: Defteri Isle
-Gunun olaylarini derle:
-- Yapilan commitler ve degisiklikler
-- Alinan kararlar ve gerekceleri
-- Karsilasilan sorunlar ve cozumleri
-- Kullanicinin verdigi yonlendirmeler
+### Step 2: Process the Ledger
+Compile the day's events:
+- Commits and changes made
+- Decisions taken and their rationale
+- Problems hit and their solutions
+- Directions given by the user
 
-### Adim 3: Bellegi Senkronize Et
-`memory.md` dosyasini guncelle:
-- Yeni ogrenimleri ekle
-- Eskimis bilgileri kaldir
-- Proje durumunu guncelle
-- Onemli kararlari kaydet
+### Step 3: Synchronize Memory
+Update `memory.md`:
+- Add new learnings
+- Remove stale information
+- Update the project state
+- Record important decisions
 
-### Adim 4: Tamamlanan Gorevleri Tasi
-- Biten gorevleri "tamamlandi" olarak isaretle
-- Tamamlanma tarihini ekle
-- Kismen biten gorevlerin durumunu guncelle
-- Bloke olan gorevleri ve nedenlerini belirt
+### Step 4: Move Completed Tasks
+- Mark finished tasks as "completed"
+- Add the completion date
+- Update the status of partially finished tasks
+- Note blocked tasks and their reasons
 
-### Adim 5: Ogrenimleri Disariya Aktar
-Bugunden cikarilan dersleri kaydet:
-- Teknik ogrenimler (yeni API, kalip, arac)
-- Surec ogrenimleri (neyin ise yaradigi/yaramadigi)
-- Proje icegoruleri
-- `knowledge-base.md` dosyasina ekle
+### Step 5: Export Learnings
+Record today's lessons:
+- Technical learnings (new APIs, patterns, tools)
+- Process learnings (what worked / what did not)
+- Project insights
+- Add them to `knowledge-base.md`
 
-### Adim 6: Denetci Calistir
-Hizli bir T1 denetim yap:
-- Commit edilmemis degisiklik var mi?
-- Kirik test var mi?
-- Gecici dosya veya debug kodu kalmis mi?
-- Guvenlik riski tasiyan bir sey var mi?
+### Step 6: Run the Auditor
+Do a quick T1 audit:
+- Any uncommitted changes?
+- Any broken tests?
+- Any temp files or debug code left behind?
+- Anything carrying a security risk?
 
-### Adim 7: Olay Gunlugu Incele
-- Gunun onemli olaylarini kronolojik sirala
-- Anormal veya dikkat gerektiren durumlar var mi?
-- Takip gerektiren konulari isaretle
+### Step 7: Review the Event Log
+- Order the day's important events chronologically
+- Anything abnormal or needing attention?
+- Flag topics that need follow-up
 
-### Adim 8: Yarini Onizle
-- Yarin icin oncelikli gorevleri belirle
-- Bagimliliklari kontrol et (baskasini bekleyen isler)
-- Takvim etkinlikleri veya son tarihler var mi?
-- Onerilen odak alanlarini listele
+### Step 8: Preview Tomorrow
+- Determine tomorrow's priority tasks
+- Check dependencies (work waiting on someone else)
+- Any calendar events or deadlines?
+- List the suggested focus areas
 
-### Adim 9: Gunluk Notlari Guncelle
-`daily-notes/GGAAYY.md` dosyasini tamamla:
+### Step 9: Update the Daily Notes
+Complete the `daily-notes/DDMMYY.md` file:
 ```markdown
-## Gun Sonu Ozeti
-- Tamamlanan: [liste]
-- Devam Eden: [liste]
-- Ertelenen: [liste]
-- Yarinki Oncelik: [liste]
+## End-of-Day Summary
+- Completed: [list]
+- In Progress: [list]
+- Deferred: [list]
+- Tomorrow's Priority: [list]
 
-## Ogrenimler
-- [ogrenimler]
+## Learnings
+- [learnings]
 
-## Kararlar
-- [kararlar ve gerekceleri]
+## Decisions
+- [decisions and their rationale]
 ```
 
-### Adim 10: Koc Analizi (Cumalari)
-Eger gun Cuma ise, haftalik kocluk analizi yap:
-- Haftalik uretkenlik ozeti
-- Hedeflere ilerleme durumu
-- Enerji ve odak kaliplari
-- Gelecek hafta icin oneriler
-- Kutlanacak basarilar
+### Step 10: Coach Analysis (Fridays)
+If it is Friday, run the weekly coaching analysis:
+- Weekly productivity summary
+- Progress toward goals
+- Energy and focus patterns
+- Suggestions for next week
+- Wins to celebrate
 
-### Adim 11: Cikis Ozeti
+### Step 11: Exit Summary
 ```
-=== BADI GUN SONU ===
-Tarih: [tarih]
-Oturum Suresi: [tahmini]
+=== BADI END OF DAY ===
+Date: [date]
+Session Length: [estimate]
 
-Tamamlanan Gorevler: [sayi]
-Commitler: [sayi]
-Satir Degisikligi: +[eklenen] / -[silinen]
+Completed Tasks: [count]
+Commits: [count]
+Line Changes: +[added] / -[removed]
 
-Devam Eden: [sayi] gorev
-Bloke: [sayi] gorev
+In Progress: [count] tasks
+Blocked: [count] tasks
 
-Yarinki Oncelikler:
-1. [oncelik]
-2. [oncelik]
-3. [oncelik]
+Tomorrow's Priorities:
+1. [priority]
+2. [priority]
+3. [priority]
 
-Denetim Durumu: TEMIZ / [sorun sayisi] UYARI
-Bellek: SENKRONIZE
+Audit Status: CLEAN / [issue count] WARNINGS
+Memory: SYNCHRONIZED
 
-[Cuma ise: Haftalik Koc Notu]
+[If Friday: Weekly Coach Note]
 =========================
 ```
 
-# Cikti Formati
-- Guncellenmis `memory.md`
-- Tamamlanmis gunluk not
-- `knowledge-base.md` guncellemesi
-- Gun sonu ozet raporu
-- (Cumalari) Haftalik kocluk raporu
+# Output Format
+- Updated `memory.md`
+- Completed daily note
+- `knowledge-base.md` update
+- End-of-day summary report
+- (Fridays) Weekly coaching report


### PR DESCRIPTION
## Summary

**Increment 2 of the body-translation phase** (after #234 / Phase 3a agents+hooks+CLAUDE.md). All **21 core-profile command bodies** (vault + active = 42 files) translated to English — the daily-ritual prompts: `start`, `sync`, `wrap-up`, `clear`, `standup`, `handoff`, `audit`, `system-audit`, `drift-detect`, `health`, `dashboard`, `coach`, `unstick`, `onboard`, `doctor`, `plugin`, `schedule`, `stats`, `ai-token`, `memory-diff`, `prompt-test`.

### Translation discipline
Faithful: structure, step counts, output-format blocks, and check logic preserved exactly (these are behavior-defining prompts). Incidental fixes caught en route:
- `prompt-test`: the documented CI grep now targets the **actual** English CLI output (`grep -q "clean"` — verified against `lib/commands/ai.js`).
- `schedule`: example reminder labels updated to the renamed `content start`/`content plan`.

## Test plan
- [x] `npm test` — **1161 pass / 0 fail**
- [x] `npx biome check` clean · `badi doctor` healthy
- [x] Broad Turkish scan across all 21 files: **zero residual**

## Remaining increments
3c: content command bodies (19) → 3d/e: dev (~44) → 3f-h: skills vault (59 SKILL.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)