### PR TITLE
feat(i18n): Phase 3c — English content command bodies (17 commands)

### DIFF
--- a/.claude/commands-vault/competitive-intel.md
+++ b/.claude/commands-vault/competitive-intel.md
@@ -1,163 +1,163 @@
 Competitive analysis command. Analyzes the market, competitors, and opportunities with a comprehensive competitive-intelligence framework.
 
-# Gerekli Araclar
-- Read (mevcut veriler)
-- Write (rapor yazimi)
-- Grep (veri taramasi)
-- Glob (kaynak bulma)
-- Bash (veri isleme)
+# Required Tools
+- Read (existing data)
+- Write (report writing)
+- Grep (data scan)
+- Glob (source discovery)
+- Bash (data processing)
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-### Adim 1: Cerceve Tanimla
-Kullanicidan su bilgileri al:
-- **Urun/Hizmet:** Analiz edilecek urun veya hizmetin adi ve kisa tanimi
-- **Pazar Kategorisi:** Hangi sektorde, hangi niÃ§te?
-- **Hedef Pazar:** Cografi ve demografik hedef
-- **Bilinen Rakipler:** Kullanicinin bildigi rakip listesi
-- **Analiz Amaci:** Neden yapiliyor? (yeni urun lansmani, fiyat guncelleme, strateji revizyonu, vb.)
-- **Odak Alani:** Tum pazar mi, belirli bir segment mi?
+### Step 1: Define the Frame
+Get from the user:
+- **Product/Service:** Name and short definition of what is being analyzed
+- **Market Category:** Which sector, which niche?
+- **Target Market:** Geographic and demographic target
+- **Known Competitors:** The competitor list the user knows
+- **Analysis Purpose:** Why is it being done? (new product launch, price update, strategy revision, etc.)
+- **Focus Area:** The whole market or a specific segment?
 
-### Adim 2: 3 Paralel Arastirma Ajani
+### Step 2: 3 Parallel Research Agents
 
-**Ajan 1: Dogrudan Rakip Analizi**
-- Her dogrudan rakip icin:
-  - Urun/hizmet ozellikleri ve kapasite karsilastirmasi
-  - Fiyatlandirma modeli ve fiyat noktalari
-  - Hedef musteri profili
-  - Teknik altyapi ve teknoloji tercihleri
-  - Pazarlama stratejisi ve kanallari
-  - Marka konumlandirmasi
-  - Musteri yorumlari ve memnuniyet sinyalleri
-  - Bilinen zayif noktalari
+**Agent 1: Direct Competitor Analysis**
+- For each direct competitor:
+  - Product/service features and capability comparison
+  - Pricing model and price points
+  - Target customer profile
+  - Technical infrastructure and technology choices
+  - Marketing strategy and channels
+  - Brand positioning
+  - Customer reviews and satisfaction signals
+  - Known weak points
 
-**Ajan 2: Yakin Alternatif ve Dolayli Rakip Analizi**
-- Acik kaynak alternatifleri
-- Farkli yaklasimla ayni sorunu cozen cozumler
-- Kendin yap (DIY) alternatifleri
-- Potansiyel yeni girisler (komsu pazardan genisleyenler)
-- Ikame urunler ve hizmetler
+**Agent 2: Near-Alternative and Indirect Competitor Analysis**
+- Open-source alternatives
+- Solutions solving the same problem differently
+- DIY alternatives
+- Potential new entrants (expanding from adjacent markets)
+- Substitute products and services
 
-**Ajan 3: Pazar Baglami Analizi**
-- Pazar buyuklugu ve buyume trendi
-- Son fonlama ve yatirim haberleri
-- Birlesme ve satin alma hareketleri
-- Regulasyon degisiklikleri
-- Teknoloji trendleri ve etkileri
-- Musteri davranisi degisimleri
-- Ekonomik faktorler
+**Agent 3: Market Context Analysis**
+- Market size and growth trend
+- Recent funding and investment news
+- M&A activity
+- Regulatory changes
+- Technology trends and their impact
+- Customer behavior shifts
+- Economic factors
 
-### Adim 3: Karsilastirma Matrisi
-Kapsamli karsilastirma tablosu olustur:
+### Step 3: Comparison Matrix
+Build a comprehensive comparison table:
 
-| Kriter | Bizim Urun | Rakip A | Rakip B | Rakip C | Rakip D |
-|--------|-----------|---------|---------|---------|---------|
-| Fiyat Araligi | | | | | |
-| Hedef Musteri | | | | | |
-| Temel Ozellikler | | | | | |
-| Benzersiz Deger | | | | | |
-| Guclu Yonler | | | | | |
-| Zayif Yonler | | | | | |
-| Pazar Payi (tahmini) | | | | | |
-| Teknoloji | | | | | |
-| Musteri Destek | | | | | |
-| Entegrasyonlar | | | | | |
-| Mobil Deneyim | | | | | |
-| Olceklenebilirlik | | | | | |
+| Criterion | Our Product | Comp A | Comp B | Comp C | Comp D |
+|-----------|-------------|--------|--------|--------|--------|
+| Price Range | | | | | |
+| Target Customer | | | | | |
+| Core Features | | | | | |
+| Unique Value | | | | | |
+| Strengths | | | | | |
+| Weaknesses | | | | | |
+| Market Share (est.) | | | | | |
+| Technology | | | | | |
+| Customer Support | | | | | |
+| Integrations | | | | | |
+| Mobile Experience | | | | | |
+| Scalability | | | | | |
 
-### Adim 4: Stratejik Icgoruler
-Analizden cikarilan sonuclar:
+### Step 4: Strategic Insights
+Conclusions drawn from the analysis:
 
-**Pazar Bosluklari:**
-- Rakiplerin karsilamadigi ihtiyaclar
-- Yetersiz hizmet verilen segmentler
-- Fiyat boslugu firsatlari
-- Ozellik boslugu firsatlari
+**Market Gaps:**
+- Needs competitors fail to meet
+- Underserved segments
+- Price-gap opportunities
+- Feature-gap opportunities
 
-**Tehditler:**
-- Guclu rakiplerin genisleme planlari
-- Yeni giris riskleri
-- Teknoloji degisim riskleri
-- Fiyat savasi riskleri
+**Threats:**
+- Strong competitors' expansion plans
+- New-entrant risks
+- Technology-shift risks
+- Price-war risks
 
-**Benzersiz Avantajlar:**
-- Taklit edilmesi zor guclu yonlerimiz
-- Teknoloji veya veri avantajlari
-- Iliski ve guvenirllik avantajlari
-- Hiz ve ceikliklik avantajlari
+**Unique Advantages:**
+- Our hard-to-copy strengths
+- Technology or data advantages
+- Relationship and trust advantages
+- Speed and agility advantages
 
-### Adim 5: Oneriler
-Stratejik oneriler sun:
+### Step 5: Recommendations
+Offer strategic recommendations:
 
-**Konumlandirma Stratejisi:**
-- Onerilen konum ve mesajlasma
-- Hangi segmentte yoğunlasmali?
-- Farklilastirma vurgulari
+**Positioning Strategy:**
+- Suggested position and messaging
+- Which segment to concentrate on?
+- Differentiation emphases
 
-**Fiyatlandirma Onerisi:**
-- Rekabetci fiyat noktasi
-- Katman ve paketleme onerisi
-- Deger bazli fiyatlandirma firsatlari
+**Pricing Suggestion:**
+- Competitive price point
+- Tiering and packaging suggestion
+- Value-based pricing opportunities
 
-**Ozellik Onceliklendirmesi:**
-- Rekabetci parite icin gereken ozellikler
-- Farklilastirici ozellik firsatlari
-- Kisa ve uzun vadeli yol haritasi onerisi
+**Feature Prioritization:**
+- Features needed for competitive parity
+- Differentiating feature opportunities
+- Short- and long-term roadmap suggestion
 
-**Mesajlasma Stratejisi:**
-- Anahtar mesajlar
-- Kacinilmasi gereken ifadeler
-- Kanit noktalari (proof points)
+**Messaging Strategy:**
+- Key messages
+- Phrases to avoid
+- Proof points
 
-### Adim 6: Markdown Rapor Olustur
+### Step 6: Build the Markdown Report
 
-# Cikti Formati
+# Output Format
 ```markdown
-# Rekabet Analizi Raporu - [tarih]
+# Competitive Analysis Report - [date]
 
-## Yonetici Ozeti
-[3-5 cumle ozet: pazar durumu, ana bulgular, stratejik oneri]
+## Executive Summary
+[3-5 sentence summary: market state, key findings, strategic recommendation]
 
-## Pazar Genel Gorunumu
-- Pazar Buyuklugu: [tahmini]
-- Buyume Trendi: [yuzde/yil]
-- Rekabet Yogunlugu: [DUSUK/ORTA/YUKSEK]
+## Market Overview
+- Market Size: [estimate]
+- Growth Trend: [percent/year]
+- Competitive Intensity: [LOW/MEDIUM/HIGH]
 
-## Rakip Profilleri
-### Rakip A: [isim]
-[detayli profil]
+## Competitor Profiles
+### Competitor A: [name]
+[detailed profile]
 
-### Rakip B: [isim]
-[detayli profil]
+### Competitor B: [name]
+[detailed profile]
 
 ...
 
-## Karsilastirma Matrisi
-[tablo]
+## Comparison Matrix
+[table]
 
-## Stratejik Icgoruler
-### Firsatlar
-[firsatlar]
+## Strategic Insights
+### Opportunities
+[opportunities]
 
-### Tehditler
-[tehditler]
+### Threats
+[threats]
 
-### Avantajlarimiz
-[avantajlar]
+### Our Advantages
+[advantages]
 
-## Oneriler
-### Kisa Vadeli (0-3 ay)
-[aksiyonlar]
+## Recommendations
+### Short Term (0-3 months)
+[actions]
 
-### Orta Vadeli (3-6 ay)
-[aksiyonlar]
+### Mid Term (3-6 months)
+[actions]
 
-### Uzun Vadeli (6-12 ay)
-[aksiyonlar]
+### Long Term (6-12 months)
+[actions]
 
-## Kaynaklar
-[kullanilan veri kaynaklari]
+## Sources
+[data sources used]
 
-## Sonraki Guncelleme
-Onerilen: [tarih] (3 ayda bir)
+## Next Update
+Suggested: [date] (quarterly)
 ```

--- a/.claude/commands-vault/content-brand-voice.md
+++ b/.claude/commands-vault/content-brand-voice.md
@@ -1,78 +1,78 @@
 Brand voice definition and management command. Creates a brand voice guide to keep tone, style, and personality consistent across all content.
 
-# Gerekli Araclar
-- Read (mevcut icerikler, web sitesi metinleri) -- Write (rehber) -- Grep (mevcut ton/stil analizi) -- ...
+# Required Tools
+- Read (existing content, website copy) -- Write (guide) -- Grep (current tone/style analysis) -- ...
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-## 1. Marka Kisiligi
-**Temel:** marka adi -- ne yapiyorsunuz (tek cumle, asansor konusmasi) -- kimi hedefliyorsunuz (yas, meslek, ilgi) -- ...
+## 1. Brand Personality
+**Basics:** brand name -- what you do (one sentence, elevator pitch) -- who you target (age, profession, interests) -- ...
 
-**Farklilik:** rakiplerden fark (tek cumle) -- musteriler neden seciyor (en sik geri bildirim) -- hangi duyguyu uyandirmak (guven, heyecan, huzur, ilham)
+**Differentiation:** difference from competitors (one sentence) -- why customers choose you (most frequent feedback) -- which emotion to evoke (trust, excitement, calm, inspiration)
 
-**Sinirlar:** asla kullanilmayacak ton/kelime (kirmizi cizgi) -- kacinilacak konular (siyaset, din, tartismali) -- hassas noktalar (sektor spesifik)
+**Boundaries:** tone/words never to use (red lines) -- topics to avoid (politics, religion, controversy) -- sensitive points (sector-specific)
 
-## 2. Ton Spektrumu (7 eksen, 1-10)
-| Eksen | Sol Uc (1) | Sag Uc (10) | Konum |
-|-------|-----------|-------------|-------|
-| Resmiyet | Resmi, kurumsal | Samimi, arkadasca | [1-10] |
-| Ciddiyet | Ciddi, agirbasli | Eglenceli, sacma | [1-10] |
-| Tekniklik | Teknik, jargonlu | Sade, herkesin anladigi | [1-10] |
-| Cesaret | Guvenli, konservatif | Provokatif, cesur | [1-10] |
-| Uzunluk | Kisa, ozel | Detayli, hikayeci | [1-10] |
-| Enerji | Sakin, olculu | Enerjik, heyecanli | [1-10] |
-| Otorite | Mucevahir, ogenici | Uzman, ogretici | [1-10] |
+## 2. Tone Spectrum (7 axes, 1-10)
+| Axis | Left End (1) | Right End (10) | Position |
+|------|--------------|----------------|----------|
+| Formality | Formal, corporate | Friendly, casual | [1-10] |
+| Seriousness | Serious, solemn | Playful, silly | [1-10] |
+| Technicality | Technical, jargon-heavy | Plain, universally clear | [1-10] |
+| Boldness | Safe, conservative | Provocative, daring | [1-10] |
+| Length | Short, concise | Detailed, narrative | [1-10] |
+| Energy | Calm, measured | Energetic, excited | [1-10] |
+| Authority | Modest, learning | Expert, teaching | [1-10] |
 
-Her konum icin kisa aciklama.
+A short note for each position.
 
-## 3. Dil Kurallari
-**Hitap:** Sen / Siz / Degisken (platforma gore) -- Biz / Marka adi (3. tekil) / Ben (kisisel marka)
+## 3. Language Rules
+**Address:** informal you / formal you / variable (per platform) -- We / Brand name (3rd person) / I (personal brand)
 
-**Kullanilacak kelimeler:** marka ile ozdeslesmesi gereken 10-15 kelime (ornek: "basit, guclu, ozgur, cesur, net, hizli") -- sektorel terim (kullanilacaksa) -- ...
+**Words to use:** 10-15 words the brand should own (example: "simple, powerful, free, bold, clear, fast") -- sector terms (if used) -- ...
 
-**Kacinilacak:** rakip terim/marka adi -- klise ("dunya lideri, en iyi, bir numara, devrim niteliginde") -- jargon (hedef kitle teknik degilse) -- ...
+**Words to avoid:** competitor terms/brand names -- cliches ("world leader, the best, number one, revolutionary") -- jargon (if the audience is non-technical) -- ...
 
-**Emoji Politikasi:**
-| Platform | Kullanim | Oneri |
-|----------|----------|-------|
-| Instagram | Serbest/Orta/Kisitli | [tercih 5-10] |
-| Twitter/X | Serbest/Orta/Kisitli | [tercih] |
-| LinkedIn | Kisitli/Minimal | [sadece profesyonel] |
-| TikTok | Serbest | [trend] |
-| E-posta | Kisitli/Yok | [varsa secilmis] |
+**Emoji Policy:**
+| Platform | Usage | Suggestion |
+|----------|-------|------------|
+| Instagram | Free/Medium/Limited | [preference 5-10] |
+| Twitter/X | Free/Medium/Limited | [preference] |
+| LinkedIn | Limited/Minimal | [professional only] |
+| TikTok | Free | [trends] |
+| Email | Limited/None | [curated if any] |
 
-**Noktalama:** unlem (serbest/sinirli-cumle basina 1/yok) -- buyuk harf (baslik/vurgu/hic) -- uc nokta (serbest/sinirli/yok) -- ...
+**Punctuation:** exclamation marks (free/limited-1 per sentence/none) -- capitals (headings/emphasis/never) -- ellipsis (free/limited/none) -- ...
 
-## 4. Platform Adaptasyonu (her platform icin ton kaymasi)
-- **Instagram:** ton kaymasi [+/-] -- gorsel oncelikli, metin destekleyici -- Story samimi, post duzenli -- ...
-- **Twitter/X:** ton kaymasi [+/-] -- daha keskin, cesur -- tartismaya acik, gorus bildiren -- ...
-- **LinkedIn:** ton kaymasi [+/-] -- profesyonel, olculu -- deger odakli, deneyim paylasan -- ...
-- **TikTok:** ton kaymasi [+/-] -- daha genc, trend -- konusma dili, dogal -- ...
-- **YouTube:** ton kaymasi [+/-] -- detayli, ogretici -- kisisel baglanti onemli -- ...
-- **E-posta:** ton kaymasi [+/-] -- konu satiri merak uyandirici (spam degil) -- govde degerli/saygili, net CTA
+## 4. Platform Adaptation (tone shift per platform)
+- **Instagram:** tone shift [+/-] -- visual first, copy supporting -- Story casual, posts polished -- ...
+- **Twitter/X:** tone shift [+/-] -- sharper, bolder -- open to debate, opinionated -- ...
+- **LinkedIn:** tone shift [+/-] -- professional, measured -- value-driven, experience-sharing -- ...
+- **TikTok:** tone shift [+/-] -- younger, on-trend -- conversational, natural -- ...
+- **YouTube:** tone shift [+/-] -- detailed, instructive -- personal connection matters -- ...
+- **Email:** tone shift [+/-] -- subject line curiosity-driven (not spammy) -- body valuable/respectful, clear CTA
 
-## 5. Ornek Icerikler
+## 5. Example Content
 
-**Iyi Post:** `[marka sesine uyan IG postu]` — Neden: [aciklama]
+**Good Post:** `[an IG post matching the brand voice]` — Why: [explanation]
 
-**Kotu Post:** `[uyumsuz post]` — Neden: [aciklama]
+**Bad Post:** `[a mismatched post]` — Why: [explanation]
 
-**Iyi Thread:** `[Twitter/X thread]`
+**Good Thread:** `[Twitter/X thread]`
 
-**Iyi LinkedIn:** `[LinkedIn post]`
+**Good LinkedIn:** `[LinkedIn post]`
 
-**Kontrol Listesi:** [ ] Hitap dogru -- [ ] Emoji politikasi -- [ ] Kacinilacak kelime yok -- ...
+**Checklist:** [ ] Address style correct -- [ ] Emoji policy followed -- [ ] No avoided words -- ...
 
-## 6. Kaydet ve Entegre Et
-1. `.claude/workspace/marka-sesi.md` yaz
-2. Su komutlar bu dosyayi okur: `/content-generate` (post metni), `/content-visual-brief` (gorsel yonetmenlik), `/content-video-script` (senaryo), `/content-calendar` (tema), `/content-carousel`
-3. Guncelleme tarihi ekle
-4. Versiyon notu (degisiklikte)
+## 6. Save and Integrate
+1. Write `.claude/workspace/marka-sesi.md`
+2. These commands read this file: `/content-generate` (post copy), `/content-visual-brief` (visual direction), `/content-video-script` (scripts), `/content-calendar` (themes), `/content-carousel`
+3. Add the update date
+4. Version note (on change)
 
-# Cikti Formati
+# Output Format
 ```
-[kisaltildi]
+[abridged]
 ```
 
-# Not
-- 3 ayda bir gozden gecir -- yeni ekip uyesine ilk paylasilacak belge -- tutarsizlikta hemen guncelle -- ...
+# Notes
+- Review every 3 months -- the first document to share with a new team member -- update immediately on inconsistency -- ...

--- a/.claude/commands-vault/content-calendar.md
+++ b/.claude/commands-vault/content-calendar.md
@@ -1,82 +1,82 @@
 Content calendar command. Creates a weekly or monthly social media content plan with themes, platforms, and timing.
 
-# Gerekli Araclar
-- Read (marka sesi, mevcut takvim, proje baglami) -- Write (takvim dosyasi) -- Grep (onceki icerik taramasi) -- ...
+# Required Tools
+- Read (brand voice, current calendar, project context) -- Write (calendar file) -- Grep (previous content scan) -- ...
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-## 1. Takvim Parametreleri
-- **Donem:** Bu hafta / Gelecek hafta / Bu ay / Gelecek ay / Ozel aralik
-- **Platformlar:** [ ] Instagram (Post/Story/Reel) [ ] Twitter-X [ ] LinkedIn [ ] TikTok / ...
-- **Siklik:** her platform icin haftalik kac icerik (IG Post/Story/Reel, Twitter, ...)
-- **Temalar:** ana tema -- kampanya/lansman (varsa) -- mevsimsel -- evergreen
-- **Hedef:** Buyume / Etkilesim / Satis / Bilinirlik / Trafik
-- **Kaynaklar:** blog yazilari -- urun gorselleri -- musteri yorum/referans -- etkinlik takvimi -- ...
-- **Ozel Gunler:** milli/dini bayramlar -- sektor etkinlikleri -- marka yildonumleri -- urun lansmanlari
+## 1. Calendar Parameters
+- **Period:** This week / Next week / This month / Next month / Custom range
+- **Platforms:** [ ] Instagram (Post/Story/Reel) [ ] Twitter-X [ ] LinkedIn [ ] TikTok / ...
+- **Frequency:** weekly content count per platform (IG Post/Story/Reel, Twitter, ...)
+- **Themes:** main theme -- campaign/launch (if any) -- seasonal -- evergreen
+- **Goal:** Growth / Engagement / Sales / Awareness / Traffic
+- **Resources:** blog posts -- product visuals -- customer reviews/testimonials -- event calendar -- ...
+- **Special Days:** national/religious holidays -- industry events -- brand anniversaries -- product launches
 
-## 2. Tema Haritasi
-| Gun | Tema | Icerik Turu | Enerji |
-|-----|------|-------------|--------|
-| Pazartesi | Motivasyon/Hafta Basli | Ilham, hedef | Yuksek |
-| Sali | Egitici/Ipucu | Tutorial, nasil yapilir | Orta |
-| Carsamba | Perde Arkasi/Topluluk | Gunluk rutin, ekip, surec | Samimi |
-| Persembe | Urun/Hizmet | Tanitim, ozellik, demo | Satis |
-| Cuma | Eglence/Trend | Meme, challenge, trend ses | Eglenceli |
-| Cumartesi | UGC/Sosyal Kanit | Musteri hikayesi, referans | Guvenilir |
-| Pazar | Ilham/Yansitma | Haftalik ozet, gelecek teaser | Dusunceli |
+## 2. Theme Map
+| Day | Theme | Content Type | Energy |
+|-----|-------|--------------|--------|
+| Monday | Motivation/Week Start | Inspiration, goals | High |
+| Tuesday | Educational/Tips | Tutorials, how-tos | Medium |
+| Wednesday | Behind the Scenes/Community | Daily routine, team, process | Casual |
+| Thursday | Product/Service | Promotion, features, demo | Sales |
+| Friday | Fun/Trends | Memes, challenges, trending sounds | Playful |
+| Saturday | UGC/Social Proof | Customer stories, testimonials | Trustworthy |
+| Sunday | Inspiration/Reflection | Weekly recap, upcoming teaser | Thoughtful |
 
-Uyarlama:
-- E-ticaret: Per → yeni urun, Cum → flash indirim
-- SaaS: Sal → ozellik spotlight, Per → kullanim ipucu
-- Kisisel marka: Pzt → dusunce liderligi, Car → kisisel hikaye -- ...
+Adaptations:
+- E-commerce: Thu → new product, Fri → flash sale
+- SaaS: Tue → feature spotlight, Thu → usage tip
+- Personal brand: Mon → thought leadership, Wed → personal story -- ...
 
-## 3. Icerik Matrisi
-| Tarih | Gun | Platform | Format | Tema | Konu Ozeti | CTA | Durum |
-|-------|-----|----------|--------|------|-----------|-----|-------|
-| [tarih] | Pzt | IG Post | Karousel (5) | Egitici | [konu] | Kaydet | Planli |
-| [tarih] | Pzt | Twitter | Thread (5) | Egitici | [konu] | RT | Planli |
-| [tarih] | Pzt | IG Story | Anket | Topluluk | [soru] | Oy ver | Planli |
-| [tarih] | Sal | IG Reel | 30s video | Ipucu | [konu] | Takip et | Planli |
-| [tarih] | Sal | LinkedIn | Post | Dusunce | [konu] | Yorum yap | Planli |
+## 3. Content Matrix
+| Date | Day | Platform | Format | Theme | Topic Summary | CTA | Status |
+|------|-----|----------|--------|-------|---------------|-----|--------|
+| [date] | Mon | IG Post | Carousel (5) | Educational | [topic] | Save | Planned |
+| [date] | Mon | Twitter | Thread (5) | Educational | [topic] | RT | Planned |
+| [date] | Mon | IG Story | Poll | Community | [question] | Vote | Planned |
+| [date] | Tue | IG Reel | 30s video | Tip | [topic] | Follow | Planned |
+| [date] | Tue | LinkedIn | Post | Thought | [topic] | Comment | Planned |
 | ... | ... | ... | ... | ... | ... | ... | ... |
 
-Format secimi: tek gorsel (hizli mesaj, alistilar, duyuru) -- karousel (egitici, liste, adim) -- video/reel (demo, ipucu, trend, perde arkasi) -- ...
+Format selection: single visual (quick message, habits, announcements) -- carousel (educational, lists, steps) -- video/reel (demos, tips, trends, behind the scenes) -- ...
 
-## 4. Her Icerik Icin Kisa Brief
+## 4. Short Brief per Content Item
 ```
-[kisaltildi]
-```
-
-## 5. Ozel Gun ve Kampanya Entegrasyonu
-**Takvim Isaretleri:** `[tarih]: [ozel gun] — [planlanan icerik]` / `[tarih]: [kampanya basla] — [hazirlik]` / `[tarih]: [kampanya bit] — [ozet]`
-
-**Kampanya Icerikleri (varsa):** oncesi teaser (tarih araligi) -- lansman gunu (tarih + ozel plan) -- sure (tarih araligi + gunluk akis) -- ...
-
-**Sezonsal:** mevsim degisikligi -- bayram/tatil -- sektor etkinlikleri -- ...
-
-## 6. Kaydet ve Izleme
-1. `.claude/workspace/takvim/` kontrol/olustur
-2. `[YYYY-MM]-icerik-takvimi.md` olustur
-3. Performans kolonlari ekle (sonradan doldurulacak): etkilesim (begeni/yorum/paylas), erisim, tiklama, donusum, not
-
-# Cikti Formati
-```
-[kisaltildi]
+[abridged]
 ```
 
-# Icerik Dagiliim Rehberi (80/20)
-| Tur | Oran | Amac |
-|-----|------|------|
-| Deger (egitici, ilham, eglence) | %80 | Guven ve otorite |
-| Satis (tanitim, CTA, teklif) | %20 | Donusum ve gelir |
+## 5. Special Day and Campaign Integration
+**Calendar Markers:** `[date]: [special day] — [planned content]` / `[date]: [campaign start] — [preparation]` / `[date]: [campaign end] — [recap]`
 
-| Format | Oran | Neden |
-|--------|------|-------|
-| Karousel | %30 | En yuksek kaydetme |
-| Reel/Video | %30 | En yuksek erisim |
-| Tek gorsel | %20 | Hizli tuketim, bilinirlik |
-| Story | %15 | Gunluk etkilesim, yakinlik |
-| Canli yayin | %5 | Derin baglanti, Q&A |
+**Campaign Content (if any):** pre-launch teasers (date range) -- launch day (date + special plan) -- duration (date range + daily flow) -- ...
 
-# Ipuclari
-- Esnek tut — gundeme gore %20 spontane pay -- her hafta en az 1 "kaydet" odakli (egitici/liste) -- platformlar arasi uyarlama yap, birebir kopyalama -- ...
+**Seasonal:** season change -- holidays -- industry events -- ...
+
+## 6. Save and Track
+1. Check/create `.claude/workspace/takvim/`
+2. Create `[YYYY-MM]-icerik-takvimi.md`
+3. Add performance columns (filled later): engagement (likes/comments/shares), reach, clicks, conversion, notes
+
+# Output Format
+```
+[abridged]
+```
+
+# Content Distribution Guide (80/20)
+| Type | Ratio | Purpose |
+|------|-------|---------|
+| Value (educational, inspiration, fun) | 80% | Trust and authority |
+| Sales (promos, CTA, offers) | 20% | Conversion and revenue |
+
+| Format | Ratio | Why |
+|--------|-------|-----|
+| Carousel | 30% | Highest saves |
+| Reel/Video | 30% | Highest reach |
+| Single visual | 20% | Quick consumption, awareness |
+| Story | 15% | Daily engagement, closeness |
+| Live | 5% | Deep connection, Q&A |
+
+# Tips
+- Stay flexible — keep a 20% spontaneous share for current events -- at least 1 "save"-focused piece per week (educational/list) -- adapt across platforms, no verbatim copying -- ...

--- a/.claude/commands-vault/content-carousel.md
+++ b/.claude/commands-vault/content-carousel.md
@@ -1,77 +1,77 @@
 Carousel (multi-frame) content command. Produces educational or storytelling carousel content for Instagram, LinkedIn, and other platforms.
 
-# Gerekli Araclar
-- Read (marka sesi, konu, onceki icerikler) -- Write (karousel dosyasi) -- Grep (ilgili icerik) -- ...
+# Required Tools
+- Read (brand voice, topic, previous content) -- Write (carousel file) -- Grep (related content) -- ...
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-## 1. Karousel Bilgileri
-- **Platform:** Instagram / LinkedIn / Twitter (thread uyarlama) / Facebook / Diger
-- **Konu:** detay
-- **Amac:** Egitici (ipucu, adim) / Hikaye (deneyim, musteri) / Liste (X sey, X neden, X hata) / Karsilastirma (A vs B, oncesi/sonrasi) / ...
-- **Kare Sayisi:** 5-10 (varsayilan 7)
-- **Ton:** Samimi / Profesyonel / Eglenceli / Ilham / Teknik
-- **Gorsel Stil:** Temiz/Minimalist (beyaz alan) / Renkli-Bold (canli, buyuk tipografi) / Fotografik (foto + overlay) / Illustratif (cizim, ikon) / ...
+## 1. Carousel Details
+- **Platform:** Instagram / LinkedIn / Twitter (thread adaptation) / Facebook / Other
+- **Topic:** detail
+- **Purpose:** Educational (tips, steps) / Story (experience, customer) / List (X things, X reasons, X mistakes) / Comparison (A vs B, before/after) / ...
+- **Frame Count:** 5-10 (default 7)
+- **Tone:** Friendly / Professional / Fun / Inspirational / Technical
+- **Visual Style:** Clean/Minimalist (white space) / Colorful-Bold (vivid, large typography) / Photographic (photo + overlay) / Illustrative (drawings, icons) / ...
 
-## 2. Akis Yapisi
+## 2. Flow Structures
 
-**Egitici:** `Kare 1: KAPAK (dikkat + "Kaydet!" CTA) | Kare 2: GIRIS (problem/baglam) | Kare 3-N: ICERIK (her karede 1 ipucu) | Son: OZET + CTA (Takip/Kaydet/Paylas)`
+**Educational:** `Frame 1: COVER (attention + "Save!" CTA) | Frame 2: INTRO (problem/context) | Frames 3-N: CONTENT (1 tip per frame) | Last: SUMMARY + CTA (Follow/Save/Share)`
 
-**Hikaye:** `Kare 1: KAPAK (merak) | Kare 2: BASLANGIC (durum/problem) | Kare 3-N: GELISIM | Son-1: SONUC (ders) | Son: CTA ("Sana da oldu mu?")`
+**Story:** `Frame 1: COVER (curiosity) | Frame 2: SETUP (situation/problem) | Frames 3-N: DEVELOPMENT | Last-1: OUTCOME (lesson) | Last: CTA ("Has it happened to you?")`
 
-**Liste:** `Kare 1: KAPAK ("[Sayi] [konu]") | Kare 2-N: MADDELER (1-2 madde/kare) | Son: BONUS + CTA (Kaydet)`
+**List:** `Frame 1: COVER ("[Number] [topic]") | Frames 2-N: ITEMS (1-2 items/frame) | Last: BONUS + CTA (Save)`
 
-**Karsilastirma:** `Kare 1: KAPAK ("A vs B" / "Yapma/Yap") | Kare 2-N: sol-sag veya oncesi-sonrasi | Son: SONUC + CTA`
+**Comparison:** `Frame 1: COVER ("A vs B" / "Don't/Do") | Frames 2-N: left-right or before-after | Last: CONCLUSION + CTA`
 
-**Soru-Cevap:** `Kare 1: KAPAK ("En cok sorulan X soru") | Kare 2-N: 1 soru+cevap/kare | Son: CTA ("DM at")`
+**Q&A:** `Frame 1: COVER ("The X most-asked questions") | Frames 2-N: 1 question+answer per frame | Last: CTA ("DM me")`
 
-## 3. Her Kare Icerigi
-- **Metin:** Baslik (kisa, vurgulu, maks 8 kelime) -- Govde (2-4 cumle veya 3-5 madde) -- Vurgu (bold/renk) -- ...
-- **Tasarim:** Arka plan rengi/gorseli -- metin konumu (ust/orta/alt, sol/sag/orta) -- font boyut hiyerarsisi (baslik>govde>not) -- ...
-- **Okunabilirlik:** Baslik 2s okunabilir mi -- govde 5s -- metin/arka plan kontrasti -- ...
+## 3. Per-Frame Content
+- **Copy:** Heading (short, punchy, max 8 words) -- Body (2-4 sentences or 3-5 bullets) -- Emphasis (bold/color) -- ...
+- **Design:** Background color/image -- text position (top/middle/bottom, left/right/center) -- font size hierarchy (heading>body>note) -- ...
+- **Readability:** Heading readable in 2s -- body in 5s -- text/background contrast -- ...
 
-## 4. Gorsel Tutarlilik
-- **Tutarli ogeler:** ayni renk paleti (hafif varyasyon OK) -- ayni font ailesi + hiyerarsi -- birincil/ikincil/vurgu rengi tutarli -- ...
-- **Kaydirma motivasyonu:** "Ama en onemlisi..." (kesilme) -- ok isareti (→/↓) -- sayfa numarasi -- ...
+## 4. Visual Consistency
+- **Consistent elements:** same color palette (slight variation OK) -- same font family + hierarchy -- primary/secondary/accent color consistent -- ...
+- **Swipe motivation:** "But the most important one..." (cliffhanger) -- arrow markers (→/↓) -- page numbers -- ...
 
