### PR TITLE
feat(i18n): Phase 3d — English dev command bodies, batch 1 (20 commands)

### DIFF
--- a/.claude/commands-vault/a11y-audit.md
+++ b/.claude/commands-vault/a11y-audit.md
@@ -1,54 +1,54 @@
 Web accessibility (WCAG 2.1) audit command. axe-core-based checks via PageSpeed Insights.
 
-# Gerekli Araclar
-- Bash (badi a11y komutu cagirisi)
+# Required Tools
+- Bash (badi a11y command invocation)
 
-# Prosedur
+# Procedure
 
-### Adim 1: URL Al
-Kullanicidan test edilecek URL al.
+### Step 1: Get the URL
+Take the URL to test from the user.
 
-### Adim 2: Badi CLI Calistir
+### Step 2: Run the Badi CLI
 
 ```bash
 badi a11y [url]              # Mobile audit
 badi a11y [url] --desktop    # Desktop audit
 ```
 
-### Adim 3: Sonuclari Yorumla
+### Step 3: Interpret the Results
 
-Skor bandlari:
-- **90-100**: Mukemmel, coq iyi
-- **70-89**: Iyi ama iyilestirilebilir
-- **< 70**: Ciddi sorunlar var
+Score bands:
+- **90-100**: Excellent
+- **70-89**: Good but improvable
+- **< 70**: Serious problems
 
-### Adim 4: Yaygin Hatalar ve Cozumleri
+### Step 4: Common Failures and Fixes
 
-Basarisiz auditlere gore somut duzeltme oneri ver:
+Give concrete fixes per failed audit:
 
-- **color-contrast**: "Foreground/background kontrast orani 4.5:1 olmali (AA), 7:1 (AAA)"
-- **image-alt**: "Tum `<img>` elemanlarina anlamli `alt` ekle, decorative ise `alt=\"\"`"
-- **label**: "Form input'lari `<label for=\"\">` ile eslestir"
-- **link-name**: "Link metinleri aciklayici olmali, \"tikla\" yerine gercek eylem"
-- **button-name**: "Butonlarin erisilebilir isimi olmali (aria-label veya text icerik)"
-- **heading-order**: "Baslik hiyerarsisi h1->h2->h3 (atlama yok)"
-- **landmark-one-main**: "Her sayfada bir `<main>` landmark olmali"
-- **html-has-lang**: "`<html lang=\"tr\">` veya `<html lang=\"en\">` tanimla"
+- **color-contrast**: "Foreground/background contrast ratio must be 4.5:1 (AA), 7:1 (AAA)"
+- **image-alt**: "Add meaningful `alt` to every `<img>`; `alt=\"\"` when decorative"
+- **label**: "Pair form inputs with `<label for=\"\">`"
+- **link-name**: "Link texts must be descriptive — the real action instead of 'click here'"
+- **button-name**: "Buttons need accessible names (aria-label or text content)"
+- **heading-order**: "Heading hierarchy h1->h2->h3 (no skips)"
+- **landmark-one-main**: "Every page needs one `<main>` landmark"
+- **html-has-lang**: "Define `<html lang=\"en\">` (or the page language)"
 
-### Adim 5: Manuel Test Hatirlatmasi
+### Step 5: Manual Testing Reminder
 
-Axe-core otomatiklastirilamaz test eder. Manuel test gereken alanlar:
+Axe-core tests what can be automated. Areas needing manual tests:
 - Keyboard navigation (Tab, Enter, Space, Arrow keys)
-- Screen reader testi (VoiceOver, NVDA)
-- 200% zoom okunabilirlik
+- Screen reader testing (VoiceOver, NVDA)
+- 200% zoom readability
 - Video/audio captioning
 
-### Adim 6: Kapsamli Denetim
+### Step 6: Comprehensive Audit
 
-- `/lighthouse [url]` ile full Lighthouse raporu (performance + SEO + a11y)
-- WCAG quickref linkini ver
+- Full Lighthouse report with `/lighthouse [url]` (performance + SEO + a11y)
+- Provide the WCAG quickref link
 
-# Ornek
+# Example
 ```
 /a11y-audit https://example.com
 ```

--- a/.claude/commands-vault/adr.md
+++ b/.claude/commands-vault/adr.md
@@ -1,75 +1,75 @@
 Architecture Decision Record (ADR) command. Documents architectural decisions in a structured format.
 
-# Gerekli Araclar
-- Read (mevcut ADR'ler)
-- Write (yeni ADR dosyasi)
-- Grep (iliskili karar arama)
-- Agent (architecture-advisor ajani)
+# Required Tools
+- Read (existing ADRs)
+- Write (new ADR file)
+- Grep (related decision search)
+- Agent (architecture-advisor agent)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Karar Baglamini Topla
-Kullanicidan:
-- Karar gerektiren durum nedir?
-- Hangi kisitlamalar var? (zaman, butce, teknik)
-- Kim etkilenecek?
+### Step 1: Gather the Decision Context
+From the user:
+- What situation requires a decision?
+- What constraints exist? (time, budget, technical)
+- Who is affected?
 
-### Adim 2: Alternatifleri Degerlendir
-Architecture-advisor ajanina devret:
-- Mevcut mimarivi analiz et
-- En az 3 alternatif belirle
-- Her alternatif icin artilari/eksileri listele
-- Trade-off analizi yap
+### Step 2: Evaluate the Alternatives
+Delegate to the architecture-advisor agent:
+- Analyze the current architecture
+- Identify at least 3 alternatives
+- List pros/cons for each alternative
+- Run a trade-off analysis
 
-### Adim 3: Karari Belgele
-ADR formatinda yaz:
+### Step 3: Document the Decision
+Write in ADR format:
 ```markdown
-# ADR-[numara]: [Baslik]
-Tarih: [tarih]
-Durum: KABUL EDILDI
+# ADR-[number]: [Title]
+Date: [date]
+Status: ACCEPTED
 
-## Baglam
-[Karari gerektiren durum, kisitlamalar, paydas ihtiyaclari]
+## Context
+[The situation requiring the decision, constraints, stakeholder needs]
 
-## Karar
-[Secilen yaklasim ve gerekcesi]
+## Decision
+[The chosen approach and its rationale]
 
-## Degerendirilen Alternatifler
-### Alternatif A: [isim]
-- Artilari: ...
-- Eksileri: ...
-- Neden secilmedi: ...
+## Considered Alternatives
+### Alternative A: [name]
+- Pros: ...
+- Cons: ...
+- Why not chosen: ...
 
-### Alternatif B: [isim]
+### Alternative B: [name]
 ...
 
-## Sonuclar
-### Pozitif
+## Consequences
+### Positive
 - ...
-### Negatif
+### Negative
 - ...
-### Notr
+### Neutral
 - ...
 
-## Iliskili Kararlar
-- ADR-XX: [iliskili karar]
+## Related Decisions
+- ADR-XX: [related decision]
 ```
 
-### Adim 4: Kaydet
-- `docs/adr/` dizinine kaydet (yoksa olustur)
-- ADR numarasini sirali ata
-- INDEX.md'yi guncelle (varsa)
+### Step 4: Save
+- Save into `docs/adr/` (create if missing)
+- Assign the ADR number sequentially
+- Update INDEX.md (if present)
 
-### Adim 5: Iliskili Dokumanlari Guncelle
-- CLAUDE.md veya knowledge-base.md'ye referans ekle (uygunsa)
-- Iliskili ADR'lere capraz referans ekle
+### Step 5: Update Related Documents
+- Add a reference to CLAUDE.md or knowledge-base.md (where fitting)
+- Add cross-references to related ADRs
 
-# Cikti Formati
+# Output Format
 ```
 === BADI ADR ===
-Numara: ADR-[numara]
-Baslik: [karar basligi]
-Durum: KABUL EDILDI
-Dosya: docs/adr/[numara]-[baslik].md
+Number: ADR-[number]
+Title: [decision title]
+Status: ACCEPTED
+File: docs/adr/[number]-[title].md
 ================
 ```

--- a/.claude/commands-vault/ai-review.md
+++ b/.claude/commands-vault/ai-review.md
@@ -1,60 +1,60 @@
 AI code review of the staged git diff via the Claude API.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi ai review)
 
-# On Kosul
+# Prerequisite
 
-ANTHROPIC_API_KEY ortam degiskeni tanimli olmali:
+The ANTHROPIC_API_KEY environment variable must be set:
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
 ```
-Kayit: https://console.anthropic.com/settings/keys
+Sign-up: https://console.anthropic.com/settings/keys
 
-# Prosedur
+# Procedure
 
-### Adim 1: Degisiklikleri Stage Et
+### Step 1: Stage the Changes
 ```bash
-git add [dosyalar]
+git add [files]
 ```
 
-### Adim 2: AI Review
+### Step 2: AI Review
 ```bash
 badi ai review
 ```
 
-Claude Haiku 4.5 modeli ile staged diff incelenir. ~1-3 saniye suren hizli cevir.
+The staged diff is reviewed with the Claude Haiku 4.5 model. A fast pass taking ~1-3 seconds.
 
-### Adim 3: Yorumla
+### Step 3: Interpret
 
-Bulgular 5 kategoride:
-1. **KRITIK guvenlik** — hemen duzelt
-2. **Bug potansiyeli** — test kapsami kontrol
-3. **Performans** — hotpath degisiklikleri
-4. **Kod kalitesi** — DRY, naming, complexity
-5. **Olumlu gozlemler** — iyi yapilmis seyler
+Findings in 5 categories:
+1. **CRITICAL security** — fix immediately
+2. **Bug potential** — check test coverage
+3. **Performance** — hot-path changes
+4. **Code quality** — DRY, naming, complexity
+5. **Positive observations** — things done well
 
-### Adim 4: Aksiyon
+### Step 4: Action
 
-- Kritik bulgu: Commit etme, once duzelt
-- Yuksek: Inceleme notu ekle, ayri commit
-- Orta/Dusuk: TODO/issue olustur
+- Critical finding: do not commit; fix first
+- High: add a review note, separate commit
+- Medium/Low: create a TODO/issue
 
-### Adim 5: Takip
+### Step 5: Follow-up
 
-Her commit oncesi kullanmak icin git hook:
+A git hook to use before every commit:
 ```bash
 # .git/hooks/pre-commit
 badi ai review || exit 1
 ```
 
-# Maliyet
+# Cost
 
 - Haiku 4.5: ~$0.25 / 1M input, ~$1.25 / 1M output
-- Ortalama review: 2-3K input, 500-1000 output tokens
-- **Yaklasik maliyet: $0.001 per review**
+- Average review: 2-3K input, 500-1000 output tokens
+- **Approximate cost: $0.001 per review**
 
-# Ornek
+# Example
 
 ```
 git add src/auth.js

--- a/.claude/commands-vault/ai-translate.md
+++ b/.claude/commands-vault/ai-translate.md
@@ -1,63 +1,60 @@
 Markdown file translation. Technical/content translation via the Claude API (without breaking markdown structure).
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi ai translate)
 
-# On Kosul
+# Prerequisite
 
-ANTHROPIC_API_KEY gerekli.
+ANTHROPIC_API_KEY required.
 
-# Prosedur
+# Procedure
 
-### Adim 1: Kaynak Dosya
-Markdown dosya yolu (ornek: `docs/guide.md`, `blog/post-tr.md`).
+### Step 1: Source File
+A markdown file path (example: `docs/guide.md`, `blog/post-tr.md`).
 
-### Adim 2: Cevir
+### Step 2: Translate
 ```bash
-badi ai translate [file.md]                  # Varsayilan EN
-badi ai translate [file.md] --to en          # Ingilizce
-badi ai translate [file.md] --to de          # Almanca
-badi ai translate [file.md] --to fr          # Fransizca
-badi ai translate [file.md] --to es          # Ispanyolca
+badi ai translate [file.md]                  # Default EN
+badi ai translate [file.md] --to en          # English
+badi ai translate [file.md] --to de          # German
+badi ai translate [file.md] --to fr          # French
+badi ai translate [file.md] --to es          # Spanish
 ```
 
-### Adim 3: Cikti
+### Step 3: Output
 
-Kaynak dosya yaninde `-[lang]` suffixli yeni dosya:
+A new file next to the source with a `-[lang]` suffix:
 - `guide.md` -> `guide-en.md`
 
-### Adim 4: Kullanim Durumlari
+### Step 4: Use Cases
 
-- **Icerik pazarlama**: TR post -> EN, EN post -> TR
-- **Teknik dokuman**: README.md -> README-en.md
+- **Content marketing**: TR post -> EN, EN post -> TR
+- **Technical docs**: README.md -> README-en.md
 - **App Store**: release-notes-tr.md -> release-notes-en.md
-- **Blog**: coklu dil destegi
+- **Blog**: multi-language support
 
-### Adim 5: Markdown Korumasi
+### Step 5: Markdown Preservation
 