-## 5. Caption ve Gorsel Brief
-**Caption:** ilk satir hook (kesilme noktasi oncesi) -- govde destekleyici bilgi -- CTA (Kaydet/Etiketle/Yorum) -- ...
+## 5. Caption and Visual Brief
+**Caption:** first line is the hook (before the cut-off point) -- body supporting info -- CTA (Save/Tag/Comment) -- ...
 
-**Her Kare Brief:**
+**Per-Frame Brief:**
 ```
-Kare [no]: arka plan [renk/gorsel/gradient] -- metin "[baslik]" + "[govde]" -- konum [ust-orta/orta/alt] -- ...
-```
-
-**Canva/Figma:** sablon boyutu (1080x1080 veya 1080x1350) -- katman sirasi (arka plan → gorsel → metin → logo → numara) -- font (baslik + govde) -- ...
-
-## 6. Kaydet ve Paketle
-1. `.claude/workspace/icerikler/` kontrol
-2. `[YYYY-MM-DD]-karousel-[konu-kebab].md` kaydet
-3. Kullaniciya ozet sun
-
-# Cikti Formati
-```
-[kisaltildi]
+Frame [no]: background [color/image/gradient] -- text "[heading]" + "[body]" -- position [top-center/middle/bottom] -- ...
 ```
 
-# Karousel En Iyi Uygulamalar
-| Kural | Aciklama |
-|-------|----------|
-| 1 Kare = 1 Fikir | Her kare tek mesaj |
-| Ilk kare = %80 basari | Kapak kaydirmayi belirler |
-| 7 kare ideal | 5'ten az sigi, 10'dan fazla yorucu |
-| Kaydir motivasyonu | Her kare sonrakini merak ettirsin |
-| Son kare = CTA | Kaydet, paylas, takip et |
-| Tutarli tasarim | Ayni renk/font/yapi |
-| Okunabilirlik | 3 saniyede okunabilir miktar |
-| Bos alan | Sikis yok, nefes alani |
+**Canva/Figma:** template size (1080x1080 or 1080x1350) -- layer order (background → image → text → logo → number) -- fonts (heading + body) -- ...
 
-# Karousel Turleri ve Performans
-| Tur | Kaydetme | Paylasma | Etkilesim | En Uygun Platform |
-|-----|---------|---------|-----------|-------------------|
-| Egitici | Cok yuksek | Yuksek | Orta | Instagram, LinkedIn |
-| Liste | Yuksek | Orta | Orta | Instagram |
-| Hikaye | Orta | Yuksek | Cok yuksek | Instagram, LinkedIn |
-| Karsilastirma | Yuksek | Orta | Orta | Instagram, Twitter |
-| Adim adim | Cok yuksek | Yuksek | Orta | Instagram, LinkedIn |
-| Motivasyon | Orta | Cok yuksek | Dusuk | Instagram |
+## 6. Save and Package
+1. Check `.claude/workspace/icerikler/`
+2. Save `[YYYY-MM-DD]-carousel-[topic-kebab].md`
+3. Present a summary to the user
+
+# Output Format
+```
+[abridged]
+```
+
+# Carousel Best Practices
+| Rule | Explanation |
+|------|-------------|
+| 1 Frame = 1 Idea | One message per frame |
+| First frame = 80% of success | The cover decides the swipe |
+| 7 frames ideal | Fewer than 5 feels thin, more than 10 tires |
+| Swipe motivation | Each frame should tease the next |
+| Last frame = CTA | Save, share, follow |
+| Consistent design | Same color/font/structure |
+| Readability | Readable within 3 seconds |
+| White space | No crowding, breathing room |
+
+# Carousel Types and Performance
+| Type | Saves | Shares | Engagement | Best Platform |
+|------|-------|--------|------------|---------------|
+| Educational | Very high | High | Medium | Instagram, LinkedIn |
+| List | High | Medium | Medium | Instagram |
+| Story | Medium | High | Very high | Instagram, LinkedIn |
+| Comparison | High | Medium | Medium | Instagram, Twitter |
+| Step-by-step | Very high | High | Medium | Instagram, LinkedIn |
+| Motivation | Medium | Very high | Low | Instagram |

--- a/.claude/commands-vault/content-close.md
+++ b/.claude/commands-vault/content-close.md
@@ -1,143 +1,143 @@
 Content session close command. Summarizes the day's output, prepares for tomorrow, and notes learnings.
 