-AI sunlari korur:
-- Kod blogu (```...```)
-- Link yapisi
-- Baslik hiyerarsisi (##, ###)
-- Liste formati
-- Hashtag'ler (lokalizasyon yapilir)
+The AI preserves:
+- Code blocks (```...```)
+- Link structure
+- Heading hierarchy (##, ###)
+- List formatting
+- Hashtags (localized)
 
-### Adim 6: Alternatif
+### Step 6: Relationship to the Content Engine
 
-Mevcut icerik motoru `--lang tr,en` ile paralel uretim de yapiyor:
-```bash
-badi content post "konu" --lang tr,en
-```
+The content engine (`badi content ...`) produces English-only output (v1.32+).
+To publish in another language, generate first and then translate the file
+with `ai translate`.
 
-Ayni zamanda uretim icin daha hizli; sonradan cevirmek icin `ai translate`.
+# Cost
 
-# Maliyet
+- ~5K chars of content: ~$0.003-0.005 per translation
 
-- ~5K char icerik: ~$0.003-0.005 per ceviri
-
-# Ornek
+# Example
 
 ```
-/ai-translate blog/yazi-tr.md --to en
+/ai-translate blog/post-tr.md --to en
 /ai-translate docs/guide.md --to de
 ```

--- a/.claude/commands-vault/bundle-analyze.md
+++ b/.claude/commands-vault/bundle-analyze.md
@@ -1,51 +1,51 @@
 Bundle size + framework detection + largest assets + heavy-dependency warnings.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi dev bundle)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Build Al
+### Step 1: Build
 ```bash
 npm run build
 ```
 
-### Adim 2: Analiz
+### Step 2: Analyze
 ```bash
 badi dev bundle
 ```
 
-### Adim 3: Gosterilenler
+### Step 3: What Is Shown
 
-- **Framework tespit**: Next.js, Vite, Webpack, Expo
-- **Build ciktisi**: dist/, build/, .next/, out/, web-build/
-- **Toplam boyut**: MB cinsinden
-- **En buyuk 10 asset**: JS, MJS, CSS
-- **Agir bagimliliklar**: moment, lodash, axios, jquery — alternatif onerisi
+- **Framework detection**: Next.js, Vite, Webpack, Expo
+- **Build output**: dist/, build/, .next/, out/, web-build/
+- **Total size**: in MB
+- **10 largest assets**: JS, MJS, CSS
+- **Heavy dependencies**: moment, lodash, axios, jquery — alternative suggestions
 
-### Adim 4: Alarm Esikleri
+### Step 4: Alert Thresholds
 
-- **Asset > 500KB**: KRITIK — code splitting yap
-- **Asset > 200KB**: Dikkat — lazy load dusun
-- **Toplam > 5MB**: Web vitals etkiler
+- **Asset > 500KB**: CRITICAL — apply code splitting
+- **Asset > 200KB**: Attention — consider lazy loading
+- **Total > 5MB**: Affects web vitals
 
-### Adim 5: Derin Analiz
+### Step 5: Deep Analysis
 
-Framework ozel araclar:
+Framework-specific tools:
 - **Webpack**: `npx webpack-bundle-analyzer`
 - **Vite**: `npx vite-bundle-visualizer`
 - **Next.js**: `npx @next/bundle-analyzer`
 
-### Adim 6: Yaygin Cozumler
+### Step 6: Common Fixes
 
 - **Code splitting**: `import()` dynamic imports
 - **Tree shaking**: ESM + sideEffects: false
 - **Lazy load**: React.lazy, Vue defineAsyncComponent
-- **CDN externals**: React/Vue CDN'den
+- **CDN externals**: React/Vue from a CDN
 - **Minification**: production mode
 - **Compression**: gzip/brotli
 
-# Ornek
+# Example
 
 ```
 npm run build

--- a/.claude/commands-vault/changelog-gen.md
+++ b/.claude/commands-vault/changelog-gen.md
@@ -1,64 +1,64 @@
 CHANGELOG.md update command. Generates a changelog from git history grouped by conventional commit types.
 
-# Gerekli Araclar
-- Bash (badi changelog komutu cagirisi)
+# Required Tools
+- Bash (badi changelog command invocation)
 - git
 
-# Prosedur
+# Procedure
 
-### Adim 1: Son Tag'i Bul
+### Step 1: Find the Latest Tag
 ```bash
 git describe --tags --abbrev=0
 ```
 
-### Adim 2: Version Sayisini Belirle
+### Step 2: Decide the Version Number
 
-Kullaniciya yeni surumu sor:
-- Breaking change varsa: major (2.0.0)
-- Yeni ozellik (feat) varsa: minor (1.5.0)
-- Sadece fix varsa: patch (1.4.3)
+Ask the user for the new version:
+- If there are breaking changes: major (2.0.0)
+- If there are new features (feat): minor (1.5.0)
+- If only fixes: patch (1.4.3)
 
-### Adim 3: Badi CLI Ile Changelog Uret
+### Step 3: Generate the Changelog with the Badi CLI
 
-Onizleme (yazmaz):
+Preview (does not write):
 ```bash
-badi changelog                              # Son tag'den HEAD
-badi changelog --from v1.0.0                # Belirli tag'den
-badi changelog --from v1.0.0 --to v2.0.0    # Arada
+badi changelog                              # From the latest tag to HEAD
+badi changelog --from v1.0.0                # From a specific tag
+badi changelog --from v1.0.0 --to v2.0.0    # Between two
 ```
 
-CHANGELOG.md'ye yaz:
+Write to CHANGELOG.md:
 ```bash
 badi changelog --write --version 1.5.0
 ```
 
-### Adim 4: Manuel Rotus
+### Step 4: Manual Touch-up
 
-Otomatik urettikten sonra:
-- Kullanici okunabilirligi icin gerekirse duzenle
-- Breaking change'leri uste cikar
-- Feature hash'lerini kaldir (kullanici icin anlamsiz)
-- Kategorileri yeniden sirala (Eklenen -> Duzeltilen -> Diger)
+After auto-generating:
+- Edit for reader clarity where needed
+- Surface the breaking changes to the top
+- Drop commit hashes (meaningless to users)
+- Reorder the categories (Added -> Fixed -> Other)
 
-### Adim 5: Tag + Release
+### Step 5: Tag + Release
 
-Changelog hazir olduktan sonra:
+Once the changelog is ready:
 ```bash
 git add CHANGELOG.md package.json
 git commit -m "chore: vX.Y.Z release"
 git tag vX.Y.Z
 git push origin main --tags
-gh release create vX.Y.Z --title "vX.Y.Z - Baslik" --notes-file RELEASE_NOTES.md
+gh release create vX.Y.Z --title "vX.Y.Z - Title" --notes-file RELEASE_NOTES.md
 ```
 
-### Adim 6: npm Publish (varsa)
+### Step 6: npm Publish (if applicable)
 
 ```bash
 npm publish --access public
 ```
 
-# Ornek
+# Example
 ```
-/changelog-gen              # onizleme
-/changelog-gen 1.5.0        # v1.5.0 olarak dosyaya yaz
+/changelog-gen              # preview
+/changelog-gen 1.5.0        # write to file as v1.5.0
 ```

--- a/.claude/commands-vault/conv-commit.md
+++ b/.claude/commands-vault/conv-commit.md
@@ -1,69 +1,69 @@
 Conventional commit helper command. Reads staged files, suggests type/scope/message, and validates.
 
-# Gerekli Araclar
-- Bash (badi commit komutu cagirisi)
+# Required Tools
+- Bash (badi commit command invocation)
 - git
 
-# Prosedur
+# Procedure
 
-### Adim 1: Staged Degisiklikleri Oku
+### Step 1: Read the Staged Changes
 ```bash
 git diff --cached --stat
 git diff --cached | head -100
 ```
 
-### Adim 2: Tip Secimi
+### Step 2: Type Selection
 
-Degisiklige gore:
-- **feat**: Yeni kullanici ozelligi eklendiyse
-- **fix**: Mevcut bir hata duzeltildiyse
-- **refactor**: Davranis degismedi, iskelelim (rename, extract)
-- **perf**: Performans iyilestirmesi olcumlu
-- **docs**: Sadece markdown/yorum degisikligi
-- **test**: Sadece test dosyalari
-- **chore**: Bakim, config, bagimlilik
-- **ci**: `.github/workflows` vb
-- **build**: Build sistemi (webpack, tsconfig vb)
+By the nature of the change:
+- **feat**: A new user-facing feature
+- **fix**: An existing bug fixed
+- **refactor**: Behavior unchanged, restructuring (rename, extract)
+- **perf**: A measured performance improvement
+- **docs**: Markdown/comment-only changes
+- **test**: Test files only
+- **chore**: Maintenance, config, dependencies
+- **ci**: `.github/workflows` etc.
+- **build**: Build system (webpack, tsconfig, etc.)
 
-### Adim 3: Scope Belirle (opsiyonel)
+### Step 3: Pick a Scope (optional)
 
-Etkilenen alan: `auth`, `api`, `ui`, `db`, `config`, modul adi vb.
+The affected area: `auth`, `api`, `ui`, `db`, `config`, a module name, etc.
 
-### Adim 4: Kisa Mesaj Yaz
+### Step 4: Write the Short Message
 
-Kurallar:
-- Emir kipi, kucuk harf ile basla
-- Nokta koyma
-- < 100 karakter (< 70 tercih)
-- WHY > WHAT (commit gecmisi okunabilir olmali)
+Rules:
+- Imperative mood, start lowercase
+- No trailing period
+- < 100 characters (< 70 preferred)
+- WHY > WHAT (the commit history must stay readable)
 
-### Adim 5: Badi CLI Ile Kontrol + Commit
+### Step 5: Check + Commit with the Badi CLI
 
 ```bash
-# Sadece rehberlik
+# Guidance only
 badi commit
 
-# Conventional format dogrulamasi + commit
-badi commit --message "feat(auth): JWT refresh token eklendi"
+# Conventional-format validation + commit
+badi commit --message "feat(auth): add JWT refresh tokens"
 
-# Son commit lint kontrolu
+# Lint check on the last commit
 badi commit --check
 ```
 
-### Adim 6: Body ve Footer (opsiyonel)
+### Step 6: Body and Footer (optional)
 
-Karmasik degisiklikler icin:
+For complex changes:
 ```
-feat(auth): JWT refresh token eklendi
+feat(auth): add JWT refresh tokens
 
-15 dakikalik expire yerine 1h + refresh paterni.
-Mobile clientlar icin offline kullanim destegi.
+1h + refresh pattern instead of a 15-minute expiry.
+Offline support for mobile clients.
 
 Closes #123
-BREAKING CHANGE: access_token yerine tokens.access kullanilmali
+BREAKING CHANGE: use tokens.access instead of access_token
 ```
 
-# Ornek
+# Example
 ```
 /conv-commit
 ```

--- a/.claude/commands-vault/deps-update.md
+++ b/.claude/commands-vault/deps-update.md
@@ -1,66 +1,66 @@
 Safe dependency update analysis. Patch/minor/major categorization with optional automatic patch application.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi dev deps)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Tarama
+### Step 1: Scan
 ```bash
 badi dev deps
 ```
 
-Paket yoneticisi (npm/yarn/pnpm) otomatik tespit edilir.
+The package manager (npm/yarn/pnpm) is auto-detected.
 
-### Adim 2: Kategoriler
+### Step 2: Categories
 
-Her guncelleme su kategorilerde:
-- **Patch** (1.2.X) — Guvenli, auto-apply edilebilir
-- **Minor** (1.X.0) — Yeni ozellik, test gerekli
-- **Major** (X.0.0) — Break change potansiyeli, manuel inceleme
+Every update falls into:
+- **Patch** (1.2.X) — Safe, auto-applicable
+- **Minor** (1.X.0) — New features, tests required
+- **Major** (X.0.0) — Breaking-change potential, manual review
 
-### Adim 3: Patch Otomatik Uygula
+### Step 3: Auto-Apply Patches
 ```bash
 badi dev deps --apply-patch
 ```
 
-Sadece patch seviyesini uygular (en guvenli).
+Applies only the patch level (the safest).
 
-### Adim 4: Minor/Major Strateji
+### Step 4: Minor/Major Strategy
 
 **Minor:**
 ```bash
-npm update [paket]
+npm update [package]
 npm test
 ```
 
 **Major:**
-1. Changelog oku (npmjs.com/package/X)
-2. Break change notlari kontrol
-3. Tek tek guncelle: `npm install paket@latest`
-4. Tam test suite
+1. Read the changelog (npmjs.com/package/X)
+2. Check the breaking-change notes
+3. Update one at a time: `npm install package@latest`
+4. Full test suite
 
-### Adim 5: Guvenlik Onceligi
+### Step 5: Security Priority
 
-Kritik CVE varsa:
+If a critical CVE exists:
 ```bash
 npm audit
 npm audit fix              # Patch + minor auto
-npm audit fix --force      # Major dahil (riskli)
+npm audit fix --force      # Including major (risky)
 ```
 
-### Adim 6: Haftalik Rutin
+### Step 6: Weekly Routine
 
 ```bash
-# Pazartesi sabahi
+# Monday morning
 badi dev deps
-badi dev deps --apply-patch   # Patch'leri uygula
-npm test                       # Testler gecti mi
+badi dev deps --apply-patch   # Apply the patches
+npm test                       # Did the tests pass
 git add package-lock.json
 git commit -m "chore(deps): patch updates"
 ```
 
-# Ornek
+# Example
 
 ```
 /deps-update

--- a/.claude/commands-vault/dns-audit.md
+++ b/.claude/commands-vault/dns-audit.md
@@ -1,41 +1,41 @@
 DNS record audit command. Checks A/AAAA/MX/TXT/SPF/DMARC/CAA records and scores email security.
 
-# Gerekli Araclar
-- Bash (badi dns komutu cagirisi)
+# Required Tools
+- Bash (badi dns command invocation)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Domain Al
-Kullanicidan domain alinir. Argumansiz cagirildi ise sorarak alinir.
+### Step 1: Get the Domain
+Take the domain from the user. If invoked without an argument, ask for it.
 
-### Adim 2: Badi CLI Calistir
+### Step 2: Run the Badi CLI
 ```bash
 badi dns [domain]
 ```
 
-### Adim 3: Sonucu Yorumla
+### Step 3: Interpret the Result
 
-Cikti su alanlari icerir:
-- **A/AAAA**: IPv4/IPv6 kayitlari
-- **MX**: Mail server'lar (priority bazli)
-- **NS**: Name server'lar
-- **TXT/SPF/DMARC**: Email guvenlik
-- **CAA**: Cert authority kisitlamasi
-- **SOA**: Zone authority bilgisi
+The output covers:
+- **A/AAAA**: IPv4/IPv6 records
+- **MX**: Mail servers (by priority)
+- **NS**: Name servers
+- **TXT/SPF/DMARC**: Email security
+- **CAA**: Cert authority restriction
+- **SOA**: Zone authority info
 
-### Adim 4: Email Guvenlik Onerileri
+### Step 4: Email Security Suggestions
 
-Eksik kayitlara gore:
-- **SPF yoksa**: "SPF kaydi ekleyelim mi? Ornek: `v=spf1 include:_spf.google.com ~all`"
-- **DMARC yoksa**: "DMARC policy oneriyorum: `v=DMARC1; p=quarantine; rua=mailto:dmarc@...`"
-- **CAA yoksa**: "CAA kaydi saldiriya karsi koruma saglar. Let's Encrypt icin: `0 issue \"letsencrypt.org\"`"
+Based on missing records:
+- **No SPF**: "Shall we add an SPF record? Example: `v=spf1 include:_spf.google.com ~all`"
+- **No DMARC**: "I suggest a DMARC policy: `v=DMARC1; p=quarantine; rua=mailto:dmarc@...`"
+- **No CAA**: "A CAA record protects against mis-issuance. For Let's Encrypt: `0 issue \"letsencrypt.org\"`"
 
-### Adim 5: Takip Komutlari
+### Step 5: Follow-up Commands
 
-- Guvenlik eksikligi varsa: `/ssl-check [domain]` oner
-- WHOIS bilgisi icin: `/whois [domain]` oner
+- If security gaps exist: suggest `/ssl-check [domain]`
+- For WHOIS info: suggest `/whois [domain]`
 
-# Ornek
+# Example
 ```
 /dns-audit example.com
 ```

--- a/.claude/commands-vault/docker-lint.md
+++ b/.claude/commands-vault/docker-lint.md
@@ -1,65 +1,65 @@
 Dockerfile best-practice checks. Security, size, and reproducibility warnings.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi dev docker-lint)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Kontrol
+### Step 1: Check
 ```bash
 badi dev docker-lint
 ```
 
-### Adim 2: Kontrol Edilenler
+### Step 2: What Is Checked
 
 **FROM:**
-- `:latest` yerine versiyon sabitleme (guvenlik + reproducibility)
-- Alpine/distroless tercihi onerisi
+- Version pinning instead of `:latest` (security + reproducibility)
+- Alpine/distroless preference suggestion
 
 **USER:**
-- USER direktifi yoksa root olarak calisir (guvenlik riski)
-- Non-root user olusturulmasi onerilir
+- Without a USER directive it runs as root (security risk)
+- Creating a non-root user is recommended
 
 **HEALTHCHECK:**
-- Orchestration icin zorunlu
-- HTTP endpoint veya komut
+- Mandatory for orchestration
+- HTTP endpoint or command
 
 **RUN apt-get:**
-- `update` + `install` ayni RUN'da (cache busting)
-- `--no-install-recommends` (boyut)
-- `rm -rf /var/lib/apt/lists/*` (temizlik)
+- `update` + `install` in the same RUN (cache busting)
+- `--no-install-recommends` (size)
+- `rm -rf /var/lib/apt/lists/*` (cleanup)
 
 **ADD vs COPY:**
-- ADD tar ozelligi harici kullanilmamali
-- Local dosyalar icin COPY
+- ADD should not be used outside its tar feature
+- COPY for local files
 
-**Izinler:**
-- `chmod 777` yasak
-- 755 veya daha sıkı
+**Permissions:**
+- `chmod 777` forbidden
+- 755 or tighter
 
-**Port:**
-- EXPOSE < 1024 root gerektirir
+**Ports:**
+- EXPOSE < 1024 requires root
 
 **.dockerignore:**
-- Mevcut olmali (node_modules, .git vs)
+- Must exist (node_modules, .git, etc.)
 
-### Adim 3: Ileri Araclar
+### Step 3: Advanced Tools
 
-Detayli analiz icin:
+For detailed analysis:
 ```bash
 brew install hadolint
 hadolint Dockerfile
 ```
 
-### Adim 4: Yaygin Fix'ler
+### Step 4: Common Fixes
 
 ```dockerfile
-# ONCE
+# BEFORE
 FROM node:latest
 RUN apt-get update
 RUN apt-get install -y python3
 
-# SONRA
+# AFTER
 FROM node:20-alpine
 RUN apt-get update && apt-get install -y --no-install-recommends python3 \
     && rm -rf /var/lib/apt/lists/*
@@ -67,7 +67,7 @@ USER node
 HEALTHCHECK --interval=30s CMD curl -f http://localhost:3000/health || exit 1
 ```
 
-# Ornek
+# Example
 
 ```
 /docker-lint

--- a/.claude/commands-vault/docs-audit.md
+++ b/.claude/commands-vault/docs-audit.md
@@ -1,65 +1,65 @@
 Documentation audit command. Evaluates completeness, freshness, and quality of technical documentation.
 
-# Gerekli Araclar
-- Read (dokumantasyon dosyalari)
-- Grep (referans taramasi)
-- Glob (dosya bulma)
-- Bash (git log, dosya tarihleri)
+# Required Tools
+- Read (documentation files)
+- Grep (reference scan)
+- Glob (file discovery)
+- Bash (git log, file dates)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Dokumantasyon Envanteri
-Tum dokumantasyon dosyalarini tara:
-- README.md dosyalari (kok + alt dizinler)
-- API dokumantasyonu
-- Mimari dokumantasyon (ADR'ler dahil)
-- Kullanici kilavuzlari
-- Gelistirici kilavuzlari
-- Kurulum/baslatma talimatlari
+### Step 1: Documentation Inventory
+Scan all documentation files:
+- README.md files (root + subdirectories)
+- API documentation
+- Architecture documentation (including ADRs)
+- User guides
+- Developer guides
+- Install/getting-started instructions
 - CHANGELOG, CONTRIBUTING, SECURITY
-- Kod ici yorumlar (JSDoc, docstring vb.)
+- In-code comments (JSDoc, docstrings, etc.)
 
-### Adim 2: Tamllik Kontrolu
-Her dokuman icin kontrol et:
-- [ ] Guncel mi? (son degisiklik tarihi vs ilgili kod degisikligi)
-- [ ] Referans edilen dosya/fonksiyonlar hala mevcut mu?
-- [ ] Kurulum adimlari calisir durumda mi?
-- [ ] Kod ornekleri guncel mi?
-- [ ] Kirik linkler var mi?
-- [ ] Eksik bolumler var mi?
+### Step 2: Completeness Check
+For each document, verify:
+- [ ] Is it current? (last change date vs. related code changes)
+- [ ] Do referenced files/functions still exist?
+- [ ] Do the install steps still work?
+- [ ] Are the code examples current?
+- [ ] Any broken links?
+- [ ] Any missing sections?
 
-### Adim 3: Kapsam Boslugu Analizi
-Belgelenmemis alanlari tespit et:
-- Dokumantasyonu olmayan public API'ler
-- README'si olmayan onemli dizinler
-- Aciklamasi olmayan konfigur  asyon dosyalari
-- Belgelenmemis ortam degiskenleri
-- Eksik hata kodu aciklamalari
+### Step 3: Coverage Gap Analysis
+Detect undocumented areas:
+- Public APIs without documentation
+- Important directories without a README
+- Configuration files without explanations
+- Undocumented environment variables
+- Missing error-code descriptions
 
-### Adim 4: Kalite Degerlendirmesi
-- Tutarli format ve ton kullaniliyor mu?
-- Hedef kitle icin uygun seviye mi?
-- Kod ornekleri calisir durumda mi?
-- Gorseller/diyagramlar guncel mi?
+### Step 4: Quality Assessment
+- Consistent format and tone?
+- The right level for the target audience?
+- Do the code examples run?
+- Are visuals/diagrams current?
 
-### Adim 5: Rapor ve Aksiyon Plani
-Bulgulari onceliklendir:
-- **KRITIK**: Yanlis/yaniltici bilgi
-- **YUKSEK**: Tamamen eksik dokumantasyon
-- **ORTA**: Guncel olmayan icerik
-- **DUSUK**: Iyilestirilebilir format/stil
+### Step 5: Report and Action Plan
+Prioritize the findings:
+- **CRITICAL**: Wrong/misleading information
+- **HIGH**: Entirely missing documentation
+- **MEDIUM**: Outdated content
+- **LOW**: Improvable format/style
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI DOKUMANTASYON DENETIMI ===
-Taranan Dosya: [sayi]
-Kapsam Skoru: [yuzde]%
+=== BADI DOCUMENTATION AUDIT ===
+Files Scanned: [count]
+Coverage Score: [percent]%
 
-KRITIK: [sayi] bulgu
-YUKSEK: [sayi] bulgu
-ORTA: [sayi] bulgu
-DUSUK: [sayi] bulgu
+CRITICAL: [count] findings
+HIGH: [count] findings
+MEDIUM: [count] findings
+LOW: [count] findings
 
-En Acil: [ilk 3 aksiyon]
+Most Urgent: [top 3 actions]
 ===================================
 ```

--- a/.claude/commands-vault/env-check.md
+++ b/.claude/commands-vault/env-check.md
@@ -1,53 +1,53 @@
 .env file validation. Detects missing, extra, empty, and placeholder values + .gitignore check.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi dev env-check)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Kontrol
+### Step 1: Check
 ```bash
 badi dev env-check
 ```
 
-Referans dosya tespiti: `.env.example`, `.env.template`, `.env.sample`
+Reference file detection: `.env.example`, `.env.template`, `.env.sample`
 
-### Adim 2: Bulgular
+### Step 2: Findings
 
-**Eksik (KRITIK):**
-- .env.example'da var, .env'de yok
-- Kullanici eklenmeli
+**Missing (CRITICAL):**
+- In .env.example, not in .env
+- The user must add it
 
-**Fazladan (UYARI):**
-- .env'de var, .env.example'da yok
-- Dokumantasyon eksik — .env.example'a ekle
+**Extra (WARNING):**
+- In .env, not in .env.example
+- Documentation gap — add to .env.example
 
-**Bos deger (UYARI):**
-- `KEY=` veya `KEY=""` formati
-- Degeri doldur
+**Empty value (WARNING):**
+- The `KEY=` or `KEY=""` form
+- Fill in the value
 
-**Placeholder (KRITIK):**
+**Placeholder (CRITICAL):**
 - `your_api_key`, `xxx`, `changeme`, `todo`, `<...>`
-- Gercek degerlerle guncellenmemis
+- Not updated with real values
 
-**gitignore (KRITIK):**
-- .env dosyasi .gitignore'da yoksa ACIL ekle
+**gitignore (CRITICAL):**
+- If .env is not in .gitignore, add it URGENTLY
 
-### Adim 3: Yaygin Pattern
+### Step 3: Common Pattern
 
 ```bash
-# .env.example (commit edilir, yer tutucularla)
+# .env.example (committed, with placeholders)
 DATABASE_URL=postgresql://user:password@localhost/dbname
 API_KEY=your_api_key_here
 NODE_ENV=development
 
-# .env (commit edilmez, gercek degerlerle)
+# .env (not committed, with real values)
 DATABASE_URL=postgresql://prod_user:real_password@prod.host/prod_db
 API_KEY=sk-abc123...
 NODE_ENV=production
 ```
 
-### Adim 4: Otomasyon
+### Step 4: Automation
 
 Pre-commit hook:
 ```bash
@@ -61,15 +61,15 @@ CI pipeline:
   run: badi dev env-check
 ```
 
-### Adim 5: Secret Scanner ile Birlestir
+### Step 5: Combine with the Secret Scanner
 
-Kapsamli guvenlik:
+Comprehensive security:
 ```bash
-badi dev env-check     # .env dogrulama
-badi secret-scan       # Kod icinde sir tarama
+badi dev env-check     # .env validation
+badi secret-scan       # in-code secret scan
 ```
 
-# Ornek
+# Example
 
 ```
 /env-check

--- a/.claude/commands-vault/lighthouse.md
+++ b/.claude/commands-vault/lighthouse.md
@@ -1,44 +1,44 @@
 Lighthouse audit command. Performance, Accessibility, Best Practices, SEO scores and Core Web Vitals via the Google PageSpeed Insights API.
 
-# Gerekli Araclar
-- Bash (badi lighthouse komutu cagirisi)
+# Required Tools
+- Bash (badi lighthouse command invocation)
 
-# Prosedur
+# Procedure
 
-### Adim 1: URL Al
-Kullanicidan tam URL al. http/https onekine dikkat. Argumansiz cagirildiysa sor.
+### Step 1: Get the URL
+Take a full URL from the user. Mind the http/https prefix. Ask if invoked without an argument.
 
-### Adim 2: Strateji Secimi
+### Step 2: Strategy Selection
 
-Mobile mi desktop mi? Genelde **mobile** varsayilan cunku Google mobile-first indexing yapiyor.
+Mobile or desktop? **Mobile** is usually the default since Google does mobile-first indexing.
 
 ```bash
-badi lighthouse [url]              # Mobile (varsayilan)
+badi lighthouse [url]              # Mobile (default)
 badi lighthouse [url] --desktop    # Desktop
 ```
 
-### Adim 3: Sonucu Yorumla
+### Step 3: Interpret the Result
 
-Skorlar 4 kategoride:
-- **Performance** - hiz metrikleri
-- **Accessibility** - axe-core tabanli
+Scores in 4 categories:
+- **Performance** - speed metrics
+- **Accessibility** - axe-core based
 - **Best Practices** - HTTPS, console errors
 - **SEO** - meta tags, crawlability
 
 Core Web Vitals:
-- **FCP** < 1.8s (iyi), < 3.0s (orta)
-- **LCP** < 2.5s (iyi), < 4.0s (orta)
-- **TBT** < 200ms (iyi), < 600ms (orta)
-- **CLS** < 0.1 (iyi), < 0.25 (orta)
+- **FCP** < 1.8s (good), < 3.0s (fair)
+- **LCP** < 2.5s (good), < 4.0s (fair)
+- **TBT** < 200ms (good), < 600ms (fair)
+- **CLS** < 0.1 (good), < 0.25 (fair)
 
-### Adim 4: Iyilestirme Onerileri
+### Step 4: Improvement Suggestions
 
-Skor < 90 kategorilerde kullaniciya somut oneriler ver:
-- Performance dusuk: "Image optimization, code splitting, caching"
-- A11y dusuk: "`/a11y-audit [url]` ile detay al"
-- SEO dusuk: "`badi seo audit [url]` ile detayli rapor"
+For categories under 90, give the user concrete suggestions:
+- Low Performance: "Image optimization, code splitting, caching"
+- Low A11y: "Get detail with `/a11y-audit [url]`"
+- Low SEO: "Detailed report via `badi seo audit [url]`"
 
-# Ornek
+# Example
 ```
 /lighthouse https://example.com
 /lighthouse https://example.com --desktop

--- a/.claude/commands-vault/post-mortem.md
+++ b/.claude/commands-vault/post-mortem.md
@@ -1,77 +1,77 @@
 Post-incident analysis (post-mortem) command. Documents root-cause analysis of production incidents and major failures.
 
-# Gerekli Araclar
-- Read (log dosyalari, olay kayitlari)
-- Write (post-mortem raporu)
-- Grep (hata kalip arama)
-- Bash (git log, zaman damgasi analizi)
+# Required Tools
+- Read (log files, incident records)
+- Write (post-mortem report)
+- Grep (error pattern search)
+- Bash (git log, timestamp analysis)
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-### Adim 1: Olay Ozetini Topla
-- Olay ne zaman basladi? (ilk tespit)
-- Olay ne zaman cozuldu? (tam kurtarma)
-- Etki alani: Kac kullanici / hangi servisler etkilendi?
-- Ciddiyet: KRITIK / YUKSEK / ORTA / DUSUK
+### Step 1: Collect the Incident Summary
+- When did the incident start? (first detection)
+- When was it resolved? (full recovery)
+- Blast radius: how many users / which services were affected?
+- Severity: CRITICAL / HIGH / MEDIUM / LOW
 
-### Adim 2: Zaman Cizelgesini Olustur
-Dakika dakika olay kronolojisi:
+### Step 2: Build the Timeline
+A minute-by-minute incident chronology:
 ```
-[HH:MM] Ilk alarm / tespit
-[HH:MM] Mudahale basladi
-[HH:MM] Kok neden belirlendi
-[HH:MM] Duzeltme uygulandi
-[HH:MM] Dogrulama tamamlandi
-[HH:MM] Tam kurtarma
+[HH:MM] First alarm / detection
+[HH:MM] Response started
+[HH:MM] Root cause identified
+[HH:MM] Fix applied
+[HH:MM] Verification complete
+[HH:MM] Full recovery
 ```
 
-### Adim 3: Kok Neden Analizi
-5 Neden teknigini uygula:
-1. Neden oldu? -> ...
-2. Bu neden oldu? -> ...
-3. Bu neden oldu? -> ...
-4. Bu neden oldu? -> ...
-5. Bu neden oldu? -> (kok neden)
+### Step 3: Root Cause Analysis
+Apply the 5 Whys technique:
+1. Why did it happen? -> ...
+2. Why did that happen? -> ...
+3. Why did that happen? -> ...
+4. Why did that happen? -> ...
+5. Why did that happen? -> (root cause)
 
-Teknik kok neden + organizasyonel kok neden ayri belirle.
+Identify the technical root cause and the organizational root cause separately.
 
-### Adim 4: Iyi Giden / Kotu Giden Analizi
-**Iyi Giden:**
-- Hizli tespit edilen seyler
-- Etkili mudahaleler
-- Iyi calisan sistemler
+### Step 4: What Went Well / Badly
+**Went Well:**
+- Things detected quickly
+- Effective interventions
+- Systems that worked
 
-**Kotu Giden:**
-- Gec fark edilen sorunlar
-- Yanlis yonlendirmeler
-- Eksik alarm/izleme
+**Went Badly:**
+- Problems noticed late
+- Wrong turns
+- Missing alarms/monitoring
 
-**Sansli Olan:**
-- Daha kotuye gidebilecek ama gitmemis durumlar
+**Got Lucky:**
+- Situations that could have gone worse but didn't
 
-### Adim 5: Aksiyon Maddeleri
-Her madde icin: sahip, oncelik, hedef tarih
-- **Hemen** (bu hafta): Acil duzeltmeler
-- **Kisa Vadeli** (bu sprint): Onleyici tedbirler
-- **Uzun Vadeli** (bu cayrek): Yapisal iyilestirmeler
+### Step 5: Action Items
+For each item: owner, priority, target date
+- **Immediate** (this week): Urgent fixes
+- **Short Term** (this sprint): Preventive measures
+- **Long Term** (this quarter): Structural improvements
 
-### Adim 6: Rapor Olustur ve Kaydet
-`post-mortems/[tarih]-[olay-adi].md` dosyasina kaydet.
+### Step 6: Build and Save the Report
+Save to `post-mortems/[date]-[incident-name].md`.
 
-# Cikti Formati
+# Output Format
 ```
 === BADI POST-MORTEM ===
-Olay: [olay adi]
-Tarih: [tarih]
-Ciddiyet: [seviye]
-Etki Suresi: [dakika/saat]
-Kok Neden: [tek cumle ozet]
-Aksiyon: [sayi] madde
-Dosya: post-mortems/[tarih]-[olay-adi].md
+Incident: [incident name]
+Date: [date]
+Severity: [level]
+Impact Duration: [minutes/hours]
+Root Cause: [one-sentence summary]
+Actions: [count] items
+File: post-mortems/[date]-[incident-name].md
 ========================
 ```
 
-# Not
-- Suclamayan, ogrenme odakli dil kullan
-- "Kim" degil "ne" ve "neden" sorusu sor
-- Her post-mortem sonrasi knowledge-base.md'ye aday goster
+# Notes
+- Use blameless, learning-focused language
+- Ask "what" and "why", not "who"
+- Nominate every post-mortem into knowledge-base.md

--- a/.claude/commands-vault/refactor.md
+++ b/.claude/commands-vault/refactor.md
@@ -1,47 +1,47 @@
 Refactoring command. Detects code smells and creates a safe refactoring plan.
 
-# Gerekli Araclar
-- Read (kod okuma)
-- Grep (kalip tarama)
-- Glob (dosya bulma)
-- Agent (refactoring-advisor ajani)
-- Bash (test calistirma)
+# Required Tools
+- Read (code reading)
+- Grep (pattern scan)
+- Glob (file discovery)
+- Agent (refactoring-advisor agent)
+- Bash (running tests)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Kapsami Belirle
-- Belirli dosya/fonksiyon mu yoksa modul mu?
-- Kullanicinin hedefi nedir? (performans, okunabilirlik, test edilebilirlik, SOLID uyumu)
+### Step 1: Define the Scope
+- A specific file/function or a module?
+- What is the user's goal? (performance, readability, testability, SOLID compliance)
 
-### Adim 2: Refactoring-Advisor Ajanina Devret
-Ajana su bilgileri ilet:
-- Hedef dosya/dosyalar
-- Kullanicinin amaci
-- Mevcut test kapsami durumu
+### Step 2: Delegate to the Refactoring-Advisor Agent
+Pass the agent:
+- Target file(s)
+- The user's goal
+- Current test coverage state
 
-### Adim 3: Oneri Incelemesi
-Ajanin onerilerini kullaniciya sun:
-- Her oneri icin once/sonra ornegi
-- Risk degerlendirmesi
-- Etkilenecek diger dosyalar
+### Step 3: Review the Suggestions
+Present the agent's suggestions to the user:
+- A before/after example for each suggestion
+- Risk assessment
+- Other files that will be affected
 
-### Adim 4: Onaylanan Degisiklikleri Uygula
-Kullanici onayiyla:
-- Refactoring adimlarini sirali uygula
-- Her adimdan sonra testleri calistir
-- Basarisiz olursa geri al
+### Step 4: Apply the Approved Changes
+With user approval:
+- Apply the refactoring steps in order
+- Run the tests after each step
+- Roll back on failure
 
-### Adim 5: Dogrula ve Belgele
-- Tum testlerin gectigini dogrula
-- Degisiklik ozetini gunluk nota ekle
-- Buyuk refactoring'ler icin ADR olusturmayi oner
+### Step 5: Verify and Document
+- Verify all tests pass
+- Add a change summary to the daily note
+- Suggest an ADR for large refactorings
 
-# Cikti Formati
+# Output Format
 ```
 === BADI REFACTORING ===
-Kapsam: [dosya/modul]
-Tespit: [kod kokusu sayisi]
-Uygulanan: [refactoring sayisi]
-Testler: GECTI / BASARISIZ
+Scope: [file/module]
+Detected: [code smell count]
+Applied: [refactoring count]
+Tests: PASSED / FAILED
 ========================
 ```

--- a/.claude/commands-vault/scaffold.md
+++ b/.claude/commands-vault/scaffold.md
@@ -1,59 +1,59 @@
 Code scaffolding command. Analyzes project structure and generates consistent module, component, or API skeletons.
 
-# Gerekli Araclar
-- Read (mevcut kod kaliplari)
-- Write (iskele dosyalari)
-- Grep (kalip tarama)
-- Glob (dosya yapisi analizi)
-- Agent (code-generator ajani)
+# Required Tools
+- Read (existing code patterns)
+- Write (scaffold files)
+- Grep (pattern scan)
+- Glob (file structure analysis)
+- Agent (code-generator agent)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Iskele Turunu Belirle
-Kullanicidan ne olusturulacagini ogren:
-- **Modul/Bilesen** — Yeni UI bileseni veya is mantigi modulu
-- **API Endpoint** — Yeni REST/GraphQL endpoint seti
-- **CRUD** — Model tanimindan tam CRUD islemleri
-- **Test** — Mevcut kod icin test iskelesi
-- **Migration** — Veritabani goc dosyasi
-- **Middleware** — Ara katman iskelesi
-- **Servis** — Yeni servis sinifi/modulu
+### Step 1: Determine the Scaffold Type
+Learn from the user what to create:
+- **Module/Component** — A new UI component or business-logic module
+- **API Endpoint** — A new REST/GraphQL endpoint set
+- **CRUD** — Full CRUD operations from a model definition
+- **Test** — Test scaffolding for existing code
+- **Migration** — A database migration file
+- **Middleware** — Middleware skeleton
+- **Service** — A new service class/module
 