-# Gerekli Araclar
-- Read (bugunun icerikleri, notlar)
-- Glob (bugun olusturulan dosyalar)
-- Grep (placeholder kontrolu)
-- Write (gunluk not guncelleme)
-- Bash (tarih ve dosya listeleme)
+# Required Tools
+- Read (today's content, notes)
+- Glob (files created today)
+- Grep (placeholder check)
+- Write (daily note update)
+- Bash (date and file listing)
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-### Adim 1: Bugun Uretilenleri Topla
-`.claude/workspace/` altindaki bugun tarihli dosyalari bul:
-- `icerikler/` — Post ve karousel
-- `senaryolar/` — Video
-- `gorseller/` — Gorsel brief
-- `takvim/` — Takvim guncellemeleri
+### Step 1: Collect Today's Output
+Find today's files under `.claude/workspace/`:
+- `icerikler/` — Posts and carousels
+- `senaryolar/` — Videos
+- `gorseller/` — Visual briefs
+- `takvim/` — Calendar updates
 
-Her dosya icin:
-- Dosya adi
-- Icerik turu
-- Tamamlanmis mi? (placeholder var mi?)
-- Hangi platform icin?
+For each file:
+- File name
+- Content type
+- Complete? (any placeholders?)
+- For which platform?
 
-### Adim 2: Tamamlanmislik Kontrolu
-Her taslakta placeholder isaretleri ara:
-- `[...]` (kose parantezli yer tutucular)
+### Step 2: Completion Check
+Look for placeholder markers in every draft:
+- `[...]` (bracketed placeholders)
 - `TODO`, `TBD`, `FIXME`
-- Bos bolumler
+- Empty sections
 
-**Tamamlanan**: Placeholder yok, yayina hazir
-**Kismi**: Bazi yerler dolu, bazilar eksik
-**Taslak**: Cogu yer bos
+**Complete**: No placeholders, publish-ready
+**Partial**: Some parts filled, some missing
+**Draft**: Mostly empty
 
-### Adim 3: Yayinlama Planlamasi
-Tamamlanan icerikler icin yayinlama zamani onerisi:
-- Platform bazli optimal saatler
-- Tema uyumu (gun/saat)
-- Takvime ekleme onerisi
+### Step 3: Publishing Plan
+Suggest publish times for completed content:
+- Platform-optimal hours
+- Theme fit (day/time)
+- Suggestion to add to the calendar
 
 ```
-[Icerik] -> [Platform] -> [Gun] [Saat]
+[Content] -> [Platform] -> [Day] [Time]
 ```
 
-### Adim 4: Yarin Icin Hazirlik
-Yarina hazirlik notu olustur:
-- **Yarin ne var?** Takvimden kontrol et
-- **Tamamlanmayan taslak var mi?** Yarinin ilk isi olsun
-- **Devam eden diziler var mi?** (karousel serisi, video serisi)
-- **Trend firsat var mi?** (guncel olay, ozel gun)
+### Step 4: Prepare for Tomorrow
+Create a prep note for tomorrow:
+- **What's on tomorrow?** Check the calendar
+- **Any unfinished drafts?** Make them tomorrow's first job
+- **Any ongoing series?** (carousel series, video series)
+- **Any trend opportunities?** (current events, special days)
 
-### Adim 5: Ogrenilenler ve Notlar
-Bugun cikan icgoruleri not et:
-- **Ne iyi gitti?** (kolay yaratilan icerikler)
-- **Ne zor geldi?** (takildigin yerler)
-- **Yeni fikir dogdugu var mi?** (gelecek kullanim icin)
-- **Marka sesinde duzeltme gerekli mi?**
+### Step 5: Learnings and Notes
+Note today's insights:
+- **What went well?** (content that came easily)
+- **What was hard?** (where you got stuck)
+- **Any new ideas born?** (for future use)
+- **Does the brand voice need a correction?**
 
-Ogrenilenler `knowledge-nominations.md` dosyasina aday olarak eklenebilir.
+Learnings can be nominated into `knowledge-nominations.md`.
 
-### Adim 6: Seans Notunu Kapat
-`.claude/workspace/icerik-notlari/[tarih].md` dosyasini guncelle:
+### Step 6: Close the Session Note
+Update `.claude/workspace/icerik-notlari/[date].md`:
 
 ```markdown
-# Icerik Notlari — [tarih]
+# Content Notes — [date]
 
-## Bugunki Oncelik
-[sabah belirlenen oncelik]
+## Today's Priority
+[the priority set in the morning]
 
-## Tamamlananlar
-- [x] [icerik 1] — [platform]
-- [x] [icerik 2] — [platform]
+## Completed
+- [x] [content 1] — [platform]
+- [x] [content 2] — [platform]
 
-## Kismi Tamamlananlar
-- [ ] [icerik 3] — [neyin eksik]
+## Partially Completed
+- [ ] [content 3] — [what's missing]
 
-## Fikirler / Notlar
-- [yeni fikir]
-- [ogrenilen]
+## Ideas / Notes
+- [new idea]
+- [learning]
 
-## Yarin Icin
-- [ ] [oncelik 1]
-- [ ] [oncelik 2]
+## For Tomorrow
+- [ ] [priority 1]
+- [ ] [priority 2]
 
-## Performans Notlari
-[varsa rakamlar]
+## Performance Notes
+[numbers if any]
 ```
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI ICERIK KAPANIS ===
-Tarih: [tarih]
-Sure: [tahmini calisma suresi]
+=== BADI CONTENT CLOSE ===
+Date: [date]
+Duration: [estimated working time]
 
 -------------------------------------------
-BUGUN URETILENLER
+PRODUCED TODAY
 -------------------------------------------
-Tamamlanan: [sayi]
-Kismi: [sayi]
-Taslak: [sayi]
-Toplam: [sayi]
+Complete: [count]
+Partial: [count]
+Draft: [count]
+Total: [count]
 
 -------------------------------------------
-DETAY LISTE
+DETAIL LIST
 -------------------------------------------
-TAMAMLANAN:
-  + [dosya 1] ([platform])
-  + [dosya 2] ([platform])
+COMPLETE:
+  + [file 1] ([platform])
+  + [file 2] ([platform])
 
-KISMI:
-  ~ [dosya 3] ([eksik neleri])
-
--------------------------------------------
-YAYINLAMA ONERILERI
--------------------------------------------
-| Icerik | Platform | Onerilen Zaman |
-|--------|----------|----------------|
+PARTIAL:
+  ~ [file 3] ([what's missing])
 
 -------------------------------------------
-YARIN IÇIN
+PUBLISHING SUGGESTIONS
 -------------------------------------------
-Oncelikler:
-1. [kismi tamamlanan bitir]
-2. [takvim planli icerik]
-3. [yeni fikir]
+| Content | Platform | Suggested Time |
+|---------|----------|----------------|
 
 -------------------------------------------
-OGRENILENLER
+FOR TOMORROW
 -------------------------------------------
-- [not 1]
-- [not 2]
+Priorities:
+1. [finish the partial one]
+2. [calendar-planned content]
+3. [new idea]
 
 -------------------------------------------
-SEANS NOTU
+LEARNINGS
 -------------------------------------------
-Dosya: .claude/workspace/icerik-notlari/[tarih].md
+- [note 1]
+- [note 2]
+
+-------------------------------------------
+SESSION NOTE
+-------------------------------------------
+File: .claude/workspace/icerik-notlari/[date].md
 ============================
 ```
 
-# Ne Zaman Kullanilir
-- Her gun icerik uretimi bitince (aksam rituelu)
-- Batch uretim seansi sonunda
-- Hafta sonu haftalik kapanis icin
+# When to Use
+- Every day when content production ends (evening ritual)
+- At the end of a batch production session
+- For the weekly close on weekends

--- a/.claude/commands-vault/content-generate.md
+++ b/.claude/commands-vault/content-generate.md
@@ -1,73 +1,73 @@
 Social media content generation command. Produces ready-to-use posts, captions, visual briefs, and hashtags for the given platform and type.
 
-# Gerekli Araclar
-- Read (marka sesi, onceki icerikler, proje baglami) -- Write (icerik dosyasi) -- Grep (onceki icerik taramasi) -- ...
+# Required Tools
+- Read (brand voice, previous content, project context) -- Write (content file) -- Grep (previous content scan) -- ...
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-## 1. Girdi Topla
-- **Platform:** Instagram / Twitter-X / LinkedIn / TikTok / YouTube / Facebook / Hepsi
-- **Tur:** Bilgilendirici (ipucu, liste, nasil) / Ilham (motivasyon, basari) / Eglence (meme, trend) / Satis (urun, indirim, lansman) / ...
-- **Konu/Mesaj:** detay
-- **Ton:** Samimi / Profesyonel / Eglenceli / Ilham / Provokatif / Minimal
-- **Gorsel brief isteniyor mu?** (evet/hayir) -- ...
+## 1. Gather Input
+- **Platform:** Instagram / Twitter-X / LinkedIn / TikTok / YouTube / Facebook / All
+- **Type:** Informative (tips, lists, how-tos) / Inspirational (motivation, success) / Entertainment (memes, trends) / Sales (product, discount, launch) / ...
+- **Topic/Message:** detail
+- **Tone:** Friendly / Professional / Fun / Inspirational / Provocative / Minimal
+- **Visual brief wanted?** (yes/no) -- ...
 
-## 2. Marka Baglami
-**Zorunlu:** `.claude/workspace/marka-sesi.md` (ton, hitap, emoji politikasi) -- `memory.md` (kampanya/lansman/proje)
+## 2. Brand Context
+**Mandatory:** `.claude/workspace/marka-sesi.md` (tone, address style, emoji policy) -- `memory.md` (campaign/launch/project)
 
-**Opsiyonel:** `.claude/workspace/icerikler/` (son 5, tekrar onleme) -- `.claude/workspace/takvim/` (zamanlama uyumu) -- `knowledge-base.md` (kacinilacak ifadeler, kurallar)
+**Optional:** `.claude/workspace/icerikler/` (last 5, repeat prevention) -- `.claude/workspace/takvim/` (timing fit) -- `knowledge-base.md` (phrases to avoid, rules)
 
-Marka sesi yoksa `/content-brand-voice` onerirken zorunlu tutma.
+If no brand voice exists, suggest `/content-brand-voice` without making it mandatory.
 
-## 3. Platform Kurallari
+## 3. Platform Rules
 
-**Instagram:** Post maks 2200 karakter (ilk 125 kritik, kesilme noktasi) -- hashtag 20-30 (nis+genel, ilk yoruma da OK) -- gorsel 1080x1080 veya 1080x1350 -- ...
+**Instagram:** post max 2200 chars (first 125 critical, cut-off point) -- hashtags 20-30 (niche+general, first comment also OK) -- visuals 1080x1080 or 1080x1350 -- ...
 
-**Twitter/X:** maks 280 karakter (thread'de her tweet ayri) -- thread: 1/ ana mesaj, 2-N/ destek, son/ CTA -- hashtag 1-3 (fazlasi spam) -- ...
+**Twitter/X:** max 280 chars (each tweet in a thread separate) -- thread: 1/ main message, 2-N/ support, last/ CTA -- hashtags 1-3 (more reads as spam) -- ...
 
-**LinkedIn:** maks 3000 karakter (ilk 210 "daha fazla" oncesi) -- ton profesyonel + insani, kisisel deneyim -- hashtag 3-5 (sektorel) -- ...
+**LinkedIn:** max 3000 chars (first 210 before "see more") -- tone professional + human, personal experience -- hashtags 3-5 (sector) -- ...
 
-**TikTok:** caption maks 2200 (kisa tut) -- video oncelikli, metin destekleyici -- hashtag 3-5 (trend + nis) -- ...
+**TikTok:** caption max 2200 (keep it short) -- video first, text supporting -- hashtags 3-5 (trend + niche) -- ...
 
-**YouTube:** baslik maks 100 karakter (anahtar kelime) -- aciklama 5000 karakter (ilk 2-3 satir SEO kritik) -- etiket 10-15 -- ...
+**YouTube:** title max 100 chars (keyword) -- description 5000 chars (first 2-3 lines SEO-critical) -- tags 10-15 -- ...
 
-**Facebook:** post 63,206 limit ama optimal 40-80 kelime -- soru sormak etkilesimi artirir -- link aciklamasi kisa-net
+**Facebook:** post limit 63,206 but optimal 40-80 words -- asking a question lifts engagement -- link description short and clear
 
-## 4. Icerik Varyasyonlari (3 yaklasim)
+## 4. Content Variations (3 approaches)
 
-**A — Dogrudan Deger:** net acik mesaj -- hemen fayda -- "Iste X yapmanin Y yolu..."
+**A — Direct Value:** clear open message -- immediate benefit -- "Here are Y ways to do X..."
 
-**B — Hikaye:** kisisel deneyim/senaryo ile basla -- duygu baglantisi -- "Gecen hafta X yasadim ve..."
+**B — Story:** open with personal experience/scenario -- emotional connection -- "Last week I experienced X and..."
 
-**C — Soru/Merak:** soru/sasirtici iddia ile ac -- merak boslugu -- "Cogu kisi X'i yanlis yapiyor. Iste nedeni..."
+**C — Question/Curiosity:** open with a question/surprising claim -- curiosity gap -- "Most people do X wrong. Here's why..."
 
-Her varyasyon icin: tam metin (kopyala-yapistir hazir) -- platform hashtag listesi -- CTA -- ...
+For each variation: full copy (copy-paste ready) -- platform hashtag list -- CTA -- ...
 
-## 5. Gorsel Brief (istenildiyse)
-Her varyasyon icin: **Aciklama** (obje/sahne/duygu) -- **Boyut** (1080x1080, 1080x1350, 1920x1080 vb.) -- **Stil** (Fotografik/Minimalist/Illustrasyon/Tipografik/Collage) -- ...
+## 5. Visual Brief (if requested)
+For each variation: **Description** (object/scene/emotion) -- **Size** (1080x1080, 1080x1350, 1920x1080 etc.) -- **Style** (Photographic/Minimalist/Illustration/Typographic/Collage) -- ...
 
-## 6. Paketle ve Kaydet
-1. `.claude/workspace/icerikler/` kontrol/olustur
-2. `[YYYY-MM-DD]-[konu-kebab].md` olustur
-3. Varyasyon + brief + metadata tek dosyaya yaz
-4. Ozet sun
+## 6. Package and Save
+1. Check/create `.claude/workspace/icerikler/`
+2. Create `[YYYY-MM-DD]-[topic-kebab].md`
+3. Write variations + brief + metadata into one file
+4. Present a summary
 
-# Cikti Formati
+# Output Format
 ```
-[kisaltildi]
+[abridged]
 ```
 
-# Zamanlama Rehberi
-| Platform | En Iyi Gunler | En Iyi Saatler | Neden |
-|----------|--------------|----------------|-------|
-| Instagram | Sal, Per | 11:00-13:00, 19:00-21:00 | Oglen molasi ve aksam bos zamani |
-| Twitter/X | Pzt, Car | 09:00-11:00, 13:00-15:00 | Is basi ve oglen sonrasi |
-| LinkedIn | Sal, Car, Per | 08:00-10:00, 17:00-18:00 | Is basi ve cikis |
-| TikTok | Crs, Cum | 19:00-23:00 | Aksam bos zamani |
-| YouTube | Cum, Cts | 14:00-16:00 | Hafta sonu izleme |
-| Facebook | Car, Per | 12:00-15:00 | Oglen ve ogleden sonra |
+# Timing Guide
+| Platform | Best Days | Best Hours | Why |
+|----------|-----------|------------|-----|
+| Instagram | Tue, Thu | 11:00-13:00, 19:00-21:00 | Lunch break and evening downtime |
+| Twitter/X | Mon, Wed | 09:00-11:00, 13:00-15:00 | Work start and post-lunch |
+| LinkedIn | Tue, Wed, Thu | 08:00-10:00, 17:00-18:00 | Work start and end of day |
+| TikTok | Wed, Fri | 19:00-23:00 | Evening downtime |
+| YouTube | Fri, Sat | 14:00-16:00 | Weekend viewing |
+| Facebook | Wed, Thu | 12:00-15:00 | Noon and afternoon |
 
-Not: genel veridir, hedef kitleye gore degisir. Analitik varsa onlara oncelik.
+Note: general data; varies with the target audience. Prioritize analytics when available.
 
-# Ipuclari
-- Coklu platformda her birine ozel uyarla (kopyalama yok) -- hashtag: %30 buyuk (100K+), %50 orta (10K-100K), %20 nis (<10K) -- her 5'inden 1'i satis odakli (80/20) -- ...
+# Tips
+- On multi-platform, adapt for each one (no copy-paste) -- hashtags: 30% large (100K+), 50% medium (10K-100K), 20% niche (<10K) -- 1 in 5 sales-focused (80/20) -- ...

--- a/.claude/commands-vault/content-idea.md
+++ b/.claude/commands-vault/content-idea.md
@@ -1,128 +1,128 @@
 Content idea generation command. Creates a structured idea list for a topic, theme, or platform.
 
-# Gerekli Araclar
-- Read (marka sesi, gecmis icerikler, trend notlari)
-- Grep (tekrar kontrol)
-- Glob (arsiv tarama)
-- Bash (trend verisi, zaman)
+# Required Tools
+- Read (brand voice, past content, trend notes)
+- Grep (repeat check)
+- Glob (archive scan)
+- Bash (trend data, time)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Fikir Parametreleri
-Kullanicidan:
-- **Konu alani:** Genel tema veya sektor (opsiyonel)
-- **Platform:** Hangi platform icin? (varsa)
-- **Format:** Post / Karousel / Video / Hepsi
-- **Ton:** Marka sesi ile uyumlu olmali (otomatik)
-- **Adet:** Kac fikir? (varsayilan: 10)
-- **Amac:** Etkilesim / Satis / Bilinirlik / Egitim
+### Step 1: Idea Parameters
+From the user:
+- **Topic area:** General theme or sector (optional)
+- **Platform:** For which platform? (if any)
+- **Format:** Post / Carousel / Video / All
+- **Tone:** Must match the brand voice (automatic)
+- **Count:** How many ideas? (default: 10)
+- **Goal:** Engagement / Sales / Awareness / Education
 
-### Adim 2: Kaynak Taramasi
-Fikir kaynaklarindan besleme yap:
+### Step 2: Source Scan
+Feed from idea sources:
 
-**Ic kaynaklar:**
-- Son 30 gun uretilen icerikler (tekrar onleme)
-- Bekleyen taslaklar (gelistirilebilir)
-- Musteri sorulari / SSS
-- Mevcut urun / hizmet listesi
+**Internal sources:**
+- Content produced in the last 30 days (repeat prevention)
+- Pending drafts (improvable)
+- Customer questions / FAQ
+- Current product / service list
 
-**Dis kaynaklar (varsa):**
-- Mevsimsel takvim (ay / hafta bazli)
-- Ozel gunler (dunya X gunu, bayramlar)
-- Sektor trendleri
-- Populer format ornekleri
+**External sources (if available):**
+- Seasonal calendar (month / week)
+- Special days (world X day, holidays)
+- Industry trends
+- Popular format examples
 
-### Adim 3: 10 Fikir Uret
-Farkli aciilar icin kategorize et:
+### Step 3: Generate 10 Ideas
+Categorize by different angles:
 
-**Egitici (3-4 fikir):**
-- Nasil yapilir
-- X ipucu liste
-- Yaygin hata
-- Baslangic kilavuzu
+**Educational (3-4 ideas):**
+- How-to
+- X-tip lists
+- Common mistakes
+- Beginner guides
 
-**Hikaye (2-3 fikir):**
-- Kisisel deneyim
-- Musteri basari hikayesi
-- Perde arkasi
+**Story (2-3 ideas):**
+- Personal experience
+- Customer success story
+- Behind the scenes
 
-**Eglence/Trend (2-3 fikir):**
-- Meme uyarlamasi
-- Trend format
+**Fun/Trend (2-3 ideas):**
+- Meme adaptation
+- Trending format
 - Challenge
 
-**Satis Odakli (1-2 fikir):**
-- Urun tanitim
-- Indirim duyurusu
-- Vaka calismasi
+**Sales-Focused (1-2 ideas):**
+- Product promo
+- Discount announcement
+- Case study
 
-### Adim 4: Her Fikir Icin Hizli Brief
-Her fikir icin mini ozet:
+### Step 4: Quick Brief per Idea
+A mini summary for each idea:
 ```
-[numara]. [Platform] — [Format] — [Baslik]
-   Ton: [ton]
-   Hook: [ilk cumle fikri]
-   Mesaj: [tek cumle ozet]
-   CTA: [onerilen cagri]
-   Etki: [DUSUK / ORTA / YUKSEK]
-   Efor: [DUSUK / ORTA / YUKSEK]
+[number]. [Platform] — [Format] — [Title]
+   Tone: [tone]
+   Hook: [first-sentence idea]
+   Message: [one-sentence summary]
+   CTA: [suggested call]
+   Impact: [LOW / MEDIUM / HIGH]
+   Effort: [LOW / MEDIUM / HIGH]
 ```
 
-### Adim 5: Oncelik Oneri
-Etki/Efor oranina gore siralama yap:
-- **Hizli Kazanc** (Yuksek etki, dusuk efor) — Bugun yap
-- **Stratejik** (Yuksek etki, yuksek efor) — Planla
-- **Dolgu** (Dusuk etki, dusuk efor) — Firsat ciktiginda
-- **Kacin** (Dusuk etki, yuksek efor) — Listeden cikar
+### Step 5: Priority Suggestion
+Rank by impact/effort ratio:
+- **Quick Win** (High impact, low effort) — Do today
+- **Strategic** (High impact, high effort) — Plan it
+- **Filler** (Low impact, low effort) — When the chance comes
+- **Avoid** (Low impact, high effort) — Drop from the list
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI ICERIK FIKIRLERI ===
-Tarih: [tarih]
-Konu Alani: [alan]
+=== BADI CONTENT IDEAS ===
+Date: [date]
+Topic Area: [area]
 Platform: [platform]
-Adet: [sayi]
+Count: [number]
 
 -------------------------------------------
-HIZLI KAZANC (Bugun Yap)
+QUICK WINS (Do Today)
 -------------------------------------------
-1. [Platform] [Format]: [baslik]
-   Hook: [cumle]
-   Mesaj: [ozet]
-   CTA: [cagri]
-   Sure: ~[dakika]
+1. [Platform] [Format]: [title]
+   Hook: [sentence]
+   Message: [summary]
+   CTA: [call]
+   Time: ~[minutes]
 
 2. ...
 
 -------------------------------------------
-STRATEJIK (Planla)
+STRATEGIC (Plan)
 -------------------------------------------
-3. [Platform] [Format]: [baslik]
+3. [Platform] [Format]: [title]
    ...
 
 -------------------------------------------
-DOLGU
+FILLER
 -------------------------------------------
 4. ...
 
 -------------------------------------------
-OZEL GUN BAGLANTILARI
+SPECIAL DAY TIE-INS
 -------------------------------------------
-Yaklasan ozel gunler:
-- [tarih]: [etkinlik] -> fikir: [oneri]
+Upcoming special days:
+- [date]: [event] -> idea: [suggestion]
 
 -------------------------------------------
-SONRAKI ADIM
+NEXT STEP
 -------------------------------------------
-Hizli baslangic:
-  badi content post "[secilen fikir]"
-  badi content karousel "[secilen fikir]"
+Quick start:
+  badi content post "[chosen idea]"
+  badi content carousel "[chosen idea]"
   /content-generate
 =============================
 ```
 
-# Ne Zaman Kullanilir
-- Fikir takildiginda (yaratici tikanma)
-- Haftalik planlama oncesi
-- Trend yakalamak icin
-- Uretimi hizlandirmak icin (hazir fikir havuzu)
+# When to Use
+- When stuck for ideas (creative block)
+- Before weekly planning
+- To catch trends
+- To speed up production (a ready idea pool)

--- a/.claude/commands-vault/content-perf.md
+++ b/.claude/commands-vault/content-perf.md
@@ -1,81 +1,81 @@
 Content performance tracking command. Tracks likes, comments, reach, and ROI for published content.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi content perf)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Veri Ekleme
+### Step 1: Add Data
 
-Her yayindan sonra metric'leri kaydet:
+Record the metrics after every publish:
 
 ```bash
-badi content perf add --file 2026-04-19-konu.md \
+badi content perf add --file 2026-04-19-topic.md \
   --platform instagram \
   --likes 150 --comments 12 --shares 5 --saves 20 \
   --reach 2500 \
   --effort 1.5
 ```
 
-Parametreler:
-- `--file` — Icerik dosyasi adi
+Parameters:
+- `--file` — Content file name
 - `--platform` — instagram/twitter/linkedin/tiktok/facebook
-- `--likes/--comments/--shares/--saves/--reach` — Metrikler
-- `--effort` — Uretim suresi (saat)
+- `--likes/--comments/--shares/--saves/--reach` — Metrics
+- `--effort` — Production time (hours)
 
-### Adim 2: Raporlar
+### Step 2: Reports
 
 ```bash
-badi content perf              # Haftalik ozet (varsayilan)
+badi content perf              # Weekly summary (default)
 badi content perf --week
 badi content perf --month
-badi content perf list         # Tum kayitlar
+badi content perf list         # All records
 ```
 
-### Adim 3: Trend Analizi
+### Step 3: Trend Analysis
 
 ```bash
 badi content perf --trend
 ```
 
-Onceki ve mevcut donem karsilastirmasi:
-- Toplam etkilesim degisimi (%)
-- Platform bazli trendler
+Previous vs. current period comparison:
+- Total engagement change (%)
+- Platform-level trends
 
-### Adim 4: ROI Analizi
+### Step 4: ROI Analysis
 
 ```bash
 badi content perf --roi
 ```
 
-Platform bazli Etkilesim/Efor orani. Hangi platform saatinize en cok degiyor?
+Engagement/effort ratio per platform. Which platform pays the most for your hour?
 
-### Adim 5: Platform Filtresi
+### Step 5: Platform Filter
 
 ```bash
 badi content perf --platform instagram --month
 ```
 
-### Adim 6: Yorum + Aksiyon
+### Step 6: Interpretation + Action
 
-Rapor sonuclarina gore kullaniciya:
-- En iyi performans: "Bu formati tekrar deneyelim mi?"
-- Dusuk ROI: "Bu platformda vakit ayirma stratejisi?"
-- Negatif trend: "Icerik karmasi revize edilsin mi?"
+Based on the report, tell the user:
+- Best performer: "Shall we repeat this format?"
+- Low ROI: "Rethink the time investment on this platform?"
+- Negative trend: "Should the content mix be revised?"
 
-### Adim 7: Haftalik Rutin
+### Step 7: Weekly Routine
 
-Perseembe/Cuma akşami haftalik degerlendirme:
+Thursday/Friday evening weekly evaluation:
 ```bash
-badi content perf --trend      # Hafta degerlendir
-badi content plan              # Onumuzdeki hafta planla
+badi content perf --trend      # Evaluate the week
+badi content plan              # Plan next week
 ```
 
-# Ornek
+# Example
 
 ```
-/content-perf                  # Haftalik ozet
-/content-perf --trend          # Trend karsilastirma
-/content-perf --roi            # ROI siralama
+/content-perf                  # Weekly summary
+/content-perf --trend          # Trend comparison
+/content-perf --roi            # ROI ranking
 /content-perf add --file ... --platform linkedin --likes 85 ...
 ```

--- a/.claude/commands-vault/content-plan.md
+++ b/.claude/commands-vault/content-plan.md
@@ -1,136 +1,136 @@
 Weekly content planning session command. Sets next week's content strategy, themes, and production targets.
 
-# Gerekli Araclar
-- Read (marka sesi, gecmis takvim, performans)
-- Write (yeni takvim dosyasi)
-- Grep (gecmis icerik analizi)
-- Glob (dosya arama)
-- Bash (tarih hesaplama)
+# Required Tools
+- Read (brand voice, past calendars, performance)
+- Write (new calendar file)
+- Grep (past content analysis)
+- Glob (file search)
+- Bash (date calculations)
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-### Adim 1: Gecen Hafta Degerlendirmesi
-Son 7 gunun uretim ciktisini analiz et:
-- Kac icerik uretildi? (platform bazli)
-- Hangileri planlanmisti, hangileri spontane?
-- Tamamlanmayan planli icerik var mi?
-- En cok hangi formati uretiyorsun? (post, karousel, video)
+### Step 1: Last Week's Review
+Analyze the last 7 days of production output:
+- How much content was produced? (per platform)
+- Which were planned, which spontaneous?
+- Any planned content left unfinished?
+- Which format do you produce most? (post, carousel, video)
 
-Soru sor:
-- **En iyi 3 icerigin neydi?** (etkilesim veya tatmin bazli)
-- **En zor olani hangisiydi?** (neden zorlandin?)
+Ask:
+- **What were your 3 best pieces?** (by engagement or satisfaction)
+- **Which was the hardest?** (why was it hard?)
 
-### Adim 2: Gelecek Hafta Temalari
-Haftaya ait tema haritasi olustur:
+### Step 2: Next Week's Themes
+Build the week's theme map:
 
-**Veri kaynaklari:**
-- Ozel gunler ve etkinlikler (takvime bak)
-- Mevsimsel firsatlar
-- Gundem konulari (marka uyumlu)
-- Devam eden kampanyalar
-- Musteri sorulari / SSS
+**Data sources:**
+- Special days and events (check the calendar)
+- Seasonal opportunities
+- Current topics (brand-fit)
+- Ongoing campaigns
+- Customer questions / FAQ
 
-Her gun icin 1 ana tema belirle:
+Set 1 main theme per day:
 ```
-Pazartesi: [tema] — [neden]
-Sali: [tema]
+Monday: [theme] — [why]
+Tuesday: [theme]
 ...
 ```
 
-### Adim 3: Platform Dagilimi
-Her platform icin haftalik hedef belirle:
+### Step 3: Platform Distribution
+Set a weekly target per platform:
 
-| Platform | Format | Hedef Sayi | Tema Baglantisi |
-|----------|--------|-----------|-----------------|
+| Platform | Format | Target Count | Theme Link |
+|----------|--------|--------------|------------|
 | Instagram Post | ... | ... | ... |
 | Instagram Reel | ... | ... | ... |
 | Twitter/X | ... | ... | ... |
 | LinkedIn | ... | ... | ... |
 | TikTok | ... | ... | ... |
 
-Not: Platform basina 3-5 icerik yeterli (kalite > kantite).
+Note: 3-5 items per platform is enough (quality > quantity).
 
-### Adim 4: Icerik Matrisini Olustur
-Her gun ve platform icin net planlama:
+### Step 4: Build the Content Matrix
+Clear planning per day and platform:
 
 ```
-Pazartesi:
-  - IG Post: "[konu]" (tema: [tema])
-  - Twitter: thread "[konu]"
+Monday:
+  - IG Post: "[topic]" (theme: [theme])
+  - Twitter: thread "[topic]"
 
-Sali:
-  - IG Reel: 30s "[konu]"
-  - LinkedIn: "[konu]"
+Tuesday:
+  - IG Reel: 30s "[topic]"
+  - LinkedIn: "[topic]"
 
 ...
 ```
 
-### Adim 5: Uretim Baseceli
-Icerikleri ne zaman uretecegini planla:
-- Batch uretim gunu (ornek: Pazartesi sabahi tum hafta)
-- Gunluk uretim (her gun o gunun icerigi)
-- Karma model (onceden hazirlanmis + guncel)
+### Step 5: Production Cadence
+Plan when you will produce the content:
+- Batch production day (example: Monday morning for the whole week)
+- Daily production (each day for that day)
+- Mixed model (prepared ahead + current)
 
-Ipucu: Batch uretim verimlidir, ama guncel icerik dinamik kalir.
+Tip: batch production is efficient, but topical content keeps things dynamic.
 
-### Adim 6: Takvim Dosyasini Kaydet
-`/content-calendar` komutu ile detayli dosyayi olustur veya:
-`badi content calendar "[hafta-tarihi]"` CLI komutunu oner.
+### Step 6: Save the Calendar File
+Create the detailed file with the `/content-calendar` command, or suggest the
+`badi content calendar "[week-date]"` CLI command.
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI ICERIK PLANI ===
-Hafta: [baslangic] - [bitis]
-Tarih: [tarih]
+=== BADI CONTENT PLAN ===
+Week: [start] - [end]
+Date: [date]
 
 -------------------------------------------
-GECEN HAFTA OZETI
+LAST WEEK SUMMARY
 -------------------------------------------
-Uretilen: [sayi] icerik
-Plan uyumu: [yuzde]%
-En iyi: [icerik]
-En zor: [icerik]
+Produced: [count] items
+Plan fit: [percent]%
+Best: [content]
+Hardest: [content]
 
-Ogrenilen: [1-2 madde]
-
--------------------------------------------
-GELECEK HAFTA TEMALARI
--------------------------------------------
-Pzt: [tema]
-Sal: [tema]
-Car: [tema]
-Per: [tema]
-Cum: [tema]
-Cts: [tema]
-Paz: [tema]
+Learned: [1-2 items]
 
 -------------------------------------------
-PLATFORM DAGILIMI
+NEXT WEEK THEMES
 -------------------------------------------
-Toplam hedef: [sayi] icerik
-[tablo]
+Mon: [theme]
+Tue: [theme]
+Wed: [theme]
+Thu: [theme]
+Fri: [theme]
+Sat: [theme]
+Sun: [theme]
 
 -------------------------------------------
-OZEL GUNLER
+PLATFORM DISTRIBUTION
 -------------------------------------------
-[varsa liste, yoksa "yok"]
+Total target: [count] items
+[table]
 
 -------------------------------------------
-URETIM PROGRAMI
+SPECIAL DAYS
 -------------------------------------------
-Batch: [gun/saat]
-Gunluk: [gun/saat]
+[list if any, otherwise "none"]
 
 -------------------------------------------
-SONRAKI ADIM
+PRODUCTION SCHEDULE
 -------------------------------------------
-  badi content calendar "[hafta-tarihi]"
-  veya
-  /content-calendar komutu
+Batch: [day/time]
+Daily: [day/time]
+
+-------------------------------------------
+NEXT STEP
+-------------------------------------------
+  badi content calendar "[week-date]"
+  or
+  the /content-calendar command
 ========================
 ```
 
-# Ne Zaman Kullanilir
-- Pazar aksami veya Pazartesi sabahi (haftalik planlama)
-- Yeni kampanya oncesi
-- Performans dususlerinden sonra yeniden planlama
+# When to Use
+- Sunday evening or Monday morning (weekly planning)
+- Before a new campaign
+- Re-planning after performance dips

--- a/.claude/commands-vault/content-search.md
+++ b/.claude/commands-vault/content-search.md
@@ -1,59 +1,59 @@
 Content archive search command. Keyword search, similarity detection, and filtering across all generated content.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi content search)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Arama Sorgusunu Al
+### Step 1: Get the Search Query
 
-Kullanici sorguyu verir (konu, kelime, hashtag). Kelime yoksa en son icerikleri goster.
+The user provides the query (topic, word, hashtag). With no query, show the most recent content.
 
-### Adim 2: Arama Calistir
-
-```bash
-badi content search "uretkenlik"
-```
-
-Aranacak alanlar:
-- `.claude/workspace/icerikler/` (post, karousel)
-- `.claude/workspace/senaryolar/` (video)
-- `.claude/workspace/gorseller/` (gorsel brief)
-- `.claude/workspace/takvim/` (takvim)
-- `.claude/workspace/sablonlar/` (custom sablon)
-- `marka-sesi.md` (marka sesi)
-
-### Adim 3: Filtreler
+### Step 2: Run the Search
 
 ```bash
-badi content search [sorgu] --platform instagram   # Platform filtresi
-badi content search [sorgu] --tur post             # Tur filtresi
-badi content search [sorgu] --son 30               # Son 30 gun
-badi content search [sorgu] --hashtag urkentlik    # Hashtag
-badi content search [sorgu] --format json          # JSON cikti
+badi content search "productivity"
 ```
 
-### Adim 4: Sonuc Yorumu
+Fields to search:
+- `.claude/workspace/icerikler/` (posts, carousels)
+- `.claude/workspace/senaryolar/` (videos)
+- `.claude/workspace/gorseller/` (visual briefs)
+- `.claude/workspace/takvim/` (calendars)
+- `.claude/workspace/sablonlar/` (custom templates)
+- `marka-sesi.md` (brand voice)
 
-Her sonuc icin:
-- Skor (keyword frekans + guncellik bonusu)
-- Dizin (icerikler, senaryolar, vs)
-- Snippet (eslesen satirin kisa hali)
+### Step 3: Filters
 
-### Adim 5: Benzerlik Uyarisi
+```bash
+badi content search [query] --platform instagram   # Platform filter
+badi content search [query] --type post            # Type filter
+badi content search [query] --last 30              # Last 30 days
+badi content search [query] --hashtag productivity # Hashtag
+badi content search [query] --format json          # JSON output
+```
 
-Kullanici yeni icerik olusturacaksa, ayni konuda %60+ benzerlik varsa uyari. `--force` ile atlanabilir.
+### Step 4: Interpret the Results
 
-### Adim 6: Takip Aksiyonlari
+For each result:
+- Score (keyword frequency + recency bonus)
+- Directory (icerikler, senaryolar, etc.)
+- Snippet (short form of the matching line)
 
-- Tekrarlayan konu tespit: "Farkli acidan yaklasim onerisi verelim mi?"
-- Hic bulunamadiysa: "`/content-generate` ile yeni olusturalim mi?"
-- Eski icerik guncellenebilir: "Bu konuyu guncellemek ister misiniz?"
+### Step 5: Similarity Warning
 
-# Ornek
+If the user is about to create new content and 60%+ similarity exists on the same topic, warn. Skippable with `--force`.
+
+### Step 6: Follow-up Actions
+
+- Recurring topic detected: "Shall we suggest a different angle?"
+- Nothing found: "Shall we create something new with `/content-generate`?"
+- Old content could be refreshed: "Would you like to update this topic?"
+
+# Example
 
 ```
-/content-search "produktivite"
-/content-search "AI" --platform linkedin --son 7
-/content-search "tutorial" --tur video
+/content-search "productivity"
+/content-search "AI" --platform linkedin --last 7
+/content-search "tutorial" --type video
 ```

--- a/.claude/commands-vault/content-start.md
+++ b/.claude/commands-vault/content-start.md
@@ -1,138 +1,138 @@
 Content production session start command. Gives the daily content session a structured start, shows pending work, and sets priorities.
 
-# Gerekli Araclar
-- Read (marka sesi, takvim, mevcut icerikler)
-- Glob (workspace dosyalari)
-- Grep (trend ve kalip aramalari)
-- Bash (tarih ve dosya tarihi)
-- Write (gunluk not)
+# Required Tools
+- Read (brand voice, calendar, existing content)
+- Glob (workspace files)
+- Grep (trend and pattern searches)
+- Bash (date and file dates)
+- Write (daily note)
 
-# Prosedur (7 Adim)
+# Procedure (7 Steps)
 
-### Adim 1: Baglam Yukle
-Su dosyalari oku:
-- `.claude/workspace/marka-sesi.md` — Marka tonu ve kurallari
-- `.claude/workspace/takvim/` — En son icerik takvimi
-- `.claude/workspace/icerikler/` — Son 10 icerik
-- `.claude/workspace/senaryolar/` — Son 5 video senaryosu
-- `memory.md` — Aktif kampanya veya proje
+### Step 1: Load Context
+Read these files:
+- `.claude/workspace/marka-sesi.md` — Brand tone and rules
+- `.claude/workspace/takvim/` — The latest content calendar
+- `.claude/workspace/icerikler/` — Last 10 content items
+- `.claude/workspace/senaryolar/` — Last 5 video scripts
+- `memory.md` — Active campaign or project
 
-Bu dosyalar yoksa kullaniciyi yonlendir:
-- Marka sesi yoksa: `badi content brand` oner
-- Takvim yoksa: `badi content calendar` oner
+If these files do not exist, guide the user:
+- No brand voice: suggest `badi content brand`
+- No calendar: suggest `badi content calendar`
 
-### Adim 2: Bugun Ne Var?
-Takvimde bugun icin planlanmis icerikleri listele:
-- Hangi platformlara post atilacak?
-- Hangi temalar planlanmis?
-- Bekleyen taslak var mi?
+### Step 2: What's On Today?
+List the content planned for today in the calendar:
+- Which platforms get posts?
+- Which themes are planned?
+- Any pending drafts?
 
-Eger bugun icin planli icerik yoksa, haftanin gunune gore tema oner:
-- Pazartesi: Motivasyon / Hafta basligi
-- Sali: Egitici / Ipucu
-- Carsamba: Perde arkasi / Topluluk
-- Persembe: Urun / Hizmet
-- Cuma: Eglence / Trend
-- Cumartesi: UGC / Sosyal kanit
-- Pazar: Ilham / Haftalik ozet
+If nothing is planned for today, suggest a theme by day of week:
+- Monday: Motivation / Week opener
+- Tuesday: Educational / Tips
+- Wednesday: Behind the scenes / Community
+- Thursday: Product / Service
+- Friday: Fun / Trends
+- Saturday: UGC / Social proof
+- Sunday: Inspiration / Weekly recap
 
-### Adim 3: Bekleyen Taslaklar
-`.claude/workspace/icerikler/` ve `.claude/workspace/senaryolar/` icindeki son 7 gunluk dosyalari tara. Her birisi icin:
-- Dosya adi ve tarihi
-- Doldurulmus mu, yoksa hala placeholder'li mi?
-- Hangi platform icin?
+### Step 3: Pending Drafts
+Scan the last 7 days of files in `.claude/workspace/icerikler/` and `.claude/workspace/senaryolar/`. For each:
+- File name and date
+- Filled in, or still holding placeholders?
+- For which platform?
 
-Tamamlanmamis (placeholder iceren) taslaklari on plana cikar.
+Surface the unfinished (placeholder-containing) drafts.
 
-### Adim 4: Son Performans (varsa)
-Eger `.claude/workspace/performans.md` veya benzeri bir takip dosyasi varsa:
-- Gecen hafta en iyi performans gosteren 3 icerik
-- En dusuk performans gosteren 3 icerik
-- Trend notu (artis/azalis)
+### Step 4: Recent Performance (if available)
+If `.claude/workspace/performans.md` or a similar tracking file exists:
+- Last week's 3 best-performing pieces
+- The 3 lowest performers
+- Trend note (rising/falling)
 
-### Adim 5: Fikir Onerileri
-Su kaynaklardan fikir uret:
-- Bu ayki ozel gunler ve etkinlikler
-- Gundem / trend konulari (marka uyumlu olanlar)
-- Evergreen icerik sablonlari
-- Bekleyen SSS veya musteri sorulari
+### Step 5: Idea Suggestions
+Generate ideas from these sources:
+- This month's special days and events
+- Current/trending topics (brand-fit ones)
+- Evergreen content templates
+- Pending FAQ or customer questions
 
-3-5 somut icerik fikri sun:
+Offer 3-5 concrete content ideas:
 ```
-1. [Platform] — [Format] — [Konu]: [neden onemli]
+1. [Platform] — [Format] — [Topic]: [why it matters]
 2. ...
 ```
 
-### Adim 6: Bugunun Onceligi
-Kullaniciya bugun odaklanmasi gereken tek seyi sor veya oner:
-- En kritik icerik (yayin tarihi yaklasmis)
-- En yuksek etkili firsat (trend, ozel gun)
-- En hizli kazanc (hazir taslak tamamlama)
+### Step 6: Today's Priority
+Ask or suggest the single thing to focus on today:
+- The most critical content (publish date approaching)
+- The highest-impact opportunity (trend, special day)
+- The fastest win (finishing a ready draft)
 
-### Adim 7: Seans Notu Baslat
-`.claude/workspace/icerik-notlari/` dizini altinda bugunun gunluk not dosyasini olustur:
+### Step 7: Start the Session Note
+Create today's note file under `.claude/workspace/icerik-notlari/`:
 
 ```
-# Icerik Notlari — [tarih]
+# Content Notes — [date]
 
-## Bugunki Oncelik
-[secilen oncelik]
+## Today's Priority
+[chosen priority]
 
-## Planli Uretimler
-- [ ] [icerik 1]
-- [ ] [icerik 2]
+## Planned Production
+- [ ] [content 1]
+- [ ] [content 2]
 
-## Fikirler / Notlar
+## Ideas / Notes
 - ...
 
-## Tamamlananlar
-(gun icinde doldurulacak)
+## Completed
+(filled during the day)
 ```
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI ICERIK SEANSI ===
-Tarih: [tarih] ([gun adi])
-Marka Sesi: [yuklendi / eksik]
+=== BADI CONTENT SESSION ===
+Date: [date] ([day name])
+Brand Voice: [loaded / missing]
 
 -------------------------------------------
-BUGUN TAKVIMDEN
+FROM TODAY'S CALENDAR
 -------------------------------------------
-[planli icerikler veya "bugun icin planli icerik yok"]
+[planned content or "nothing planned for today"]
 
-Haftanin temasi: [gun bazli tema]
-
--------------------------------------------
-BEKLEYEN TASLAKLAR
--------------------------------------------
-[tamamlanmamis taslak listesi]
-Toplam: [sayi] taslak
+Theme of the day: [day-based theme]
 
 -------------------------------------------
-SON PERFORMANS
+PENDING DRAFTS
 -------------------------------------------
-[varsa ozet, yoksa "veri yok"]
+[unfinished draft list]
+Total: [count] drafts
 
 -------------------------------------------
-FIKIR ONERILERI
+RECENT PERFORMANCE
 -------------------------------------------
-1. [Platform] [Format]: [konu]
+[summary if available, otherwise "no data"]
+
+-------------------------------------------
+IDEA SUGGESTIONS
+-------------------------------------------
+1. [Platform] [Format]: [topic]
 2. ...
 
 -------------------------------------------
-BUGUN ODAKLAN
+FOCUS TODAY
 -------------------------------------------
-Tek oncelik: [net oneri]
+Single priority: [clear suggestion]
 
-Baslamak icin:
-  badi content post "[konu]"
-  badi content karousel "[konu]"
-  badi content video "[konu]"
+To get started:
+  badi content post "[topic]"
+  badi content carousel "[topic]"
+  badi content video "[topic]"
   /content-generate
 ==============================
 ```
 
-# Ne Zaman Kullanilir
-- Her gun icerik uretmeye baslarken (sabah rituelnu)
-- Uretim tikanikligi yasarken
-- Haftaya baslarken
+# When to Use
+- Every day when starting content production (morning ritual)
+- When production feels stuck
+- At the start of the week

--- a/.claude/commands-vault/content-status.md
+++ b/.claude/commands-vault/content-status.md
@@ -1,156 +1,156 @@
 Content production status panel. Shows current output volume, pending items, calendar fit, and trend data.
 
-# Gerekli Araclar
-- Read (workspace dosyalari)
-- Glob (tum icerik dizinleri)
-- Grep (placeholder ve durum tespiti)
-- Bash (dosya tarihi, sayma)
+# Required Tools
+- Read (workspace files)
+- Glob (all content directories)
+- Grep (placeholder and status detection)
+- Bash (file dates, counting)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Envanter Topla
-`.claude/workspace/` altindaki tum icerik dosyalarini tara:
-- `icerikler/` — Post ve karousel sayisi
-- `senaryolar/` — Video senaryo sayisi
-- `gorseller/` — Gorsel brief sayisi
-- `takvim/` — Takvim dosyalari
-- `marka-sesi.md` varsa
+### Step 1: Take Inventory
+Scan all content files under `.claude/workspace/`:
+- `icerikler/` — Post and carousel count
+- `senaryolar/` — Video script count
+- `gorseller/` — Visual brief count
+- `takvim/` — Calendar files
+- `marka-sesi.md` if present
 
-Dosya basina metadata cikar:
-- Olusturma tarihi
-- Son degisiklik tarihi
-- Dosya boyutu (doluluk gostergesi)
-- Placeholder sayisi
+Per file, extract metadata:
+- Creation date
+- Last modified date
+- File size (fill indicator)
+- Placeholder count
 
-### Adim 2: Zaman Bazli Gruplama
+### Step 2: Time-Based Grouping
 
-**Bugun:** Bugun olusturulan/duzenlenen
-**Bu hafta:** Son 7 gun
-**Bu ay:** Son 30 gun
-**Eski:** 30+ gun
+**Today:** Created/edited today
+**This week:** Last 7 days
+**This month:** Last 30 days
+**Old:** 30+ days
 
-Her grup icin:
-- Toplam sayi
-- Tamamlanmislik orani
+For each group:
+- Total count
+- Completion ratio
 
-### Adim 3: Tamamlanmislik Analizi
-Her icerigin durumunu belirle:
+### Step 3: Completion Analysis
+Determine each item's status:
 
-**TAMAMLANAN (yayina hazir):**
-- Placeholder yok
-- Tum bolumler dolu
-- Gorsel notu var
+**COMPLETE (publish-ready):**
+- No placeholders
+- All sections filled
+- Visual note present
 
-**KISMI (duzenleme gerekli):**
-- Bazi yerler dolu
-- Ana mesaj belirli ama detaylar eksik
+**PARTIAL (needs editing):**
+- Some parts filled
+- Main message set but details missing
 
-**TASLAK (yeni olusturulmus):**
-- Cogunlukla placeholder
-- Temel yapi var
+**DRAFT (freshly created):**
+- Mostly placeholders
+- Basic structure present
 
-**OLMUS (arsiv adayi):**
-- 30+ gundur dokunulmamis
-- Hala placeholder
+**STALE (archive candidate):**
+- Untouched for 30+ days
+- Still holding placeholders
 
-### Adim 4: Takvim Uyum Kontrolu
-Eger takvim dosyasi varsa:
-- Planli icerikler kac tane?
-- Kac tanesi uretilmis?
-- Kac tanesi yayinlanmis?
-- Gecikme var mi?
+### Step 4: Calendar Fit Check
+If a calendar file exists:
+- How many items planned?
+- How many produced?
+- How many published?
+- Any delays?
 
 ```
-Plan uyum orani: [yuzde]%
+Plan fit ratio: [percent]%
 ```
 
-### Adim 5: Trend ve Oneriler
-Son 2 haftanin trendlerini hesapla:
-- Uretim hizi (gun basina ortalama)
-- En cok uretilen format
-- En az uretilen format (kapali kanal uyarisi)
-- Duraksamalar (0 uretim gunleri)
+### Step 5: Trends and Suggestions
+Compute the last 2 weeks' trends:
+- Production speed (average per day)
+- Most produced format
+- Least produced format (dormant channel warning)
+- Stalls (zero-production days)
 
-Oneriler uret:
-- Ihmal edilen platformlar
-- Eskimeye baslayan taslaklar
-- Bitmemis isler
+Generate suggestions:
+- Neglected platforms
+- Drafts starting to go stale
+- Unfinished work
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI ICERIK DURUMU ===
-Tarih: [tarih] [saat]
+=== BADI CONTENT STATUS ===
+Date: [date] [time]
 
 -------------------------------------------
-ENVANTER
+INVENTORY
 -------------------------------------------
-Toplam Dosya: [sayi]
+Total Files: [count]
 
-Postlar/Karouseller: [sayi]
-Video Senaryolari:   [sayi]
-Gorsel Brifler:      [sayi]
-Takvimler:           [sayi]
+Posts/Carousels:    [count]
+Video Scripts:      [count]
+Visual Briefs:      [count]
+Calendars:          [count]
 
-Marka Sesi: [VAR / YOK]
-
--------------------------------------------
-ZAMAN DAGILIMI
--------------------------------------------
-Bugun:     [sayi]  [======    ]
-Bu Hafta:  [sayi]  [========  ]
-Bu Ay:     [sayi]  [==========]
-Eski:      [sayi]
+Brand Voice: [PRESENT / MISSING]
 
 -------------------------------------------
-TAMAMLANMISLIK
+TIME DISTRIBUTION
 -------------------------------------------
-Tamamlanan:  [sayi] (%[oran])
-Kismi:       [sayi]
-Taslak:      [sayi]
-Olmus:       [sayi]
+Today:      [count]  [======    ]
+This Week:  [count]  [========  ]
+This Month: [count]  [==========]
+Old:        [count]
 
 -------------------------------------------
-TAKVIM UYUMU
+COMPLETION
 -------------------------------------------
-Planli:      [sayi]
-Uretilmis:   [sayi]
-Yayinlanmis: [sayi]
-Uyum:        [yuzde]%
+Complete:  [count] (%[ratio])
+Partial:   [count]
+Draft:     [count]
+Stale:     [count]
 
 -------------------------------------------
-TREND (Son 2 Hafta)
+CALENDAR FIT
 -------------------------------------------
-Gunluk Ortalama: [sayi] icerik
-En Populer: [format] ([sayi])
-En Az: [format] ([sayi])
-Duraksamalar: [gun sayisi]
+Planned:    [count]
+Produced:   [count]
+Published:  [count]
+Fit:        [percent]%
 
 -------------------------------------------
-UYARILAR
+TREND (Last 2 Weeks)
 -------------------------------------------
-- [eskime uyarisi]
-- [kapali kanal]
-- [gecikmis icerik]
+Daily Average: [count] items
+Most Popular: [format] ([count])
+Least: [format] ([count])
+Stalls: [day count]
 
 -------------------------------------------
-ONERILER
+WARNINGS
 -------------------------------------------
-1. [somut oneri]
-2. [somut oneri]
-3. [somut oneri]
+- [staleness warning]
+- [dormant channel]
+- [overdue content]
 
 -------------------------------------------
-HIZLI AKSIYONLAR
+SUGGESTIONS
 -------------------------------------------
-Eksik taslak bitir:   [dosya]
-Yeni icerik uret:     badi content [tur] "[konu]"
-Takvim olustur:       badi content calendar "[donem]"
-Fikir uret:           /content-idea
+1. [concrete suggestion]
+2. [concrete suggestion]
+3. [concrete suggestion]
+
+-------------------------------------------
+QUICK ACTIONS
+-------------------------------------------
+Finish a pending draft:  [file]
+Produce new content:     badi content [type] "[topic]"
+Create a calendar:       badi content calendar "[period]"
+Generate ideas:          /content-idea
 ==========================
 ```
 
-# Ne Zaman Kullanilir
-- Gunluk durum kontrolu
-- Haftalik retro oncesi
-- Tikanma anlarinda ("ne yapmaliyim?")
-- Plan vs gerceklik karsilastirmasi
+# When to Use
+- Daily status check
+- Before the weekly retro
+- In stuck moments ("what should I do?")
+- Plan vs. reality comparison

--- a/.claude/commands-vault/content-template.md
+++ b/.claude/commands-vault/content-template.md
@@ -1,74 +1,74 @@
 Content template inheritance command. Custom template creation and inheritance-chain management for recurring content types.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi content template)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Mevcut Sablonlar
+### Step 1: Existing Templates
 
 ```bash
 badi content template list
 ```
 
-Yerlesik sablonlar (standart): post, karousel, video, gorsel, takvim, marka.
-Ozel sablonlar `.claude/workspace/sablonlar/` altinda.
+Built-in templates (standard): post, carousel, video, visual, calendar, brand.
+Custom templates live under `.claude/workspace/sablonlar/`.
 
-### Adim 2: Ozel Sablon Olustur
+### Step 2: Create a Custom Template
 
 ```bash
-badi content template olustur saas-lansmani --extends post --description "SaaS urun lansmani"
+badi content template create saas-launch --extends post --description "SaaS product launch"
 ```
 
-Parametreler:
-- `isim` — Sablon adi (slug)
-- `--extends` — Yerlesik sablon (post/content-carousel/video/gorsel/takvim)
-- `--description` — Kisa aciklama (opsiyonel)
+Parameters:
+- `name` — Template name (slug)
+- `--extends` — Built-in base (post/carousel/video/visual/calendar)
+- `--description` — Short description (optional)
 
-Olusturulan dosya `.claude/workspace/sablonlar/[isim].md` — frontmatter + ozel bolumler.
+The created file is `.claude/workspace/sablonlar/[name].md` — frontmatter + custom sections.
 
-### Adim 3: Sablonu Duzenle
+### Step 3: Edit the Template
 
-Olusan dosyayi ac ve ozel bolumler ekle:
+Open the created file and add custom sections:
 ```markdown
 ---
-name: saas-lansmani
+name: saas-launch
 extends: post
-description: SaaS urun lansmani
+description: SaaS product launch
 ---
 
-## Ozel: Onizleme Linki
-[Ucretsiz deneme URL'si]
+## Custom: Preview Link
+[Free trial URL]
 
-## Ozel: Teknik Detay
-[Stack, entegrasyonlar, fiyatlama]
+## Custom: Technical Detail
+[Stack, integrations, pricing]
 ```
 
-### Adim 4: Sablonu Kullan
+### Step 4: Use the Template
 
 ```bash
-badi content post "Yeni CRM Lansman" --template saas-lansmani
+badi content post "New CRM Launch" --template saas-launch
 ```
 
-Yerlesik sablon + ozel sablon birlestirilir (H2 baslik eslestirme ile).
+The built-in template and the custom template are merged (by H2 heading matching).
 
-### Adim 5: Sablon Sil
+### Step 5: Delete a Template
 
 ```bash
-badi content template sil saas-lansmani
+badi content template delete saas-launch
 ```
 
-### Adim 6: Kullanim Senaryolari
+### Step 6: Usage Scenarios
 
-- **Marka kategorileri**: Urun lansmani, etkinlik duyurusu, case study, customer story
-- **Icerik serileri**: Pazartesi motivasyon, Persembe tutorial
-- **Platform ozelleri**: LinkedIn vs Twitter ayri tonda
-- **Musteri sablonlari**: Her musteri icin ayri ton/stil
+- **Brand categories**: Product launch, event announcement, case study, customer story
+- **Content series**: Monday motivation, Thursday tutorial
+- **Platform specials**: LinkedIn vs Twitter in different tones
+- **Client templates**: A separate tone/style per client
 
-# Ornek
+# Example
 
 ```
 /content-template list
-/content-template olustur linkedin-insight --extends post
-/content-generate "AI trendi" --template linkedin-insight
+/content-template create linkedin-insight --extends post
+/content-generate "AI trend" --template linkedin-insight
 ```

--- a/.claude/commands-vault/content-video-script.md
+++ b/.claude/commands-vault/content-video-script.md
@@ -1,85 +1,85 @@
 Video script command. Scene-by-scene scripts, captions, and visualization plans for Reels, Shorts, TikTok, and YouTube.
 
-# Gerekli Araclar
-- Read (marka sesi, onceki senaryolar, proje baglami) -- Write (senaryo dosyasi) -- Grep (trend ve referans taramasi) -- ...
+# Required Tools
+- Read (brand voice, previous scripts, project context) -- Write (script file) -- Grep (trend and reference scan) -- ...
 
-# Prosedur (7 Adim)
+# Procedure (7 Steps)
 
-## 1. Video Bilgilerini Topla
-- **Platform:** Instagram Reels / YouTube Shorts / TikTok / YouTube uzun / Hepsi
-- **Sure:** 15s (Story, hizli ipucu) / 30s (Reels-Shorts std) / 60s (uzun) / 3-10dk (YT orta) / ...
-- **Tur:** Egitici (nasil yapilir, ipucu) / Eglence (komedi, trend, skit) / Tanitim (urun, marka) / Perde arkasi / ...
-- **Konu:** detay
-- **Hedef:** Takipci / Etkilesim / Satis / Bilinirlik / Trafik
-- **Konusmaci:** Yuz (talking head) / Sadece el-urun / Voiceover + gorsel / Faceless (metin+gorsel) / ...
-- **Muzik/Ses:** Trend ses (ad belirt) / Orijinal / VO + arka plan / ASMR-dogal / ...
+## 1. Gather Video Details
+- **Platform:** Instagram Reels / YouTube Shorts / TikTok / YouTube long-form / All
+- **Length:** 15s (Story, quick tip) / 30s (Reels-Shorts std) / 60s (long) / 3-10min (YT mid) / ...
+- **Type:** Educational (how-to, tips) / Entertainment (comedy, trend, skit) / Promo (product, brand) / Behind the scenes / ...
+- **Topic:** detail
+- **Goal:** Followers / Engagement / Sales / Awareness / Traffic
+- **Speaker:** Face (talking head) / Hands-product only / Voiceover + visuals / Faceless (text+visuals) / ...
+- **Music/Sound:** Trending sound (name it) / Original / VO + background / ASMR-natural / ...
 
-## 2. Hook (1-3s, hayati)
-| Hook Turu | Ornek | Ne Zaman |
-|-----------|-------|----------|
-| Sasirtici Iddia | "Cogu kisi bunu yanlis yapiyor" | Egitici, listicle |
-| Soru | "Hic X'i denedin mi?" | Etkilesim |
-| Sonucu Once | [donusum] "Nasil mi yaptim?" | Oncesi/sonrasi |
-| Istatistik | "Insanlarin %87'si bunu bilmiyor" | Bilgilendirici |
-| Merak Boslugu | "Bunu ogrendigimde her sey degisti" | Hikaye |
-| Aciliyet | "Bunu hemen yapmalisin" | Uyari, ipucu |
-| Tartisma | "[Populer gorus] yanlis. Iste neden..." | Trend |
-| Gorunen Deger | [liste/ipucu gorunur] "Kaydet!" | Egitici |
+## 2. Hook (1-3s, vital)
+| Hook Type | Example | When |
+|-----------|---------|------|
+| Surprising Claim | "Most people do this wrong" | Educational, listicle |
+| Question | "Have you ever tried X?" | Engagement |
+| Result First | [transformation] "Want to know how?" | Before/after |
+| Statistic | "87% of people don't know this" | Informative |
+| Curiosity Gap | "Everything changed when I learned this" | Story |
+| Urgency | "You need to do this right now" | Warnings, tips |
+| Controversy | "[Popular opinion] is wrong. Here's why..." | Trend |
+| Visible Value | [list/tip visible] "Save this!" | Educational |
 
-Hook yazimi: ilk 1s dikkat yakala -- ekran hareket/metin degisimi -- ses tonunda enerji/merak -- ...
+Hook writing: capture attention in the first 1s -- on-screen motion/text change -- energy/curiosity in the voice -- ...
 
-## 3. Yapi Sablonu
-**15s:** `[0-2] Hook | [2-12] Govde (tek mesaj) | [12-15] CTA (kaydet/paylas)`
+## 3. Structure Templates
+**15s:** `[0-2] Hook | [2-12] Body (single message) | [12-15] CTA (save/share)`
 
-**30s:** `[0-3] Hook | [3-12] Bolum 1 (baglam/problem) | [12-25] Bolum 2 (cozum) | [25-30] CTA`
+**30s:** `[0-3] Hook | [3-12] Part 1 (context/problem) | [12-25] Part 2 (solution) | [25-30] CTA`
 
-**60s:** `[0-3] Hook | [3-15] Bolum 1 (problem) | [15-35] Bolum 2 (cozum) | [35-50] Bolum 3 (ornek) | [50-60] CTA`
+**60s:** `[0-3] Hook | [3-15] Part 1 (problem) | [15-35] Part 2 (solution) | [35-50] Part 3 (example) | [50-60] CTA`
 
-**3-10dk (YT):** `[0-30s] Hook+video vadi | [30s-1m] Giris+kimlik | [1m-X] Ana icerik (bolumler) | [X-son] Ozet+CTA+sonraki video`
+**3-10min (YT):** `[0-30s] Hook+value promise | [30s-1m] Intro+identity | [1m-X] Main content (chapters) | [X-end] Recap+CTA+next video`
 
-## 4. Sahne Sahne Senaryo
-Her sahne icin tam detay.
+## 4. Scene-by-Scene Script
+Full detail for every scene.
 ```
-[kisaltildi]
+[abridged]
 ```
 
-## 5. Altyazi ve Caption
-**Platform Caption:** platform bazli aciklama -- ilk satir hook/deger vadisi (kesilme noktasi oncesi) -- hashtag stratejisi -- ...
+## 5. Subtitles and Caption
+**Platform Caption:** per-platform description -- first line hook/value promise (before the cut-off point) -- hashtag strategy -- ...
 
-**Ekran Ustu Metin:**
-| Saniye | Metin | Konum | Stil |
-|--------|-------|-------|------|
-| 0-3 | [hook] | Orta | Buyuk, bold |
-| 3-8 | [destek] | Alt | Normal |
+**On-Screen Text:**
+| Second | Text | Position | Style |
+|--------|------|----------|-------|
+| 0-3 | [hook] | Center | Large, bold |
+| 3-8 | [support] | Bottom | Normal |
 | ... | ... | ... | ... |
 
-**Subtitle:** otomatik acik mi -- anahtar kelimeler vurgulu (renk/bold) -- font/boyut onerisi
+**Subtitles:** auto-captions on? -- keywords emphasized (color/bold) -- font/size suggestion
 
-## 6. Post-Produksiyon
-- **Muzik/Efekt:** arka plan turu (pop/lo-fi/epik/akustik/elektronik) -- ses efektleri (whoosh, pop, ding — nerede) -- trend ses kaynagi -- ...
-- **Gecisler:** kesme/yumusak/zoom/whip pan -- metin animasyon (belirme/kayma/yazma/bounce) -- ozel efekt (speed ramp, split, green screen)
-- **Renk:** filtre/LUT (sicak/soguk/vintage/yuksek kontrast) -- gradasyon notu -- parlaklik/kontrast
-- **Hiz:** yavaslatma (dramatik, detay) -- hizlandirma (tekrar islem, montaj) -- normal bolge
+## 6. Post-Production
+- **Music/FX:** background genre (pop/lo-fi/epic/acoustic/electronic) -- sound effects (whoosh, pop, ding — where) -- trending sound source -- ...
+- **Transitions:** cut/smooth/zoom/whip pan -- text animation (appear/slide/typewriter/bounce) -- special effects (speed ramp, split, green screen)
+- **Color:** filter/LUT (warm/cool/vintage/high contrast) -- grading note -- brightness/contrast
+- **Speed:** slow-mo (drama, detail) -- speed-up (repeated actions, montage) -- normal zones
 
-## 7. Thumbnail Brief ve Kaydet
-**YouTube Thumbnail (YT videolari):** 1280x720 -- ana gorsel -- metin (maks 5-6 kelime, okunabilir) -- ...
+## 7. Thumbnail Brief and Save
+**YouTube Thumbnail (YT videos):** 1280x720 -- main visual -- text (max 5-6 words, readable) -- ...
 
-Kaydet: `.claude/workspace/senaryolar/[YYYY-MM-DD]-[konu-kebab].md`
+Save: `.claude/workspace/senaryolar/[YYYY-MM-DD]-[topic-kebab].md`
 
-# Cikti Formati
+# Output Format
 ```
-[kisaltildi]
+[abridged]
 ```
 
-# Video Formati Referansi
-| Platform | Oran | Cozunurluk | Maks Sure | Format |
-|----------|------|-----------|-----------|--------|
+# Video Format Reference
+| Platform | Aspect | Resolution | Max Length | Format |
+|----------|--------|------------|------------|--------|
 | Instagram Reels | 9:16 | 1080x1920 | 90s | MP4 |
 | YouTube Shorts | 9:16 | 1080x1920 | 60s | MP4 |
-| TikTok | 9:16 | 1080x1920 | 10dk | MP4 |
-| YouTube | 16:9 | 1920x1080 | Sinir yok | MP4 |
+| TikTok | 9:16 | 1080x1920 | 10min | MP4 |
+| YouTube | 16:9 | 1920x1080 | No limit | MP4 |
 | Facebook Reels | 9:16 | 1080x1920 | 90s | MP4 |
-| LinkedIn Video | 1:1/16:9 | 1080x1080 | 10dk | MP4 |
+| LinkedIn Video | 1:1/16:9 | 1080x1080 | 10min | MP4 |
 
-# Ipuclari
-- Her video tek mesaj -- ilk 3s basarinin %70'i -- ekran metni konusmayla uyumlu ama birebir ayni degil -- ...
+# Tips
+- One message per video -- the first 3s are 70% of the outcome -- on-screen text complements the speech but is not verbatim -- ...

--- a/.claude/commands-vault/content-visual-brief.md
+++ b/.claude/commands-vault/content-visual-brief.md
@@ -1,32 +1,32 @@
 Visual brief command. Detailed design instructions, color palettes, and AI image prompts for social visuals, banners, and video frames.
 
-# Gerekli Araclar
-- Read (marka rehberi, onceki gorseller, proje baglami) -- Write (brief dosyasi) -- Grep (marka renk/font referanslari) -- ...
+# Required Tools
+- Read (brand guide, previous visuals, project context) -- Write (brief file) -- Grep (brand color/font references) -- ...
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-## 1. Gorsel Ihtiyacini Tanimla
-Kullanicidan al:
-- **Kullanim Alani:** Post (tek kare) / Story / Reel kapak / Karousel (kac kare?) / YouTube thumbnail / ...
-- **Platform:** Instagram / Twitter / LinkedIn / YouTube / Facebook / Pinterest / Blog / E-posta / Reklam / Diger
-- **Icerik:** Ana mesaj/baslik, urun/kisi/sahne/soyut konsept, marka ogeleri (logo/slogan), veri/istatistik (infografik)
-- **Stil:** Fotografik / Minimalist / Illustrasyon / 3D Render / ...
-- **Renk:** Marka / Belirli palet / Serbest / Mevsimsel
-- **Metin:** Yazi olacak mi? (baslik, alt baslik, CTA, istatistik)
-- **Ton:** Ciddi / Eglenceli / Luks / Teknik / Sicak / Soguk
+## 1. Define the Visual Need
+Get from the user:
+- **Use Case:** Post (single frame) / Story / Reel cover / Carousel (how many frames?) / YouTube thumbnail / ...
+- **Platform:** Instagram / Twitter / LinkedIn / YouTube / Facebook / Pinterest / Blog / Email / Ads / Other
+- **Content:** Main message/headline, product/person/scene/abstract concept, brand elements (logo/slogan), data/statistics (infographic)
+- **Style:** Photographic / Minimalist / Illustration / 3D Render / ...
+- **Color:** Brand / Specific palette / Free / Seasonal
+- **Text:** Will there be copy? (headline, subhead, CTA, statistic)
+- **Tone:** Serious / Fun / Luxury / Technical / Warm / Cool
 
-## 2. Marka Rehberini Yukle
-- `.claude/workspace/marka-sesi.md` — renkler, fontlar, stil
-- `.claude/workspace/gorseller/` — onceki briefler
-- Marka logosu ve kullanim kurallari
+## 2. Load the Brand Guide
+- `.claude/workspace/marka-sesi.md` — colors, fonts, style
+- `.claude/workspace/gorseller/` — previous briefs
+- Brand logo and usage rules
 
-Yoksa: kullanicidan temel bilgi (birincil renk, font) al veya serbest tasarim modu.
+If none: collect the basics from the user (primary color, font) or free-design mode.
 
-## 3. Boyut ve Teknik Ozellikler
-| Kullanim | Boyut (px) | En-Boy Orani | Dosya Formati |
-|----------|-----------|-------------|---------------|
-| Instagram Kare | 1080x1080 | 1:1 | PNG/JPG |
-| Instagram Dikey | 1080x1350 | 4:5 | PNG/JPG |
+## 3. Size and Technical Specs
+| Use | Size (px) | Aspect | File Format |
+|-----|-----------|--------|-------------|
+| Instagram Square | 1080x1080 | 1:1 | PNG/JPG |
+| Instagram Portrait | 1080x1350 | 4:5 | PNG/JPG |
 | Instagram Story/Reel | 1080x1920 | 9:16 | PNG/JPG |
 | Twitter/X Post | 1600x900 | 16:9 | PNG/JPG |
 | LinkedIn Post | 1200x627 | 1.91:1 | PNG/JPG |
@@ -37,49 +37,49 @@ Yoksa: kullanicidan temel bilgi (birincil renk, font) al veya serbest tasarim mo
 | YouTube Banner | 2560x1440 | 16:9 | PNG |
 | Pinterest Pin | 1000x1500 | 2:3 | PNG/JPG |
 | Blog Header | 1200x628 | 1.91:1 | PNG/JPG |
-| E-posta Header | 600x200 | 3:1 | PNG/JPG |
-| Meta Ads (kare) | 1080x1080 | 1:1 | PNG/JPG |
-| Meta Ads (dikey) | 1080x1350 | 4:5 | PNG/JPG |
+| Email Header | 600x200 | 3:1 | PNG/JPG |
+| Meta Ads (square) | 1080x1080 | 1:1 | PNG/JPG |
+| Meta Ads (portrait) | 1080x1350 | 4:5 | PNG/JPG |
 | Google Ads Banner | 1200x628 | 1.91:1 | PNG/JPG |
 
-## 4. Detayli Brief
-- **Kompozisyon:** ana odak (orta/uc'te bir/alt-ust) -- gorsel hiyerarsi -- bos alan kullanimi -- ...
-- **Renk Paleti:** birincil [#hex] (arka plan/vurgu) -- ikincil [#hex] -- vurgu [#hex] (CTA, onemli metin) -- ...
-- **Tipografi (metin varsa):** baslik [font/boyut/kalinlik/renk] -- alt baslik [...] -- govde [...] -- ...
-- **Arka Plan:** duz/gradient/fotograf/doku/soyut + detayli aciklama
-- **Objeler:** ana obje (urun/kisi/ikon) -- destekleyici (serit, cerceve, ok, badge) -- logo konum/boyut -- ...
+## 4. Detailed Brief
+- **Composition:** main focus (center/rule-of-thirds/top-bottom) -- visual hierarchy -- white-space usage -- ...
+- **Color Palette:** primary [#hex] (background/accent) -- secondary [#hex] -- accent [#hex] (CTA, key text) -- ...
+- **Typography (if text):** headline [font/size/weight/color] -- subhead [...] -- body [...] -- ...
+- **Background:** solid/gradient/photo/texture/abstract + detailed description
+- **Objects:** main object (product/person/icon) -- supporting (strips, frames, arrows, badges) -- logo position/size -- ...
 
-## 5. AI Promptlari (3 arac)
-**Midjourney:** `/imagine [aciklama], [stil], [atmosfer], [teknik] --ar [oran] --v 6.1 --style raw`
-- Ingilizce -- `--style raw`, `--stylize 50-200` -- `--ar 1:1/4:5/16:9` -- ...
+## 5. AI Prompts (3 tools)
+**Midjourney:** `/imagine [description], [style], [mood], [technique] --ar [ratio] --v 6.1 --style raw`
+- English -- `--style raw`, `--stylize 50-200` -- `--ar 1:1/4:5/16:9` -- ...
 
-**DALL-E:** `[Detayli dogal dil aciklamasi, stil ve atmosfer dahil]`
-- TR/EN -- net betimleyici cumleler -- stil ve duygu acik -- ...
+**DALL-E:** `[Detailed natural-language description including style and mood]`
+- Clear descriptive sentences -- style and emotion explicit -- ...
 
-**Flux/Stable Diffusion:** `[pozitif prompt], [stil etiketleri], [teknik]` + `Negative: [istenmeyen]`
-- Etiket bazli (virgulle) -- Steps: 30-50, CFG: 7-12 -- Sampler: DPM++ 2M Karras
+**Flux/Stable Diffusion:** `[positive prompt], [style tags], [technique]` + `Negative: [unwanted]`
+- Tag-based (comma-separated) -- Steps: 30-50, CFG: 7-12 -- Sampler: DPM++ 2M Karras
 
-## 6. Canva/Figma Notu ve Kaydet
-- **Canva:** sablon kategorisi -- oge turleri (metin/sekil/ikon) -- katman sirasi (arka plan → objeler → metin → logo)
-- **Figma:** frame boyutu -- auto layout -- bilesen yapisi
+## 6. Canva/Figma Note and Save
+- **Canva:** template category -- element types (text/shape/icon) -- layer order (background → objects → text → logo)
+- **Figma:** frame size -- auto layout -- component structure
 
-Kaydet: `.claude/workspace/gorseller/[YYYY-MM-DD]-[konu]-brief.md`
+Save: `.claude/workspace/gorseller/[YYYY-MM-DD]-[topic]-brief.md`
 
-# Cikti Formati
+# Output Format
 ```
-[kisaltildi]
+[abridged]
 ```
 
-# Stil Referans Tablosu
-| Stil | Ornek Kullanim | Uygun Platformlar | Ton |
-|------|---------------|-------------------|-----|
-| Minimalist | Tech urun, SaaS | LinkedIn, Twitter | Profesyonel |
-| Fotografik | Yasam tarz, gida, seyahat | Instagram, Pinterest | Sicak |
-| Illustrasyon | Egitim, cocuk, eglence | Instagram, Blog | Eglenceli |
-| Tipografik | Motivasyon, alistilar | Instagram, Twitter | Ilham |
-| 3D Render | Teknoloji, oyun | Instagram, YouTube | Modern |
-| Gradient | App tanitim, dijital | LinkedIn, Twitter | Modern |
-| Flat Design | Infografik, sunum | LinkedIn, Blog | Net |
-| Retro | Nostalji, moda, muzik | Instagram, Pinterest | Yaratici |
-| Neon | Gece hayati, oyun, muzik | Instagram, TikTok | Enerjik |
-| Collage | Moda, sanat, etkinlik | Instagram, Pinterest | Yaratici |
+# Style Reference Table
+| Style | Example Use | Fit Platforms | Tone |
+|-------|-------------|---------------|------|
+| Minimalist | Tech products, SaaS | LinkedIn, Twitter | Professional |
+| Photographic | Lifestyle, food, travel | Instagram, Pinterest | Warm |
+| Illustration | Education, kids, fun | Instagram, Blog | Playful |
+| Typographic | Motivation, habits | Instagram, Twitter | Inspirational |
+| 3D Render | Technology, gaming | Instagram, YouTube | Modern |
+| Gradient | App promos, digital | LinkedIn, Twitter | Modern |
+| Flat Design | Infographics, decks | LinkedIn, Blog | Clear |
+| Retro | Nostalgia, fashion, music | Instagram, Pinterest | Creative |
+| Neon | Nightlife, gaming, music | Instagram, TikTok | Energetic |
+| Collage | Fashion, art, events | Instagram, Pinterest | Creative |

--- a/.claude/commands-vault/launch.md
+++ b/.claude/commands-vault/launch.md
@@ -1,123 +1,123 @@
 Product launch plan command. Creates a comprehensive plan for a new product or feature launch.
 
-# Gerekli Araclar
-- Read (proje verileri)
-- Grep (pazar arastirmasi verileri)
-- Write (plan dosyasi)
-- Bash (mevcut proje analizi)
-- Glob (kaynak taramasi)
+# Required Tools
+- Read (project data)
+- Grep (market research data)
+- Write (plan file)
+- Bash (current project analysis)
+- Glob (resource scan)
 
-# Prosedur (7 Adim)
+# Procedure (7 Steps)
 
-### Adim 1: Urun Ozeti
-Kullanicidan su bilgileri al:
-- Urun/ozellik adi
-- Tek cumlelik deger onerisi
-- Hedef kitle tanimlamasi
-- Lansman tarihi veya zaman dilimi
-- Basari metrikleri (KPI)
+### Step 1: Product Summary
+Get from the user:
+- Product/feature name
+- One-sentence value proposition
+- Target audience definition
+- Launch date or time window
+- Success metrics (KPIs)
 
-Ozeti olustur:
-- Problem tanimi (hangi sorunu cozuyor?)
-- Cozum tanimi (nasil cozuyor?)
-- Benzersiz deger onerisi (neden bu cozum?)
-- Hedef pazar buyuklugu tahmini
+Build the summary:
+- Problem statement (what problem does it solve?)
+- Solution statement (how does it solve it?)
+- Unique value proposition (why this solution?)
+- Target market size estimate
 
-### Adim 2: Rekabet Arastirmasi
-Rekabet ortamini analiz et:
-- Dogrudan rakipler (ayni sorunu cozenler, 3-5 adet)
-- Dolayli rakipler (alternatif cozumler)
-- Her rakip icin: guclu yonler, zayif yonler, fiyatlandirma
-- Pazar boslugu analizi
-- Farklilastirma firsatlari
-- Rakip konumlandirma matrisi
+### Step 2: Competitive Research
+Analyze the competitive landscape:
+- Direct competitors (solving the same problem, 3-5)
+- Indirect competitors (alternative solutions)
+- For each competitor: strengths, weaknesses, pricing
+- Market gap analysis
+- Differentiation opportunities
+- Competitor positioning matrix
 
-### Adim 3: Konumlandirma
-- Hedef kitle segmentasyonu (birincil, ikincil persona)
-- Benzersiz satis onerisi (USP) tanimi
-- Mesajlasma cercevesi:
-  - Baslik (headline)
-  - Alt baslik (subheadline)
-  - 3 temel fayda maddesi
-  - Sosyal kanit stratejisi (referans, istatistik, logo)
-- Ton ve ses (marka uyumlu)
-- Anahtar kelimeler ve SEO stratejisi
+### Step 3: Positioning
+- Target audience segmentation (primary, secondary personas)
+- Unique selling proposition (USP) definition
+- Messaging framework:
+  - Headline
+  - Subheadline
+  - 3 core benefit bullets
+  - Social proof strategy (testimonials, statistics, logos)
+- Tone and voice (brand-aligned)
+- Keywords and SEO strategy
 
-### Adim 4: Fiyat Analizi
-- Maliyet tabani hesabi
-- Rakip fiyatlandirma karsilastirmasi
-- Deger bazli fiyatlandirma onerisi
-- Fiyat katmanlari (uygunsa):
-  - Ucretsiz / Freemium
-  - Baslangic
-  - Profesyonel
-  - Kurumsal
-- Tanitim fiyati stratejisi
-- Gelir projeksiyonu (3-6-12 ay)
+### Step 4: Pricing Analysis
+- Cost-base calculation
+- Competitor pricing comparison
+- Value-based pricing suggestion
+- Price tiers (if applicable):
+  - Free / Freemium
+  - Starter
+  - Professional
+  - Enterprise
+- Intro pricing strategy
+- Revenue projection (3-6-12 months)
 
-### Adim 5: Landing Page Taslagi
-Donusum odakli sayfa yapisi tasarla:
-- **Hero Bolumu:** Baslik + deger onerisi + birincil CTA + gorsel yer tutucu
-- **Problem/Cozum:** Kullanicinin acisini tanimla, cozumu goster
-- **Ozellikler:** 3-6 temel ozellik, faydalarla birlikte
-- **Nasil Calisir:** 3-4 adimli gorsel akis
-- **Sosyal Kanit:** Referanslar, musteri logolari, istatistikler
-- **Fiyatlandirma:** Karsilastirmali tablo
-- **SSS:** 5-8 sik sorulan soru
-- **Son CTA:** Guclu kapansis mesaji + aksiyon butonu
-- **Teknik:** SEO meta taglari, OG image, yapisal veri
+### Step 5: Landing Page Draft
+Design a conversion-driven page structure:
+- **Hero Section:** Headline + value proposition + primary CTA + visual placeholder
+- **Problem/Solution:** Name the user's pain, show the solution
+- **Features:** 3-6 core features, with benefits
+- **How It Works:** A 3-4 step visual flow
+- **Social Proof:** Testimonials, customer logos, statistics
+- **Pricing:** Comparison table
+- **FAQ:** 5-8 frequent questions
+- **Final CTA:** Strong closing message + action button
+- **Technical:** SEO meta tags, OG image, structured data
 
-### Adim 6: Go-to-Market Kontrol Listesi
+### Step 6: Go-to-Market Checklist
 
-**Lansman Oncesi (-2 hafta):**
-- [ ] Landing page gelistirme ve test
-- [ ] E-posta listesi segmentasyonu ve hazirligi
-- [ ] Sosyal medya icerik takvimi olusturma
-- [ ] Basin bulteni taslagi ve dagitim listesi
-- [ ] Beta test grubu geri bildirim toplama
-- [ ] Destek dokumantasyonu (SSS, kilavuzlar)
-- [ ] Analitik ve izleme kurulumu (GA, Mixpanel, vb.)
-- [ ] A/B test planlari
+**Pre-Launch (-2 weeks):**
+- [ ] Landing page build and test
+- [ ] Email list segmentation and prep
+- [ ] Social media content calendar
+- [ ] Press release draft and distribution list
+- [ ] Beta group feedback collection
+- [ ] Support documentation (FAQ, guides)
+- [ ] Analytics and tracking setup (GA, Mixpanel, etc.)
+- [ ] A/B test plans
 
-**Lansman Gunu:**
-- [ ] Landing page yayina alma
-- [ ] E-posta kampanyasi gonderimi (saat bazli)
-- [ ] Sosyal medya paylasim plani (platform bazli, saat bazli)
-- [ ] Product Hunt / Hacker News gonderisi (uygunsa)
-- [ ] Topluluk duyurulari (Discord, Slack, forum)
-- [ ] Canli destek ekibi hazir
-- [ ] Gercek zamanli metrik takibi
+**Launch Day:**
+- [ ] Landing page go-live
+- [ ] Email campaign send (by hour)
+- [ ] Social media posting plan (per platform, per hour)
+- [ ] Product Hunt / Hacker News post (if fitting)
+- [ ] Community announcements (Discord, Slack, forums)
+- [ ] Live support team ready
+- [ ] Real-time metric tracking
 
-**Lansman Sonrasi (+2 hafta):**
-- [ ] Gunluk metrik takibi ve raporlama
-- [ ] Kullanici geri bildirimi toplama ve analiz
-- [ ] Hata ve sorun takibi (oncelikli duzeltme)
-- [ ] Icerik pazarlamasi (blog, video, podcast)
-- [ ] Performans optimizasyonu (sayfa hizi, donusum)
-- [ ] Retrospektif ve ogrenimler raporu
+**Post-Launch (+2 weeks):**
+- [ ] Daily metric tracking and reporting
+- [ ] User feedback collection and analysis
+- [ ] Bug and issue tracking (prioritized fixes)
+- [ ] Content marketing (blog, video, podcast)
+- [ ] Performance optimization (page speed, conversion)
+- [ ] Retrospective and learnings report
 
-### Adim 7: Plan Dosyasi Olustur
-`launch-plan-[urun-adi].md` dosyasini olustur:
-- Tum adimlarin ciktisini tek dokumanda birlesir
-- Tarihli kontrol listesi ile takip edilebilir format
-- Sorumluluk atamalari icin bos alanlar
+### Step 7: Create the Plan File
+Create `launch-plan-[product-name].md`:
+- Combines every step's output into one document
+- Trackable format with a dated checklist
+- Blank fields for ownership assignments
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI LANSMAN PLANI ===
-Urun: [urun adi]
-Hedef Tarih: [tarih]
-Durum: TASLAK
+=== BADI LAUNCH PLAN ===
+Product: [product name]
+Target Date: [date]
+Status: DRAFT
 
-Olusturulan: launch-plan-[urun-adi].md
+Created: launch-plan-[product-name].md
 
-Icindekiler:
-1. Urun Ozeti ve Deger Onerisi
-2. Rekabet Analizi Matrisi
-3. Konumlandirma ve Mesajlasma
-4. Fiyatlandirma Stratejisi
-5. Landing Page Taslagi
-6. Go-to-Market Kontrol Listesi
-7. Basari Metrikleri ve KPI
+Contents:
+1. Product Summary and Value Proposition
+2. Competitive Analysis Matrix
+3. Positioning and Messaging
+4. Pricing Strategy
+5. Landing Page Draft
+6. Go-to-Market Checklist
+7. Success Metrics and KPIs
 ===========================
 ```

--- a/.claude/commands-vault/proposal.md
+++ b/.claude/commands-vault/proposal.md
@@ -1,146 +1,146 @@
 Client proposal command. Builds a professional client proposal from project summaries. Valid for 30 days.
 
-# Gerekli Araclar
-- Read (proje verileri, mevcut brifing)
-- Write (teklif dosyasi)
-- Grep (benzer teklif arama)
+# Required Tools
+- Read (project data, existing brief)
+- Write (proposal file)
+- Grep (similar proposal search)
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-### Adim 1: Genel Bakis
-Kullanicidan su bilgileri al:
-- **Musteri Adi:** Sirket veya kisi
-- **Ihtiyaclar:** Musterinin belirttigi sorunlar ve istekler
-- **Istenen Sonuclar:** Basari kriterleri ve beklentiler
-- **Kisitlamalar:** Butce araligi, zaman kisiti, teknik sinirlar
-- **Karar Verici:** Kim onaylayacak? Teknik mi, is mi?
-- **Rekabet:** Baska teklifler de mi degerlendiriliyor?
+### Step 1: Overview
+Get from the user:
+- **Client Name:** Company or person
+- **Needs:** The problems and requests the client stated
+- **Desired Outcomes:** Success criteria and expectations
+- **Constraints:** Budget range, time limits, technical boundaries
+- **Decision Maker:** Who approves? Technical or business?
+- **Competition:** Are other proposals being evaluated?
 
-Mevcut bir brifing varsa (`briefs/` dizininde), onu temel al.
+If an existing brief exists (in `briefs/`), build on it.
 
-### Adim 2: Kapsam Tanimla
-Teslimatlari fazlara ayir:
+### Step 2: Define the Scope
+Split the deliverables into phases:
 
-**Faz 1: [isim]**
-- Teslimatlar: [detayli liste]
-- Beklenen ciktilar: [somut sonuclar]
-- Sure: [tahmini]
-- Bagimliliklar: [on kosullar]
+**Phase 1: [name]**
+- Deliverables: [detailed list]
+- Expected outputs: [concrete results]
+- Duration: [estimate]
+- Dependencies: [prerequisites]
 
-**Faz 2: [isim]**
+**Phase 2: [name]**
 - ...
 
-Her faz icin:
-- Varsayimlar (ne saglanacak, ne bekleniyor)
-- Kapsam disi birakilan maddeler (acikca belirt)
-- Kabul kriterleri
+For each phase:
+- Assumptions (what will be provided, what is expected)
+- Out-of-scope items (state explicitly)
+- Acceptance criteria
 
-### Adim 3: Zaman Cizelgesi
-Fazlari takvim haftlarina esle:
+### Step 3: Timeline
+Map the phases to calendar weeks:
 
-| Hafta | Faz | Teslimatlar | Kilometre Tasi |
-|-------|-----|-------------|----------------|
-| 1-2 | Arastirma & Tasarim | ... | Tasarim Onayi |
-| 3-5 | Gelistirme | ... | MVP Demo |
-| 6 | Test & Iyilestirme | ... | QA Onayi |
-| 7 | Lansman & Destek | ... | Canli Yayim |
+| Week | Phase | Deliverables | Milestone |
+|------|-------|--------------|-----------|
+| 1-2 | Research & Design | ... | Design Approval |
+| 3-5 | Development | ... | MVP Demo |
+| 6 | Test & Polish | ... | QA Approval |
+| 7 | Launch & Support | ... | Go-Live |
 
-- Her faz arasinda 2-3 gunluk inceleme tamponu birak
-- Kilometre taslarini acikca isaretle
-- Kritik yol analizini belirt
+- Leave a 2-3 day review buffer between phases
+- Mark milestones explicitly
+- Note the critical path
 
-### Adim 4: Fiyatlandirma (2 Secenek)
+### Step 4: Pricing (2 Options)
 
-**Secenek A: Tam Kapsam (Onerilen)**
-| Kalem | Birim | Miktar | Birim Fiyat | Toplam |
-|-------|-------|--------|-------------|--------|
+**Option A: Full Scope (Recommended)**
+| Item | Unit | Quantity | Unit Price | Total |
+|------|------|----------|------------|-------|
 | ... | ... | ... | ... | ... |
-- Alt toplam: [tutar]
-- KDV: [tutar]
-- **Genel Toplam: [tutar]**
+- Subtotal: [amount]
+- VAT: [amount]
+- **Grand Total: [amount]**
 
-**Secenek B: MVP / Azaltilmis Kapsam**
-| Kalem | Birim | Miktar | Birim Fiyat | Toplam |
-|-------|-------|--------|-------------|--------|
+**Option B: MVP / Reduced Scope**
+| Item | Unit | Quantity | Unit Price | Total |
+|------|------|----------|------------|-------|
 | ... | ... | ... | ... | ... |
-- **Genel Toplam: [tutar]**
+- **Grand Total: [amount]**
 
-**Opsiyonel Ek Hizmetler:**
-- [hizmet]: [fiyat]
-- [hizmet]: [fiyat]
+**Optional Add-on Services:**
+- [service]: [price]
+- [service]: [price]
 
-### Adim 5: Sartlar ve Kosullar
-Teklif sartlarini belirt:
+### Step 5: Terms and Conditions
+State the proposal terms:
 
-- **Gecerlilik:** Bu teklif [tarih] tarihine kadar (30 gun) gecerlidir.
-- **Odeme Takvimi:**
-  - %30 sozlesme imzasinda (baslangic)
-  - %40 MVP tesliminde (ara odeme)
-  - %30 final teslimde ve kabul sonrasinda
-- **Revizyon Politikasi:**
-  - Her faz icin [sayi] tur revizyon dahildir
-  - Ek revizyonlar saatlik ucretlendirilir
-- **Fikri Mulkiyet:**
-  - Tum ozel kod ve tasarimlar final odeemede musteriye devredilir
-  - Ucuncu parti lisanslar musteriye bildirilir
-- **Gizlilik:** Karsilikli gizlilik anlasmasi (NDA) uygulanir
-- **Iptal Kosullari:**
-  - Her iki taraf [sayi] gun onceden bildirimle iptal edebilir
-  - Tamamlanan calisma icin odeme yapilir
-- **Iletisim:** Haftalik ilerleme raporu + [aralikla] toplanti
-- **Degisiklik Talepleri:** Kapsam disindaki talepler ayrica fiyatlandirilir
+- **Validity:** This proposal is valid until [date] (30 days).
+- **Payment Schedule:**
+  - 30% at contract signature (start)
+  - 40% at MVP delivery (interim)
+  - 30% at final delivery and acceptance
+- **Revision Policy:**
+  - [count] revision rounds included per phase
+  - Extra revisions billed hourly
+- **Intellectual Property:**
+  - All custom code and designs transfer to the client at final payment
+  - Third-party licenses disclosed to the client
+- **Confidentiality:** A mutual NDA applies
+- **Cancellation:**
+  - Either party may cancel with [count] days notice
+  - Completed work is paid for
+- **Communication:** Weekly progress report + meetings at [interval]
+- **Change Requests:** Out-of-scope requests are priced separately
 
-### Adim 6: Teklif Dosyasi Olustur
-`proposals/[musteri-adi]-proposal.md` dosyasina kaydet.
+### Step 6: Create the Proposal File
+Save to `proposals/[client-name]-proposal.md`.
 
-# Cikti Yapisi
+# Output Structure
 ```markdown
-# Proje Teklifi: [Proje Adi]
-**Hazirlayan:** [isim]
-**Musteri:** [musteri adi]
-**Tarih:** [tarih]
-**Gecerlilik:** [son tarih] (30 gun)
+# Project Proposal: [Project Name]
+**Prepared by:** [name]
+**Client:** [client name]
+**Date:** [date]
+**Validity:** [end date] (30 days)
 
-## 1. Yonetici Ozeti
-[2-3 paragraf: sorun, cozum, deger]
+## 1. Executive Summary
+[2-3 paragraphs: problem, solution, value]
 
-## 2. Problem Anlayisi
-[musterinin durumu ve ihtiyaclari]
+## 2. Understanding the Problem
+[the client's situation and needs]
 
-## 3. Onerilen Yaklasim
-[fazli cozum plani]
+## 3. Proposed Approach
+[phased solution plan]
 
-## 4. Kapsam ve Teslimatlar
-[detayli kapsam tablosu]
+## 4. Scope and Deliverables
+[detailed scope table]
 
-## 5. Zaman Cizelgesi
-[haftalik plan tablosu]
+## 5. Timeline
+[weekly plan table]
 
-## 6. Yatirim
-[2 secenekli fiyatlandirma]
+## 6. Investment
+[2-option pricing]
 
-## 7. Sartlar ve Kosullar
-[yukaridaki sartlar]
+## 7. Terms and Conditions
+[the terms above]
 
-## 8. Sonraki Adimlar
-1. Teklifin incelenmesi
-2. Soru-cevap toplantisi
-3. Sozlesme imzasi
-4. Baslangic toplantisi (kickoff)
+## 8. Next Steps
+1. Proposal review
+2. Q&A meeting
+3. Contract signature
+4. Kickoff meeting
 ```
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI MUSTERI TEKLIFI ===
-Musteri: [musteri adi]
-Tarih: [tarih]
-Gecerlilik: 30 gun ([son tarih])
+=== BADI CLIENT PROPOSAL ===
+Client: [client name]
+Date: [date]
+Validity: 30 days ([end date])
 
-Faz Sayisi: [sayi]
-Secenek A: [toplam tutar]
-Secenek B: [toplam tutar]
-Tahmini Sure: [hafta sayisi] hafta
+Phase Count: [count]
+Option A: [total]
+Option B: [total]
+Estimated Duration: [weeks] weeks
 
-Dosya: proposals/[musteri-adi]-proposal.md
+File: proposals/[client-name]-proposal.md
 =============================
 ```

--- a/.claude/commands/competitive-intel.md
+++ b/.claude/commands/competitive-intel.md
@@ -1,163 +1,163 @@
 Competitive analysis command. Analyzes the market, competitors, and opportunities with a comprehensive competitive-intelligence framework.
 
-# Gerekli Araclar
-- Read (mevcut veriler)
-- Write (rapor yazimi)
-- Grep (veri taramasi)
-- Glob (kaynak bulma)
-- Bash (veri isleme)
+# Required Tools
+- Read (existing data)
+- Write (report writing)
+- Grep (data scan)
+- Glob (source discovery)
+- Bash (data processing)
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-### Adim 1: Cerceve Tanimla
-Kullanicidan su bilgileri al:
-- **Urun/Hizmet:** Analiz edilecek urun veya hizmetin adi ve kisa tanimi
-- **Pazar Kategorisi:** Hangi sektorde, hangi niÃ§te?
-- **Hedef Pazar:** Cografi ve demografik hedef
-- **Bilinen Rakipler:** Kullanicinin bildigi rakip listesi
-- **Analiz Amaci:** Neden yapiliyor? (yeni urun lansmani, fiyat guncelleme, strateji revizyonu, vb.)
-- **Odak Alani:** Tum pazar mi, belirli bir segment mi?
+### Step 1: Define the Frame
+Get from the user:
+- **Product/Service:** Name and short definition of what is being analyzed
+- **Market Category:** Which sector, which niche?
+- **Target Market:** Geographic and demographic target
+- **Known Competitors:** The competitor list the user knows
+- **Analysis Purpose:** Why is it being done? (new product launch, price update, strategy revision, etc.)
+- **Focus Area:** The whole market or a specific segment?
 
-### Adim 2: 3 Paralel Arastirma Ajani
+### Step 2: 3 Parallel Research Agents
 
-**Ajan 1: Dogrudan Rakip Analizi**
-- Her dogrudan rakip icin:
-  - Urun/hizmet ozellikleri ve kapasite karsilastirmasi
-  - Fiyatlandirma modeli ve fiyat noktalari
-  - Hedef musteri profili
-  - Teknik altyapi ve teknoloji tercihleri
-  - Pazarlama stratejisi ve kanallari
-  - Marka konumlandirmasi
-  - Musteri yorumlari ve memnuniyet sinyalleri
-  - Bilinen zayif noktalari
+**Agent 1: Direct Competitor Analysis**
+- For each direct competitor:
+  - Product/service features and capability comparison
+  - Pricing model and price points
+  - Target customer profile
+  - Technical infrastructure and technology choices
+  - Marketing strategy and channels
+  - Brand positioning
+  - Customer reviews and satisfaction signals
+  - Known weak points
 
-**Ajan 2: Yakin Alternatif ve Dolayli Rakip Analizi**
-- Acik kaynak alternatifleri
-- Farkli yaklasimla ayni sorunu cozen cozumler
-- Kendin yap (DIY) alternatifleri
-- Potansiyel yeni girisler (komsu pazardan genisleyenler)
-- Ikame urunler ve hizmetler
+**Agent 2: Near-Alternative and Indirect Competitor Analysis**
+- Open-source alternatives
+- Solutions solving the same problem differently
+- DIY alternatives
+- Potential new entrants (expanding from adjacent markets)
+- Substitute products and services
 
-**Ajan 3: Pazar Baglami Analizi**
-- Pazar buyuklugu ve buyume trendi
-- Son fonlama ve yatirim haberleri
-- Birlesme ve satin alma hareketleri
-- Regulasyon degisiklikleri
-- Teknoloji trendleri ve etkileri
-- Musteri davranisi degisimleri
-- Ekonomik faktorler
+**Agent 3: Market Context Analysis**
+- Market size and growth trend
+- Recent funding and investment news
+- M&A activity
+- Regulatory changes
+- Technology trends and their impact
+- Customer behavior shifts
+- Economic factors
 
-### Adim 3: Karsilastirma Matrisi
-Kapsamli karsilastirma tablosu olustur:
+### Step 3: Comparison Matrix
+Build a comprehensive comparison table:
 
-| Kriter | Bizim Urun | Rakip A | Rakip B | Rakip C | Rakip D |
-|--------|-----------|---------|---------|---------|---------|
-| Fiyat Araligi | | | | | |
-| Hedef Musteri | | | | | |
-| Temel Ozellikler | | | | | |
-| Benzersiz Deger | | | | | |
-| Guclu Yonler | | | | | |
-| Zayif Yonler | | | | | |
-| Pazar Payi (tahmini) | | | | | |
-| Teknoloji | | | | | |
-| Musteri Destek | | | | | |
-| Entegrasyonlar | | | | | |
-| Mobil Deneyim | | | | | |
-| Olceklenebilirlik | | | | | |
+| Criterion | Our Product | Comp A | Comp B | Comp C | Comp D |
+|-----------|-------------|--------|--------|--------|--------|
+| Price Range | | | | | |
+| Target Customer | | | | | |
+| Core Features | | | | | |
+| Unique Value | | | | | |
+| Strengths | | | | | |
+| Weaknesses | | | | | |
+| Market Share (est.) | | | | | |
+| Technology | | | | | |
+| Customer Support | | | | | |
+| Integrations | | | | | |
+| Mobile Experience | | | | | |
+| Scalability | | | | | |
 
-### Adim 4: Stratejik Icgoruler
-Analizden cikarilan sonuclar:
+### Step 4: Strategic Insights
+Conclusions drawn from the analysis:
 
-**Pazar Bosluklari:**
-- Rakiplerin karsilamadigi ihtiyaclar
-- Yetersiz hizmet verilen segmentler
-- Fiyat boslugu firsatlari
-- Ozellik boslugu firsatlari
+**Market Gaps:**
+- Needs competitors fail to meet
+- Underserved segments
+- Price-gap opportunities
+- Feature-gap opportunities
 
-**Tehditler:**
-- Guclu rakiplerin genisleme planlari
-- Yeni giris riskleri
-- Teknoloji degisim riskleri
-- Fiyat savasi riskleri
+**Threats:**
+- Strong competitors' expansion plans
+- New-entrant risks
+- Technology-shift risks
+- Price-war risks
 
-**Benzersiz Avantajlar:**
-- Taklit edilmesi zor guclu yonlerimiz
-- Teknoloji veya veri avantajlari
-- Iliski ve guvenirllik avantajlari
-- Hiz ve ceikliklik avantajlari
+**Unique Advantages:**
+- Our hard-to-copy strengths
+- Technology or data advantages
+- Relationship and trust advantages
+- Speed and agility advantages
 
-### Adim 5: Oneriler
-Stratejik oneriler sun:
+### Step 5: Recommendations
+Offer strategic recommendations:
 
-**Konumlandirma Stratejisi:**
-- Onerilen konum ve mesajlasma
-- Hangi segmentte yoğunlasmali?
-- Farklilastirma vurgulari
+**Positioning Strategy:**
+- Suggested position and messaging
+- Which segment to concentrate on?
+- Differentiation emphases
 
-**Fiyatlandirma Onerisi:**
-- Rekabetci fiyat noktasi
-- Katman ve paketleme onerisi
-- Deger bazli fiyatlandirma firsatlari
+**Pricing Suggestion:**
+- Competitive price point
+- Tiering and packaging suggestion
+- Value-based pricing opportunities
 
-**Ozellik Onceliklendirmesi:**
-- Rekabetci parite icin gereken ozellikler
-- Farklilastirici ozellik firsatlari
-- Kisa ve uzun vadeli yol haritasi onerisi
+**Feature Prioritization:**
+- Features needed for competitive parity
+- Differentiating feature opportunities
+- Short- and long-term roadmap suggestion
 
-**Mesajlasma Stratejisi:**
-- Anahtar mesajlar
-- Kacinilmasi gereken ifadeler
-- Kanit noktalari (proof points)
+**Messaging Strategy:**
+- Key messages
+- Phrases to avoid
+- Proof points
 
-### Adim 6: Markdown Rapor Olustur
+### Step 6: Build the Markdown Report
 
-# Cikti Formati
+# Output Format
 ```markdown
-# Rekabet Analizi Raporu - [tarih]
+# Competitive Analysis Report - [date]
 
-## Yonetici Ozeti
-[3-5 cumle ozet: pazar durumu, ana bulgular, stratejik oneri]
+## Executive Summary
+[3-5 sentence summary: market state, key findings, strategic recommendation]
 
-## Pazar Genel Gorunumu
-- Pazar Buyuklugu: [tahmini]
-- Buyume Trendi: [yuzde/yil]
-- Rekabet Yogunlugu: [DUSUK/ORTA/YUKSEK]
+## Market Overview
+- Market Size: [estimate]
+- Growth Trend: [percent/year]
+- Competitive Intensity: [LOW/MEDIUM/HIGH]
 
-## Rakip Profilleri
-### Rakip A: [isim]
-[detayli profil]
+## Competitor Profiles
+### Competitor A: [name]
+[detailed profile]
 
-### Rakip B: [isim]
-[detayli profil]
+### Competitor B: [name]
+[detailed profile]
 
 ...
 
-## Karsilastirma Matrisi
-[tablo]
+## Comparison Matrix
+[table]
 
-## Stratejik Icgoruler
-### Firsatlar
-[firsatlar]
+## Strategic Insights
+### Opportunities
+[opportunities]
 
-### Tehditler
-[tehditler]
+### Threats
+[threats]
 
-### Avantajlarimiz
-[avantajlar]
+### Our Advantages
+[advantages]
 
-## Oneriler
-### Kisa Vadeli (0-3 ay)
-[aksiyonlar]
+## Recommendations
+### Short Term (0-3 months)
+[actions]
 
-### Orta Vadeli (3-6 ay)
-[aksiyonlar]
+### Mid Term (3-6 months)
+[actions]
 
-### Uzun Vadeli (6-12 ay)
-[aksiyonlar]
+### Long Term (6-12 months)
+[actions]
 
-## Kaynaklar
-[kullanilan veri kaynaklari]
+## Sources
+[data sources used]
 
-## Sonraki Guncelleme
-Onerilen: [tarih] (3 ayda bir)
+## Next Update
+Suggested: [date] (quarterly)
 ```

--- a/.claude/commands/content-brand-voice.md
+++ b/.claude/commands/content-brand-voice.md
@@ -1,78 +1,78 @@
 Brand voice definition and management command. Creates a brand voice guide to keep tone, style, and personality consistent across all content.
 
-# Gerekli Araclar
-- Read (mevcut icerikler, web sitesi metinleri) -- Write (rehber) -- Grep (mevcut ton/stil analizi) -- ...
+# Required Tools
+- Read (existing content, website copy) -- Write (guide) -- Grep (current tone/style analysis) -- ...
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-## 1. Marka Kisiligi
-**Temel:** marka adi -- ne yapiyorsunuz (tek cumle, asansor konusmasi) -- kimi hedefliyorsunuz (yas, meslek, ilgi) -- ...
+## 1. Brand Personality
+**Basics:** brand name -- what you do (one sentence, elevator pitch) -- who you target (age, profession, interests) -- ...
 
-**Farklilik:** rakiplerden fark (tek cumle) -- musteriler neden seciyor (en sik geri bildirim) -- hangi duyguyu uyandirmak (guven, heyecan, huzur, ilham)
+**Differentiation:** difference from competitors (one sentence) -- why customers choose you (most frequent feedback) -- which emotion to evoke (trust, excitement, calm, inspiration)
 
-**Sinirlar:** asla kullanilmayacak ton/kelime (kirmizi cizgi) -- kacinilacak konular (siyaset, din, tartismali) -- hassas noktalar (sektor spesifik)
+**Boundaries:** tone/words never to use (red lines) -- topics to avoid (politics, religion, controversy) -- sensitive points (sector-specific)
 
-## 2. Ton Spektrumu (7 eksen, 1-10)
-| Eksen | Sol Uc (1) | Sag Uc (10) | Konum |
-|-------|-----------|-------------|-------|
-| Resmiyet | Resmi, kurumsal | Samimi, arkadasca | [1-10] |
-| Ciddiyet | Ciddi, agirbasli | Eglenceli, sacma | [1-10] |
-| Tekniklik | Teknik, jargonlu | Sade, herkesin anladigi | [1-10] |
-| Cesaret | Guvenli, konservatif | Provokatif, cesur | [1-10] |
-| Uzunluk | Kisa, ozel | Detayli, hikayeci | [1-10] |
-| Enerji | Sakin, olculu | Enerjik, heyecanli | [1-10] |
-| Otorite | Mucevahir, ogenici | Uzman, ogretici | [1-10] |
+## 2. Tone Spectrum (7 axes, 1-10)
+| Axis | Left End (1) | Right End (10) | Position |
+|------|--------------|----------------|----------|
+| Formality | Formal, corporate | Friendly, casual | [1-10] |
+| Seriousness | Serious, solemn | Playful, silly | [1-10] |
+| Technicality | Technical, jargon-heavy | Plain, universally clear | [1-10] |
+| Boldness | Safe, conservative | Provocative, daring | [1-10] |
+| Length | Short, concise | Detailed, narrative | [1-10] |
+| Energy | Calm, measured | Energetic, excited | [1-10] |
+| Authority | Modest, learning | Expert, teaching | [1-10] |
 
-Her konum icin kisa aciklama.
+A short note for each position.
 
-## 3. Dil Kurallari
-**Hitap:** Sen / Siz / Degisken (platforma gore) -- Biz / Marka adi (3. tekil) / Ben (kisisel marka)
+## 3. Language Rules
+**Address:** informal you / formal you / variable (per platform) -- We / Brand name (3rd person) / I (personal brand)
 
-**Kullanilacak kelimeler:** marka ile ozdeslesmesi gereken 10-15 kelime (ornek: "basit, guclu, ozgur, cesur, net, hizli") -- sektorel terim (kullanilacaksa) -- ...
+**Words to use:** 10-15 words the brand should own (example: "simple, powerful, free, bold, clear, fast") -- sector terms (if used) -- ...
 
-**Kacinilacak:** rakip terim/marka adi -- klise ("dunya lideri, en iyi, bir numara, devrim niteliginde") -- jargon (hedef kitle teknik degilse) -- ...
+**Words to avoid:** competitor terms/brand names -- cliches ("world leader, the best, number one, revolutionary") -- jargon (if the audience is non-technical) -- ...
 
-**Emoji Politikasi:**
-| Platform | Kullanim | Oneri |
-|----------|----------|-------|
-| Instagram | Serbest/Orta/Kisitli | [tercih 5-10] |
-| Twitter/X | Serbest/Orta/Kisitli | [tercih] |
-| LinkedIn | Kisitli/Minimal | [sadece profesyonel] |
-| TikTok | Serbest | [trend] |
-| E-posta | Kisitli/Yok | [varsa secilmis] |
+**Emoji Policy:**
+| Platform | Usage | Suggestion |
+|----------|-------|------------|
+| Instagram | Free/Medium/Limited | [preference 5-10] |
+| Twitter/X | Free/Medium/Limited | [preference] |
+| LinkedIn | Limited/Minimal | [professional only] |
+| TikTok | Free | [trends] |
+| Email | Limited/None | [curated if any] |
 
-**Noktalama:** unlem (serbest/sinirli-cumle basina 1/yok) -- buyuk harf (baslik/vurgu/hic) -- uc nokta (serbest/sinirli/yok) -- ...
+**Punctuation:** exclamation marks (free/limited-1 per sentence/none) -- capitals (headings/emphasis/never) -- ellipsis (free/limited/none) -- ...
 
-## 4. Platform Adaptasyonu (her platform icin ton kaymasi)
-- **Instagram:** ton kaymasi [+/-] -- gorsel oncelikli, metin destekleyici -- Story samimi, post duzenli -- ...
-- **Twitter/X:** ton kaymasi [+/-] -- daha keskin, cesur -- tartismaya acik, gorus bildiren -- ...
-- **LinkedIn:** ton kaymasi [+/-] -- profesyonel, olculu -- deger odakli, deneyim paylasan -- ...
-- **TikTok:** ton kaymasi [+/-] -- daha genc, trend -- konusma dili, dogal -- ...
-- **YouTube:** ton kaymasi [+/-] -- detayli, ogretici -- kisisel baglanti onemli -- ...
-- **E-posta:** ton kaymasi [+/-] -- konu satiri merak uyandirici (spam degil) -- govde degerli/saygili, net CTA
+## 4. Platform Adaptation (tone shift per platform)
+- **Instagram:** tone shift [+/-] -- visual first, copy supporting -- Story casual, posts polished -- ...
+- **Twitter/X:** tone shift [+/-] -- sharper, bolder -- open to debate, opinionated -- ...
+- **LinkedIn:** tone shift [+/-] -- professional, measured -- value-driven, experience-sharing -- ...
+- **TikTok:** tone shift [+/-] -- younger, on-trend -- conversational, natural -- ...
+- **YouTube:** tone shift [+/-] -- detailed, instructive -- personal connection matters -- ...
+- **Email:** tone shift [+/-] -- subject line curiosity-driven (not spammy) -- body valuable/respectful, clear CTA
 
-## 5. Ornek Icerikler
+## 5. Example Content
 
-**Iyi Post:** `[marka sesine uyan IG postu]` — Neden: [aciklama]
+**Good Post:** `[an IG post matching the brand voice]` — Why: [explanation]
 
-**Kotu Post:** `[uyumsuz post]` — Neden: [aciklama]
+**Bad Post:** `[a mismatched post]` — Why: [explanation]
 
-**Iyi Thread:** `[Twitter/X thread]`
+**Good Thread:** `[Twitter/X thread]`
 
-**Iyi LinkedIn:** `[LinkedIn post]`
+**Good LinkedIn:** `[LinkedIn post]`
 
-**Kontrol Listesi:** [ ] Hitap dogru -- [ ] Emoji politikasi -- [ ] Kacinilacak kelime yok -- ...
+**Checklist:** [ ] Address style correct -- [ ] Emoji policy followed -- [ ] No avoided words -- ...
 
-## 6. Kaydet ve Entegre Et
-1. `.claude/workspace/marka-sesi.md` yaz
-2. Su komutlar bu dosyayi okur: `/content-generate` (post metni), `/content-visual-brief` (gorsel yonetmenlik), `/content-video-script` (senaryo), `/content-calendar` (tema), `/content-carousel`
-3. Guncelleme tarihi ekle
-4. Versiyon notu (degisiklikte)
+## 6. Save and Integrate
+1. Write `.claude/workspace/marka-sesi.md`
+2. These commands read this file: `/content-generate` (post copy), `/content-visual-brief` (visual direction), `/content-video-script` (scripts), `/content-calendar` (themes), `/content-carousel`
+3. Add the update date
+4. Version note (on change)
 
-# Cikti Formati
+# Output Format
 ```
-[kisaltildi]
+[abridged]
 ```
 
-# Not
-- 3 ayda bir gozden gecir -- yeni ekip uyesine ilk paylasilacak belge -- tutarsizlikta hemen guncelle -- ...
+# Notes
+- Review every 3 months -- the first document to share with a new team member -- update immediately on inconsistency -- ...

--- a/.claude/commands/content-calendar.md
+++ b/.claude/commands/content-calendar.md
@@ -1,82 +1,82 @@
 Content calendar command. Creates a weekly or monthly social media content plan with themes, platforms, and timing.
 
-# Gerekli Araclar
-- Read (marka sesi, mevcut takvim, proje baglami) -- Write (takvim dosyasi) -- Grep (onceki icerik taramasi) -- ...
+# Required Tools
+- Read (brand voice, current calendar, project context) -- Write (calendar file) -- Grep (previous content scan) -- ...
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-## 1. Takvim Parametreleri
-- **Donem:** Bu hafta / Gelecek hafta / Bu ay / Gelecek ay / Ozel aralik
-- **Platformlar:** [ ] Instagram (Post/Story/Reel) [ ] Twitter-X [ ] LinkedIn [ ] TikTok / ...
-- **Siklik:** her platform icin haftalik kac icerik (IG Post/Story/Reel, Twitter, ...)
-- **Temalar:** ana tema -- kampanya/lansman (varsa) -- mevsimsel -- evergreen
-- **Hedef:** Buyume / Etkilesim / Satis / Bilinirlik / Trafik
-- **Kaynaklar:** blog yazilari -- urun gorselleri -- musteri yorum/referans -- etkinlik takvimi -- ...
-- **Ozel Gunler:** milli/dini bayramlar -- sektor etkinlikleri -- marka yildonumleri -- urun lansmanlari
+## 1. Calendar Parameters
+- **Period:** This week / Next week / This month / Next month / Custom range
+- **Platforms:** [ ] Instagram (Post/Story/Reel) [ ] Twitter-X [ ] LinkedIn [ ] TikTok / ...
+- **Frequency:** weekly content count per platform (IG Post/Story/Reel, Twitter, ...)
+- **Themes:** main theme -- campaign/launch (if any) -- seasonal -- evergreen
+- **Goal:** Growth / Engagement / Sales / Awareness / Traffic
+- **Resources:** blog posts -- product visuals -- customer reviews/testimonials -- event calendar -- ...
+- **Special Days:** national/religious holidays -- industry events -- brand anniversaries -- product launches
 
-## 2. Tema Haritasi
-| Gun | Tema | Icerik Turu | Enerji |
-|-----|------|-------------|--------|
-| Pazartesi | Motivasyon/Hafta Basli | Ilham, hedef | Yuksek |
-| Sali | Egitici/Ipucu | Tutorial, nasil yapilir | Orta |
-| Carsamba | Perde Arkasi/Topluluk | Gunluk rutin, ekip, surec | Samimi |
-| Persembe | Urun/Hizmet | Tanitim, ozellik, demo | Satis |
-| Cuma | Eglence/Trend | Meme, challenge, trend ses | Eglenceli |
-| Cumartesi | UGC/Sosyal Kanit | Musteri hikayesi, referans | Guvenilir |
-| Pazar | Ilham/Yansitma | Haftalik ozet, gelecek teaser | Dusunceli |
+## 2. Theme Map
+| Day | Theme | Content Type | Energy |
+|-----|-------|--------------|--------|
+| Monday | Motivation/Week Start | Inspiration, goals | High |
+| Tuesday | Educational/Tips | Tutorials, how-tos | Medium |
+| Wednesday | Behind the Scenes/Community | Daily routine, team, process | Casual |
+| Thursday | Product/Service | Promotion, features, demo | Sales |
+| Friday | Fun/Trends | Memes, challenges, trending sounds | Playful |
+| Saturday | UGC/Social Proof | Customer stories, testimonials | Trustworthy |
+| Sunday | Inspiration/Reflection | Weekly recap, upcoming teaser | Thoughtful |
 
-Uyarlama:
-- E-ticaret: Per → yeni urun, Cum → flash indirim
-- SaaS: Sal → ozellik spotlight, Per → kullanim ipucu
-- Kisisel marka: Pzt → dusunce liderligi, Car → kisisel hikaye -- ...
+Adaptations:
+- E-commerce: Thu → new product, Fri → flash sale
+- SaaS: Tue → feature spotlight, Thu → usage tip
+- Personal brand: Mon → thought leadership, Wed → personal story -- ...
 
-## 3. Icerik Matrisi
-| Tarih | Gun | Platform | Format | Tema | Konu Ozeti | CTA | Durum |
-|-------|-----|----------|--------|------|-----------|-----|-------|
-| [tarih] | Pzt | IG Post | Karousel (5) | Egitici | [konu] | Kaydet | Planli |
-| [tarih] | Pzt | Twitter | Thread (5) | Egitici | [konu] | RT | Planli |
-| [tarih] | Pzt | IG Story | Anket | Topluluk | [soru] | Oy ver | Planli |
-| [tarih] | Sal | IG Reel | 30s video | Ipucu | [konu] | Takip et | Planli |
-| [tarih] | Sal | LinkedIn | Post | Dusunce | [konu] | Yorum yap | Planli |
+## 3. Content Matrix
+| Date | Day | Platform | Format | Theme | Topic Summary | CTA | Status |
+|------|-----|----------|--------|-------|---------------|-----|--------|
+| [date] | Mon | IG Post | Carousel (5) | Educational | [topic] | Save | Planned |
+| [date] | Mon | Twitter | Thread (5) | Educational | [topic] | RT | Planned |
+| [date] | Mon | IG Story | Poll | Community | [question] | Vote | Planned |
+| [date] | Tue | IG Reel | 30s video | Tip | [topic] | Follow | Planned |
+| [date] | Tue | LinkedIn | Post | Thought | [topic] | Comment | Planned |
 | ... | ... | ... | ... | ... | ... | ... | ... |
 
-Format secimi: tek gorsel (hizli mesaj, alistilar, duyuru) -- karousel (egitici, liste, adim) -- video/reel (demo, ipucu, trend, perde arkasi) -- ...
+Format selection: single visual (quick message, habits, announcements) -- carousel (educational, lists, steps) -- video/reel (demos, tips, trends, behind the scenes) -- ...
 
-## 4. Her Icerik Icin Kisa Brief
+## 4. Short Brief per Content Item
 ```
-[kisaltildi]
-```
-
-## 5. Ozel Gun ve Kampanya Entegrasyonu
-**Takvim Isaretleri:** `[tarih]: [ozel gun] — [planlanan icerik]` / `[tarih]: [kampanya basla] — [hazirlik]` / `[tarih]: [kampanya bit] — [ozet]`
-
-**Kampanya Icerikleri (varsa):** oncesi teaser (tarih araligi) -- lansman gunu (tarih + ozel plan) -- sure (tarih araligi + gunluk akis) -- ...
-
-**Sezonsal:** mevsim degisikligi -- bayram/tatil -- sektor etkinlikleri -- ...
-
-## 6. Kaydet ve Izleme
-1. `.claude/workspace/takvim/` kontrol/olustur
-2. `[YYYY-MM]-icerik-takvimi.md` olustur
-3. Performans kolonlari ekle (sonradan doldurulacak): etkilesim (begeni/yorum/paylas), erisim, tiklama, donusum, not
-
-# Cikti Formati
-```
-[kisaltildi]
+[abridged]
 ```
 
-# Icerik Dagiliim Rehberi (80/20)
-| Tur | Oran | Amac |
-|-----|------|------|
-| Deger (egitici, ilham, eglence) | %80 | Guven ve otorite |
-| Satis (tanitim, CTA, teklif) | %20 | Donusum ve gelir |
+## 5. Special Day and Campaign Integration
+**Calendar Markers:** `[date]: [special day] — [planned content]` / `[date]: [campaign start] — [preparation]` / `[date]: [campaign end] — [recap]`
 
-| Format | Oran | Neden |
-|--------|------|-------|
-| Karousel | %30 | En yuksek kaydetme |
-| Reel/Video | %30 | En yuksek erisim |
-| Tek gorsel | %20 | Hizli tuketim, bilinirlik |
-| Story | %15 | Gunluk etkilesim, yakinlik |
-| Canli yayin | %5 | Derin baglanti, Q&A |
+**Campaign Content (if any):** pre-launch teasers (date range) -- launch day (date + special plan) -- duration (date range + daily flow) -- ...
 
-# Ipuclari
-- Esnek tut — gundeme gore %20 spontane pay -- her hafta en az 1 "kaydet" odakli (egitici/liste) -- platformlar arasi uyarlama yap, birebir kopyalama -- ...
+**Seasonal:** season change -- holidays -- industry events -- ...
+
+## 6. Save and Track
+1. Check/create `.claude/workspace/takvim/`
+2. Create `[YYYY-MM]-icerik-takvimi.md`
+3. Add performance columns (filled later): engagement (likes/comments/shares), reach, clicks, conversion, notes
+
+# Output Format
+```
+[abridged]
+```
+
+# Content Distribution Guide (80/20)
+| Type | Ratio | Purpose |
+|------|-------|---------|
+| Value (educational, inspiration, fun) | 80% | Trust and authority |
+| Sales (promos, CTA, offers) | 20% | Conversion and revenue |
+
+| Format | Ratio | Why |
+|--------|-------|-----|
+| Carousel | 30% | Highest saves |
+| Reel/Video | 30% | Highest reach |
+| Single visual | 20% | Quick consumption, awareness |
+| Story | 15% | Daily engagement, closeness |
+| Live | 5% | Deep connection, Q&A |
+
+# Tips
+- Stay flexible — keep a 20% spontaneous share for current events -- at least 1 "save"-focused piece per week (educational/list) -- adapt across platforms, no verbatim copying -- ...

--- a/.claude/commands/content-carousel.md
+++ b/.claude/commands/content-carousel.md
@@ -1,77 +1,77 @@
 Carousel (multi-frame) content command. Produces educational or storytelling carousel content for Instagram, LinkedIn, and other platforms.
 
-# Gerekli Araclar
-- Read (marka sesi, konu, onceki icerikler) -- Write (karousel dosyasi) -- Grep (ilgili icerik) -- ...
+# Required Tools
+- Read (brand voice, topic, previous content) -- Write (carousel file) -- Grep (related content) -- ...
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-## 1. Karousel Bilgileri
-- **Platform:** Instagram / LinkedIn / Twitter (thread uyarlama) / Facebook / Diger
-- **Konu:** detay
-- **Amac:** Egitici (ipucu, adim) / Hikaye (deneyim, musteri) / Liste (X sey, X neden, X hata) / Karsilastirma (A vs B, oncesi/sonrasi) / ...
-- **Kare Sayisi:** 5-10 (varsayilan 7)
-- **Ton:** Samimi / Profesyonel / Eglenceli / Ilham / Teknik
-- **Gorsel Stil:** Temiz/Minimalist (beyaz alan) / Renkli-Bold (canli, buyuk tipografi) / Fotografik (foto + overlay) / Illustratif (cizim, ikon) / ...
+## 1. Carousel Details
+- **Platform:** Instagram / LinkedIn / Twitter (thread adaptation) / Facebook / Other
+- **Topic:** detail
+- **Purpose:** Educational (tips, steps) / Story (experience, customer) / List (X things, X reasons, X mistakes) / Comparison (A vs B, before/after) / ...
+- **Frame Count:** 5-10 (default 7)
+- **Tone:** Friendly / Professional / Fun / Inspirational / Technical
+- **Visual Style:** Clean/Minimalist (white space) / Colorful-Bold (vivid, large typography) / Photographic (photo + overlay) / Illustrative (drawings, icons) / ...
 
-## 2. Akis Yapisi
+## 2. Flow Structures
 
-**Egitici:** `Kare 1: KAPAK (dikkat + "Kaydet!" CTA) | Kare 2: GIRIS (problem/baglam) | Kare 3-N: ICERIK (her karede 1 ipucu) | Son: OZET + CTA (Takip/Kaydet/Paylas)`
+**Educational:** `Frame 1: COVER (attention + "Save!" CTA) | Frame 2: INTRO (problem/context) | Frames 3-N: CONTENT (1 tip per frame) | Last: SUMMARY + CTA (Follow/Save/Share)`
 
-**Hikaye:** `Kare 1: KAPAK (merak) | Kare 2: BASLANGIC (durum/problem) | Kare 3-N: GELISIM | Son-1: SONUC (ders) | Son: CTA ("Sana da oldu mu?")`
+**Story:** `Frame 1: COVER (curiosity) | Frame 2: SETUP (situation/problem) | Frames 3-N: DEVELOPMENT | Last-1: OUTCOME (lesson) | Last: CTA ("Has it happened to you?")`
 
-**Liste:** `Kare 1: KAPAK ("[Sayi] [konu]") | Kare 2-N: MADDELER (1-2 madde/kare) | Son: BONUS + CTA (Kaydet)`
+**List:** `Frame 1: COVER ("[Number] [topic]") | Frames 2-N: ITEMS (1-2 items/frame) | Last: BONUS + CTA (Save)`
 
-**Karsilastirma:** `Kare 1: KAPAK ("A vs B" / "Yapma/Yap") | Kare 2-N: sol-sag veya oncesi-sonrasi | Son: SONUC + CTA`
+**Comparison:** `Frame 1: COVER ("A vs B" / "Don't/Do") | Frames 2-N: left-right or before-after | Last: CONCLUSION + CTA`
 
-**Soru-Cevap:** `Kare 1: KAPAK ("En cok sorulan X soru") | Kare 2-N: 1 soru+cevap/kare | Son: CTA ("DM at")`
+**Q&A:** `Frame 1: COVER ("The X most-asked questions") | Frames 2-N: 1 question+answer per frame | Last: CTA ("DM me")`
 
-## 3. Her Kare Icerigi
-- **Metin:** Baslik (kisa, vurgulu, maks 8 kelime) -- Govde (2-4 cumle veya 3-5 madde) -- Vurgu (bold/renk) -- ...
-- **Tasarim:** Arka plan rengi/gorseli -- metin konumu (ust/orta/alt, sol/sag/orta) -- font boyut hiyerarsisi (baslik>govde>not) -- ...
-- **Okunabilirlik:** Baslik 2s okunabilir mi -- govde 5s -- metin/arka plan kontrasti -- ...
+## 3. Per-Frame Content
+- **Copy:** Heading (short, punchy, max 8 words) -- Body (2-4 sentences or 3-5 bullets) -- Emphasis (bold/color) -- ...
+- **Design:** Background color/image -- text position (top/middle/bottom, left/right/center) -- font size hierarchy (heading>body>note) -- ...
+- **Readability:** Heading readable in 2s -- body in 5s -- text/background contrast -- ...
 
-## 4. Gorsel Tutarlilik
-- **Tutarli ogeler:** ayni renk paleti (hafif varyasyon OK) -- ayni font ailesi + hiyerarsi -- birincil/ikincil/vurgu rengi tutarli -- ...
-- **Kaydirma motivasyonu:** "Ama en onemlisi..." (kesilme) -- ok isareti (→/↓) -- sayfa numarasi -- ...
+## 4. Visual Consistency
+- **Consistent elements:** same color palette (slight variation OK) -- same font family + hierarchy -- primary/secondary/accent color consistent -- ...
+- **Swipe motivation:** "But the most important one..." (cliffhanger) -- arrow markers (→/↓) -- page numbers -- ...
 
-## 5. Caption ve Gorsel Brief
-**Caption:** ilk satir hook (kesilme noktasi oncesi) -- govde destekleyici bilgi -- CTA (Kaydet/Etiketle/Yorum) -- ...
+## 5. Caption and Visual Brief
+**Caption:** first line is the hook (before the cut-off point) -- body supporting info -- CTA (Save/Tag/Comment) -- ...
 
-**Her Kare Brief:**
+**Per-Frame Brief:**
 ```
-Kare [no]: arka plan [renk/gorsel/gradient] -- metin "[baslik]" + "[govde]" -- konum [ust-orta/orta/alt] -- ...
-```
-
-**Canva/Figma:** sablon boyutu (1080x1080 veya 1080x1350) -- katman sirasi (arka plan → gorsel → metin → logo → numara) -- font (baslik + govde) -- ...
-
-## 6. Kaydet ve Paketle
-1. `.claude/workspace/icerikler/` kontrol
-2. `[YYYY-MM-DD]-karousel-[konu-kebab].md` kaydet
-3. Kullaniciya ozet sun
-
-# Cikti Formati
-```
-[kisaltildi]
+Frame [no]: background [color/image/gradient] -- text "[heading]" + "[body]" -- position [top-center/middle/bottom] -- ...
 ```
 
-# Karousel En Iyi Uygulamalar
-| Kural | Aciklama |
-|-------|----------|
-| 1 Kare = 1 Fikir | Her kare tek mesaj |
-| Ilk kare = %80 basari | Kapak kaydirmayi belirler |
-| 7 kare ideal | 5'ten az sigi, 10'dan fazla yorucu |
-| Kaydir motivasyonu | Her kare sonrakini merak ettirsin |
-| Son kare = CTA | Kaydet, paylas, takip et |
-| Tutarli tasarim | Ayni renk/font/yapi |
-| Okunabilirlik | 3 saniyede okunabilir miktar |
-| Bos alan | Sikis yok, nefes alani |
+**Canva/Figma:** template size (1080x1080 or 1080x1350) -- layer order (background → image → text → logo → number) -- fonts (heading + body) -- ...
 
-# Karousel Turleri ve Performans
-| Tur | Kaydetme | Paylasma | Etkilesim | En Uygun Platform |
-|-----|---------|---------|-----------|-------------------|
-| Egitici | Cok yuksek | Yuksek | Orta | Instagram, LinkedIn |
-| Liste | Yuksek | Orta | Orta | Instagram |
-| Hikaye | Orta | Yuksek | Cok yuksek | Instagram, LinkedIn |
-| Karsilastirma | Yuksek | Orta | Orta | Instagram, Twitter |
-| Adim adim | Cok yuksek | Yuksek | Orta | Instagram, LinkedIn |
-| Motivasyon | Orta | Cok yuksek | Dusuk | Instagram |
+## 6. Save and Package
+1. Check `.claude/workspace/icerikler/`
+2. Save `[YYYY-MM-DD]-carousel-[topic-kebab].md`
+3. Present a summary to the user
+
+# Output Format
+```
+[abridged]
+```
+
+# Carousel Best Practices
+| Rule | Explanation |
+|------|-------------|
+| 1 Frame = 1 Idea | One message per frame |
+| First frame = 80% of success | The cover decides the swipe |
+| 7 frames ideal | Fewer than 5 feels thin, more than 10 tires |
+| Swipe motivation | Each frame should tease the next |
+| Last frame = CTA | Save, share, follow |
+| Consistent design | Same color/font/structure |
+| Readability | Readable within 3 seconds |
+| White space | No crowding, breathing room |
+
+# Carousel Types and Performance
+| Type | Saves | Shares | Engagement | Best Platform |
+|------|-------|--------|------------|---------------|
+| Educational | Very high | High | Medium | Instagram, LinkedIn |
+| List | High | Medium | Medium | Instagram |
+| Story | Medium | High | Very high | Instagram, LinkedIn |
+| Comparison | High | Medium | Medium | Instagram, Twitter |
+| Step-by-step | Very high | High | Medium | Instagram, LinkedIn |
+| Motivation | Medium | Very high | Low | Instagram |

--- a/.claude/commands/content-close.md
+++ b/.claude/commands/content-close.md
@@ -1,143 +1,143 @@
 Content session close command. Summarizes the day's output, prepares for tomorrow, and notes learnings.
 
-# Gerekli Araclar
-- Read (bugunun icerikleri, notlar)
-- Glob (bugun olusturulan dosyalar)
-- Grep (placeholder kontrolu)
-- Write (gunluk not guncelleme)
-- Bash (tarih ve dosya listeleme)
+# Required Tools
+- Read (today's content, notes)
+- Glob (files created today)
+- Grep (placeholder check)
+- Write (daily note update)
+- Bash (date and file listing)
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-### Adim 1: Bugun Uretilenleri Topla
-`.claude/workspace/` altindaki bugun tarihli dosyalari bul:
-- `icerikler/` — Post ve karousel
-- `senaryolar/` — Video
-- `gorseller/` — Gorsel brief
-- `takvim/` — Takvim guncellemeleri
+### Step 1: Collect Today's Output
+Find today's files under `.claude/workspace/`:
+- `icerikler/` — Posts and carousels
+- `senaryolar/` — Videos
+- `gorseller/` — Visual briefs
+- `takvim/` — Calendar updates
 
-Her dosya icin:
-- Dosya adi
-- Icerik turu
-- Tamamlanmis mi? (placeholder var mi?)
-- Hangi platform icin?
+For each file:
+- File name
+- Content type
+- Complete? (any placeholders?)
+- For which platform?
 
-### Adim 2: Tamamlanmislik Kontrolu
-Her taslakta placeholder isaretleri ara:
-- `[...]` (kose parantezli yer tutucular)
+### Step 2: Completion Check
+Look for placeholder markers in every draft:
+- `[...]` (bracketed placeholders)
 - `TODO`, `TBD`, `FIXME`
-- Bos bolumler
+- Empty sections
 
-**Tamamlanan**: Placeholder yok, yayina hazir
-**Kismi**: Bazi yerler dolu, bazilar eksik
-**Taslak**: Cogu yer bos
+**Complete**: No placeholders, publish-ready
+**Partial**: Some parts filled, some missing
+**Draft**: Mostly empty
 
-### Adim 3: Yayinlama Planlamasi
-Tamamlanan icerikler icin yayinlama zamani onerisi:
-- Platform bazli optimal saatler
-- Tema uyumu (gun/saat)
-- Takvime ekleme onerisi
+### Step 3: Publishing Plan
+Suggest publish times for completed content:
+- Platform-optimal hours
+- Theme fit (day/time)
+- Suggestion to add to the calendar
 
 ```
-[Icerik] -> [Platform] -> [Gun] [Saat]
+[Content] -> [Platform] -> [Day] [Time]
 ```
 
-### Adim 4: Yarin Icin Hazirlik
-Yarina hazirlik notu olustur:
-- **Yarin ne var?** Takvimden kontrol et
-- **Tamamlanmayan taslak var mi?** Yarinin ilk isi olsun
-- **Devam eden diziler var mi?** (karousel serisi, video serisi)
-- **Trend firsat var mi?** (guncel olay, ozel gun)
+### Step 4: Prepare for Tomorrow
+Create a prep note for tomorrow:
+- **What's on tomorrow?** Check the calendar
+- **Any unfinished drafts?** Make them tomorrow's first job
+- **Any ongoing series?** (carousel series, video series)
+- **Any trend opportunities?** (current events, special days)
 
-### Adim 5: Ogrenilenler ve Notlar
-Bugun cikan icgoruleri not et:
-- **Ne iyi gitti?** (kolay yaratilan icerikler)
-- **Ne zor geldi?** (takildigin yerler)
-- **Yeni fikir dogdugu var mi?** (gelecek kullanim icin)
-- **Marka sesinde duzeltme gerekli mi?**
+### Step 5: Learnings and Notes
+Note today's insights:
+- **What went well?** (content that came easily)
+- **What was hard?** (where you got stuck)
+- **Any new ideas born?** (for future use)
+- **Does the brand voice need a correction?**
 
-Ogrenilenler `knowledge-nominations.md` dosyasina aday olarak eklenebilir.
+Learnings can be nominated into `knowledge-nominations.md`.
 
-### Adim 6: Seans Notunu Kapat
-`.claude/workspace/icerik-notlari/[tarih].md` dosyasini guncelle:
+### Step 6: Close the Session Note
+Update `.claude/workspace/icerik-notlari/[date].md`:
 
 ```markdown
-# Icerik Notlari — [tarih]
+# Content Notes — [date]
 
-## Bugunki Oncelik
-[sabah belirlenen oncelik]
+## Today's Priority
+[the priority set in the morning]
 
-## Tamamlananlar
-- [x] [icerik 1] — [platform]
-- [x] [icerik 2] — [platform]
+## Completed
+- [x] [content 1] — [platform]
+- [x] [content 2] — [platform]
 
-## Kismi Tamamlananlar
-- [ ] [icerik 3] — [neyin eksik]
+## Partially Completed
+- [ ] [content 3] — [what's missing]
 
-## Fikirler / Notlar
-- [yeni fikir]
-- [ogrenilen]
+## Ideas / Notes
+- [new idea]
+- [learning]
 
-## Yarin Icin
-- [ ] [oncelik 1]
-- [ ] [oncelik 2]
+## For Tomorrow
+- [ ] [priority 1]
+- [ ] [priority 2]
 
-## Performans Notlari
-[varsa rakamlar]
+## Performance Notes
+[numbers if any]
 ```
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI ICERIK KAPANIS ===
-Tarih: [tarih]
-Sure: [tahmini calisma suresi]
+=== BADI CONTENT CLOSE ===
+Date: [date]
+Duration: [estimated working time]
 
 -------------------------------------------
-BUGUN URETILENLER
+PRODUCED TODAY
 -------------------------------------------
-Tamamlanan: [sayi]
-Kismi: [sayi]
-Taslak: [sayi]
-Toplam: [sayi]
+Complete: [count]
+Partial: [count]
+Draft: [count]
+Total: [count]
 
 -------------------------------------------
-DETAY LISTE
+DETAIL LIST
 -------------------------------------------
-TAMAMLANAN:
-  + [dosya 1] ([platform])
-  + [dosya 2] ([platform])
+COMPLETE:
+  + [file 1] ([platform])
+  + [file 2] ([platform])
 
-KISMI:
-  ~ [dosya 3] ([eksik neleri])
-
--------------------------------------------
-YAYINLAMA ONERILERI
--------------------------------------------
-| Icerik | Platform | Onerilen Zaman |
-|--------|----------|----------------|
+PARTIAL:
+  ~ [file 3] ([what's missing])
 
 -------------------------------------------
-YARIN IÇIN
+PUBLISHING SUGGESTIONS
 -------------------------------------------
-Oncelikler:
-1. [kismi tamamlanan bitir]
-2. [takvim planli icerik]
-3. [yeni fikir]
+| Content | Platform | Suggested Time |
+|---------|----------|----------------|
 
 -------------------------------------------
-OGRENILENLER
+FOR TOMORROW
 -------------------------------------------
-- [not 1]
-- [not 2]
+Priorities:
+1. [finish the partial one]
+2. [calendar-planned content]
+3. [new idea]
 
 -------------------------------------------
-SEANS NOTU
+LEARNINGS
 -------------------------------------------
-Dosya: .claude/workspace/icerik-notlari/[tarih].md
+- [note 1]
+- [note 2]
+
+-------------------------------------------
+SESSION NOTE
+-------------------------------------------
+File: .claude/workspace/icerik-notlari/[date].md
 ============================
 ```
 
-# Ne Zaman Kullanilir
-- Her gun icerik uretimi bitince (aksam rituelu)
-- Batch uretim seansi sonunda
-- Hafta sonu haftalik kapanis icin
+# When to Use
+- Every day when content production ends (evening ritual)
+- At the end of a batch production session
+- For the weekly close on weekends

--- a/.claude/commands/content-generate.md
+++ b/.claude/commands/content-generate.md
@@ -1,73 +1,73 @@
 Social media content generation command. Produces ready-to-use posts, captions, visual briefs, and hashtags for the given platform and type.
 
-# Gerekli Araclar
-- Read (marka sesi, onceki icerikler, proje baglami) -- Write (icerik dosyasi) -- Grep (onceki icerik taramasi) -- ...
+# Required Tools
+- Read (brand voice, previous content, project context) -- Write (content file) -- Grep (previous content scan) -- ...
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-## 1. Girdi Topla
-- **Platform:** Instagram / Twitter-X / LinkedIn / TikTok / YouTube / Facebook / Hepsi
-- **Tur:** Bilgilendirici (ipucu, liste, nasil) / Ilham (motivasyon, basari) / Eglence (meme, trend) / Satis (urun, indirim, lansman) / ...
-- **Konu/Mesaj:** detay
-- **Ton:** Samimi / Profesyonel / Eglenceli / Ilham / Provokatif / Minimal
-- **Gorsel brief isteniyor mu?** (evet/hayir) -- ...
+## 1. Gather Input
+- **Platform:** Instagram / Twitter-X / LinkedIn / TikTok / YouTube / Facebook / All
+- **Type:** Informative (tips, lists, how-tos) / Inspirational (motivation, success) / Entertainment (memes, trends) / Sales (product, discount, launch) / ...
+- **Topic/Message:** detail
+- **Tone:** Friendly / Professional / Fun / Inspirational / Provocative / Minimal
+- **Visual brief wanted?** (yes/no) -- ...
 
-## 2. Marka Baglami
-**Zorunlu:** `.claude/workspace/marka-sesi.md` (ton, hitap, emoji politikasi) -- `memory.md` (kampanya/lansman/proje)
+## 2. Brand Context
+**Mandatory:** `.claude/workspace/marka-sesi.md` (tone, address style, emoji policy) -- `memory.md` (campaign/launch/project)
 
-**Opsiyonel:** `.claude/workspace/icerikler/` (son 5, tekrar onleme) -- `.claude/workspace/takvim/` (zamanlama uyumu) -- `knowledge-base.md` (kacinilacak ifadeler, kurallar)
+**Optional:** `.claude/workspace/icerikler/` (last 5, repeat prevention) -- `.claude/workspace/takvim/` (timing fit) -- `knowledge-base.md` (phrases to avoid, rules)
 
-Marka sesi yoksa `/content-brand-voice` onerirken zorunlu tutma.
+If no brand voice exists, suggest `/content-brand-voice` without making it mandatory.
 
-## 3. Platform Kurallari
+## 3. Platform Rules
 
-**Instagram:** Post maks 2200 karakter (ilk 125 kritik, kesilme noktasi) -- hashtag 20-30 (nis+genel, ilk yoruma da OK) -- gorsel 1080x1080 veya 1080x1350 -- ...
+**Instagram:** post max 2200 chars (first 125 critical, cut-off point) -- hashtags 20-30 (niche+general, first comment also OK) -- visuals 1080x1080 or 1080x1350 -- ...
 
-**Twitter/X:** maks 280 karakter (thread'de her tweet ayri) -- thread: 1/ ana mesaj, 2-N/ destek, son/ CTA -- hashtag 1-3 (fazlasi spam) -- ...
+**Twitter/X:** max 280 chars (each tweet in a thread separate) -- thread: 1/ main message, 2-N/ support, last/ CTA -- hashtags 1-3 (more reads as spam) -- ...
 
-**LinkedIn:** maks 3000 karakter (ilk 210 "daha fazla" oncesi) -- ton profesyonel + insani, kisisel deneyim -- hashtag 3-5 (sektorel) -- ...
+**LinkedIn:** max 3000 chars (first 210 before "see more") -- tone professional + human, personal experience -- hashtags 3-5 (sector) -- ...
 
-**TikTok:** caption maks 2200 (kisa tut) -- video oncelikli, metin destekleyici -- hashtag 3-5 (trend + nis) -- ...
+**TikTok:** caption max 2200 (keep it short) -- video first, text supporting -- hashtags 3-5 (trend + niche) -- ...
 
-**YouTube:** baslik maks 100 karakter (anahtar kelime) -- aciklama 5000 karakter (ilk 2-3 satir SEO kritik) -- etiket 10-15 -- ...
+**YouTube:** title max 100 chars (keyword) -- description 5000 chars (first 2-3 lines SEO-critical) -- tags 10-15 -- ...
 
-**Facebook:** post 63,206 limit ama optimal 40-80 kelime -- soru sormak etkilesimi artirir -- link aciklamasi kisa-net
+**Facebook:** post limit 63,206 but optimal 40-80 words -- asking a question lifts engagement -- link description short and clear
 
-## 4. Icerik Varyasyonlari (3 yaklasim)
+## 4. Content Variations (3 approaches)
 
-**A — Dogrudan Deger:** net acik mesaj -- hemen fayda -- "Iste X yapmanin Y yolu..."
+**A — Direct Value:** clear open message -- immediate benefit -- "Here are Y ways to do X..."
 
-**B — Hikaye:** kisisel deneyim/senaryo ile basla -- duygu baglantisi -- "Gecen hafta X yasadim ve..."
+**B — Story:** open with personal experience/scenario -- emotional connection -- "Last week I experienced X and..."
 
-**C — Soru/Merak:** soru/sasirtici iddia ile ac -- merak boslugu -- "Cogu kisi X'i yanlis yapiyor. Iste nedeni..."
+**C — Question/Curiosity:** open with a question/surprising claim -- curiosity gap -- "Most people do X wrong. Here's why..."
 
-Her varyasyon icin: tam metin (kopyala-yapistir hazir) -- platform hashtag listesi -- CTA -- ...
+For each variation: full copy (copy-paste ready) -- platform hashtag list -- CTA -- ...
 
-## 5. Gorsel Brief (istenildiyse)
-Her varyasyon icin: **Aciklama** (obje/sahne/duygu) -- **Boyut** (1080x1080, 1080x1350, 1920x1080 vb.) -- **Stil** (Fotografik/Minimalist/Illustrasyon/Tipografik/Collage) -- ...
+## 5. Visual Brief (if requested)
+For each variation: **Description** (object/scene/emotion) -- **Size** (1080x1080, 1080x1350, 1920x1080 etc.) -- **Style** (Photographic/Minimalist/Illustration/Typographic/Collage) -- ...
 
-## 6. Paketle ve Kaydet
-1. `.claude/workspace/icerikler/` kontrol/olustur
-2. `[YYYY-MM-DD]-[konu-kebab].md` olustur
-3. Varyasyon + brief + metadata tek dosyaya yaz
-4. Ozet sun
+## 6. Package and Save
+1. Check/create `.claude/workspace/icerikler/`
+2. Create `[YYYY-MM-DD]-[topic-kebab].md`
+3. Write variations + brief + metadata into one file
+4. Present a summary
 
-# Cikti Formati
+# Output Format
 ```
-[kisaltildi]
+[abridged]
 ```
 
-# Zamanlama Rehberi
-| Platform | En Iyi Gunler | En Iyi Saatler | Neden |
-|----------|--------------|----------------|-------|
-| Instagram | Sal, Per | 11:00-13:00, 19:00-21:00 | Oglen molasi ve aksam bos zamani |
-| Twitter/X | Pzt, Car | 09:00-11:00, 13:00-15:00 | Is basi ve oglen sonrasi |
-| LinkedIn | Sal, Car, Per | 08:00-10:00, 17:00-18:00 | Is basi ve cikis |
-| TikTok | Crs, Cum | 19:00-23:00 | Aksam bos zamani |
-| YouTube | Cum, Cts | 14:00-16:00 | Hafta sonu izleme |
-| Facebook | Car, Per | 12:00-15:00 | Oglen ve ogleden sonra |
+# Timing Guide
+| Platform | Best Days | Best Hours | Why |
+|----------|-----------|------------|-----|
+| Instagram | Tue, Thu | 11:00-13:00, 19:00-21:00 | Lunch break and evening downtime |
+| Twitter/X | Mon, Wed | 09:00-11:00, 13:00-15:00 | Work start and post-lunch |
+| LinkedIn | Tue, Wed, Thu | 08:00-10:00, 17:00-18:00 | Work start and end of day |
+| TikTok | Wed, Fri | 19:00-23:00 | Evening downtime |
+| YouTube | Fri, Sat | 14:00-16:00 | Weekend viewing |
+| Facebook | Wed, Thu | 12:00-15:00 | Noon and afternoon |
 
-Not: genel veridir, hedef kitleye gore degisir. Analitik varsa onlara oncelik.
+Note: general data; varies with the target audience. Prioritize analytics when available.
 
-# Ipuclari
-- Coklu platformda her birine ozel uyarla (kopyalama yok) -- hashtag: %30 buyuk (100K+), %50 orta (10K-100K), %20 nis (<10K) -- her 5'inden 1'i satis odakli (80/20) -- ...
+# Tips
+- On multi-platform, adapt for each one (no copy-paste) -- hashtags: 30% large (100K+), 50% medium (10K-100K), 20% niche (<10K) -- 1 in 5 sales-focused (80/20) -- ...

--- a/.claude/commands/content-idea.md
+++ b/.claude/commands/content-idea.md
@@ -1,128 +1,128 @@
 Content idea generation command. Creates a structured idea list for a topic, theme, or platform.
 
-# Gerekli Araclar
-- Read (marka sesi, gecmis icerikler, trend notlari)
-- Grep (tekrar kontrol)
-- Glob (arsiv tarama)
-- Bash (trend verisi, zaman)
+# Required Tools
+- Read (brand voice, past content, trend notes)
+- Grep (repeat check)
+- Glob (archive scan)
+- Bash (trend data, time)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Fikir Parametreleri
-Kullanicidan:
-- **Konu alani:** Genel tema veya sektor (opsiyonel)
-- **Platform:** Hangi platform icin? (varsa)
-- **Format:** Post / Karousel / Video / Hepsi
-- **Ton:** Marka sesi ile uyumlu olmali (otomatik)
-- **Adet:** Kac fikir? (varsayilan: 10)
-- **Amac:** Etkilesim / Satis / Bilinirlik / Egitim
+### Step 1: Idea Parameters
+From the user:
+- **Topic area:** General theme or sector (optional)
+- **Platform:** For which platform? (if any)
+- **Format:** Post / Carousel / Video / All
+- **Tone:** Must match the brand voice (automatic)
+- **Count:** How many ideas? (default: 10)
+- **Goal:** Engagement / Sales / Awareness / Education
 
-### Adim 2: Kaynak Taramasi
-Fikir kaynaklarindan besleme yap:
+### Step 2: Source Scan
+Feed from idea sources:
 
-**Ic kaynaklar:**
-- Son 30 gun uretilen icerikler (tekrar onleme)
-- Bekleyen taslaklar (gelistirilebilir)
-- Musteri sorulari / SSS
-- Mevcut urun / hizmet listesi
+**Internal sources:**
+- Content produced in the last 30 days (repeat prevention)
+- Pending drafts (improvable)
+- Customer questions / FAQ
+- Current product / service list
 
-**Dis kaynaklar (varsa):**
-- Mevsimsel takvim (ay / hafta bazli)
-- Ozel gunler (dunya X gunu, bayramlar)
-- Sektor trendleri
-- Populer format ornekleri
+**External sources (if available):**
+- Seasonal calendar (month / week)
+- Special days (world X day, holidays)
+- Industry trends
+- Popular format examples
 
-### Adim 3: 10 Fikir Uret
-Farkli aciilar icin kategorize et:
+### Step 3: Generate 10 Ideas
+Categorize by different angles:
 
-**Egitici (3-4 fikir):**
-- Nasil yapilir
-- X ipucu liste
-- Yaygin hata
-- Baslangic kilavuzu
+**Educational (3-4 ideas):**
+- How-to
+- X-tip lists
+- Common mistakes
+- Beginner guides
 
-**Hikaye (2-3 fikir):**
-- Kisisel deneyim
-- Musteri basari hikayesi
-- Perde arkasi
+**Story (2-3 ideas):**
+- Personal experience
+- Customer success story
+- Behind the scenes
 
-**Eglence/Trend (2-3 fikir):**
-- Meme uyarlamasi
-- Trend format
+**Fun/Trend (2-3 ideas):**
+- Meme adaptation
+- Trending format
 - Challenge
 
-**Satis Odakli (1-2 fikir):**
-- Urun tanitim
-- Indirim duyurusu
-- Vaka calismasi
+**Sales-Focused (1-2 ideas):**
+- Product promo
+- Discount announcement
+- Case study
 
-### Adim 4: Her Fikir Icin Hizli Brief
-Her fikir icin mini ozet:
+### Step 4: Quick Brief per Idea
+A mini summary for each idea:
 ```
-[numara]. [Platform] — [Format] — [Baslik]
-   Ton: [ton]
-   Hook: [ilk cumle fikri]
-   Mesaj: [tek cumle ozet]
-   CTA: [onerilen cagri]
-   Etki: [DUSUK / ORTA / YUKSEK]
-   Efor: [DUSUK / ORTA / YUKSEK]
+[number]. [Platform] — [Format] — [Title]
+   Tone: [tone]
+   Hook: [first-sentence idea]
+   Message: [one-sentence summary]
+   CTA: [suggested call]
+   Impact: [LOW / MEDIUM / HIGH]
+   Effort: [LOW / MEDIUM / HIGH]
 ```
 
-### Adim 5: Oncelik Oneri
-Etki/Efor oranina gore siralama yap:
-- **Hizli Kazanc** (Yuksek etki, dusuk efor) — Bugun yap
-- **Stratejik** (Yuksek etki, yuksek efor) — Planla
-- **Dolgu** (Dusuk etki, dusuk efor) — Firsat ciktiginda
-- **Kacin** (Dusuk etki, yuksek efor) — Listeden cikar
+### Step 5: Priority Suggestion
+Rank by impact/effort ratio:
+- **Quick Win** (High impact, low effort) — Do today
+- **Strategic** (High impact, high effort) — Plan it
+- **Filler** (Low impact, low effort) — When the chance comes
+- **Avoid** (Low impact, high effort) — Drop from the list
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI ICERIK FIKIRLERI ===
-Tarih: [tarih]
-Konu Alani: [alan]
+=== BADI CONTENT IDEAS ===
+Date: [date]
+Topic Area: [area]
 Platform: [platform]
-Adet: [sayi]
+Count: [number]
 
 -------------------------------------------
-HIZLI KAZANC (Bugun Yap)
+QUICK WINS (Do Today)
 -------------------------------------------
-1. [Platform] [Format]: [baslik]
-   Hook: [cumle]
-   Mesaj: [ozet]
-   CTA: [cagri]
-   Sure: ~[dakika]
+1. [Platform] [Format]: [title]
+   Hook: [sentence]
+   Message: [summary]
+   CTA: [call]
+   Time: ~[minutes]
 
 2. ...
 
 -------------------------------------------
-STRATEJIK (Planla)
+STRATEGIC (Plan)
 -------------------------------------------
-3. [Platform] [Format]: [baslik]
+3. [Platform] [Format]: [title]
    ...
 
 -------------------------------------------
-DOLGU
+FILLER
 -------------------------------------------
 4. ...
 
 -------------------------------------------
-OZEL GUN BAGLANTILARI
+SPECIAL DAY TIE-INS
 -------------------------------------------
-Yaklasan ozel gunler:
-- [tarih]: [etkinlik] -> fikir: [oneri]
+Upcoming special days:
+- [date]: [event] -> idea: [suggestion]
 
 -------------------------------------------
-SONRAKI ADIM
+NEXT STEP
 -------------------------------------------
-Hizli baslangic:
-  badi content post "[secilen fikir]"
-  badi content karousel "[secilen fikir]"
+Quick start:
+  badi content post "[chosen idea]"
+  badi content carousel "[chosen idea]"
   /content-generate
 =============================
 ```
 
-# Ne Zaman Kullanilir
-- Fikir takildiginda (yaratici tikanma)
-- Haftalik planlama oncesi
-- Trend yakalamak icin
-- Uretimi hizlandirmak icin (hazir fikir havuzu)
+# When to Use
+- When stuck for ideas (creative block)
+- Before weekly planning
+- To catch trends
+- To speed up production (a ready idea pool)

--- a/.claude/commands/content-perf.md
+++ b/.claude/commands/content-perf.md
@@ -1,81 +1,81 @@
 Content performance tracking command. Tracks likes, comments, reach, and ROI for published content.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi content perf)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Veri Ekleme
+### Step 1: Add Data
 
-Her yayindan sonra metric'leri kaydet:
+Record the metrics after every publish:
 
 ```bash
-badi content perf add --file 2026-04-19-konu.md \
+badi content perf add --file 2026-04-19-topic.md \
   --platform instagram \
   --likes 150 --comments 12 --shares 5 --saves 20 \
   --reach 2500 \
   --effort 1.5
 ```
 
-Parametreler:
-- `--file` — Icerik dosyasi adi
+Parameters:
+- `--file` — Content file name
 - `--platform` — instagram/twitter/linkedin/tiktok/facebook
-- `--likes/--comments/--shares/--saves/--reach` — Metrikler
-- `--effort` — Uretim suresi (saat)
+- `--likes/--comments/--shares/--saves/--reach` — Metrics
+- `--effort` — Production time (hours)
 
-### Adim 2: Raporlar
+### Step 2: Reports
 
 ```bash
-badi content perf              # Haftalik ozet (varsayilan)
+badi content perf              # Weekly summary (default)
 badi content perf --week
 badi content perf --month
-badi content perf list         # Tum kayitlar
+badi content perf list         # All records
 ```
 
-### Adim 3: Trend Analizi
+### Step 3: Trend Analysis
 
 ```bash
 badi content perf --trend
 ```
 
-Onceki ve mevcut donem karsilastirmasi:
-- Toplam etkilesim degisimi (%)
-- Platform bazli trendler
+Previous vs. current period comparison:
+- Total engagement change (%)
+- Platform-level trends
 
-### Adim 4: ROI Analizi
+### Step 4: ROI Analysis
 
 ```bash
 badi content perf --roi
 ```
 
-Platform bazli Etkilesim/Efor orani. Hangi platform saatinize en cok degiyor?
+Engagement/effort ratio per platform. Which platform pays the most for your hour?
 
-### Adim 5: Platform Filtresi
+### Step 5: Platform Filter
 
 ```bash
 badi content perf --platform instagram --month
 ```
 
-### Adim 6: Yorum + Aksiyon
+### Step 6: Interpretation + Action
 
-Rapor sonuclarina gore kullaniciya:
-- En iyi performans: "Bu formati tekrar deneyelim mi?"
-- Dusuk ROI: "Bu platformda vakit ayirma stratejisi?"
-- Negatif trend: "Icerik karmasi revize edilsin mi?"
+Based on the report, tell the user:
+- Best performer: "Shall we repeat this format?"
+- Low ROI: "Rethink the time investment on this platform?"
+- Negative trend: "Should the content mix be revised?"
 
-### Adim 7: Haftalik Rutin
+### Step 7: Weekly Routine
 
-Perseembe/Cuma akşami haftalik degerlendirme:
+Thursday/Friday evening weekly evaluation:
 ```bash
-badi content perf --trend      # Hafta degerlendir
-badi content plan              # Onumuzdeki hafta planla
+badi content perf --trend      # Evaluate the week
+badi content plan              # Plan next week
 ```
 
-# Ornek
+# Example
 
 ```
-/content-perf                  # Haftalik ozet
-/content-perf --trend          # Trend karsilastirma
-/content-perf --roi            # ROI siralama
+/content-perf                  # Weekly summary
+/content-perf --trend          # Trend comparison
+/content-perf --roi            # ROI ranking
 /content-perf add --file ... --platform linkedin --likes 85 ...
 ```

--- a/.claude/commands/content-plan.md
+++ b/.claude/commands/content-plan.md
@@ -1,136 +1,136 @@
 Weekly content planning session command. Sets next week's content strategy, themes, and production targets.
 
-# Gerekli Araclar
-- Read (marka sesi, gecmis takvim, performans)
-- Write (yeni takvim dosyasi)
-- Grep (gecmis icerik analizi)
-- Glob (dosya arama)
-- Bash (tarih hesaplama)
+# Required Tools
+- Read (brand voice, past calendars, performance)
+- Write (new calendar file)
+- Grep (past content analysis)
+- Glob (file search)
+- Bash (date calculations)
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-### Adim 1: Gecen Hafta Degerlendirmesi
-Son 7 gunun uretim ciktisini analiz et:
-- Kac icerik uretildi? (platform bazli)
-- Hangileri planlanmisti, hangileri spontane?
-- Tamamlanmayan planli icerik var mi?
-- En cok hangi formati uretiyorsun? (post, karousel, video)
+### Step 1: Last Week's Review
+Analyze the last 7 days of production output:
+- How much content was produced? (per platform)
+- Which were planned, which spontaneous?
+- Any planned content left unfinished?
+- Which format do you produce most? (post, carousel, video)
 
-Soru sor:
-- **En iyi 3 icerigin neydi?** (etkilesim veya tatmin bazli)
-- **En zor olani hangisiydi?** (neden zorlandin?)
+Ask:
+- **What were your 3 best pieces?** (by engagement or satisfaction)
+- **Which was the hardest?** (why was it hard?)
 
-### Adim 2: Gelecek Hafta Temalari
-Haftaya ait tema haritasi olustur:
+### Step 2: Next Week's Themes
+Build the week's theme map:
 
-**Veri kaynaklari:**
-- Ozel gunler ve etkinlikler (takvime bak)
-- Mevsimsel firsatlar
-- Gundem konulari (marka uyumlu)
-- Devam eden kampanyalar
-- Musteri sorulari / SSS
+**Data sources:**
+- Special days and events (check the calendar)
+- Seasonal opportunities
+- Current topics (brand-fit)
+- Ongoing campaigns
+- Customer questions / FAQ
 
-Her gun icin 1 ana tema belirle:
+Set 1 main theme per day:
 ```
-Pazartesi: [tema] — [neden]
-Sali: [tema]
+Monday: [theme] — [why]
+Tuesday: [theme]
 ...
 ```
 
-### Adim 3: Platform Dagilimi
-Her platform icin haftalik hedef belirle:
+### Step 3: Platform Distribution
+Set a weekly target per platform:
 
-| Platform | Format | Hedef Sayi | Tema Baglantisi |
-|----------|--------|-----------|-----------------|
+| Platform | Format | Target Count | Theme Link |
+|----------|--------|--------------|------------|
 | Instagram Post | ... | ... | ... |
 | Instagram Reel | ... | ... | ... |
 | Twitter/X | ... | ... | ... |
 | LinkedIn | ... | ... | ... |
 | TikTok | ... | ... | ... |
 
-Not: Platform basina 3-5 icerik yeterli (kalite > kantite).
+Note: 3-5 items per platform is enough (quality > quantity).
 
-### Adim 4: Icerik Matrisini Olustur
-Her gun ve platform icin net planlama:
+### Step 4: Build the Content Matrix
+Clear planning per day and platform:
 
 ```
-Pazartesi:
-  - IG Post: "[konu]" (tema: [tema])
-  - Twitter: thread "[konu]"
+Monday:
+  - IG Post: "[topic]" (theme: [theme])
+  - Twitter: thread "[topic]"
 
-Sali:
-  - IG Reel: 30s "[konu]"
-  - LinkedIn: "[konu]"
+Tuesday:
+  - IG Reel: 30s "[topic]"
+  - LinkedIn: "[topic]"
 
 ...
 ```
 
-### Adim 5: Uretim Baseceli
-Icerikleri ne zaman uretecegini planla:
-- Batch uretim gunu (ornek: Pazartesi sabahi tum hafta)
-- Gunluk uretim (her gun o gunun icerigi)
-- Karma model (onceden hazirlanmis + guncel)
+### Step 5: Production Cadence
+Plan when you will produce the content:
+- Batch production day (example: Monday morning for the whole week)
+- Daily production (each day for that day)
+- Mixed model (prepared ahead + current)
 
-Ipucu: Batch uretim verimlidir, ama guncel icerik dinamik kalir.
+Tip: batch production is efficient, but topical content keeps things dynamic.
 
-### Adim 6: Takvim Dosyasini Kaydet
-`/content-calendar` komutu ile detayli dosyayi olustur veya:
-`badi content calendar "[hafta-tarihi]"` CLI komutunu oner.
+### Step 6: Save the Calendar File
+Create the detailed file with the `/content-calendar` command, or suggest the
+`badi content calendar "[week-date]"` CLI command.
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI ICERIK PLANI ===
-Hafta: [baslangic] - [bitis]
-Tarih: [tarih]
+=== BADI CONTENT PLAN ===
+Week: [start] - [end]
+Date: [date]
 
 -------------------------------------------
-GECEN HAFTA OZETI
+LAST WEEK SUMMARY
 -------------------------------------------
-Uretilen: [sayi] icerik
-Plan uyumu: [yuzde]%
-En iyi: [icerik]
-En zor: [icerik]
+Produced: [count] items
+Plan fit: [percent]%
+Best: [content]
+Hardest: [content]
 
-Ogrenilen: [1-2 madde]
-
--------------------------------------------
-GELECEK HAFTA TEMALARI
--------------------------------------------
-Pzt: [tema]
-Sal: [tema]
-Car: [tema]
-Per: [tema]
-Cum: [tema]
-Cts: [tema]
-Paz: [tema]
+Learned: [1-2 items]
 
 -------------------------------------------
-PLATFORM DAGILIMI
+NEXT WEEK THEMES
 -------------------------------------------
-Toplam hedef: [sayi] icerik
-[tablo]
+Mon: [theme]
+Tue: [theme]
+Wed: [theme]
+Thu: [theme]
+Fri: [theme]
+Sat: [theme]
+Sun: [theme]
 
 -------------------------------------------
-OZEL GUNLER
+PLATFORM DISTRIBUTION
 -------------------------------------------
-[varsa liste, yoksa "yok"]
+Total target: [count] items
+[table]
 
 -------------------------------------------
-URETIM PROGRAMI
+SPECIAL DAYS
 -------------------------------------------
-Batch: [gun/saat]
-Gunluk: [gun/saat]
+[list if any, otherwise "none"]
 
 -------------------------------------------
-SONRAKI ADIM
+PRODUCTION SCHEDULE
 -------------------------------------------
-  badi content calendar "[hafta-tarihi]"
-  veya
-  /content-calendar komutu
+Batch: [day/time]
+Daily: [day/time]
+
+-------------------------------------------
+NEXT STEP
+-------------------------------------------
+  badi content calendar "[week-date]"
+  or
+  the /content-calendar command
 ========================
 ```
 
-# Ne Zaman Kullanilir
-- Pazar aksami veya Pazartesi sabahi (haftalik planlama)
-- Yeni kampanya oncesi
-- Performans dususlerinden sonra yeniden planlama
+# When to Use
+- Sunday evening or Monday morning (weekly planning)
+- Before a new campaign
+- Re-planning after performance dips

--- a/.claude/commands/content-search.md
+++ b/.claude/commands/content-search.md
@@ -1,59 +1,59 @@
 Content archive search command. Keyword search, similarity detection, and filtering across all generated content.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi content search)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Arama Sorgusunu Al
+### Step 1: Get the Search Query
 
-Kullanici sorguyu verir (konu, kelime, hashtag). Kelime yoksa en son icerikleri goster.
+The user provides the query (topic, word, hashtag). With no query, show the most recent content.
 
-### Adim 2: Arama Calistir
-
-```bash
-badi content search "uretkenlik"
-```
-
-Aranacak alanlar:
-- `.claude/workspace/icerikler/` (post, karousel)
-- `.claude/workspace/senaryolar/` (video)
-- `.claude/workspace/gorseller/` (gorsel brief)
-- `.claude/workspace/takvim/` (takvim)
-- `.claude/workspace/sablonlar/` (custom sablon)
-- `marka-sesi.md` (marka sesi)
-
-### Adim 3: Filtreler
+### Step 2: Run the Search
 
 ```bash
-badi content search [sorgu] --platform instagram   # Platform filtresi
-badi content search [sorgu] --tur post             # Tur filtresi
-badi content search [sorgu] --son 30               # Son 30 gun
-badi content search [sorgu] --hashtag urkentlik    # Hashtag
-badi content search [sorgu] --format json          # JSON cikti
+badi content search "productivity"
 ```
 
-### Adim 4: Sonuc Yorumu
+Fields to search:
+- `.claude/workspace/icerikler/` (posts, carousels)
+- `.claude/workspace/senaryolar/` (videos)
+- `.claude/workspace/gorseller/` (visual briefs)
+- `.claude/workspace/takvim/` (calendars)
+- `.claude/workspace/sablonlar/` (custom templates)
+- `marka-sesi.md` (brand voice)
 
-Her sonuc icin:
-- Skor (keyword frekans + guncellik bonusu)
-- Dizin (icerikler, senaryolar, vs)
-- Snippet (eslesen satirin kisa hali)
+### Step 3: Filters
 
-### Adim 5: Benzerlik Uyarisi
+```bash
+badi content search [query] --platform instagram   # Platform filter
+badi content search [query] --type post            # Type filter
+badi content search [query] --last 30              # Last 30 days
+badi content search [query] --hashtag productivity # Hashtag
+badi content search [query] --format json          # JSON output
+```
 
-Kullanici yeni icerik olusturacaksa, ayni konuda %60+ benzerlik varsa uyari. `--force` ile atlanabilir.
+### Step 4: Interpret the Results
 
-### Adim 6: Takip Aksiyonlari
+For each result:
+- Score (keyword frequency + recency bonus)
+- Directory (icerikler, senaryolar, etc.)
+- Snippet (short form of the matching line)
 
-- Tekrarlayan konu tespit: "Farkli acidan yaklasim onerisi verelim mi?"
-- Hic bulunamadiysa: "`/content-generate` ile yeni olusturalim mi?"
-- Eski icerik guncellenebilir: "Bu konuyu guncellemek ister misiniz?"
+### Step 5: Similarity Warning
 
-# Ornek
+If the user is about to create new content and 60%+ similarity exists on the same topic, warn. Skippable with `--force`.
+
+### Step 6: Follow-up Actions
+
+- Recurring topic detected: "Shall we suggest a different angle?"
+- Nothing found: "Shall we create something new with `/content-generate`?"
+- Old content could be refreshed: "Would you like to update this topic?"
+
+# Example
 
 ```
-/content-search "produktivite"
-/content-search "AI" --platform linkedin --son 7
-/content-search "tutorial" --tur video
+/content-search "productivity"
+/content-search "AI" --platform linkedin --last 7
+/content-search "tutorial" --type video
 ```

--- a/.claude/commands/content-start.md
+++ b/.claude/commands/content-start.md
@@ -1,138 +1,138 @@
 Content production session start command. Gives the daily content session a structured start, shows pending work, and sets priorities.
 
-# Gerekli Araclar
-- Read (marka sesi, takvim, mevcut icerikler)
-- Glob (workspace dosyalari)
-- Grep (trend ve kalip aramalari)
-- Bash (tarih ve dosya tarihi)
-- Write (gunluk not)
+# Required Tools
+- Read (brand voice, calendar, existing content)
+- Glob (workspace files)
+- Grep (trend and pattern searches)
+- Bash (date and file dates)
+- Write (daily note)
 
-# Prosedur (7 Adim)
+# Procedure (7 Steps)
 
-### Adim 1: Baglam Yukle
-Su dosyalari oku:
-- `.claude/workspace/marka-sesi.md` — Marka tonu ve kurallari
-- `.claude/workspace/takvim/` — En son icerik takvimi
-- `.claude/workspace/icerikler/` — Son 10 icerik
-- `.claude/workspace/senaryolar/` — Son 5 video senaryosu
-- `memory.md` — Aktif kampanya veya proje
+### Step 1: Load Context
+Read these files:
+- `.claude/workspace/marka-sesi.md` — Brand tone and rules
+- `.claude/workspace/takvim/` — The latest content calendar
+- `.claude/workspace/icerikler/` — Last 10 content items
+- `.claude/workspace/senaryolar/` — Last 5 video scripts
+- `memory.md` — Active campaign or project
 
-Bu dosyalar yoksa kullaniciyi yonlendir:
-- Marka sesi yoksa: `badi content brand` oner
-- Takvim yoksa: `badi content calendar` oner
+If these files do not exist, guide the user:
+- No brand voice: suggest `badi content brand`
+- No calendar: suggest `badi content calendar`
 
-### Adim 2: Bugun Ne Var?
-Takvimde bugun icin planlanmis icerikleri listele:
-- Hangi platformlara post atilacak?
-- Hangi temalar planlanmis?
-- Bekleyen taslak var mi?
+### Step 2: What's On Today?
+List the content planned for today in the calendar:
+- Which platforms get posts?
+- Which themes are planned?
+- Any pending drafts?
 
-Eger bugun icin planli icerik yoksa, haftanin gunune gore tema oner:
-- Pazartesi: Motivasyon / Hafta basligi
-- Sali: Egitici / Ipucu
-- Carsamba: Perde arkasi / Topluluk
-- Persembe: Urun / Hizmet
-- Cuma: Eglence / Trend
-- Cumartesi: UGC / Sosyal kanit
-- Pazar: Ilham / Haftalik ozet
+If nothing is planned for today, suggest a theme by day of week:
+- Monday: Motivation / Week opener
+- Tuesday: Educational / Tips
+- Wednesday: Behind the scenes / Community
+- Thursday: Product / Service
+- Friday: Fun / Trends
+- Saturday: UGC / Social proof
+- Sunday: Inspiration / Weekly recap
 
-### Adim 3: Bekleyen Taslaklar
-`.claude/workspace/icerikler/` ve `.claude/workspace/senaryolar/` icindeki son 7 gunluk dosyalari tara. Her birisi icin:
-- Dosya adi ve tarihi
-- Doldurulmus mu, yoksa hala placeholder'li mi?
-- Hangi platform icin?
+### Step 3: Pending Drafts
+Scan the last 7 days of files in `.claude/workspace/icerikler/` and `.claude/workspace/senaryolar/`. For each:
+- File name and date
+- Filled in, or still holding placeholders?
+- For which platform?
 
-Tamamlanmamis (placeholder iceren) taslaklari on plana cikar.
+Surface the unfinished (placeholder-containing) drafts.
 
-### Adim 4: Son Performans (varsa)
-Eger `.claude/workspace/performans.md` veya benzeri bir takip dosyasi varsa:
-- Gecen hafta en iyi performans gosteren 3 icerik
-- En dusuk performans gosteren 3 icerik
-- Trend notu (artis/azalis)
+### Step 4: Recent Performance (if available)
+If `.claude/workspace/performans.md` or a similar tracking file exists:
+- Last week's 3 best-performing pieces
+- The 3 lowest performers
+- Trend note (rising/falling)
 
-### Adim 5: Fikir Onerileri
-Su kaynaklardan fikir uret:
-- Bu ayki ozel gunler ve etkinlikler
-- Gundem / trend konulari (marka uyumlu olanlar)
-- Evergreen icerik sablonlari
-- Bekleyen SSS veya musteri sorulari
+### Step 5: Idea Suggestions
+Generate ideas from these sources:
+- This month's special days and events
+- Current/trending topics (brand-fit ones)
+- Evergreen content templates
+- Pending FAQ or customer questions
 
-3-5 somut icerik fikri sun:
+Offer 3-5 concrete content ideas:
 ```
-1. [Platform] — [Format] — [Konu]: [neden onemli]
+1. [Platform] — [Format] — [Topic]: [why it matters]
 2. ...
 ```
 
-### Adim 6: Bugunun Onceligi
-Kullaniciya bugun odaklanmasi gereken tek seyi sor veya oner:
-- En kritik icerik (yayin tarihi yaklasmis)
-- En yuksek etkili firsat (trend, ozel gun)
-- En hizli kazanc (hazir taslak tamamlama)
+### Step 6: Today's Priority
+Ask or suggest the single thing to focus on today:
+- The most critical content (publish date approaching)
+- The highest-impact opportunity (trend, special day)
+- The fastest win (finishing a ready draft)
 
-### Adim 7: Seans Notu Baslat
-`.claude/workspace/icerik-notlari/` dizini altinda bugunun gunluk not dosyasini olustur:
+### Step 7: Start the Session Note
+Create today's note file under `.claude/workspace/icerik-notlari/`:
 
 ```
-# Icerik Notlari — [tarih]
+# Content Notes — [date]
 
-## Bugunki Oncelik
-[secilen oncelik]
+## Today's Priority
+[chosen priority]
 
-## Planli Uretimler
-- [ ] [icerik 1]
-- [ ] [icerik 2]
+## Planned Production
+- [ ] [content 1]
+- [ ] [content 2]
 
-## Fikirler / Notlar
+## Ideas / Notes
 - ...
 
-## Tamamlananlar
-(gun icinde doldurulacak)
+## Completed
+(filled during the day)
 ```
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI ICERIK SEANSI ===
-Tarih: [tarih] ([gun adi])
-Marka Sesi: [yuklendi / eksik]
+=== BADI CONTENT SESSION ===
+Date: [date] ([day name])
+Brand Voice: [loaded / missing]
 
 -------------------------------------------
-BUGUN TAKVIMDEN
+FROM TODAY'S CALENDAR
 -------------------------------------------
-[planli icerikler veya "bugun icin planli icerik yok"]
+[planned content or "nothing planned for today"]
 
-Haftanin temasi: [gun bazli tema]
-
--------------------------------------------
-BEKLEYEN TASLAKLAR
--------------------------------------------
-[tamamlanmamis taslak listesi]
-Toplam: [sayi] taslak
+Theme of the day: [day-based theme]
 
 -------------------------------------------
-SON PERFORMANS
+PENDING DRAFTS
 -------------------------------------------
-[varsa ozet, yoksa "veri yok"]
+[unfinished draft list]
+Total: [count] drafts
 
 -------------------------------------------
-FIKIR ONERILERI
+RECENT PERFORMANCE
 -------------------------------------------
-1. [Platform] [Format]: [konu]
+[summary if available, otherwise "no data"]
+
+-------------------------------------------
+IDEA SUGGESTIONS
+-------------------------------------------
+1. [Platform] [Format]: [topic]
 2. ...
 
 -------------------------------------------
-BUGUN ODAKLAN
+FOCUS TODAY
 -------------------------------------------
-Tek oncelik: [net oneri]
+Single priority: [clear suggestion]
 
-Baslamak icin:
-  badi content post "[konu]"
-  badi content karousel "[konu]"
-  badi content video "[konu]"
+To get started:
+  badi content post "[topic]"
+  badi content carousel "[topic]"
+  badi content video "[topic]"
   /content-generate
 ==============================
 ```
 
-# Ne Zaman Kullanilir
-- Her gun icerik uretmeye baslarken (sabah rituelnu)
-- Uretim tikanikligi yasarken
-- Haftaya baslarken
+# When to Use
+- Every day when starting content production (morning ritual)
+- When production feels stuck
+- At the start of the week

--- a/.claude/commands/content-status.md
+++ b/.claude/commands/content-status.md
@@ -1,156 +1,156 @@
 Content production status panel. Shows current output volume, pending items, calendar fit, and trend data.
 
-# Gerekli Araclar
-- Read (workspace dosyalari)
-- Glob (tum icerik dizinleri)
-- Grep (placeholder ve durum tespiti)
-- Bash (dosya tarihi, sayma)
+# Required Tools
+- Read (workspace files)
+- Glob (all content directories)
+- Grep (placeholder and status detection)
+- Bash (file dates, counting)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Envanter Topla
-`.claude/workspace/` altindaki tum icerik dosyalarini tara:
-- `icerikler/` — Post ve karousel sayisi
-- `senaryolar/` — Video senaryo sayisi
-- `gorseller/` — Gorsel brief sayisi
-- `takvim/` — Takvim dosyalari
-- `marka-sesi.md` varsa
+### Step 1: Take Inventory
+Scan all content files under `.claude/workspace/`:
+- `icerikler/` — Post and carousel count
+- `senaryolar/` — Video script count
+- `gorseller/` — Visual brief count
+- `takvim/` — Calendar files
+- `marka-sesi.md` if present
 
-Dosya basina metadata cikar:
-- Olusturma tarihi
-- Son degisiklik tarihi
-- Dosya boyutu (doluluk gostergesi)
-- Placeholder sayisi
+Per file, extract metadata:
+- Creation date
+- Last modified date
+- File size (fill indicator)
+- Placeholder count
 
-### Adim 2: Zaman Bazli Gruplama
+### Step 2: Time-Based Grouping
 
-**Bugun:** Bugun olusturulan/duzenlenen
-**Bu hafta:** Son 7 gun
-**Bu ay:** Son 30 gun
-**Eski:** 30+ gun
+**Today:** Created/edited today
+**This week:** Last 7 days
+**This month:** Last 30 days
+**Old:** 30+ days
 
-Her grup icin:
-- Toplam sayi
-- Tamamlanmislik orani
+For each group:
+- Total count
+- Completion ratio
 
-### Adim 3: Tamamlanmislik Analizi
-Her icerigin durumunu belirle:
+### Step 3: Completion Analysis
+Determine each item's status:
 
-**TAMAMLANAN (yayina hazir):**
-- Placeholder yok
-- Tum bolumler dolu
-- Gorsel notu var
+**COMPLETE (publish-ready):**
+- No placeholders
+- All sections filled
+- Visual note present
 
-**KISMI (duzenleme gerekli):**
-- Bazi yerler dolu
-- Ana mesaj belirli ama detaylar eksik
+**PARTIAL (needs editing):**
+- Some parts filled
+- Main message set but details missing
 
-**TASLAK (yeni olusturulmus):**
-- Cogunlukla placeholder
-- Temel yapi var
+**DRAFT (freshly created):**
+- Mostly placeholders
+- Basic structure present
 
-**OLMUS (arsiv adayi):**
-- 30+ gundur dokunulmamis
-- Hala placeholder
+**STALE (archive candidate):**
+- Untouched for 30+ days
+- Still holding placeholders
 
-### Adim 4: Takvim Uyum Kontrolu
-Eger takvim dosyasi varsa:
-- Planli icerikler kac tane?
-- Kac tanesi uretilmis?
-- Kac tanesi yayinlanmis?
-- Gecikme var mi?
+### Step 4: Calendar Fit Check
+If a calendar file exists:
+- How many items planned?
+- How many produced?
+- How many published?
+- Any delays?
 
 ```
-Plan uyum orani: [yuzde]%
+Plan fit ratio: [percent]%
 ```
 
-### Adim 5: Trend ve Oneriler
-Son 2 haftanin trendlerini hesapla:
-- Uretim hizi (gun basina ortalama)
-- En cok uretilen format
-- En az uretilen format (kapali kanal uyarisi)
-- Duraksamalar (0 uretim gunleri)
+### Step 5: Trends and Suggestions
+Compute the last 2 weeks' trends:
+- Production speed (average per day)
+- Most produced format
+- Least produced format (dormant channel warning)
+- Stalls (zero-production days)
 
-Oneriler uret:
-- Ihmal edilen platformlar
-- Eskimeye baslayan taslaklar
-- Bitmemis isler
+Generate suggestions:
+- Neglected platforms
+- Drafts starting to go stale
+- Unfinished work
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI ICERIK DURUMU ===
-Tarih: [tarih] [saat]
+=== BADI CONTENT STATUS ===
+Date: [date] [time]
 
 -------------------------------------------
-ENVANTER
+INVENTORY
 -------------------------------------------
-Toplam Dosya: [sayi]
+Total Files: [count]
 
-Postlar/Karouseller: [sayi]
-Video Senaryolari:   [sayi]
-Gorsel Brifler:      [sayi]
-Takvimler:           [sayi]
+Posts/Carousels:    [count]
+Video Scripts:      [count]
+Visual Briefs:      [count]
+Calendars:          [count]
 
-Marka Sesi: [VAR / YOK]
-
--------------------------------------------
-ZAMAN DAGILIMI
--------------------------------------------
-Bugun:     [sayi]  [======    ]
-Bu Hafta:  [sayi]  [========  ]
-Bu Ay:     [sayi]  [==========]
-Eski:      [sayi]
+Brand Voice: [PRESENT / MISSING]
 
 -------------------------------------------
-TAMAMLANMISLIK
+TIME DISTRIBUTION
 -------------------------------------------
-Tamamlanan:  [sayi] (%[oran])
-Kismi:       [sayi]
-Taslak:      [sayi]
-Olmus:       [sayi]
+Today:      [count]  [======    ]
+This Week:  [count]  [========  ]
+This Month: [count]  [==========]
+Old:        [count]
 
 -------------------------------------------
-TAKVIM UYUMU
+COMPLETION
 -------------------------------------------
-Planli:      [sayi]
-Uretilmis:   [sayi]
-Yayinlanmis: [sayi]
-Uyum:        [yuzde]%
+Complete:  [count] (%[ratio])
+Partial:   [count]
+Draft:     [count]
+Stale:     [count]
 
 -------------------------------------------
-TREND (Son 2 Hafta)
+CALENDAR FIT
 -------------------------------------------
-Gunluk Ortalama: [sayi] icerik
-En Populer: [format] ([sayi])
-En Az: [format] ([sayi])
-Duraksamalar: [gun sayisi]
+Planned:    [count]
+Produced:   [count]
+Published:  [count]
+Fit:        [percent]%
 
 -------------------------------------------
-UYARILAR
+TREND (Last 2 Weeks)
 -------------------------------------------
-- [eskime uyarisi]
-- [kapali kanal]
-- [gecikmis icerik]
+Daily Average: [count] items
+Most Popular: [format] ([count])
+Least: [format] ([count])
+Stalls: [day count]
 
 -------------------------------------------
-ONERILER
+WARNINGS
 -------------------------------------------
-1. [somut oneri]
-2. [somut oneri]
-3. [somut oneri]
+- [staleness warning]
+- [dormant channel]
+- [overdue content]
 
 -------------------------------------------
-HIZLI AKSIYONLAR
+SUGGESTIONS
 -------------------------------------------
-Eksik taslak bitir:   [dosya]
-Yeni icerik uret:     badi content [tur] "[konu]"
-Takvim olustur:       badi content calendar "[donem]"
-Fikir uret:           /content-idea
+1. [concrete suggestion]
+2. [concrete suggestion]
+3. [concrete suggestion]
+
+-------------------------------------------
+QUICK ACTIONS
+-------------------------------------------
+Finish a pending draft:  [file]
+Produce new content:     badi content [type] "[topic]"
+Create a calendar:       badi content calendar "[period]"
+Generate ideas:          /content-idea
 ==========================
 ```
 
-# Ne Zaman Kullanilir
-- Gunluk durum kontrolu
-- Haftalik retro oncesi
-- Tikanma anlarinda ("ne yapmaliyim?")
-- Plan vs gerceklik karsilastirmasi
+# When to Use
+- Daily status check
+- Before the weekly retro
+- In stuck moments ("what should I do?")
+- Plan vs. reality comparison

--- a/.claude/commands/content-template.md
+++ b/.claude/commands/content-template.md
@@ -1,74 +1,74 @@
 Content template inheritance command. Custom template creation and inheritance-chain management for recurring content types.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi content template)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Mevcut Sablonlar
+### Step 1: Existing Templates
 
 ```bash
 badi content template list
 ```
 
-Yerlesik sablonlar (standart): post, karousel, video, gorsel, takvim, marka.
-Ozel sablonlar `.claude/workspace/sablonlar/` altinda.
+Built-in templates (standard): post, carousel, video, visual, calendar, brand.
+Custom templates live under `.claude/workspace/sablonlar/`.
 
-### Adim 2: Ozel Sablon Olustur
+### Step 2: Create a Custom Template
 
 ```bash
-badi content template olustur saas-lansmani --extends post --description "SaaS urun lansmani"
+badi content template create saas-launch --extends post --description "SaaS product launch"
 ```
 
-Parametreler:
-- `isim` — Sablon adi (slug)
-- `--extends` — Yerlesik sablon (post/content-carousel/video/gorsel/takvim)
-- `--description` — Kisa aciklama (opsiyonel)
+Parameters:
+- `name` — Template name (slug)
+- `--extends` — Built-in base (post/carousel/video/visual/calendar)
+- `--description` — Short description (optional)
 
-Olusturulan dosya `.claude/workspace/sablonlar/[isim].md` — frontmatter + ozel bolumler.
+The created file is `.claude/workspace/sablonlar/[name].md` — frontmatter + custom sections.
 
-### Adim 3: Sablonu Duzenle
+### Step 3: Edit the Template
 
-Olusan dosyayi ac ve ozel bolumler ekle:
+Open the created file and add custom sections:
 ```markdown
 ---
-name: saas-lansmani
+name: saas-launch
 extends: post
-description: SaaS urun lansmani
+description: SaaS product launch
 ---
 
-## Ozel: Onizleme Linki
-[Ucretsiz deneme URL'si]
+## Custom: Preview Link
+[Free trial URL]
 
-## Ozel: Teknik Detay
-[Stack, entegrasyonlar, fiyatlama]
+## Custom: Technical Detail
+[Stack, integrations, pricing]
 ```
 
-### Adim 4: Sablonu Kullan
+### Step 4: Use the Template
 
 ```bash
-badi content post "Yeni CRM Lansman" --template saas-lansmani
+badi content post "New CRM Launch" --template saas-launch
 ```
 
-Yerlesik sablon + ozel sablon birlestirilir (H2 baslik eslestirme ile).
+The built-in template and the custom template are merged (by H2 heading matching).
 
-### Adim 5: Sablon Sil
+### Step 5: Delete a Template
 
 ```bash
-badi content template sil saas-lansmani
+badi content template delete saas-launch
 ```
 
-### Adim 6: Kullanim Senaryolari
+### Step 6: Usage Scenarios
 
-- **Marka kategorileri**: Urun lansmani, etkinlik duyurusu, case study, customer story
-- **Icerik serileri**: Pazartesi motivasyon, Persembe tutorial
-- **Platform ozelleri**: LinkedIn vs Twitter ayri tonda
-- **Musteri sablonlari**: Her musteri icin ayri ton/stil
+- **Brand categories**: Product launch, event announcement, case study, customer story
+- **Content series**: Monday motivation, Thursday tutorial
+- **Platform specials**: LinkedIn vs Twitter in different tones
+- **Client templates**: A separate tone/style per client
 
-# Ornek
+# Example
 
 ```
 /content-template list
-/content-template olustur linkedin-insight --extends post
-/content-generate "AI trendi" --template linkedin-insight
+/content-template create linkedin-insight --extends post
+/content-generate "AI trend" --template linkedin-insight
 ```

--- a/.claude/commands/content-video-script.md
+++ b/.claude/commands/content-video-script.md
@@ -1,85 +1,85 @@
 Video script command. Scene-by-scene scripts, captions, and visualization plans for Reels, Shorts, TikTok, and YouTube.
 
-# Gerekli Araclar
-- Read (marka sesi, onceki senaryolar, proje baglami) -- Write (senaryo dosyasi) -- Grep (trend ve referans taramasi) -- ...
+# Required Tools
+- Read (brand voice, previous scripts, project context) -- Write (script file) -- Grep (trend and reference scan) -- ...
 
-# Prosedur (7 Adim)
+# Procedure (7 Steps)
 
-## 1. Video Bilgilerini Topla
-- **Platform:** Instagram Reels / YouTube Shorts / TikTok / YouTube uzun / Hepsi
-- **Sure:** 15s (Story, hizli ipucu) / 30s (Reels-Shorts std) / 60s (uzun) / 3-10dk (YT orta) / ...
-- **Tur:** Egitici (nasil yapilir, ipucu) / Eglence (komedi, trend, skit) / Tanitim (urun, marka) / Perde arkasi / ...
-- **Konu:** detay
-- **Hedef:** Takipci / Etkilesim / Satis / Bilinirlik / Trafik
-- **Konusmaci:** Yuz (talking head) / Sadece el-urun / Voiceover + gorsel / Faceless (metin+gorsel) / ...
-- **Muzik/Ses:** Trend ses (ad belirt) / Orijinal / VO + arka plan / ASMR-dogal / ...
+## 1. Gather Video Details
+- **Platform:** Instagram Reels / YouTube Shorts / TikTok / YouTube long-form / All
+- **Length:** 15s (Story, quick tip) / 30s (Reels-Shorts std) / 60s (long) / 3-10min (YT mid) / ...
+- **Type:** Educational (how-to, tips) / Entertainment (comedy, trend, skit) / Promo (product, brand) / Behind the scenes / ...
+- **Topic:** detail
+- **Goal:** Followers / Engagement / Sales / Awareness / Traffic
+- **Speaker:** Face (talking head) / Hands-product only / Voiceover + visuals / Faceless (text+visuals) / ...
+- **Music/Sound:** Trending sound (name it) / Original / VO + background / ASMR-natural / ...
 
-## 2. Hook (1-3s, hayati)
-| Hook Turu | Ornek | Ne Zaman |
-|-----------|-------|----------|
-| Sasirtici Iddia | "Cogu kisi bunu yanlis yapiyor" | Egitici, listicle |
-| Soru | "Hic X'i denedin mi?" | Etkilesim |
-| Sonucu Once | [donusum] "Nasil mi yaptim?" | Oncesi/sonrasi |
-| Istatistik | "Insanlarin %87'si bunu bilmiyor" | Bilgilendirici |
-| Merak Boslugu | "Bunu ogrendigimde her sey degisti" | Hikaye |
-| Aciliyet | "Bunu hemen yapmalisin" | Uyari, ipucu |
-| Tartisma | "[Populer gorus] yanlis. Iste neden..." | Trend |
-| Gorunen Deger | [liste/ipucu gorunur] "Kaydet!" | Egitici |
+## 2. Hook (1-3s, vital)
+| Hook Type | Example | When |
+|-----------|---------|------|
+| Surprising Claim | "Most people do this wrong" | Educational, listicle |
+| Question | "Have you ever tried X?" | Engagement |
+| Result First | [transformation] "Want to know how?" | Before/after |
+| Statistic | "87% of people don't know this" | Informative |
+| Curiosity Gap | "Everything changed when I learned this" | Story |
+| Urgency | "You need to do this right now" | Warnings, tips |
+| Controversy | "[Popular opinion] is wrong. Here's why..." | Trend |
+| Visible Value | [list/tip visible] "Save this!" | Educational |
 
-Hook yazimi: ilk 1s dikkat yakala -- ekran hareket/metin degisimi -- ses tonunda enerji/merak -- ...
+Hook writing: capture attention in the first 1s -- on-screen motion/text change -- energy/curiosity in the voice -- ...
 
-## 3. Yapi Sablonu
-**15s:** `[0-2] Hook | [2-12] Govde (tek mesaj) | [12-15] CTA (kaydet/paylas)`
+## 3. Structure Templates
+**15s:** `[0-2] Hook | [2-12] Body (single message) | [12-15] CTA (save/share)`
 
-**30s:** `[0-3] Hook | [3-12] Bolum 1 (baglam/problem) | [12-25] Bolum 2 (cozum) | [25-30] CTA`
+**30s:** `[0-3] Hook | [3-12] Part 1 (context/problem) | [12-25] Part 2 (solution) | [25-30] CTA`
 
-**60s:** `[0-3] Hook | [3-15] Bolum 1 (problem) | [15-35] Bolum 2 (cozum) | [35-50] Bolum 3 (ornek) | [50-60] CTA`
+**60s:** `[0-3] Hook | [3-15] Part 1 (problem) | [15-35] Part 2 (solution) | [35-50] Part 3 (example) | [50-60] CTA`
 
-**3-10dk (YT):** `[0-30s] Hook+video vadi | [30s-1m] Giris+kimlik | [1m-X] Ana icerik (bolumler) | [X-son] Ozet+CTA+sonraki video`
+**3-10min (YT):** `[0-30s] Hook+value promise | [30s-1m] Intro+identity | [1m-X] Main content (chapters) | [X-end] Recap+CTA+next video`
 
-## 4. Sahne Sahne Senaryo
-Her sahne icin tam detay.
+## 4. Scene-by-Scene Script
+Full detail for every scene.
 ```
-[kisaltildi]
+[abridged]
 ```
 
-## 5. Altyazi ve Caption
-**Platform Caption:** platform bazli aciklama -- ilk satir hook/deger vadisi (kesilme noktasi oncesi) -- hashtag stratejisi -- ...
+## 5. Subtitles and Caption
+**Platform Caption:** per-platform description -- first line hook/value promise (before the cut-off point) -- hashtag strategy -- ...
 
-**Ekran Ustu Metin:**
-| Saniye | Metin | Konum | Stil |
-|--------|-------|-------|------|
-| 0-3 | [hook] | Orta | Buyuk, bold |
-| 3-8 | [destek] | Alt | Normal |
+**On-Screen Text:**
+| Second | Text | Position | Style |
+|--------|------|----------|-------|
+| 0-3 | [hook] | Center | Large, bold |
+| 3-8 | [support] | Bottom | Normal |
 | ... | ... | ... | ... |
 
-**Subtitle:** otomatik acik mi -- anahtar kelimeler vurgulu (renk/bold) -- font/boyut onerisi
+**Subtitles:** auto-captions on? -- keywords emphasized (color/bold) -- font/size suggestion
 
-## 6. Post-Produksiyon
-- **Muzik/Efekt:** arka plan turu (pop/lo-fi/epik/akustik/elektronik) -- ses efektleri (whoosh, pop, ding — nerede) -- trend ses kaynagi -- ...
-- **Gecisler:** kesme/yumusak/zoom/whip pan -- metin animasyon (belirme/kayma/yazma/bounce) -- ozel efekt (speed ramp, split, green screen)
-- **Renk:** filtre/LUT (sicak/soguk/vintage/yuksek kontrast) -- gradasyon notu -- parlaklik/kontrast
-- **Hiz:** yavaslatma (dramatik, detay) -- hizlandirma (tekrar islem, montaj) -- normal bolge
+## 6. Post-Production
+- **Music/FX:** background genre (pop/lo-fi/epic/acoustic/electronic) -- sound effects (whoosh, pop, ding — where) -- trending sound source -- ...
+- **Transitions:** cut/smooth/zoom/whip pan -- text animation (appear/slide/typewriter/bounce) -- special effects (speed ramp, split, green screen)
+- **Color:** filter/LUT (warm/cool/vintage/high contrast) -- grading note -- brightness/contrast
+- **Speed:** slow-mo (drama, detail) -- speed-up (repeated actions, montage) -- normal zones
 
-## 7. Thumbnail Brief ve Kaydet
-**YouTube Thumbnail (YT videolari):** 1280x720 -- ana gorsel -- metin (maks 5-6 kelime, okunabilir) -- ...
+## 7. Thumbnail Brief and Save
+**YouTube Thumbnail (YT videos):** 1280x720 -- main visual -- text (max 5-6 words, readable) -- ...
 
-Kaydet: `.claude/workspace/senaryolar/[YYYY-MM-DD]-[konu-kebab].md`
+Save: `.claude/workspace/senaryolar/[YYYY-MM-DD]-[topic-kebab].md`
 
-# Cikti Formati
+# Output Format
 ```
-[kisaltildi]
+[abridged]
 ```
 
-# Video Formati Referansi
-| Platform | Oran | Cozunurluk | Maks Sure | Format |
-|----------|------|-----------|-----------|--------|
+# Video Format Reference
+| Platform | Aspect | Resolution | Max Length | Format |
+|----------|--------|------------|------------|--------|
 | Instagram Reels | 9:16 | 1080x1920 | 90s | MP4 |
 | YouTube Shorts | 9:16 | 1080x1920 | 60s | MP4 |
-| TikTok | 9:16 | 1080x1920 | 10dk | MP4 |
-| YouTube | 16:9 | 1920x1080 | Sinir yok | MP4 |
+| TikTok | 9:16 | 1080x1920 | 10min | MP4 |
+| YouTube | 16:9 | 1920x1080 | No limit | MP4 |
 | Facebook Reels | 9:16 | 1080x1920 | 90s | MP4 |
-| LinkedIn Video | 1:1/16:9 | 1080x1080 | 10dk | MP4 |
+| LinkedIn Video | 1:1/16:9 | 1080x1080 | 10min | MP4 |
 
-# Ipuclari
-- Her video tek mesaj -- ilk 3s basarinin %70'i -- ekran metni konusmayla uyumlu ama birebir ayni degil -- ...
+# Tips
+- One message per video -- the first 3s are 70% of the outcome -- on-screen text complements the speech but is not verbatim -- ...

--- a/.claude/commands/content-visual-brief.md
+++ b/.claude/commands/content-visual-brief.md
@@ -1,32 +1,32 @@
 Visual brief command. Detailed design instructions, color palettes, and AI image prompts for social visuals, banners, and video frames.
 
-# Gerekli Araclar
-- Read (marka rehberi, onceki gorseller, proje baglami) -- Write (brief dosyasi) -- Grep (marka renk/font referanslari) -- ...
+# Required Tools
+- Read (brand guide, previous visuals, project context) -- Write (brief file) -- Grep (brand color/font references) -- ...
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-## 1. Gorsel Ihtiyacini Tanimla
-Kullanicidan al:
-- **Kullanim Alani:** Post (tek kare) / Story / Reel kapak / Karousel (kac kare?) / YouTube thumbnail / ...
-- **Platform:** Instagram / Twitter / LinkedIn / YouTube / Facebook / Pinterest / Blog / E-posta / Reklam / Diger
-- **Icerik:** Ana mesaj/baslik, urun/kisi/sahne/soyut konsept, marka ogeleri (logo/slogan), veri/istatistik (infografik)
-- **Stil:** Fotografik / Minimalist / Illustrasyon / 3D Render / ...
-- **Renk:** Marka / Belirli palet / Serbest / Mevsimsel
-- **Metin:** Yazi olacak mi? (baslik, alt baslik, CTA, istatistik)
-- **Ton:** Ciddi / Eglenceli / Luks / Teknik / Sicak / Soguk
+## 1. Define the Visual Need
+Get from the user:
+- **Use Case:** Post (single frame) / Story / Reel cover / Carousel (how many frames?) / YouTube thumbnail / ...
+- **Platform:** Instagram / Twitter / LinkedIn / YouTube / Facebook / Pinterest / Blog / Email / Ads / Other
+- **Content:** Main message/headline, product/person/scene/abstract concept, brand elements (logo/slogan), data/statistics (infographic)
+- **Style:** Photographic / Minimalist / Illustration / 3D Render / ...
+- **Color:** Brand / Specific palette / Free / Seasonal
+- **Text:** Will there be copy? (headline, subhead, CTA, statistic)
+- **Tone:** Serious / Fun / Luxury / Technical / Warm / Cool
 
-## 2. Marka Rehberini Yukle
-- `.claude/workspace/marka-sesi.md` — renkler, fontlar, stil
-- `.claude/workspace/gorseller/` — onceki briefler
-- Marka logosu ve kullanim kurallari
+## 2. Load the Brand Guide
+- `.claude/workspace/marka-sesi.md` — colors, fonts, style
+- `.claude/workspace/gorseller/` — previous briefs
+- Brand logo and usage rules
 
-Yoksa: kullanicidan temel bilgi (birincil renk, font) al veya serbest tasarim modu.
+If none: collect the basics from the user (primary color, font) or free-design mode.
 
-## 3. Boyut ve Teknik Ozellikler
-| Kullanim | Boyut (px) | En-Boy Orani | Dosya Formati |
-|----------|-----------|-------------|---------------|
-| Instagram Kare | 1080x1080 | 1:1 | PNG/JPG |
-| Instagram Dikey | 1080x1350 | 4:5 | PNG/JPG |
+## 3. Size and Technical Specs
+| Use | Size (px) | Aspect | File Format |
+|-----|-----------|--------|-------------|
+| Instagram Square | 1080x1080 | 1:1 | PNG/JPG |
+| Instagram Portrait | 1080x1350 | 4:5 | PNG/JPG |
 | Instagram Story/Reel | 1080x1920 | 9:16 | PNG/JPG |
 | Twitter/X Post | 1600x900 | 16:9 | PNG/JPG |
 | LinkedIn Post | 1200x627 | 1.91:1 | PNG/JPG |
@@ -37,49 +37,49 @@ Yoksa: kullanicidan temel bilgi (birincil renk, font) al veya serbest tasarim mo
 | YouTube Banner | 2560x1440 | 16:9 | PNG |
 | Pinterest Pin | 1000x1500 | 2:3 | PNG/JPG |
 | Blog Header | 1200x628 | 1.91:1 | PNG/JPG |
-| E-posta Header | 600x200 | 3:1 | PNG/JPG |
-| Meta Ads (kare) | 1080x1080 | 1:1 | PNG/JPG |
-| Meta Ads (dikey) | 1080x1350 | 4:5 | PNG/JPG |
+| Email Header | 600x200 | 3:1 | PNG/JPG |
+| Meta Ads (square) | 1080x1080 | 1:1 | PNG/JPG |
+| Meta Ads (portrait) | 1080x1350 | 4:5 | PNG/JPG |
 | Google Ads Banner | 1200x628 | 1.91:1 | PNG/JPG |
 
-## 4. Detayli Brief
-- **Kompozisyon:** ana odak (orta/uc'te bir/alt-ust) -- gorsel hiyerarsi -- bos alan kullanimi -- ...
-- **Renk Paleti:** birincil [#hex] (arka plan/vurgu) -- ikincil [#hex] -- vurgu [#hex] (CTA, onemli metin) -- ...
-- **Tipografi (metin varsa):** baslik [font/boyut/kalinlik/renk] -- alt baslik [...] -- govde [...] -- ...
-- **Arka Plan:** duz/gradient/fotograf/doku/soyut + detayli aciklama
-- **Objeler:** ana obje (urun/kisi/ikon) -- destekleyici (serit, cerceve, ok, badge) -- logo konum/boyut -- ...
+## 4. Detailed Brief
+- **Composition:** main focus (center/rule-of-thirds/top-bottom) -- visual hierarchy -- white-space usage -- ...
+- **Color Palette:** primary [#hex] (background/accent) -- secondary [#hex] -- accent [#hex] (CTA, key text) -- ...
+- **Typography (if text):** headline [font/size/weight/color] -- subhead [...] -- body [...] -- ...
+- **Background:** solid/gradient/photo/texture/abstract + detailed description
+- **Objects:** main object (product/person/icon) -- supporting (strips, frames, arrows, badges) -- logo position/size -- ...
 
-## 5. AI Promptlari (3 arac)
-**Midjourney:** `/imagine [aciklama], [stil], [atmosfer], [teknik] --ar [oran] --v 6.1 --style raw`
-- Ingilizce -- `--style raw`, `--stylize 50-200` -- `--ar 1:1/4:5/16:9` -- ...
+## 5. AI Prompts (3 tools)
+**Midjourney:** `/imagine [description], [style], [mood], [technique] --ar [ratio] --v 6.1 --style raw`
+- English -- `--style raw`, `--stylize 50-200` -- `--ar 1:1/4:5/16:9` -- ...
 
-**DALL-E:** `[Detayli dogal dil aciklamasi, stil ve atmosfer dahil]`
-- TR/EN -- net betimleyici cumleler -- stil ve duygu acik -- ...
+**DALL-E:** `[Detailed natural-language description including style and mood]`
+- Clear descriptive sentences -- style and emotion explicit -- ...
 
-**Flux/Stable Diffusion:** `[pozitif prompt], [stil etiketleri], [teknik]` + `Negative: [istenmeyen]`
-- Etiket bazli (virgulle) -- Steps: 30-50, CFG: 7-12 -- Sampler: DPM++ 2M Karras
+**Flux/Stable Diffusion:** `[positive prompt], [style tags], [technique]` + `Negative: [unwanted]`
+- Tag-based (comma-separated) -- Steps: 30-50, CFG: 7-12 -- Sampler: DPM++ 2M Karras
 
-## 6. Canva/Figma Notu ve Kaydet
-- **Canva:** sablon kategorisi -- oge turleri (metin/sekil/ikon) -- katman sirasi (arka plan → objeler → metin → logo)
-- **Figma:** frame boyutu -- auto layout -- bilesen yapisi
+## 6. Canva/Figma Note and Save
+- **Canva:** template category -- element types (text/shape/icon) -- layer order (background → objects → text → logo)
+- **Figma:** frame size -- auto layout -- component structure
 
-Kaydet: `.claude/workspace/gorseller/[YYYY-MM-DD]-[konu]-brief.md`
+Save: `.claude/workspace/gorseller/[YYYY-MM-DD]-[topic]-brief.md`
 
-# Cikti Formati
+# Output Format
 ```
-[kisaltildi]
+[abridged]
 ```
 
-# Stil Referans Tablosu
-| Stil | Ornek Kullanim | Uygun Platformlar | Ton |
-|------|---------------|-------------------|-----|
-| Minimalist | Tech urun, SaaS | LinkedIn, Twitter | Profesyonel |
-| Fotografik | Yasam tarz, gida, seyahat | Instagram, Pinterest | Sicak |
-| Illustrasyon | Egitim, cocuk, eglence | Instagram, Blog | Eglenceli |
-| Tipografik | Motivasyon, alistilar | Instagram, Twitter | Ilham |
-| 3D Render | Teknoloji, oyun | Instagram, YouTube | Modern |
-| Gradient | App tanitim, dijital | LinkedIn, Twitter | Modern |
-| Flat Design | Infografik, sunum | LinkedIn, Blog | Net |
-| Retro | Nostalji, moda, muzik | Instagram, Pinterest | Yaratici |
-| Neon | Gece hayati, oyun, muzik | Instagram, TikTok | Enerjik |
-| Collage | Moda, sanat, etkinlik | Instagram, Pinterest | Yaratici |
+# Style Reference Table
+| Style | Example Use | Fit Platforms | Tone |
+|-------|-------------|---------------|------|
+| Minimalist | Tech products, SaaS | LinkedIn, Twitter | Professional |
+| Photographic | Lifestyle, food, travel | Instagram, Pinterest | Warm |
+| Illustration | Education, kids, fun | Instagram, Blog | Playful |
+| Typographic | Motivation, habits | Instagram, Twitter | Inspirational |
+| 3D Render | Technology, gaming | Instagram, YouTube | Modern |
+| Gradient | App promos, digital | LinkedIn, Twitter | Modern |
+| Flat Design | Infographics, decks | LinkedIn, Blog | Clear |
+| Retro | Nostalgia, fashion, music | Instagram, Pinterest | Creative |
+| Neon | Nightlife, gaming, music | Instagram, TikTok | Energetic |
+| Collage | Fashion, art, events | Instagram, Pinterest | Creative |

--- a/.claude/commands/launch.md
+++ b/.claude/commands/launch.md
@@ -1,123 +1,123 @@
 Product launch plan command. Creates a comprehensive plan for a new product or feature launch.
 
-# Gerekli Araclar
-- Read (proje verileri)
-- Grep (pazar arastirmasi verileri)
-- Write (plan dosyasi)
-- Bash (mevcut proje analizi)
-- Glob (kaynak taramasi)
+# Required Tools
+- Read (project data)
+- Grep (market research data)
+- Write (plan file)
+- Bash (current project analysis)
+- Glob (resource scan)
 
-# Prosedur (7 Adim)
+# Procedure (7 Steps)
 
-### Adim 1: Urun Ozeti
-Kullanicidan su bilgileri al:
-- Urun/ozellik adi
-- Tek cumlelik deger onerisi
-- Hedef kitle tanimlamasi
-- Lansman tarihi veya zaman dilimi
-- Basari metrikleri (KPI)
+### Step 1: Product Summary
+Get from the user:
+- Product/feature name
+- One-sentence value proposition
+- Target audience definition
+- Launch date or time window
+- Success metrics (KPIs)
 
-Ozeti olustur:
-- Problem tanimi (hangi sorunu cozuyor?)
-- Cozum tanimi (nasil cozuyor?)
-- Benzersiz deger onerisi (neden bu cozum?)
-- Hedef pazar buyuklugu tahmini
+Build the summary:
+- Problem statement (what problem does it solve?)
+- Solution statement (how does it solve it?)
+- Unique value proposition (why this solution?)
+- Target market size estimate
 
-### Adim 2: Rekabet Arastirmasi
-Rekabet ortamini analiz et:
-- Dogrudan rakipler (ayni sorunu cozenler, 3-5 adet)
-- Dolayli rakipler (alternatif cozumler)
-- Her rakip icin: guclu yonler, zayif yonler, fiyatlandirma
-- Pazar boslugu analizi
-- Farklilastirma firsatlari
-- Rakip konumlandirma matrisi
+### Step 2: Competitive Research
+Analyze the competitive landscape:
+- Direct competitors (solving the same problem, 3-5)
+- Indirect competitors (alternative solutions)
+- For each competitor: strengths, weaknesses, pricing
+- Market gap analysis
+- Differentiation opportunities
+- Competitor positioning matrix
 
-### Adim 3: Konumlandirma
-- Hedef kitle segmentasyonu (birincil, ikincil persona)
-- Benzersiz satis onerisi (USP) tanimi
-- Mesajlasma cercevesi:
-  - Baslik (headline)
-  - Alt baslik (subheadline)
-  - 3 temel fayda maddesi
-  - Sosyal kanit stratejisi (referans, istatistik, logo)
-- Ton ve ses (marka uyumlu)
-- Anahtar kelimeler ve SEO stratejisi
+### Step 3: Positioning
+- Target audience segmentation (primary, secondary personas)
+- Unique selling proposition (USP) definition
+- Messaging framework:
+  - Headline
+  - Subheadline
+  - 3 core benefit bullets
+  - Social proof strategy (testimonials, statistics, logos)
+- Tone and voice (brand-aligned)
+- Keywords and SEO strategy
 
-### Adim 4: Fiyat Analizi
-- Maliyet tabani hesabi
-- Rakip fiyatlandirma karsilastirmasi
-- Deger bazli fiyatlandirma onerisi
-- Fiyat katmanlari (uygunsa):
-  - Ucretsiz / Freemium
-  - Baslangic
-  - Profesyonel
-  - Kurumsal
-- Tanitim fiyati stratejisi
-- Gelir projeksiyonu (3-6-12 ay)
+### Step 4: Pricing Analysis
+- Cost-base calculation
+- Competitor pricing comparison
+- Value-based pricing suggestion
+- Price tiers (if applicable):
+  - Free / Freemium
+  - Starter
+  - Professional
+  - Enterprise
+- Intro pricing strategy
+- Revenue projection (3-6-12 months)
 
-### Adim 5: Landing Page Taslagi
-Donusum odakli sayfa yapisi tasarla:
-- **Hero Bolumu:** Baslik + deger onerisi + birincil CTA + gorsel yer tutucu
-- **Problem/Cozum:** Kullanicinin acisini tanimla, cozumu goster
-- **Ozellikler:** 3-6 temel ozellik, faydalarla birlikte
-- **Nasil Calisir:** 3-4 adimli gorsel akis
-- **Sosyal Kanit:** Referanslar, musteri logolari, istatistikler
-- **Fiyatlandirma:** Karsilastirmali tablo
-- **SSS:** 5-8 sik sorulan soru
-- **Son CTA:** Guclu kapansis mesaji + aksiyon butonu
-- **Teknik:** SEO meta taglari, OG image, yapisal veri
+### Step 5: Landing Page Draft
+Design a conversion-driven page structure:
+- **Hero Section:** Headline + value proposition + primary CTA + visual placeholder
+- **Problem/Solution:** Name the user's pain, show the solution
+- **Features:** 3-6 core features, with benefits
+- **How It Works:** A 3-4 step visual flow
+- **Social Proof:** Testimonials, customer logos, statistics
+- **Pricing:** Comparison table
+- **FAQ:** 5-8 frequent questions
+- **Final CTA:** Strong closing message + action button
+- **Technical:** SEO meta tags, OG image, structured data
 
-### Adim 6: Go-to-Market Kontrol Listesi
+### Step 6: Go-to-Market Checklist
 
-**Lansman Oncesi (-2 hafta):**
-- [ ] Landing page gelistirme ve test
-- [ ] E-posta listesi segmentasyonu ve hazirligi
-- [ ] Sosyal medya icerik takvimi olusturma
-- [ ] Basin bulteni taslagi ve dagitim listesi
-- [ ] Beta test grubu geri bildirim toplama
-- [ ] Destek dokumantasyonu (SSS, kilavuzlar)
-- [ ] Analitik ve izleme kurulumu (GA, Mixpanel, vb.)
-- [ ] A/B test planlari
+**Pre-Launch (-2 weeks):**
+- [ ] Landing page build and test
+- [ ] Email list segmentation and prep
+- [ ] Social media content calendar
+- [ ] Press release draft and distribution list
+- [ ] Beta group feedback collection
+- [ ] Support documentation (FAQ, guides)
+- [ ] Analytics and tracking setup (GA, Mixpanel, etc.)
+- [ ] A/B test plans
 
-**Lansman Gunu:**
-- [ ] Landing page yayina alma
-- [ ] E-posta kampanyasi gonderimi (saat bazli)
-- [ ] Sosyal medya paylasim plani (platform bazli, saat bazli)
-- [ ] Product Hunt / Hacker News gonderisi (uygunsa)
-- [ ] Topluluk duyurulari (Discord, Slack, forum)
-- [ ] Canli destek ekibi hazir
-- [ ] Gercek zamanli metrik takibi
+**Launch Day:**
+- [ ] Landing page go-live
+- [ ] Email campaign send (by hour)
+- [ ] Social media posting plan (per platform, per hour)
+- [ ] Product Hunt / Hacker News post (if fitting)
+- [ ] Community announcements (Discord, Slack, forums)
+- [ ] Live support team ready
+- [ ] Real-time metric tracking
 
-**Lansman Sonrasi (+2 hafta):**
-- [ ] Gunluk metrik takibi ve raporlama
-- [ ] Kullanici geri bildirimi toplama ve analiz
-- [ ] Hata ve sorun takibi (oncelikli duzeltme)
-- [ ] Icerik pazarlamasi (blog, video, podcast)
-- [ ] Performans optimizasyonu (sayfa hizi, donusum)
-- [ ] Retrospektif ve ogrenimler raporu
+**Post-Launch (+2 weeks):**
+- [ ] Daily metric tracking and reporting
+- [ ] User feedback collection and analysis
+- [ ] Bug and issue tracking (prioritized fixes)
+- [ ] Content marketing (blog, video, podcast)
+- [ ] Performance optimization (page speed, conversion)
+- [ ] Retrospective and learnings report
 
-### Adim 7: Plan Dosyasi Olustur
-`launch-plan-[urun-adi].md` dosyasini olustur:
-- Tum adimlarin ciktisini tek dokumanda birlesir
-- Tarihli kontrol listesi ile takip edilebilir format
-- Sorumluluk atamalari icin bos alanlar
+### Step 7: Create the Plan File
+Create `launch-plan-[product-name].md`:
+- Combines every step's output into one document
+- Trackable format with a dated checklist
+- Blank fields for ownership assignments
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI LANSMAN PLANI ===
-Urun: [urun adi]
-Hedef Tarih: [tarih]
-Durum: TASLAK
+=== BADI LAUNCH PLAN ===
+Product: [product name]
+Target Date: [date]
+Status: DRAFT
 
-Olusturulan: launch-plan-[urun-adi].md
+Created: launch-plan-[product-name].md
 
-Icindekiler:
-1. Urun Ozeti ve Deger Onerisi
-2. Rekabet Analizi Matrisi
-3. Konumlandirma ve Mesajlasma
-4. Fiyatlandirma Stratejisi
-5. Landing Page Taslagi
-6. Go-to-Market Kontrol Listesi
-7. Basari Metrikleri ve KPI
+Contents:
+1. Product Summary and Value Proposition
+2. Competitive Analysis Matrix
+3. Positioning and Messaging
+4. Pricing Strategy
+5. Landing Page Draft
+6. Go-to-Market Checklist
+7. Success Metrics and KPIs
 ===========================
 ```

--- a/.claude/commands/proposal.md
+++ b/.claude/commands/proposal.md
@@ -1,146 +1,146 @@
 Client proposal command. Builds a professional client proposal from project summaries. Valid for 30 days.
 
-# Gerekli Araclar
-- Read (proje verileri, mevcut brifing)
-- Write (teklif dosyasi)
-- Grep (benzer teklif arama)
+# Required Tools
+- Read (project data, existing brief)
+- Write (proposal file)
+- Grep (similar proposal search)
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-### Adim 1: Genel Bakis
-Kullanicidan su bilgileri al:
-- **Musteri Adi:** Sirket veya kisi
-- **Ihtiyaclar:** Musterinin belirttigi sorunlar ve istekler
-- **Istenen Sonuclar:** Basari kriterleri ve beklentiler
-- **Kisitlamalar:** Butce araligi, zaman kisiti, teknik sinirlar
-- **Karar Verici:** Kim onaylayacak? Teknik mi, is mi?
-- **Rekabet:** Baska teklifler de mi degerlendiriliyor?
+### Step 1: Overview
+Get from the user:
+- **Client Name:** Company or person
+- **Needs:** The problems and requests the client stated
+- **Desired Outcomes:** Success criteria and expectations
+- **Constraints:** Budget range, time limits, technical boundaries
+- **Decision Maker:** Who approves? Technical or business?
+- **Competition:** Are other proposals being evaluated?
 
-Mevcut bir brifing varsa (`briefs/` dizininde), onu temel al.
+If an existing brief exists (in `briefs/`), build on it.
 
-### Adim 2: Kapsam Tanimla
-Teslimatlari fazlara ayir:
+### Step 2: Define the Scope
+Split the deliverables into phases:
 
-**Faz 1: [isim]**
-- Teslimatlar: [detayli liste]
-- Beklenen ciktilar: [somut sonuclar]
-- Sure: [tahmini]
-- Bagimliliklar: [on kosullar]
+**Phase 1: [name]**
+- Deliverables: [detailed list]
+- Expected outputs: [concrete results]
+- Duration: [estimate]
+- Dependencies: [prerequisites]
 
-**Faz 2: [isim]**
+**Phase 2: [name]**
 - ...
 
-Her faz icin:
-- Varsayimlar (ne saglanacak, ne bekleniyor)
-- Kapsam disi birakilan maddeler (acikca belirt)
-- Kabul kriterleri
+For each phase:
+- Assumptions (what will be provided, what is expected)
+- Out-of-scope items (state explicitly)
+- Acceptance criteria
 
-### Adim 3: Zaman Cizelgesi
-Fazlari takvim haftlarina esle:
+### Step 3: Timeline
+Map the phases to calendar weeks:
 
-| Hafta | Faz | Teslimatlar | Kilometre Tasi |
-|-------|-----|-------------|----------------|
-| 1-2 | Arastirma & Tasarim | ... | Tasarim Onayi |
-| 3-5 | Gelistirme | ... | MVP Demo |
-| 6 | Test & Iyilestirme | ... | QA Onayi |
-| 7 | Lansman & Destek | ... | Canli Yayim |
+| Week | Phase | Deliverables | Milestone |
+|------|-------|--------------|-----------|
+| 1-2 | Research & Design | ... | Design Approval |
+| 3-5 | Development | ... | MVP Demo |
+| 6 | Test & Polish | ... | QA Approval |
+| 7 | Launch & Support | ... | Go-Live |
 
-- Her faz arasinda 2-3 gunluk inceleme tamponu birak
-- Kilometre taslarini acikca isaretle
-- Kritik yol analizini belirt
+- Leave a 2-3 day review buffer between phases
+- Mark milestones explicitly
+- Note the critical path
 
-### Adim 4: Fiyatlandirma (2 Secenek)
+### Step 4: Pricing (2 Options)
 
-**Secenek A: Tam Kapsam (Onerilen)**
-| Kalem | Birim | Miktar | Birim Fiyat | Toplam |
-|-------|-------|--------|-------------|--------|
+**Option A: Full Scope (Recommended)**
+| Item | Unit | Quantity | Unit Price | Total |
+|------|------|----------|------------|-------|
 | ... | ... | ... | ... | ... |
-- Alt toplam: [tutar]
-- KDV: [tutar]
-- **Genel Toplam: [tutar]**
+- Subtotal: [amount]
+- VAT: [amount]
+- **Grand Total: [amount]**
 
-**Secenek B: MVP / Azaltilmis Kapsam**
-| Kalem | Birim | Miktar | Birim Fiyat | Toplam |
-|-------|-------|--------|-------------|--------|
+**Option B: MVP / Reduced Scope**
+| Item | Unit | Quantity | Unit Price | Total |
+|------|------|----------|------------|-------|
 | ... | ... | ... | ... | ... |
-- **Genel Toplam: [tutar]**
+- **Grand Total: [amount]**
 
-**Opsiyonel Ek Hizmetler:**
-- [hizmet]: [fiyat]
-- [hizmet]: [fiyat]
+**Optional Add-on Services:**
+- [service]: [price]
+- [service]: [price]
 
-### Adim 5: Sartlar ve Kosullar
-Teklif sartlarini belirt:
+### Step 5: Terms and Conditions
+State the proposal terms:
 
-- **Gecerlilik:** Bu teklif [tarih] tarihine kadar (30 gun) gecerlidir.
-- **Odeme Takvimi:**
-  - %30 sozlesme imzasinda (baslangic)
-  - %40 MVP tesliminde (ara odeme)
-  - %30 final teslimde ve kabul sonrasinda
-- **Revizyon Politikasi:**
-  - Her faz icin [sayi] tur revizyon dahildir
-  - Ek revizyonlar saatlik ucretlendirilir
-- **Fikri Mulkiyet:**
-  - Tum ozel kod ve tasarimlar final odeemede musteriye devredilir
-  - Ucuncu parti lisanslar musteriye bildirilir
-- **Gizlilik:** Karsilikli gizlilik anlasmasi (NDA) uygulanir
-- **Iptal Kosullari:**
-  - Her iki taraf [sayi] gun onceden bildirimle iptal edebilir
-  - Tamamlanan calisma icin odeme yapilir
-- **Iletisim:** Haftalik ilerleme raporu + [aralikla] toplanti
-- **Degisiklik Talepleri:** Kapsam disindaki talepler ayrica fiyatlandirilir
+- **Validity:** This proposal is valid until [date] (30 days).
+- **Payment Schedule:**
+  - 30% at contract signature (start)
+  - 40% at MVP delivery (interim)
+  - 30% at final delivery and acceptance
+- **Revision Policy:**
+  - [count] revision rounds included per phase
+  - Extra revisions billed hourly
+- **Intellectual Property:**
+  - All custom code and designs transfer to the client at final payment
+  - Third-party licenses disclosed to the client
+- **Confidentiality:** A mutual NDA applies
+- **Cancellation:**
+  - Either party may cancel with [count] days notice
+  - Completed work is paid for
+- **Communication:** Weekly progress report + meetings at [interval]
+- **Change Requests:** Out-of-scope requests are priced separately
 
-### Adim 6: Teklif Dosyasi Olustur
-`proposals/[musteri-adi]-proposal.md` dosyasina kaydet.
+### Step 6: Create the Proposal File
+Save to `proposals/[client-name]-proposal.md`.
 
-# Cikti Yapisi
+# Output Structure
 ```markdown
-# Proje Teklifi: [Proje Adi]
-**Hazirlayan:** [isim]
-**Musteri:** [musteri adi]
-**Tarih:** [tarih]
-**Gecerlilik:** [son tarih] (30 gun)
+# Project Proposal: [Project Name]
+**Prepared by:** [name]
+**Client:** [client name]
+**Date:** [date]
+**Validity:** [end date] (30 days)
 
-## 1. Yonetici Ozeti
-[2-3 paragraf: sorun, cozum, deger]
+## 1. Executive Summary
+[2-3 paragraphs: problem, solution, value]
 
-## 2. Problem Anlayisi
-[musterinin durumu ve ihtiyaclari]
+## 2. Understanding the Problem
+[the client's situation and needs]
 
-## 3. Onerilen Yaklasim
-[fazli cozum plani]
+## 3. Proposed Approach
+[phased solution plan]
 
-## 4. Kapsam ve Teslimatlar
-[detayli kapsam tablosu]
+## 4. Scope and Deliverables
+[detailed scope table]
 
-## 5. Zaman Cizelgesi
-[haftalik plan tablosu]
+## 5. Timeline
+[weekly plan table]
 
-## 6. Yatirim
-[2 secenekli fiyatlandirma]
+## 6. Investment
+[2-option pricing]
 
-## 7. Sartlar ve Kosullar
-[yukaridaki sartlar]
+## 7. Terms and Conditions
+[the terms above]
 
-## 8. Sonraki Adimlar
-1. Teklifin incelenmesi
-2. Soru-cevap toplantisi
-3. Sozlesme imzasi
-4. Baslangic toplantisi (kickoff)
+## 8. Next Steps
+1. Proposal review
+2. Q&A meeting
+3. Contract signature
+4. Kickoff meeting
 ```
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI MUSTERI TEKLIFI ===
-Musteri: [musteri adi]
-Tarih: [tarih]
-Gecerlilik: 30 gun ([son tarih])
+=== BADI CLIENT PROPOSAL ===
+Client: [client name]
+Date: [date]
+Validity: 30 days ([end date])
 
-Faz Sayisi: [sayi]
-Secenek A: [toplam tutar]
-Secenek B: [toplam tutar]
-Tahmini Sure: [hafta sayisi] hafta
+Phase Count: [count]
+Option A: [total]
+Option B: [total]
+Estimated Duration: [weeks] weeks
 
-Dosya: proposals/[musteri-adi]-proposal.md
+File: proposals/[client-name]-proposal.md
 =============================
 ```


### PR DESCRIPTION
## Summary

**Increment 3 of the body-translation phase** (after #235 / 3b core). All **17 Turkish content-profile command bodies** (vault + active = 34 files) translated: the `content-*` family + `competitive-intel`, `launch`, `proposal`. (`meta-review`/`ads-review` were born English.)

### Caught en route — stale tokens from the #227/#228 renames
- `content-search` examples: `--tur`/`--son` → `--type`/`--last`
- `content-template` examples: `olustur`/`sil` → `create`/`delete`; `gorsel`/`takvim` bases → `visual`/`calendar`
- `content-idea` quick start: `karousel` → `carousel`

Workspace data dirs (`icerikler/`, `takvim/`, `marka-sesi.md`) intentionally unchanged (CUT).

## Test plan
- [x] `npm test` — **1161 pass / 0 fail** · biome clean · doctor healthy
- [x] Broad Turkish scan across all 17 files: **zero residual**

## Remaining
3d/e: dev command bodies (~44) → 3f-h: skills vault (59 SKILL.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)