-### Adim 2: Proje Kaliplarini Analiz Et
-Mevcut proje yapisini tara:
-- Dizin yapisi ve isimlendirme kurallari
-- Import/export kaliplari
-- Hata yonetimi yaklasimi
-- Test dosyasi konumlandirmasi
-- Tip tanimi stilleri
+### Step 2: Analyze the Project Patterns
+Scan the existing project structure:
+- Directory layout and naming conventions
+- Import/export patterns
+- Error-handling approach
+- Test file placement
+- Type definition styles
 
-### Adim 3: Code-Generator Ajanina Devret
-Ajana su bilgileri ilet:
-- Iskele turu ve hedef isim
-- Tespit edilen proje kaliplari
-- Referans alinacak mevcut dosyalar
+### Step 3: Delegate to the Code-Generator Agent
+Pass the agent:
+- Scaffold type and target name
+- The detected project patterns
+- Existing files to use as references
 
-### Adim 4: Dosyalari Olustur
-Uretilen iskeleyi diske yaz:
-- Yeni dosyalari olustur
-- Gerekli index/barrel dosyalarini guncelle
-- Import'lari ekle
+### Step 4: Create the Files
+Write the generated scaffold to disk:
+- Create the new files
+- Update the necessary index/barrel files
+- Add the imports
 
-### Adim 5: Dogrula
-- Uretilen dosyalarin proje kalibina uyumunu kontrol et
-- TypeScript/lint hatasi olmadigini dogrula
-- Sonraki adimlari listele (TODO isaretli yerler)
+### Step 5: Verify
+- Check the generated files match the project conventions
+- Verify there are no TypeScript/lint errors
+- List the next steps (TODO-marked spots)
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI ISKELE ===
-Tur: [modul/api/crud/test/migration]
-Isim: [bilesen adi]
+=== BADI SCAFFOLD ===
+Type: [module/api/crud/test/migration]
+Name: [component name]
 
-Olusturulan Dosyalar:
-  + [dosya yolu] (yeni)
-  ~ [dosya yolu] (guncellendi)
+Created Files:
+  + [file path] (new)
+  ~ [file path] (updated)
 
-Sonraki: TODO isaretli yerlere is mantigi ekleyin.
+Next: add business logic at the TODO-marked spots.
 ====================
 ```

--- a/.claude/commands-vault/secret-scan.md
+++ b/.claude/commands-vault/secret-scan.md
@@ -1,63 +1,63 @@
 Project-wide secret/credential scan command. AWS/GCP/GitHub/npm/Stripe/OpenAI/Anthropic keys, JWTs, database URIs, private keys.
 
-> **Daha genis kapsam icin**: `badi security baseline` (secret-scan + npm audit), `/security-review` (Anthropic native AI semantic — Claude Code 2.1.140+).
+> **For wider coverage**: `badi security baseline` (secret-scan + npm audit), `/security-review` (Anthropic native AI semantic — Claude Code 2.1.140+).
 
-# Gerekli Araclar
-- Bash (badi secret-scan komutu cagirisi)
+# Required Tools
+- Bash (badi secret-scan command invocation)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Kapsam Belirle
+### Step 1: Define the Scope
 
-Kullaniciya sor:
-- Sadece working tree mi? (hizli)
-- Git history de dahil mi? (default 100 commit; --max-commits ile arttirilabilir)
-- CI/pipeline icin mi? (--exit-code strict + --format json)
+Ask the user:
+- Working tree only? (fast)
+- Include git history? (default 100 commits; raise with --max-commits)
+- For CI/pipelines? (--exit-code strict + --format json)
 
-### Adim 2: Tarama Calistir
+### Step 2: Run the Scan
 
 ```bash
 badi secret-scan                                       # Working tree
 badi secret-scan --git                                 # + git history
-badi secret-scan --format json                         # JSON cikti
-badi secret-scan --exit-code strict                    # her bulguda exit 1
-badi secret-scan --max-commits 500 --git               # daha derin tarihce
-badi secret-scan --ignore jwt,github-pat-fine          # belirli pattern'leri yoksay
-badi secret-scan --ignore-file .secretignore           # dosyadan oku
-badi secret-scan --patterns custom-org-patterns.json   # ek pattern yukle
+badi secret-scan --format json                         # JSON output
+badi secret-scan --exit-code strict                    # exit 1 on any finding
+badi secret-scan --max-commits 500 --git               # deeper history
+badi secret-scan --ignore jwt,github-pat-fine          # ignore specific patterns
+badi secret-scan --ignore-file .secretignore           # read from a file
+badi secret-scan --patterns custom-org-patterns.json   # load extra patterns
 ```
 
-**CI cikis kodlari:**
-- `0`  Bulgu yok (veya `--exit-code never`; veya yalniz ORTA/DUSUK varsayilanda)
-- `1`  KRITIK veya YUKSEK bulgu
+**CI exit codes:**
+- `0`  No findings (or `--exit-code never`; or only MEDIUM/LOW by default)
+- `1`  CRITICAL or HIGH finding
 
-**Kapsam disi:** symlink'ler atlanir; `git stash`/`reflog`/packed-refs taranmaz.
+**Out of scope:** symlinks are skipped; `git stash`/`reflog`/packed-refs are not scanned.
 
-### Adim 3: Sonuclari Yorumla
+### Step 3: Interpret the Results
 
-Severity bazli:
-- **KRITIK**: AWS Access/Secret, GCP, GitHub PAT (classic + fine-grained), Slack, Stripe, OpenAI, Anthropic, RSA/EC private keys
-- **YUKSEK**: npm token, SendGrid, Twilio, MongoDB/Postgres URI
-- **ORTA**: JWT token
-- **DUSUK**: Generic secret variable'lar (false positive riski yuksek — `--ignore generic-secret` yararli)
+By severity:
+- **CRITICAL**: AWS Access/Secret, GCP, GitHub PAT (classic + fine-grained), Slack, Stripe, OpenAI, Anthropic, RSA/EC private keys
+- **HIGH**: npm token, SendGrid, Twilio, MongoDB/Postgres URIs
+- **MEDIUM**: JWT tokens
+- **LOW**: Generic secret variables (high false-positive risk — `--ignore generic-secret` helps)
 
-### Adim 4: Aksiyon Plani
+### Step 4: Action Plan
 
-Her finding icin:
+For every finding:
 
-1. **Rotate** — Siri hemen gecersiz kil (git log'da bile kalmis olabilir)
-2. **Gitignore** — `.env` veya sir dosyasini `.gitignore`'a ekle
-3. **Environment variables** — Sabit degerler yerine `process.env.X` kullan
-4. **Git history temizlik** — `git filter-repo` veya `BFG` kullan
+1. **Rotate** — Invalidate the secret immediately (it may live in git log)
+2. **Gitignore** — Add the `.env` or secret file to `.gitignore`
+3. **Environment variables** — Use `process.env.X` instead of hardcoded values
+4. **Git history cleanup** — Use `git filter-repo` or `BFG`
 
-### Adim 5: On-gelecek Koruma
+### Step 5: Future Protection
 
-- `.gitignore` kontrol: `.env`, `.env.*`, `secrets.json`, `*.pem`
-- Pre-commit hook: secret-scan otomatik calistir
-- `/secret-scan --git` haftalik cronjob oneri
+- `.gitignore` check: `.env`, `.env.*`, `secrets.json`, `*.pem`
+- Pre-commit hook: run secret-scan automatically
+- Suggest a weekly `/secret-scan --git` cronjob
 
-# Ornek
+# Example
 ```
 /secret-scan
-/secret-scan --git   # git history de dahil
+/secret-scan --git   # include git history
 ```

--- a/.claude/commands-vault/spec-check.md
+++ b/.claude/commands-vault/spec-check.md
@@ -1,71 +1,71 @@
 Specification conformance command. Audits the current code against SPECIFICATION.md, detecting feature gaps and scope drift.
 
-# Gerekli Araclar
-- Read (SPECIFICATION.md, kaynak kodlar)
-- Grep (ozellik arama)
-- Glob (dosya tarama)
-- Agent (auditor ajani)
-- Bash (test calistirma)
+# Required Tools
+- Read (SPECIFICATION.md, source code)
+- Grep (feature search)
+- Glob (file scan)
+- Agent (auditor agent)
+- Bash (running tests)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Spesifikasyonu Yukle
-- `docs/SPECIFICATION.md` dosyasini oku
-- Temel ozellikleri (Must Have) cikar
-- Kabul kriterlerini listele
-- Kapsam disi (Non-Goals) maddelerini belirle
+### Step 1: Load the Specification
+- Read `docs/SPECIFICATION.md`
+- Extract the core features (Must Have)
+- List the acceptance criteria
+- Identify the Non-Goals items
 
-### Adim 2: Kod Tabani Taramas
-Her "Must Have" ozellik icin:
-- Ilgili kod dosyalarini ara (fonksiyon, rota, bilesen)
-- Kabul kriterinin karsilanip karsilanmadigini degerlendir
-- Test kapsamini kontrol et
+### Step 2: Codebase Scan
+For every "Must Have" feature:
+- Search for the related code (functions, routes, components)
+- Assess whether the acceptance criterion is met
+- Check test coverage
 
-### Adim 3: Sapma Tespiti
-**Eksik Ozellikler:**
-- Spesifikasyonda olan ama kodda bulunamayan ozellikler
+### Step 3: Drift Detection
+**Missing Features:**
+- Features in the spec but not found in the code
 
-**Kapsam Kaymasi:**
-- Kodda olan ama spesifikasyonda OLMAYAN ozellikler
-- Kapsam disi (Non-Goals) olarak belirtilmis ama uygulanmis seyler
+**Scope Creep:**
+- Features in the code but NOT in the spec
+- Things marked Non-Goals yet implemented anyway
 
-**Kismi Uygulamalar:**
-- Baslanan ama tamamlanmamis ozellikler
-- Kabul kriterini karsilamayan uygulamalar
+**Partial Implementations:**
+- Features started but not finished
+- Implementations that fail the acceptance criteria
 
-### Adim 4: Uyum Raporu Olustur
-Her ozellik icin durum:
-- **TAMAMLANDI** — Kabul kriterleri karsilandi
-- **KISMI** — Baslandi ama tamamlanmadi
-- **EKSIK** — Henuz uygulanmadi
-- **SAPMA** — Spesifikasyondan farkli uygulanmis
+### Step 4: Build the Conformance Report
+A status per feature:
+- **DONE** — Acceptance criteria met
+- **PARTIAL** — Started but unfinished
+- **MISSING** — Not implemented yet
+- **DRIFT** — Implemented differently from the spec
 
-### Adim 5: Aksiyon Onerileri
-- Oncelikli eksik ozellik listesi
-- Kapsam kaymasi duzeltme onerileri
-- TaskBoard.md guncelleme (eksikler icin yeni gorev)
+### Step 5: Action Suggestions
+- Prioritized missing-feature list
+- Scope-creep remediation suggestions
+- TaskBoard.md update (new tasks for the gaps)
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI SPESIFIKASYON UYUM KONTROLU ===
-Spesifikasyon: docs/SPECIFICATION.md
-Tarih: [tarih]
+=== BADI SPEC CONFORMANCE CHECK ===
+Specification: docs/SPECIFICATION.md
+Date: [date]
 
-Uyum Orani: [yuzde]%
+Conformance Rate: [percent]%
 
-Must Have: [tamamlanan]/[toplam]
-Should Have: [tamamlanan]/[toplam]
-Could Have: [tamamlanan]/[toplam]
+Must Have: [done]/[total]
+Should Have: [done]/[total]
+Could Have: [done]/[total]
 
-EKSIK Ozellikler:
-- [ozellik adi] — [durum]
+MISSING Features:
+- [feature name] — [status]
 
-SAPMA Tespitleri:
-- [sapma aciklamasi]
+DRIFT Findings:
+- [drift description]
 
-KAPSAM KAYMASI:
-- [non-goal olarak belirtilmis ama uygulanmis]
+SCOPE CREEP:
+- [marked non-goal but implemented]
 
-Sonraki: [oncelikli aksiyon]
+Next: [priority action]
 =========================================
 ```

--- a/.claude/commands-vault/ssl-check.md
+++ b/.claude/commands-vault/ssl-check.md
@@ -1,42 +1,42 @@
 SSL certificate analysis command. Checks certificate validity, TLS version, and cipher strength for a domain.
 
-# Gerekli Araclar
-- Bash (badi ssl komutu cagirisi)
+# Required Tools
+- Bash (badi ssl command invocation)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Domain Kontrolu
-Kullanicidan domain al. Argumansiz cagirildiysa hangi domaini test etmek istedigini sor.
+### Step 1: Domain Check
+Take the domain from the user. If invoked without an argument, ask which domain to test.
 
-### Adim 2: Badi CLI Calistir
+### Step 2: Run the Badi CLI
 ```bash
 badi ssl [domain]
 ```
 
-Ornek:
+Example:
 ```bash
 badi ssl example.com
 badi ssl github.com
 ```
 
-### Adim 3: Sonucu Yorumla
-Ciktiyi kullaniciya aktarirken dikkat edilecek noktalar:
+### Step 3: Interpret the Result
+Points to watch while relaying the output:
 
-- **Expire < 30 gun**: Kullaniciyi uyar, yenileme planlamasi oner
-- **TLS < 1.2**: Guvenlik acigi, yukseltme zorunlu
-- **Zayif cipher (RC4, 3DES, MD5)**: Guncelleme oner
-- **SAN kontrol**: Kullaniciya domain listesi goster
+- **Expiry < 30 days**: Warn the user, suggest renewal planning
+- **TLS < 1.2**: Security hole, upgrade mandatory
+- **Weak ciphers (RC4, 3DES, MD5)**: Suggest an update
+- **SAN check**: Show the user the domain list
 
-### Adim 4: Takip Adimlari Oner
+### Step 4: Suggest Follow-ups
 
-Duruma gore:
-- Expire yakinsa: "Let's Encrypt otomatik yenileme scripti yazalim mi?"
-- Zayif cipher varsa: "Nginx/Apache config ornegi gerekiyor mu?"
-- OK durumunda: "`badi dns [domain]` ile DNS kontrolu yapmak ister misiniz?"
+Depending on the situation:
+- Expiry near: "Shall we write a Let's Encrypt auto-renew script?"
+- Weak ciphers: "Need an Nginx/Apache config example?"
+- All OK: "Want a DNS check with `badi dns [domain]`?"
 
-# Ornek Kullanim
+# Example Usage
 
 ```
-Kullanici: /ssl-check example.com
-Asistan: [badi ssl example.com calistirir, ciktiyi ozetler]
+User: /ssl-check example.com
+Assistant: [runs badi ssl example.com, summarizes the output]
 ```

--- a/.claude/commands-vault/whois.md
+++ b/.claude/commands-vault/whois.md
@@ -1,41 +1,41 @@
 Domain WHOIS command. Checks registration date, expiry, registrar, and transfer lock status.
 
-# Gerekli Araclar
-- Bash (badi whois komutu cagirisi)
+# Required Tools
+- Bash (badi whois command invocation)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Badi CLI Calistir
+### Step 1: Run the Badi CLI
 ```bash
 badi whois [domain]
 ```
 
-### Adim 2: Sonucu Yorumla
+### Step 2: Interpret the Result
 
-Onemli alanlar:
-- **Registrar**: Domain saglayicisi
-- **Creation Date**: Ilk tescil
-- **Expiration Date**: Yenileme zamani
-- **Domain Status**: Transfer Lock, Update Lock durumlari
-- **Name Servers**: DNS yonetim
+Key fields:
+- **Registrar**: Domain provider
+- **Creation Date**: First registration
+- **Expiration Date**: Renewal time
+- **Domain Status**: Transfer Lock, Update Lock states
+- **Name Servers**: DNS management
 
-### Adim 3: Uyarilar
+### Step 3: Warnings
 
-- **Expire < 30 gun**: "Acil yenileme gerekli"
-- **Expire 30-90 gun**: "Yenileme planlayin"
-- **Transfer Lock yok**: "Domain hijacking'e karsi lock'u acin"
-- **Update Lock yok**: "Kritik domain icin lock oneriyorum"
+- **Expiry < 30 days**: "Urgent renewal needed"
+- **Expiry 30-90 days**: "Plan the renewal"
+- **No Transfer Lock**: "Enable the lock against domain hijacking"
+- **No Update Lock**: "I recommend the lock for critical domains"
 
-### Adim 4: Kapsamli Domain Saglik Kontrolu
+### Step 4: Full Domain Health Check
 
-Kullaniciya su uclu kontrolu oner:
-- `/whois [domain]` — zaten yapildi
-- `/dns-audit [domain]` — DNS ve email guvenlik
-- `/ssl-check [domain]` — SSL sertifika
+Suggest the triple check to the user:
+- `/whois [domain]` — already done
+- `/dns-audit [domain]` — DNS and email security
+- `/ssl-check [domain]` — SSL certificate
 
-Ya da tek komutla hepsini yap: "Domain saglik kontrolunu yapabilirim, 3 komut calistirmami ister misin?"
+Or do it all at once: "I can run the full domain health check — want me to run all 3 commands?"
 
-# Ornek
+# Example
 ```
 /whois example.com
 ```

--- a/.claude/commands/a11y-audit.md
+++ b/.claude/commands/a11y-audit.md
@@ -1,54 +1,54 @@
 Web accessibility (WCAG 2.1) audit command. axe-core-based checks via PageSpeed Insights.
 
-# Gerekli Araclar
-- Bash (badi a11y komutu cagirisi)
+# Required Tools
+- Bash (badi a11y command invocation)
 
-# Prosedur
+# Procedure
 
-### Adim 1: URL Al
-Kullanicidan test edilecek URL al.
+### Step 1: Get the URL
+Take the URL to test from the user.
 
-### Adim 2: Badi CLI Calistir
+### Step 2: Run the Badi CLI
 
 ```bash
 badi a11y [url]              # Mobile audit
 badi a11y [url] --desktop    # Desktop audit
 ```
 
-### Adim 3: Sonuclari Yorumla
+### Step 3: Interpret the Results
 
-Skor bandlari:
-- **90-100**: Mukemmel, coq iyi
-- **70-89**: Iyi ama iyilestirilebilir
-- **< 70**: Ciddi sorunlar var
+Score bands:
+- **90-100**: Excellent
+- **70-89**: Good but improvable
+- **< 70**: Serious problems
 
-### Adim 4: Yaygin Hatalar ve Cozumleri
+### Step 4: Common Failures and Fixes
 
-Basarisiz auditlere gore somut duzeltme oneri ver:
+Give concrete fixes per failed audit:
 
-- **color-contrast**: "Foreground/background kontrast orani 4.5:1 olmali (AA), 7:1 (AAA)"
-- **image-alt**: "Tum `<img>` elemanlarina anlamli `alt` ekle, decorative ise `alt=\"\"`"
-- **label**: "Form input'lari `<label for=\"\">` ile eslestir"
-- **link-name**: "Link metinleri aciklayici olmali, \"tikla\" yerine gercek eylem"
-- **button-name**: "Butonlarin erisilebilir isimi olmali (aria-label veya text icerik)"
-- **heading-order**: "Baslik hiyerarsisi h1->h2->h3 (atlama yok)"
-- **landmark-one-main**: "Her sayfada bir `<main>` landmark olmali"
-- **html-has-lang**: "`<html lang=\"tr\">` veya `<html lang=\"en\">` tanimla"
+- **color-contrast**: "Foreground/background contrast ratio must be 4.5:1 (AA), 7:1 (AAA)"
+- **image-alt**: "Add meaningful `alt` to every `<img>`; `alt=\"\"` when decorative"
+- **label**: "Pair form inputs with `<label for=\"\">`"
+- **link-name**: "Link texts must be descriptive — the real action instead of 'click here'"
+- **button-name**: "Buttons need accessible names (aria-label or text content)"
+- **heading-order**: "Heading hierarchy h1->h2->h3 (no skips)"
+- **landmark-one-main**: "Every page needs one `<main>` landmark"
+- **html-has-lang**: "Define `<html lang=\"en\">` (or the page language)"
 
-### Adim 5: Manuel Test Hatirlatmasi
+### Step 5: Manual Testing Reminder
 
-Axe-core otomatiklastirilamaz test eder. Manuel test gereken alanlar:
+Axe-core tests what can be automated. Areas needing manual tests:
 - Keyboard navigation (Tab, Enter, Space, Arrow keys)
-- Screen reader testi (VoiceOver, NVDA)
-- 200% zoom okunabilirlik
+- Screen reader testing (VoiceOver, NVDA)
+- 200% zoom readability
 - Video/audio captioning
 
-### Adim 6: Kapsamli Denetim
+### Step 6: Comprehensive Audit
 
-- `/lighthouse [url]` ile full Lighthouse raporu (performance + SEO + a11y)
-- WCAG quickref linkini ver
+- Full Lighthouse report with `/lighthouse [url]` (performance + SEO + a11y)
+- Provide the WCAG quickref link
 
-# Ornek
+# Example
 ```
 /a11y-audit https://example.com
 ```

--- a/.claude/commands/adr.md
+++ b/.claude/commands/adr.md
@@ -1,75 +1,75 @@
 Architecture Decision Record (ADR) command. Documents architectural decisions in a structured format.
 
-# Gerekli Araclar
-- Read (mevcut ADR'ler)
-- Write (yeni ADR dosyasi)
-- Grep (iliskili karar arama)
-- Agent (architecture-advisor ajani)
+# Required Tools
+- Read (existing ADRs)
+- Write (new ADR file)
+- Grep (related decision search)
+- Agent (architecture-advisor agent)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Karar Baglamini Topla
-Kullanicidan:
-- Karar gerektiren durum nedir?
-- Hangi kisitlamalar var? (zaman, butce, teknik)
-- Kim etkilenecek?
+### Step 1: Gather the Decision Context
+From the user:
+- What situation requires a decision?
+- What constraints exist? (time, budget, technical)
+- Who is affected?
 
-### Adim 2: Alternatifleri Degerlendir
-Architecture-advisor ajanina devret:
-- Mevcut mimarivi analiz et
-- En az 3 alternatif belirle
-- Her alternatif icin artilari/eksileri listele
-- Trade-off analizi yap
+### Step 2: Evaluate the Alternatives
+Delegate to the architecture-advisor agent:
+- Analyze the current architecture
+- Identify at least 3 alternatives
+- List pros/cons for each alternative
+- Run a trade-off analysis
 
-### Adim 3: Karari Belgele
-ADR formatinda yaz:
+### Step 3: Document the Decision
+Write in ADR format:
 ```markdown
-# ADR-[numara]: [Baslik]
-Tarih: [tarih]
-Durum: KABUL EDILDI
+# ADR-[number]: [Title]
+Date: [date]
+Status: ACCEPTED
 
-## Baglam
-[Karari gerektiren durum, kisitlamalar, paydas ihtiyaclari]
+## Context
+[The situation requiring the decision, constraints, stakeholder needs]
 
-## Karar
-[Secilen yaklasim ve gerekcesi]
+## Decision
+[The chosen approach and its rationale]
 
-## Degerendirilen Alternatifler
-### Alternatif A: [isim]
-- Artilari: ...
-- Eksileri: ...
-- Neden secilmedi: ...
+## Considered Alternatives
+### Alternative A: [name]
+- Pros: ...
+- Cons: ...
+- Why not chosen: ...
 
-### Alternatif B: [isim]
+### Alternative B: [name]
 ...
 
-## Sonuclar
-### Pozitif
+## Consequences
+### Positive
 - ...
-### Negatif
+### Negative
 - ...
-### Notr
+### Neutral
 - ...
 
-## Iliskili Kararlar
-- ADR-XX: [iliskili karar]
+## Related Decisions
+- ADR-XX: [related decision]
 ```
 
-### Adim 4: Kaydet
-- `docs/adr/` dizinine kaydet (yoksa olustur)
-- ADR numarasini sirali ata
-- INDEX.md'yi guncelle (varsa)
+### Step 4: Save
+- Save into `docs/adr/` (create if missing)
+- Assign the ADR number sequentially
+- Update INDEX.md (if present)
 
-### Adim 5: Iliskili Dokumanlari Guncelle
-- CLAUDE.md veya knowledge-base.md'ye referans ekle (uygunsa)
-- Iliskili ADR'lere capraz referans ekle
+### Step 5: Update Related Documents
+- Add a reference to CLAUDE.md or knowledge-base.md (where fitting)
+- Add cross-references to related ADRs
 
-# Cikti Formati
+# Output Format
 ```
 === BADI ADR ===
-Numara: ADR-[numara]
-Baslik: [karar basligi]
-Durum: KABUL EDILDI
-Dosya: docs/adr/[numara]-[baslik].md
+Number: ADR-[number]
+Title: [decision title]
+Status: ACCEPTED
+File: docs/adr/[number]-[title].md
 ================
 ```

--- a/.claude/commands/ai-review.md
+++ b/.claude/commands/ai-review.md
@@ -1,60 +1,60 @@
 AI code review of the staged git diff via the Claude API.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi ai review)
 
-# On Kosul
+# Prerequisite
 
-ANTHROPIC_API_KEY ortam degiskeni tanimli olmali:
+The ANTHROPIC_API_KEY environment variable must be set:
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
 ```
-Kayit: https://console.anthropic.com/settings/keys
+Sign-up: https://console.anthropic.com/settings/keys
 
-# Prosedur
+# Procedure
 
-### Adim 1: Degisiklikleri Stage Et
+### Step 1: Stage the Changes
 ```bash
-git add [dosyalar]
+git add [files]
 ```
 
-### Adim 2: AI Review
+### Step 2: AI Review
 ```bash
 badi ai review
 ```
 
-Claude Haiku 4.5 modeli ile staged diff incelenir. ~1-3 saniye suren hizli cevir.
+The staged diff is reviewed with the Claude Haiku 4.5 model. A fast pass taking ~1-3 seconds.
 
-### Adim 3: Yorumla
+### Step 3: Interpret
 
-Bulgular 5 kategoride:
-1. **KRITIK guvenlik** — hemen duzelt
-2. **Bug potansiyeli** — test kapsami kontrol
-3. **Performans** — hotpath degisiklikleri
-4. **Kod kalitesi** — DRY, naming, complexity
-5. **Olumlu gozlemler** — iyi yapilmis seyler
+Findings in 5 categories:
+1. **CRITICAL security** — fix immediately
+2. **Bug potential** — check test coverage
+3. **Performance** — hot-path changes
+4. **Code quality** — DRY, naming, complexity
+5. **Positive observations** — things done well
 
-### Adim 4: Aksiyon
+### Step 4: Action
 
-- Kritik bulgu: Commit etme, once duzelt
-- Yuksek: Inceleme notu ekle, ayri commit
-- Orta/Dusuk: TODO/issue olustur
+- Critical finding: do not commit; fix first
+- High: add a review note, separate commit
+- Medium/Low: create a TODO/issue
 
-### Adim 5: Takip
+### Step 5: Follow-up
 
-Her commit oncesi kullanmak icin git hook:
+A git hook to use before every commit:
 ```bash
 # .git/hooks/pre-commit
 badi ai review || exit 1
 ```
 
-# Maliyet
+# Cost
 
 - Haiku 4.5: ~$0.25 / 1M input, ~$1.25 / 1M output
-- Ortalama review: 2-3K input, 500-1000 output tokens
-- **Yaklasik maliyet: $0.001 per review**
+- Average review: 2-3K input, 500-1000 output tokens
+- **Approximate cost: $0.001 per review**
 
-# Ornek
+# Example
 
 ```
 git add src/auth.js

--- a/.claude/commands/ai-translate.md
+++ b/.claude/commands/ai-translate.md
@@ -1,63 +1,60 @@
 Markdown file translation. Technical/content translation via the Claude API (without breaking markdown structure).
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi ai translate)
 
-# On Kosul
+# Prerequisite
 
-ANTHROPIC_API_KEY gerekli.
+ANTHROPIC_API_KEY required.
 
-# Prosedur
+# Procedure
 
-### Adim 1: Kaynak Dosya
-Markdown dosya yolu (ornek: `docs/guide.md`, `blog/post-tr.md`).
+### Step 1: Source File
+A markdown file path (example: `docs/guide.md`, `blog/post-tr.md`).
 
-### Adim 2: Cevir
+### Step 2: Translate
 ```bash
-badi ai translate [file.md]                  # Varsayilan EN
-badi ai translate [file.md] --to en          # Ingilizce
-badi ai translate [file.md] --to de          # Almanca
-badi ai translate [file.md] --to fr          # Fransizca
-badi ai translate [file.md] --to es          # Ispanyolca
+badi ai translate [file.md]                  # Default EN
+badi ai translate [file.md] --to en          # English
+badi ai translate [file.md] --to de          # German
+badi ai translate [file.md] --to fr          # French
+badi ai translate [file.md] --to es          # Spanish
 ```
 
-### Adim 3: Cikti
+### Step 3: Output
 
-Kaynak dosya yaninde `-[lang]` suffixli yeni dosya:
+A new file next to the source with a `-[lang]` suffix:
 - `guide.md` -> `guide-en.md`
 
-### Adim 4: Kullanim Durumlari
+### Step 4: Use Cases
 
-- **Icerik pazarlama**: TR post -> EN, EN post -> TR
-- **Teknik dokuman**: README.md -> README-en.md
+- **Content marketing**: TR post -> EN, EN post -> TR
+- **Technical docs**: README.md -> README-en.md
 - **App Store**: release-notes-tr.md -> release-notes-en.md
-- **Blog**: coklu dil destegi
+- **Blog**: multi-language support
 
-### Adim 5: Markdown Korumasi
+### Step 5: Markdown Preservation
 
-AI sunlari korur:
-- Kod blogu (```...```)
-- Link yapisi
-- Baslik hiyerarsisi (##, ###)
-- Liste formati
-- Hashtag'ler (lokalizasyon yapilir)
+The AI preserves:
+- Code blocks (```...```)
+- Link structure
+- Heading hierarchy (##, ###)
+- List formatting
+- Hashtags (localized)
 
-### Adim 6: Alternatif
+### Step 6: Relationship to the Content Engine
 
-Mevcut icerik motoru `--lang tr,en` ile paralel uretim de yapiyor:
-```bash
-badi content post "konu" --lang tr,en
-```
+The content engine (`badi content ...`) produces English-only output (v1.32+).
+To publish in another language, generate first and then translate the file
+with `ai translate`.
 
-Ayni zamanda uretim icin daha hizli; sonradan cevirmek icin `ai translate`.
+# Cost
 
-# Maliyet
+- ~5K chars of content: ~$0.003-0.005 per translation
 
-- ~5K char icerik: ~$0.003-0.005 per ceviri
-
-# Ornek
+# Example
 
 ```
-/ai-translate blog/yazi-tr.md --to en
+/ai-translate blog/post-tr.md --to en
 /ai-translate docs/guide.md --to de
 ```

--- a/.claude/commands/bundle-analyze.md
+++ b/.claude/commands/bundle-analyze.md
@@ -1,51 +1,51 @@
 Bundle size + framework detection + largest assets + heavy-dependency warnings.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi dev bundle)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Build Al
+### Step 1: Build
 ```bash
 npm run build
 ```
 
-### Adim 2: Analiz
+### Step 2: Analyze
 ```bash
 badi dev bundle
 ```
 
-### Adim 3: Gosterilenler
+### Step 3: What Is Shown
 
-- **Framework tespit**: Next.js, Vite, Webpack, Expo
-- **Build ciktisi**: dist/, build/, .next/, out/, web-build/
-- **Toplam boyut**: MB cinsinden
-- **En buyuk 10 asset**: JS, MJS, CSS
-- **Agir bagimliliklar**: moment, lodash, axios, jquery — alternatif onerisi
+- **Framework detection**: Next.js, Vite, Webpack, Expo
+- **Build output**: dist/, build/, .next/, out/, web-build/
+- **Total size**: in MB
+- **10 largest assets**: JS, MJS, CSS
+- **Heavy dependencies**: moment, lodash, axios, jquery — alternative suggestions
 
-### Adim 4: Alarm Esikleri
+### Step 4: Alert Thresholds
 
-- **Asset > 500KB**: KRITIK — code splitting yap
-- **Asset > 200KB**: Dikkat — lazy load dusun
-- **Toplam > 5MB**: Web vitals etkiler
+- **Asset > 500KB**: CRITICAL — apply code splitting
+- **Asset > 200KB**: Attention — consider lazy loading
+- **Total > 5MB**: Affects web vitals
 
-### Adim 5: Derin Analiz
+### Step 5: Deep Analysis
 
-Framework ozel araclar:
+Framework-specific tools:
 - **Webpack**: `npx webpack-bundle-analyzer`
 - **Vite**: `npx vite-bundle-visualizer`
 - **Next.js**: `npx @next/bundle-analyzer`
 
-### Adim 6: Yaygin Cozumler
+### Step 6: Common Fixes
 
 - **Code splitting**: `import()` dynamic imports
 - **Tree shaking**: ESM + sideEffects: false
 - **Lazy load**: React.lazy, Vue defineAsyncComponent
-- **CDN externals**: React/Vue CDN'den
+- **CDN externals**: React/Vue from a CDN
 - **Minification**: production mode
 - **Compression**: gzip/brotli
 
-# Ornek
+# Example
 
 ```
 npm run build

--- a/.claude/commands/changelog-gen.md
+++ b/.claude/commands/changelog-gen.md
@@ -1,64 +1,64 @@
 CHANGELOG.md update command. Generates a changelog from git history grouped by conventional commit types.
 
-# Gerekli Araclar
-- Bash (badi changelog komutu cagirisi)
+# Required Tools
+- Bash (badi changelog command invocation)
 - git
 
-# Prosedur
+# Procedure
 
-### Adim 1: Son Tag'i Bul
+### Step 1: Find the Latest Tag
 ```bash
 git describe --tags --abbrev=0
 ```
 
-### Adim 2: Version Sayisini Belirle
+### Step 2: Decide the Version Number
 
-Kullaniciya yeni surumu sor:
-- Breaking change varsa: major (2.0.0)
-- Yeni ozellik (feat) varsa: minor (1.5.0)
-- Sadece fix varsa: patch (1.4.3)
+Ask the user for the new version:
+- If there are breaking changes: major (2.0.0)
+- If there are new features (feat): minor (1.5.0)
+- If only fixes: patch (1.4.3)
 
-### Adim 3: Badi CLI Ile Changelog Uret
+### Step 3: Generate the Changelog with the Badi CLI
 
-Onizleme (yazmaz):
+Preview (does not write):
 ```bash
-badi changelog                              # Son tag'den HEAD
-badi changelog --from v1.0.0                # Belirli tag'den
-badi changelog --from v1.0.0 --to v2.0.0    # Arada
+badi changelog                              # From the latest tag to HEAD
+badi changelog --from v1.0.0                # From a specific tag
+badi changelog --from v1.0.0 --to v2.0.0    # Between two
 ```
 
-CHANGELOG.md'ye yaz:
+Write to CHANGELOG.md:
 ```bash
 badi changelog --write --version 1.5.0
 ```
 
-### Adim 4: Manuel Rotus
+### Step 4: Manual Touch-up
 
-Otomatik urettikten sonra:
-- Kullanici okunabilirligi icin gerekirse duzenle
-- Breaking change'leri uste cikar
-- Feature hash'lerini kaldir (kullanici icin anlamsiz)
-- Kategorileri yeniden sirala (Eklenen -> Duzeltilen -> Diger)
+After auto-generating:
+- Edit for reader clarity where needed
+- Surface the breaking changes to the top
+- Drop commit hashes (meaningless to users)
+- Reorder the categories (Added -> Fixed -> Other)
 
-### Adim 5: Tag + Release
+### Step 5: Tag + Release
 
-Changelog hazir olduktan sonra:
+Once the changelog is ready:
 ```bash
 git add CHANGELOG.md package.json
 git commit -m "chore: vX.Y.Z release"
 git tag vX.Y.Z
 git push origin main --tags
-gh release create vX.Y.Z --title "vX.Y.Z - Baslik" --notes-file RELEASE_NOTES.md
+gh release create vX.Y.Z --title "vX.Y.Z - Title" --notes-file RELEASE_NOTES.md
 ```
 
-### Adim 6: npm Publish (varsa)
+### Step 6: npm Publish (if applicable)
 
 ```bash
 npm publish --access public
 ```
 
-# Ornek
+# Example
 ```
-/changelog-gen              # onizleme
-/changelog-gen 1.5.0        # v1.5.0 olarak dosyaya yaz
+/changelog-gen              # preview
+/changelog-gen 1.5.0        # write to file as v1.5.0
 ```

--- a/.claude/commands/conv-commit.md
+++ b/.claude/commands/conv-commit.md
@@ -1,69 +1,69 @@
 Conventional commit helper command. Reads staged files, suggests type/scope/message, and validates.
 
-# Gerekli Araclar
-- Bash (badi commit komutu cagirisi)
+# Required Tools
+- Bash (badi commit command invocation)
 - git
 
-# Prosedur
+# Procedure
 
-### Adim 1: Staged Degisiklikleri Oku
+### Step 1: Read the Staged Changes
 ```bash
 git diff --cached --stat
 git diff --cached | head -100
 ```
 
-### Adim 2: Tip Secimi
+### Step 2: Type Selection
 
-Degisiklige gore:
-- **feat**: Yeni kullanici ozelligi eklendiyse
-- **fix**: Mevcut bir hata duzeltildiyse
-- **refactor**: Davranis degismedi, iskelelim (rename, extract)
-- **perf**: Performans iyilestirmesi olcumlu
-- **docs**: Sadece markdown/yorum degisikligi
-- **test**: Sadece test dosyalari
-- **chore**: Bakim, config, bagimlilik
-- **ci**: `.github/workflows` vb
-- **build**: Build sistemi (webpack, tsconfig vb)
+By the nature of the change:
+- **feat**: A new user-facing feature
+- **fix**: An existing bug fixed
+- **refactor**: Behavior unchanged, restructuring (rename, extract)
+- **perf**: A measured performance improvement
+- **docs**: Markdown/comment-only changes
+- **test**: Test files only
+- **chore**: Maintenance, config, dependencies
+- **ci**: `.github/workflows` etc.
+- **build**: Build system (webpack, tsconfig, etc.)
 
-### Adim 3: Scope Belirle (opsiyonel)
+### Step 3: Pick a Scope (optional)
 
-Etkilenen alan: `auth`, `api`, `ui`, `db`, `config`, modul adi vb.
+The affected area: `auth`, `api`, `ui`, `db`, `config`, a module name, etc.
 
-### Adim 4: Kisa Mesaj Yaz
+### Step 4: Write the Short Message
 
-Kurallar:
-- Emir kipi, kucuk harf ile basla
-- Nokta koyma
-- < 100 karakter (< 70 tercih)
-- WHY > WHAT (commit gecmisi okunabilir olmali)
+Rules:
+- Imperative mood, start lowercase
+- No trailing period
+- < 100 characters (< 70 preferred)
+- WHY > WHAT (the commit history must stay readable)
 
-### Adim 5: Badi CLI Ile Kontrol + Commit
+### Step 5: Check + Commit with the Badi CLI
 
 ```bash
-# Sadece rehberlik
+# Guidance only
 badi commit
 
-# Conventional format dogrulamasi + commit
-badi commit --message "feat(auth): JWT refresh token eklendi"
+# Conventional-format validation + commit
+badi commit --message "feat(auth): add JWT refresh tokens"
 
-# Son commit lint kontrolu
+# Lint check on the last commit
 badi commit --check
 ```
 
-### Adim 6: Body ve Footer (opsiyonel)
+### Step 6: Body and Footer (optional)
 
-Karmasik degisiklikler icin:
+For complex changes:
 ```
-feat(auth): JWT refresh token eklendi
+feat(auth): add JWT refresh tokens
 
-15 dakikalik expire yerine 1h + refresh paterni.
-Mobile clientlar icin offline kullanim destegi.
+1h + refresh pattern instead of a 15-minute expiry.
+Offline support for mobile clients.
 
 Closes #123
-BREAKING CHANGE: access_token yerine tokens.access kullanilmali
+BREAKING CHANGE: use tokens.access instead of access_token
 ```
 
-# Ornek
+# Example
 ```
 /conv-commit
 ```

--- a/.claude/commands/deps-update.md
+++ b/.claude/commands/deps-update.md
@@ -1,66 +1,66 @@
 Safe dependency update analysis. Patch/minor/major categorization with optional automatic patch application.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi dev deps)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Tarama
+### Step 1: Scan
 ```bash
 badi dev deps
 ```
 
-Paket yoneticisi (npm/yarn/pnpm) otomatik tespit edilir.
+The package manager (npm/yarn/pnpm) is auto-detected.
 
-### Adim 2: Kategoriler
+### Step 2: Categories
 
-Her guncelleme su kategorilerde:
-- **Patch** (1.2.X) — Guvenli, auto-apply edilebilir
-- **Minor** (1.X.0) — Yeni ozellik, test gerekli
-- **Major** (X.0.0) — Break change potansiyeli, manuel inceleme
+Every update falls into:
+- **Patch** (1.2.X) — Safe, auto-applicable
+- **Minor** (1.X.0) — New features, tests required
+- **Major** (X.0.0) — Breaking-change potential, manual review
 
-### Adim 3: Patch Otomatik Uygula
+### Step 3: Auto-Apply Patches
 ```bash
 badi dev deps --apply-patch
 ```
 
-Sadece patch seviyesini uygular (en guvenli).
+Applies only the patch level (the safest).
 
-### Adim 4: Minor/Major Strateji
+### Step 4: Minor/Major Strategy
 
 **Minor:**
 ```bash
-npm update [paket]
+npm update [package]
 npm test
 ```
 
 **Major:**
-1. Changelog oku (npmjs.com/package/X)
-2. Break change notlari kontrol
-3. Tek tek guncelle: `npm install paket@latest`
-4. Tam test suite
+1. Read the changelog (npmjs.com/package/X)
+2. Check the breaking-change notes
+3. Update one at a time: `npm install package@latest`
+4. Full test suite
 
-### Adim 5: Guvenlik Onceligi
+### Step 5: Security Priority
 
-Kritik CVE varsa:
+If a critical CVE exists:
 ```bash
 npm audit
 npm audit fix              # Patch + minor auto
-npm audit fix --force      # Major dahil (riskli)
+npm audit fix --force      # Including major (risky)
 ```
 
-### Adim 6: Haftalik Rutin
+### Step 6: Weekly Routine
 
 ```bash
-# Pazartesi sabahi
+# Monday morning
 badi dev deps
-badi dev deps --apply-patch   # Patch'leri uygula
-npm test                       # Testler gecti mi
+badi dev deps --apply-patch   # Apply the patches
+npm test                       # Did the tests pass
 git add package-lock.json
 git commit -m "chore(deps): patch updates"
 ```
 
-# Ornek
+# Example
 
 ```
 /deps-update

--- a/.claude/commands/dns-audit.md
+++ b/.claude/commands/dns-audit.md
@@ -1,41 +1,41 @@
 DNS record audit command. Checks A/AAAA/MX/TXT/SPF/DMARC/CAA records and scores email security.
 
-# Gerekli Araclar
-- Bash (badi dns komutu cagirisi)
+# Required Tools
+- Bash (badi dns command invocation)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Domain Al
-Kullanicidan domain alinir. Argumansiz cagirildi ise sorarak alinir.
+### Step 1: Get the Domain
+Take the domain from the user. If invoked without an argument, ask for it.
 
-### Adim 2: Badi CLI Calistir
+### Step 2: Run the Badi CLI
 ```bash
 badi dns [domain]
 ```
 
-### Adim 3: Sonucu Yorumla
+### Step 3: Interpret the Result
 
-Cikti su alanlari icerir:
-- **A/AAAA**: IPv4/IPv6 kayitlari
-- **MX**: Mail server'lar (priority bazli)
-- **NS**: Name server'lar
-- **TXT/SPF/DMARC**: Email guvenlik
-- **CAA**: Cert authority kisitlamasi
-- **SOA**: Zone authority bilgisi
+The output covers:
+- **A/AAAA**: IPv4/IPv6 records
+- **MX**: Mail servers (by priority)
+- **NS**: Name servers
+- **TXT/SPF/DMARC**: Email security
+- **CAA**: Cert authority restriction
+- **SOA**: Zone authority info
 
-### Adim 4: Email Guvenlik Onerileri
+### Step 4: Email Security Suggestions
 
-Eksik kayitlara gore:
-- **SPF yoksa**: "SPF kaydi ekleyelim mi? Ornek: `v=spf1 include:_spf.google.com ~all`"
-- **DMARC yoksa**: "DMARC policy oneriyorum: `v=DMARC1; p=quarantine; rua=mailto:dmarc@...`"
-- **CAA yoksa**: "CAA kaydi saldiriya karsi koruma saglar. Let's Encrypt icin: `0 issue \"letsencrypt.org\"`"
+Based on missing records:
+- **No SPF**: "Shall we add an SPF record? Example: `v=spf1 include:_spf.google.com ~all`"
+- **No DMARC**: "I suggest a DMARC policy: `v=DMARC1; p=quarantine; rua=mailto:dmarc@...`"
+- **No CAA**: "A CAA record protects against mis-issuance. For Let's Encrypt: `0 issue \"letsencrypt.org\"`"
 
-### Adim 5: Takip Komutlari
+### Step 5: Follow-up Commands
 
-- Guvenlik eksikligi varsa: `/ssl-check [domain]` oner
-- WHOIS bilgisi icin: `/whois [domain]` oner
+- If security gaps exist: suggest `/ssl-check [domain]`
+- For WHOIS info: suggest `/whois [domain]`
 
-# Ornek
+# Example
 ```
 /dns-audit example.com
 ```

--- a/.claude/commands/docker-lint.md
+++ b/.claude/commands/docker-lint.md
@@ -1,65 +1,65 @@
 Dockerfile best-practice checks. Security, size, and reproducibility warnings.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi dev docker-lint)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Kontrol
+### Step 1: Check
 ```bash
 badi dev docker-lint
 ```
 
-### Adim 2: Kontrol Edilenler
+### Step 2: What Is Checked
 
 **FROM:**
-- `:latest` yerine versiyon sabitleme (guvenlik + reproducibility)
-- Alpine/distroless tercihi onerisi
+- Version pinning instead of `:latest` (security + reproducibility)
+- Alpine/distroless preference suggestion
 
 **USER:**
-- USER direktifi yoksa root olarak calisir (guvenlik riski)
-- Non-root user olusturulmasi onerilir
+- Without a USER directive it runs as root (security risk)
+- Creating a non-root user is recommended
 
 **HEALTHCHECK:**
-- Orchestration icin zorunlu
-- HTTP endpoint veya komut
+- Mandatory for orchestration
+- HTTP endpoint or command
 
 **RUN apt-get:**
-- `update` + `install` ayni RUN'da (cache busting)
-- `--no-install-recommends` (boyut)
-- `rm -rf /var/lib/apt/lists/*` (temizlik)
+- `update` + `install` in the same RUN (cache busting)
+- `--no-install-recommends` (size)
+- `rm -rf /var/lib/apt/lists/*` (cleanup)
 
 **ADD vs COPY:**
-- ADD tar ozelligi harici kullanilmamali
-- Local dosyalar icin COPY
+- ADD should not be used outside its tar feature
+- COPY for local files
 
-**Izinler:**
-- `chmod 777` yasak
-- 755 veya daha sıkı
+**Permissions:**
+- `chmod 777` forbidden
+- 755 or tighter
 
-**Port:**
-- EXPOSE < 1024 root gerektirir
+**Ports:**
+- EXPOSE < 1024 requires root
 
 **.dockerignore:**
-- Mevcut olmali (node_modules, .git vs)
+- Must exist (node_modules, .git, etc.)
 
-### Adim 3: Ileri Araclar
+### Step 3: Advanced Tools
 
-Detayli analiz icin:
+For detailed analysis:
 ```bash
 brew install hadolint
 hadolint Dockerfile
 ```
 
-### Adim 4: Yaygin Fix'ler
+### Step 4: Common Fixes
 
 ```dockerfile
-# ONCE
+# BEFORE
 FROM node:latest
 RUN apt-get update
 RUN apt-get install -y python3
 
-# SONRA
+# AFTER
 FROM node:20-alpine
 RUN apt-get update && apt-get install -y --no-install-recommends python3 \
     && rm -rf /var/lib/apt/lists/*
@@ -67,7 +67,7 @@ USER node
 HEALTHCHECK --interval=30s CMD curl -f http://localhost:3000/health || exit 1
 ```
 
-# Ornek
+# Example
 
 ```
 /docker-lint

--- a/.claude/commands/docs-audit.md
+++ b/.claude/commands/docs-audit.md
@@ -1,65 +1,65 @@
 Documentation audit command. Evaluates completeness, freshness, and quality of technical documentation.
 
-# Gerekli Araclar
-- Read (dokumantasyon dosyalari)
-- Grep (referans taramasi)
-- Glob (dosya bulma)
-- Bash (git log, dosya tarihleri)
+# Required Tools
+- Read (documentation files)
+- Grep (reference scan)
+- Glob (file discovery)
+- Bash (git log, file dates)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Dokumantasyon Envanteri
-Tum dokumantasyon dosyalarini tara:
-- README.md dosyalari (kok + alt dizinler)
-- API dokumantasyonu
-- Mimari dokumantasyon (ADR'ler dahil)
-- Kullanici kilavuzlari
-- Gelistirici kilavuzlari
-- Kurulum/baslatma talimatlari
+### Step 1: Documentation Inventory
+Scan all documentation files:
+- README.md files (root + subdirectories)
+- API documentation
+- Architecture documentation (including ADRs)
+- User guides
+- Developer guides
+- Install/getting-started instructions
 - CHANGELOG, CONTRIBUTING, SECURITY
-- Kod ici yorumlar (JSDoc, docstring vb.)
+- In-code comments (JSDoc, docstrings, etc.)
 
-### Adim 2: Tamllik Kontrolu
-Her dokuman icin kontrol et:
-- [ ] Guncel mi? (son degisiklik tarihi vs ilgili kod degisikligi)
-- [ ] Referans edilen dosya/fonksiyonlar hala mevcut mu?
-- [ ] Kurulum adimlari calisir durumda mi?
-- [ ] Kod ornekleri guncel mi?
-- [ ] Kirik linkler var mi?
-- [ ] Eksik bolumler var mi?
+### Step 2: Completeness Check
+For each document, verify:
+- [ ] Is it current? (last change date vs. related code changes)
+- [ ] Do referenced files/functions still exist?
+- [ ] Do the install steps still work?
+- [ ] Are the code examples current?
+- [ ] Any broken links?
+- [ ] Any missing sections?
 
-### Adim 3: Kapsam Boslugu Analizi
-Belgelenmemis alanlari tespit et:
-- Dokumantasyonu olmayan public API'ler
-- README'si olmayan onemli dizinler
-- Aciklamasi olmayan konfigur  asyon dosyalari
-- Belgelenmemis ortam degiskenleri
-- Eksik hata kodu aciklamalari
+### Step 3: Coverage Gap Analysis
+Detect undocumented areas:
+- Public APIs without documentation
+- Important directories without a README
+- Configuration files without explanations
+- Undocumented environment variables
+- Missing error-code descriptions
 
-### Adim 4: Kalite Degerlendirmesi
-- Tutarli format ve ton kullaniliyor mu?
-- Hedef kitle icin uygun seviye mi?
-- Kod ornekleri calisir durumda mi?
-- Gorseller/diyagramlar guncel mi?
+### Step 4: Quality Assessment
+- Consistent format and tone?
+- The right level for the target audience?
+- Do the code examples run?
+- Are visuals/diagrams current?
 
-### Adim 5: Rapor ve Aksiyon Plani
-Bulgulari onceliklendir:
-- **KRITIK**: Yanlis/yaniltici bilgi
-- **YUKSEK**: Tamamen eksik dokumantasyon
-- **ORTA**: Guncel olmayan icerik
-- **DUSUK**: Iyilestirilebilir format/stil
+### Step 5: Report and Action Plan
+Prioritize the findings:
+- **CRITICAL**: Wrong/misleading information
+- **HIGH**: Entirely missing documentation
+- **MEDIUM**: Outdated content
+- **LOW**: Improvable format/style
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI DOKUMANTASYON DENETIMI ===
-Taranan Dosya: [sayi]
-Kapsam Skoru: [yuzde]%
+=== BADI DOCUMENTATION AUDIT ===
+Files Scanned: [count]
+Coverage Score: [percent]%
 
-KRITIK: [sayi] bulgu
-YUKSEK: [sayi] bulgu
-ORTA: [sayi] bulgu
-DUSUK: [sayi] bulgu
+CRITICAL: [count] findings
+HIGH: [count] findings
+MEDIUM: [count] findings
+LOW: [count] findings
 
-En Acil: [ilk 3 aksiyon]
+Most Urgent: [top 3 actions]
 ===================================
 ```

--- a/.claude/commands/env-check.md
+++ b/.claude/commands/env-check.md
@@ -1,53 +1,53 @@
 .env file validation. Detects missing, extra, empty, and placeholder values + .gitignore check.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi dev env-check)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Kontrol
+### Step 1: Check
 ```bash
 badi dev env-check
 ```
 
-Referans dosya tespiti: `.env.example`, `.env.template`, `.env.sample`
+Reference file detection: `.env.example`, `.env.template`, `.env.sample`
 
-### Adim 2: Bulgular
+### Step 2: Findings
 
-**Eksik (KRITIK):**
-- .env.example'da var, .env'de yok
-- Kullanici eklenmeli
+**Missing (CRITICAL):**
+- In .env.example, not in .env
+- The user must add it
 
-**Fazladan (UYARI):**
-- .env'de var, .env.example'da yok
-- Dokumantasyon eksik — .env.example'a ekle
+**Extra (WARNING):**
+- In .env, not in .env.example
+- Documentation gap — add to .env.example
 
-**Bos deger (UYARI):**
-- `KEY=` veya `KEY=""` formati
-- Degeri doldur
+**Empty value (WARNING):**
+- The `KEY=` or `KEY=""` form
+- Fill in the value
 
-**Placeholder (KRITIK):**
+**Placeholder (CRITICAL):**
 - `your_api_key`, `xxx`, `changeme`, `todo`, `<...>`
-- Gercek degerlerle guncellenmemis
+- Not updated with real values
 
-**gitignore (KRITIK):**
-- .env dosyasi .gitignore'da yoksa ACIL ekle
+**gitignore (CRITICAL):**
+- If .env is not in .gitignore, add it URGENTLY
 
-### Adim 3: Yaygin Pattern
+### Step 3: Common Pattern
 
 ```bash
-# .env.example (commit edilir, yer tutucularla)
+# .env.example (committed, with placeholders)
 DATABASE_URL=postgresql://user:password@localhost/dbname
 API_KEY=your_api_key_here
 NODE_ENV=development
 
-# .env (commit edilmez, gercek degerlerle)
+# .env (not committed, with real values)
 DATABASE_URL=postgresql://prod_user:real_password@prod.host/prod_db
 API_KEY=sk-abc123...
 NODE_ENV=production
 ```
 
-### Adim 4: Otomasyon
+### Step 4: Automation
 
 Pre-commit hook:
 ```bash
@@ -61,15 +61,15 @@ CI pipeline:
   run: badi dev env-check
 ```
 
-### Adim 5: Secret Scanner ile Birlestir
+### Step 5: Combine with the Secret Scanner
 
-Kapsamli guvenlik:
+Comprehensive security:
 ```bash
-badi dev env-check     # .env dogrulama
-badi secret-scan       # Kod icinde sir tarama
+badi dev env-check     # .env validation
+badi secret-scan       # in-code secret scan
 ```
 
-# Ornek
+# Example
 
 ```
 /env-check

--- a/.claude/commands/lighthouse.md
+++ b/.claude/commands/lighthouse.md
@@ -1,44 +1,44 @@
 Lighthouse audit command. Performance, Accessibility, Best Practices, SEO scores and Core Web Vitals via the Google PageSpeed Insights API.
 
-# Gerekli Araclar
-- Bash (badi lighthouse komutu cagirisi)
+# Required Tools
+- Bash (badi lighthouse command invocation)
 
-# Prosedur
+# Procedure
 
-### Adim 1: URL Al
-Kullanicidan tam URL al. http/https onekine dikkat. Argumansiz cagirildiysa sor.
+### Step 1: Get the URL
+Take a full URL from the user. Mind the http/https prefix. Ask if invoked without an argument.
 
-### Adim 2: Strateji Secimi
+### Step 2: Strategy Selection
 
-Mobile mi desktop mi? Genelde **mobile** varsayilan cunku Google mobile-first indexing yapiyor.
+Mobile or desktop? **Mobile** is usually the default since Google does mobile-first indexing.
 
 ```bash
-badi lighthouse [url]              # Mobile (varsayilan)
+badi lighthouse [url]              # Mobile (default)
 badi lighthouse [url] --desktop    # Desktop
 ```
 
-### Adim 3: Sonucu Yorumla
+### Step 3: Interpret the Result
 
-Skorlar 4 kategoride:
-- **Performance** - hiz metrikleri
-- **Accessibility** - axe-core tabanli
+Scores in 4 categories:
+- **Performance** - speed metrics
+- **Accessibility** - axe-core based
 - **Best Practices** - HTTPS, console errors
 - **SEO** - meta tags, crawlability
 
 Core Web Vitals:
-- **FCP** < 1.8s (iyi), < 3.0s (orta)
-- **LCP** < 2.5s (iyi), < 4.0s (orta)
-- **TBT** < 200ms (iyi), < 600ms (orta)
-- **CLS** < 0.1 (iyi), < 0.25 (orta)
+- **FCP** < 1.8s (good), < 3.0s (fair)
+- **LCP** < 2.5s (good), < 4.0s (fair)
+- **TBT** < 200ms (good), < 600ms (fair)
+- **CLS** < 0.1 (good), < 0.25 (fair)
 
-### Adim 4: Iyilestirme Onerileri
+### Step 4: Improvement Suggestions
 
-Skor < 90 kategorilerde kullaniciya somut oneriler ver:
-- Performance dusuk: "Image optimization, code splitting, caching"
-- A11y dusuk: "`/a11y-audit [url]` ile detay al"
-- SEO dusuk: "`badi seo audit [url]` ile detayli rapor"
+For categories under 90, give the user concrete suggestions:
+- Low Performance: "Image optimization, code splitting, caching"
+- Low A11y: "Get detail with `/a11y-audit [url]`"
+- Low SEO: "Detailed report via `badi seo audit [url]`"
 
-# Ornek
+# Example
 ```
 /lighthouse https://example.com
 /lighthouse https://example.com --desktop

--- a/.claude/commands/post-mortem.md
+++ b/.claude/commands/post-mortem.md
@@ -1,77 +1,77 @@
 Post-incident analysis (post-mortem) command. Documents root-cause analysis of production incidents and major failures.
 
-# Gerekli Araclar
-- Read (log dosyalari, olay kayitlari)
-- Write (post-mortem raporu)
-- Grep (hata kalip arama)
-- Bash (git log, zaman damgasi analizi)
+# Required Tools
+- Read (log files, incident records)
+- Write (post-mortem report)
+- Grep (error pattern search)
+- Bash (git log, timestamp analysis)
 
-# Prosedur (6 Adim)
+# Procedure (6 Steps)
 
-### Adim 1: Olay Ozetini Topla
-- Olay ne zaman basladi? (ilk tespit)
-- Olay ne zaman cozuldu? (tam kurtarma)
-- Etki alani: Kac kullanici / hangi servisler etkilendi?
-- Ciddiyet: KRITIK / YUKSEK / ORTA / DUSUK
+### Step 1: Collect the Incident Summary
+- When did the incident start? (first detection)
+- When was it resolved? (full recovery)
+- Blast radius: how many users / which services were affected?
+- Severity: CRITICAL / HIGH / MEDIUM / LOW
 
-### Adim 2: Zaman Cizelgesini Olustur
-Dakika dakika olay kronolojisi:
+### Step 2: Build the Timeline
+A minute-by-minute incident chronology:
 ```
-[HH:MM] Ilk alarm / tespit
-[HH:MM] Mudahale basladi
-[HH:MM] Kok neden belirlendi
-[HH:MM] Duzeltme uygulandi
-[HH:MM] Dogrulama tamamlandi
-[HH:MM] Tam kurtarma
+[HH:MM] First alarm / detection
+[HH:MM] Response started
+[HH:MM] Root cause identified
+[HH:MM] Fix applied
+[HH:MM] Verification complete
+[HH:MM] Full recovery
 ```
 
-### Adim 3: Kok Neden Analizi
-5 Neden teknigini uygula:
-1. Neden oldu? -> ...
-2. Bu neden oldu? -> ...
-3. Bu neden oldu? -> ...
-4. Bu neden oldu? -> ...
-5. Bu neden oldu? -> (kok neden)
+### Step 3: Root Cause Analysis
+Apply the 5 Whys technique:
+1. Why did it happen? -> ...
+2. Why did that happen? -> ...
+3. Why did that happen? -> ...
+4. Why did that happen? -> ...
+5. Why did that happen? -> (root cause)
 
-Teknik kok neden + organizasyonel kok neden ayri belirle.
+Identify the technical root cause and the organizational root cause separately.
 
-### Adim 4: Iyi Giden / Kotu Giden Analizi
-**Iyi Giden:**
-- Hizli tespit edilen seyler
-- Etkili mudahaleler
-- Iyi calisan sistemler
+### Step 4: What Went Well / Badly
+**Went Well:**
+- Things detected quickly
+- Effective interventions
+- Systems that worked
 
-**Kotu Giden:**
-- Gec fark edilen sorunlar
-- Yanlis yonlendirmeler
-- Eksik alarm/izleme
+**Went Badly:**
+- Problems noticed late
+- Wrong turns
+- Missing alarms/monitoring
 
-**Sansli Olan:**
-- Daha kotuye gidebilecek ama gitmemis durumlar
+**Got Lucky:**
+- Situations that could have gone worse but didn't
 
-### Adim 5: Aksiyon Maddeleri
-Her madde icin: sahip, oncelik, hedef tarih
-- **Hemen** (bu hafta): Acil duzeltmeler
-- **Kisa Vadeli** (bu sprint): Onleyici tedbirler
-- **Uzun Vadeli** (bu cayrek): Yapisal iyilestirmeler
+### Step 5: Action Items
+For each item: owner, priority, target date
+- **Immediate** (this week): Urgent fixes
+- **Short Term** (this sprint): Preventive measures
+- **Long Term** (this quarter): Structural improvements
 
-### Adim 6: Rapor Olustur ve Kaydet
-`post-mortems/[tarih]-[olay-adi].md` dosyasina kaydet.
+### Step 6: Build and Save the Report
+Save to `post-mortems/[date]-[incident-name].md`.
 
-# Cikti Formati
+# Output Format
 ```
 === BADI POST-MORTEM ===
-Olay: [olay adi]
-Tarih: [tarih]
-Ciddiyet: [seviye]
-Etki Suresi: [dakika/saat]
-Kok Neden: [tek cumle ozet]
-Aksiyon: [sayi] madde
-Dosya: post-mortems/[tarih]-[olay-adi].md
+Incident: [incident name]
+Date: [date]
+Severity: [level]
+Impact Duration: [minutes/hours]
+Root Cause: [one-sentence summary]
+Actions: [count] items
+File: post-mortems/[date]-[incident-name].md
 ========================
 ```
 
-# Not
-- Suclamayan, ogrenme odakli dil kullan
-- "Kim" degil "ne" ve "neden" sorusu sor
-- Her post-mortem sonrasi knowledge-base.md'ye aday goster
+# Notes
+- Use blameless, learning-focused language
+- Ask "what" and "why", not "who"
+- Nominate every post-mortem into knowledge-base.md

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -1,47 +1,47 @@
 Refactoring command. Detects code smells and creates a safe refactoring plan.
 
-# Gerekli Araclar
-- Read (kod okuma)
-- Grep (kalip tarama)
-- Glob (dosya bulma)
-- Agent (refactoring-advisor ajani)
-- Bash (test calistirma)
+# Required Tools
+- Read (code reading)
+- Grep (pattern scan)
+- Glob (file discovery)
+- Agent (refactoring-advisor agent)
+- Bash (running tests)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Kapsami Belirle
-- Belirli dosya/fonksiyon mu yoksa modul mu?
-- Kullanicinin hedefi nedir? (performans, okunabilirlik, test edilebilirlik, SOLID uyumu)
+### Step 1: Define the Scope
+- A specific file/function or a module?
+- What is the user's goal? (performance, readability, testability, SOLID compliance)
 
-### Adim 2: Refactoring-Advisor Ajanina Devret
-Ajana su bilgileri ilet:
-- Hedef dosya/dosyalar
-- Kullanicinin amaci
-- Mevcut test kapsami durumu
+### Step 2: Delegate to the Refactoring-Advisor Agent
+Pass the agent:
+- Target file(s)
+- The user's goal
+- Current test coverage state
 
-### Adim 3: Oneri Incelemesi
-Ajanin onerilerini kullaniciya sun:
-- Her oneri icin once/sonra ornegi
-- Risk degerlendirmesi
-- Etkilenecek diger dosyalar
+### Step 3: Review the Suggestions
+Present the agent's suggestions to the user:
+- A before/after example for each suggestion
+- Risk assessment
+- Other files that will be affected
 
-### Adim 4: Onaylanan Degisiklikleri Uygula
-Kullanici onayiyla:
-- Refactoring adimlarini sirali uygula
-- Her adimdan sonra testleri calistir
-- Basarisiz olursa geri al
+### Step 4: Apply the Approved Changes
+With user approval:
+- Apply the refactoring steps in order
+- Run the tests after each step
+- Roll back on failure
 
-### Adim 5: Dogrula ve Belgele
-- Tum testlerin gectigini dogrula
-- Degisiklik ozetini gunluk nota ekle
-- Buyuk refactoring'ler icin ADR olusturmayi oner
+### Step 5: Verify and Document
+- Verify all tests pass
+- Add a change summary to the daily note
+- Suggest an ADR for large refactorings
 
-# Cikti Formati
+# Output Format
 ```
 === BADI REFACTORING ===
-Kapsam: [dosya/modul]
-Tespit: [kod kokusu sayisi]
-Uygulanan: [refactoring sayisi]
-Testler: GECTI / BASARISIZ
+Scope: [file/module]
+Detected: [code smell count]
+Applied: [refactoring count]
+Tests: PASSED / FAILED
 ========================
 ```

--- a/.claude/commands/scaffold.md
+++ b/.claude/commands/scaffold.md
@@ -1,59 +1,59 @@
 Code scaffolding command. Analyzes project structure and generates consistent module, component, or API skeletons.
 
-# Gerekli Araclar
-- Read (mevcut kod kaliplari)
-- Write (iskele dosyalari)
-- Grep (kalip tarama)
-- Glob (dosya yapisi analizi)
-- Agent (code-generator ajani)
+# Required Tools
+- Read (existing code patterns)
+- Write (scaffold files)
+- Grep (pattern scan)
+- Glob (file structure analysis)
+- Agent (code-generator agent)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Iskele Turunu Belirle
-Kullanicidan ne olusturulacagini ogren:
-- **Modul/Bilesen** — Yeni UI bileseni veya is mantigi modulu
-- **API Endpoint** — Yeni REST/GraphQL endpoint seti
-- **CRUD** — Model tanimindan tam CRUD islemleri
-- **Test** — Mevcut kod icin test iskelesi
-- **Migration** — Veritabani goc dosyasi
-- **Middleware** — Ara katman iskelesi
-- **Servis** — Yeni servis sinifi/modulu
+### Step 1: Determine the Scaffold Type
+Learn from the user what to create:
+- **Module/Component** — A new UI component or business-logic module
+- **API Endpoint** — A new REST/GraphQL endpoint set
+- **CRUD** — Full CRUD operations from a model definition
+- **Test** — Test scaffolding for existing code
+- **Migration** — A database migration file
+- **Middleware** — Middleware skeleton
+- **Service** — A new service class/module
 
-### Adim 2: Proje Kaliplarini Analiz Et
-Mevcut proje yapisini tara:
-- Dizin yapisi ve isimlendirme kurallari
-- Import/export kaliplari
-- Hata yonetimi yaklasimi
-- Test dosyasi konumlandirmasi
-- Tip tanimi stilleri
+### Step 2: Analyze the Project Patterns
+Scan the existing project structure:
+- Directory layout and naming conventions
+- Import/export patterns
+- Error-handling approach
+- Test file placement
+- Type definition styles
 
-### Adim 3: Code-Generator Ajanina Devret
-Ajana su bilgileri ilet:
-- Iskele turu ve hedef isim
-- Tespit edilen proje kaliplari
-- Referans alinacak mevcut dosyalar
+### Step 3: Delegate to the Code-Generator Agent
+Pass the agent:
+- Scaffold type and target name
+- The detected project patterns
+- Existing files to use as references
 
-### Adim 4: Dosyalari Olustur
-Uretilen iskeleyi diske yaz:
-- Yeni dosyalari olustur
-- Gerekli index/barrel dosyalarini guncelle
-- Import'lari ekle
+### Step 4: Create the Files
+Write the generated scaffold to disk:
+- Create the new files
+- Update the necessary index/barrel files
+- Add the imports
 
-### Adim 5: Dogrula
-- Uretilen dosyalarin proje kalibina uyumunu kontrol et
-- TypeScript/lint hatasi olmadigini dogrula
-- Sonraki adimlari listele (TODO isaretli yerler)
+### Step 5: Verify
+- Check the generated files match the project conventions
+- Verify there are no TypeScript/lint errors
+- List the next steps (TODO-marked spots)
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI ISKELE ===
-Tur: [modul/api/crud/test/migration]
-Isim: [bilesen adi]
+=== BADI SCAFFOLD ===
+Type: [module/api/crud/test/migration]
+Name: [component name]
 
-Olusturulan Dosyalar:
-  + [dosya yolu] (yeni)
-  ~ [dosya yolu] (guncellendi)
+Created Files:
+  + [file path] (new)
+  ~ [file path] (updated)
 
-Sonraki: TODO isaretli yerlere is mantigi ekleyin.
+Next: add business logic at the TODO-marked spots.
 ====================
 ```

--- a/.claude/commands/secret-scan.md
+++ b/.claude/commands/secret-scan.md
@@ -1,63 +1,63 @@
 Project-wide secret/credential scan command. AWS/GCP/GitHub/npm/Stripe/OpenAI/Anthropic keys, JWTs, database URIs, private keys.
 
-> **Daha genis kapsam icin**: `badi security baseline` (secret-scan + npm audit), `/security-review` (Anthropic native AI semantic — Claude Code 2.1.140+).
+> **For wider coverage**: `badi security baseline` (secret-scan + npm audit), `/security-review` (Anthropic native AI semantic — Claude Code 2.1.140+).
 
-# Gerekli Araclar
-- Bash (badi secret-scan komutu cagirisi)
+# Required Tools
+- Bash (badi secret-scan command invocation)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Kapsam Belirle
+### Step 1: Define the Scope
 
-Kullaniciya sor:
-- Sadece working tree mi? (hizli)
-- Git history de dahil mi? (default 100 commit; --max-commits ile arttirilabilir)
-- CI/pipeline icin mi? (--exit-code strict + --format json)
+Ask the user:
+- Working tree only? (fast)
+- Include git history? (default 100 commits; raise with --max-commits)
+- For CI/pipelines? (--exit-code strict + --format json)
 
-### Adim 2: Tarama Calistir
+### Step 2: Run the Scan
 
 ```bash
 badi secret-scan                                       # Working tree
 badi secret-scan --git                                 # + git history
-badi secret-scan --format json                         # JSON cikti
-badi secret-scan --exit-code strict                    # her bulguda exit 1
-badi secret-scan --max-commits 500 --git               # daha derin tarihce
-badi secret-scan --ignore jwt,github-pat-fine          # belirli pattern'leri yoksay
-badi secret-scan --ignore-file .secretignore           # dosyadan oku
-badi secret-scan --patterns custom-org-patterns.json   # ek pattern yukle
+badi secret-scan --format json                         # JSON output
+badi secret-scan --exit-code strict                    # exit 1 on any finding
+badi secret-scan --max-commits 500 --git               # deeper history
+badi secret-scan --ignore jwt,github-pat-fine          # ignore specific patterns
+badi secret-scan --ignore-file .secretignore           # read from a file
+badi secret-scan --patterns custom-org-patterns.json   # load extra patterns
 ```
 
-**CI cikis kodlari:**
-- `0`  Bulgu yok (veya `--exit-code never`; veya yalniz ORTA/DUSUK varsayilanda)
-- `1`  KRITIK veya YUKSEK bulgu
+**CI exit codes:**
+- `0`  No findings (or `--exit-code never`; or only MEDIUM/LOW by default)
+- `1`  CRITICAL or HIGH finding
 
-**Kapsam disi:** symlink'ler atlanir; `git stash`/`reflog`/packed-refs taranmaz.
+**Out of scope:** symlinks are skipped; `git stash`/`reflog`/packed-refs are not scanned.
 
-### Adim 3: Sonuclari Yorumla
+### Step 3: Interpret the Results
 
-Severity bazli:
-- **KRITIK**: AWS Access/Secret, GCP, GitHub PAT (classic + fine-grained), Slack, Stripe, OpenAI, Anthropic, RSA/EC private keys
-- **YUKSEK**: npm token, SendGrid, Twilio, MongoDB/Postgres URI
-- **ORTA**: JWT token
-- **DUSUK**: Generic secret variable'lar (false positive riski yuksek — `--ignore generic-secret` yararli)
+By severity:
+- **CRITICAL**: AWS Access/Secret, GCP, GitHub PAT (classic + fine-grained), Slack, Stripe, OpenAI, Anthropic, RSA/EC private keys
+- **HIGH**: npm token, SendGrid, Twilio, MongoDB/Postgres URIs
+- **MEDIUM**: JWT tokens
+- **LOW**: Generic secret variables (high false-positive risk — `--ignore generic-secret` helps)
 
-### Adim 4: Aksiyon Plani
+### Step 4: Action Plan
 
-Her finding icin:
+For every finding:
 
-1. **Rotate** — Siri hemen gecersiz kil (git log'da bile kalmis olabilir)
-2. **Gitignore** — `.env` veya sir dosyasini `.gitignore`'a ekle
-3. **Environment variables** — Sabit degerler yerine `process.env.X` kullan
-4. **Git history temizlik** — `git filter-repo` veya `BFG` kullan
+1. **Rotate** — Invalidate the secret immediately (it may live in git log)
+2. **Gitignore** — Add the `.env` or secret file to `.gitignore`
+3. **Environment variables** — Use `process.env.X` instead of hardcoded values
+4. **Git history cleanup** — Use `git filter-repo` or `BFG`
 
-### Adim 5: On-gelecek Koruma
+### Step 5: Future Protection
 
-- `.gitignore` kontrol: `.env`, `.env.*`, `secrets.json`, `*.pem`
-- Pre-commit hook: secret-scan otomatik calistir
-- `/secret-scan --git` haftalik cronjob oneri
+- `.gitignore` check: `.env`, `.env.*`, `secrets.json`, `*.pem`
+- Pre-commit hook: run secret-scan automatically
+- Suggest a weekly `/secret-scan --git` cronjob
 
-# Ornek
+# Example
 ```
 /secret-scan
-/secret-scan --git   # git history de dahil
+/secret-scan --git   # include git history
 ```

--- a/.claude/commands/spec-check.md
+++ b/.claude/commands/spec-check.md
@@ -1,71 +1,71 @@
 Specification conformance command. Audits the current code against SPECIFICATION.md, detecting feature gaps and scope drift.
 
-# Gerekli Araclar
-- Read (SPECIFICATION.md, kaynak kodlar)
-- Grep (ozellik arama)
-- Glob (dosya tarama)
-- Agent (auditor ajani)
-- Bash (test calistirma)
+# Required Tools
+- Read (SPECIFICATION.md, source code)
+- Grep (feature search)
+- Glob (file scan)
+- Agent (auditor agent)
+- Bash (running tests)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Spesifikasyonu Yukle
-- `docs/SPECIFICATION.md` dosyasini oku
-- Temel ozellikleri (Must Have) cikar
-- Kabul kriterlerini listele
-- Kapsam disi (Non-Goals) maddelerini belirle
+### Step 1: Load the Specification
+- Read `docs/SPECIFICATION.md`
+- Extract the core features (Must Have)
+- List the acceptance criteria
+- Identify the Non-Goals items
 
-### Adim 2: Kod Tabani Taramas
-Her "Must Have" ozellik icin:
-- Ilgili kod dosyalarini ara (fonksiyon, rota, bilesen)
-- Kabul kriterinin karsilanip karsilanmadigini degerlendir
-- Test kapsamini kontrol et
+### Step 2: Codebase Scan
+For every "Must Have" feature:
+- Search for the related code (functions, routes, components)
+- Assess whether the acceptance criterion is met
+- Check test coverage
 
-### Adim 3: Sapma Tespiti
-**Eksik Ozellikler:**
-- Spesifikasyonda olan ama kodda bulunamayan ozellikler
+### Step 3: Drift Detection
+**Missing Features:**
+- Features in the spec but not found in the code
 
-**Kapsam Kaymasi:**
-- Kodda olan ama spesifikasyonda OLMAYAN ozellikler
-- Kapsam disi (Non-Goals) olarak belirtilmis ama uygulanmis seyler
+**Scope Creep:**
+- Features in the code but NOT in the spec
+- Things marked Non-Goals yet implemented anyway
 
-**Kismi Uygulamalar:**
-- Baslanan ama tamamlanmamis ozellikler
-- Kabul kriterini karsilamayan uygulamalar
+**Partial Implementations:**
+- Features started but not finished
+- Implementations that fail the acceptance criteria
 
-### Adim 4: Uyum Raporu Olustur
-Her ozellik icin durum:
-- **TAMAMLANDI** — Kabul kriterleri karsilandi
-- **KISMI** — Baslandi ama tamamlanmadi
-- **EKSIK** — Henuz uygulanmadi
-- **SAPMA** — Spesifikasyondan farkli uygulanmis
+### Step 4: Build the Conformance Report
+A status per feature:
+- **DONE** — Acceptance criteria met
+- **PARTIAL** — Started but unfinished
+- **MISSING** — Not implemented yet
+- **DRIFT** — Implemented differently from the spec
 
-### Adim 5: Aksiyon Onerileri
-- Oncelikli eksik ozellik listesi
-- Kapsam kaymasi duzeltme onerileri
-- TaskBoard.md guncelleme (eksikler icin yeni gorev)
+### Step 5: Action Suggestions
+- Prioritized missing-feature list
+- Scope-creep remediation suggestions
+- TaskBoard.md update (new tasks for the gaps)
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI SPESIFIKASYON UYUM KONTROLU ===
-Spesifikasyon: docs/SPECIFICATION.md
-Tarih: [tarih]
+=== BADI SPEC CONFORMANCE CHECK ===
+Specification: docs/SPECIFICATION.md
+Date: [date]
 
-Uyum Orani: [yuzde]%
+Conformance Rate: [percent]%
 
-Must Have: [tamamlanan]/[toplam]
-Should Have: [tamamlanan]/[toplam]
-Could Have: [tamamlanan]/[toplam]
+Must Have: [done]/[total]
+Should Have: [done]/[total]
+Could Have: [done]/[total]
 
-EKSIK Ozellikler:
-- [ozellik adi] — [durum]
+MISSING Features:
+- [feature name] — [status]
 
-SAPMA Tespitleri:
-- [sapma aciklamasi]
+DRIFT Findings:
+- [drift description]
 
-KAPSAM KAYMASI:
-- [non-goal olarak belirtilmis ama uygulanmis]
+SCOPE CREEP:
+- [marked non-goal but implemented]
 
-Sonraki: [oncelikli aksiyon]
+Next: [priority action]
 =========================================
 ```

--- a/.claude/commands/ssl-check.md
+++ b/.claude/commands/ssl-check.md
@@ -1,42 +1,42 @@
 SSL certificate analysis command. Checks certificate validity, TLS version, and cipher strength for a domain.
 
-# Gerekli Araclar
-- Bash (badi ssl komutu cagirisi)
+# Required Tools
+- Bash (badi ssl command invocation)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Domain Kontrolu
-Kullanicidan domain al. Argumansiz cagirildiysa hangi domaini test etmek istedigini sor.
+### Step 1: Domain Check
+Take the domain from the user. If invoked without an argument, ask which domain to test.
 
-### Adim 2: Badi CLI Calistir
+### Step 2: Run the Badi CLI
 ```bash
 badi ssl [domain]
 ```
 
-Ornek:
+Example:
 ```bash
 badi ssl example.com
 badi ssl github.com
 ```
 
-### Adim 3: Sonucu Yorumla
-Ciktiyi kullaniciya aktarirken dikkat edilecek noktalar:
+### Step 3: Interpret the Result
+Points to watch while relaying the output:
 
-- **Expire < 30 gun**: Kullaniciyi uyar, yenileme planlamasi oner
-- **TLS < 1.2**: Guvenlik acigi, yukseltme zorunlu
-- **Zayif cipher (RC4, 3DES, MD5)**: Guncelleme oner
-- **SAN kontrol**: Kullaniciya domain listesi goster
+- **Expiry < 30 days**: Warn the user, suggest renewal planning
+- **TLS < 1.2**: Security hole, upgrade mandatory
+- **Weak ciphers (RC4, 3DES, MD5)**: Suggest an update
+- **SAN check**: Show the user the domain list
 
-### Adim 4: Takip Adimlari Oner
+### Step 4: Suggest Follow-ups
 
-Duruma gore:
-- Expire yakinsa: "Let's Encrypt otomatik yenileme scripti yazalim mi?"
-- Zayif cipher varsa: "Nginx/Apache config ornegi gerekiyor mu?"
-- OK durumunda: "`badi dns [domain]` ile DNS kontrolu yapmak ister misiniz?"
+Depending on the situation:
+- Expiry near: "Shall we write a Let's Encrypt auto-renew script?"
+- Weak ciphers: "Need an Nginx/Apache config example?"
+- All OK: "Want a DNS check with `badi dns [domain]`?"
 
-# Ornek Kullanim
+# Example Usage
 
 ```
-Kullanici: /ssl-check example.com
-Asistan: [badi ssl example.com calistirir, ciktiyi ozetler]
+User: /ssl-check example.com
+Assistant: [runs badi ssl example.com, summarizes the output]
 ```

--- a/.claude/commands/whois.md
+++ b/.claude/commands/whois.md
@@ -1,41 +1,41 @@
 Domain WHOIS command. Checks registration date, expiry, registrar, and transfer lock status.
 
-# Gerekli Araclar
-- Bash (badi whois komutu cagirisi)
+# Required Tools
+- Bash (badi whois command invocation)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Badi CLI Calistir
+### Step 1: Run the Badi CLI
 ```bash
 badi whois [domain]
 ```
 
-### Adim 2: Sonucu Yorumla
+### Step 2: Interpret the Result
 
-Onemli alanlar:
-- **Registrar**: Domain saglayicisi
-- **Creation Date**: Ilk tescil
-- **Expiration Date**: Yenileme zamani
-- **Domain Status**: Transfer Lock, Update Lock durumlari
-- **Name Servers**: DNS yonetim
+Key fields:
+- **Registrar**: Domain provider
+- **Creation Date**: First registration
+- **Expiration Date**: Renewal time
+- **Domain Status**: Transfer Lock, Update Lock states
+- **Name Servers**: DNS management
 
-### Adim 3: Uyarilar
+### Step 3: Warnings
 
-- **Expire < 30 gun**: "Acil yenileme gerekli"
-- **Expire 30-90 gun**: "Yenileme planlayin"
-- **Transfer Lock yok**: "Domain hijacking'e karsi lock'u acin"
-- **Update Lock yok**: "Kritik domain icin lock oneriyorum"
+- **Expiry < 30 days**: "Urgent renewal needed"
+- **Expiry 30-90 days**: "Plan the renewal"
+- **No Transfer Lock**: "Enable the lock against domain hijacking"
+- **No Update Lock**: "I recommend the lock for critical domains"
 
-### Adim 4: Kapsamli Domain Saglik Kontrolu
+### Step 4: Full Domain Health Check
 
-Kullaniciya su uclu kontrolu oner:
-- `/whois [domain]` — zaten yapildi
-- `/dns-audit [domain]` — DNS ve email guvenlik
-- `/ssl-check [domain]` — SSL sertifika
+Suggest the triple check to the user:
+- `/whois [domain]` — already done
+- `/dns-audit [domain]` — DNS and email security
+- `/ssl-check [domain]` — SSL certificate
 
-Ya da tek komutla hepsini yap: "Domain saglik kontrolunu yapabilirim, 3 komut calistirmami ister misin?"
+Or do it all at once: "I can run the full domain health check — want me to run all 3 commands?"
 
-# Ornek
+# Example
 ```
 /whois example.com
 ```


### PR DESCRIPTION
## Summary

**Increment 4 of the body-translation phase** (after #236 / 3c content). The **20 smaller dev-profile command bodies** (vault + active = 40 files): `dns-audit`, `whois`, `ssl-check`, `lighthouse`, `refactor`, `bundle-analyze`, `a11y-audit`, `scaffold`, `ai-review`, `ai-translate`, `secret-scan`, `changelog-gen`, `docs-audit`, `deps-update`, `conv-commit`, `spec-check`, `docker-lint`, `adr`, `env-check`, `post-mortem`.

### Caught en route
- `ai-translate`: the "Alternative" section documented the removed `--lang tr,en` parallel-generation flag — rewritten to reflect the v1.32+ English-only content engine (generate first, then translate the file).

## Test plan
- [x] `npm test` — **1161 pass / 0 fail** · biome clean · doctor healthy
- [x] Broad Turkish scan: **zero residual** across all 20 files

## Remaining
3e: dev batch 2 — the 19 larger bodies (review, report, changelog, security-scan, hotfix, retro, deploy, debt-map, release, perf-check, mobile, aso, brief, api-doc, playbook, wp, api-test, seo, architect) → then 3f-h: skills vault (59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)