### PR TITLE
feat(i18n): Phase 3e — English dev command bodies, batch 2 (19 commands)

### DIFF
--- a/.claude/commands-vault/api-doc.md
+++ b/.claude/commands-vault/api-doc.md
@@ -1,97 +1,97 @@
 API documentation generation. Scans route definitions and produces structured API docs.
 
-# Gerekli Araclar
-- Bash (dosya sistemi) -- Read (kaynak kod) -- Grep (route/endpoint) -- Glob (dosya tespiti) -- Write (dok dosyasi) -- Agent (api-designer: detayli API analiz)
+# Required Tools
+- Bash (filesystem) -- Read (source code) -- Grep (routes/endpoints) -- Glob (file detection) -- Write (doc file) -- Agent (api-designer: detailed API analysis)
 
-# Ajan Delegasyonu
-Ana is api-designer ajanina devredilir. Ajan yoksa asagidaki adimlari dogrudan uygula.
+# Agent Delegation
+The main work is delegated to the api-designer agent. If the agent is unavailable, apply the steps below directly.
 
-## 1. Framework Tespiti
-**1a — Proje yapisi:** `package.json` framework bagimliligi -- desteklenen: Express (`express`, `app.get/post/put/delete`), Fastify (`fastify`, `fastify.route`), NestJS (`@nestjs/core`, `@Controller`, `@Get/@Post`), Koa (`koa-router`, `router.get/post`), Next.js API (`pages/api/` veya `app/api/`), Django/Flask/FastAPI
+## 1. Framework Detection
+**1a — Project structure:** `package.json` framework dependency -- supported: Express (`express`, `app.get/post/put/delete`), Fastify (`fastify`, `fastify.route`), NestJS (`@nestjs/core`, `@Controller`, `@Get/@Post`), Koa (`koa-router`, `router.get/post`), Next.js API (`pages/api/` or `app/api/`), Django/Flask/FastAPI
 
-**1b — Route dosyalari:** framework'e gore tipik konumlar -- `routes/`, `controllers/`, `api/`, `endpoints/` -- middleware dosyalari
+**1b — Route files:** typical locations per framework -- `routes/`, `controllers/`, `api/`, `endpoints/` -- middleware files
 
-## 2. Endpoint Cikartma
-**2a — Route taramasi (grep):**
+## 2. Endpoint Extraction
+**2a — Route scan (grep):**
 - Express: `router\.(get|post|put|patch|delete)\(`
 - NestJS: `@(Get|Post|Put|Patch|Delete)\(`
 - Next.js: `export (async )?function (GET|POST|PUT|DELETE)`
-- Her esleme: dosya yolu + satir no + tam route ifadesi
+- Per match: file path + line number + the full route expression
 
-**2b — Endpoint bilgisi:** HTTP metod (GET/POST/PUT/PATCH/DELETE) -- URL yolu (path parametre dahil) -- middleware zinciri (auth, validation, rate-limit) -- controller fonksiyon adi
+**2b — Endpoint info:** HTTP method (GET/POST/PUT/PATCH/DELETE) -- URL path (including path params) -- middleware chain (auth, validation, rate-limit) -- controller function name
 
-**2c — Parametre:** URL (`:id`, `[slug]`) -- query (koddan cikar) -- body (TS tip, Zod, Joi) -- header (Authorization, Content-Type, vb.)
+**2c — Parameters:** URL (`:id`, `[slug]`) -- query (extract from code) -- body (TS types, Zod, Joi) -- headers (Authorization, Content-Type, etc.)
 
-## 3. Yanit Sekilleri
-**3a — Tip tespiti:** TS interface/type -- DTO siniflari -- ornek yanit nesneleri -- hata yanit formati
+## 3. Response Shapes
+**3a — Type detection:** TS interfaces/types -- DTO classes -- sample response objects -- error response format
 
-**3b — Durum kodlari:** her endpoint'in dondurdugu HTTP kodlari -- basarili (200, 201, 204) -- hata (400, 401, 403, 404, 500) -- ozel hata yanitlari
+**3b — Status codes:** the HTTP codes each endpoint returns -- success (200, 201, 204) -- errors (400, 401, 403, 404, 500) -- custom error responses
 
-## 4. OpenAPI/Swagger Iskeleti
+## 4. OpenAPI/Swagger Skeleton
 **4a — OpenAPI 3.0:**
 ```yaml
 openapi: "3.0.0"
 info:
-  title: "[Proje Adi] API"
-  version: "[surum]"
-  description: "[aciklama]"
+  title: "[Project Name] API"
+  version: "[version]"
+  description: "[description]"
 paths:
-  /api/[kaynak]:
+  /api/[resource]:
     get:
-      summary: "[aciklama]"
+      summary: "[description]"
       parameters: [...]
       responses:
         "200":
-          description: "[aciklama]"
+          description: "[description]"
           content:
             application/json:
               schema: [...]
 ```
 
-**4b — Sema:** tespit edilen modeller icin OpenAPI sema -- `$ref` ile tekrar kullanilabilir -- enum degerleri
+**4b — Schemas:** OpenAPI schemas for the detected models -- reusable via `$ref` -- enum values
 
-## 5. Belgelenmemis Endpoint
-**5a — Mevcut dok karsilastir:** mevcut API dok dosyasi -- Swagger/OpenAPI dosyasi -- README API bolumleri
+## 5. Undocumented Endpoints
+**5a — Compare with existing docs:** the existing API doc file -- a Swagger/OpenAPI file -- README API sections
 
-**5b — Eksik rapor:** belgelenmemis endpoint listesi -- eksik parametre aciklamasi -- yanit ornegi olmayan endpoint
+**5b — Gap report:** undocumented endpoint list -- missing parameter descriptions -- endpoints without response examples
 
-## 6. Cikti
+## 6. Output
 **6a — Markdown:**
 ```markdown
-## [HTTP Metodu] [Yol]
-[Aciklama]
+## [HTTP Method] [Path]
+[Description]
 
-**Yetkilendirme:** [Gerekli/Gereksiz] [Tip]
+**Authorization:** [Required/Not required] [Type]
 
-**Parametreler:**
-| Isim | Konum | Tip | Zorunlu | Aciklama |
-|------|--------|-----|---------|----------|
-| id   | path   | string | Evet | Kaynak kimlik numarasi |
+**Parameters:**
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| id   | path | string | Yes | The resource identifier |
 
-**Istek Govdesi:**
+**Request Body:**
 ```json
-{ "alan": "tip - aciklama" }
+{ "field": "type - description" }
 ```
 
-**Basarili Yanit (200):**
+**Success Response (200):**
 ```json
-{ "ornek": "yanit" }
+{ "example": "response" }
 ```
 
-**Hata Yanitlari:**
-- `401` - Yetkilendirme hatasi
-- `404` - Kaynak bulunamadi
+**Error Responses:**
+- `401` - Authorization error
+- `404` - Resource not found
 ```
 
-**6b — OpenAPI YAML (istege bagli):** kullaniciya sor -- onayla `openapi.yaml` yaz -- gecerlilik dogrula
+**6b — OpenAPI YAML (optional):** ask the user -- on approval write `openapi.yaml` -- validate it
 
-**6c — Ozet rapor:**
+**6c — Summary report:**
 ```
-=== API DOKUMANTASYON OZETI ===
-Framework: [tespit]
-Toplam Endpoint: [sayi]
-  GET/POST/PUT/DELETE: [sayilar]
-Belgelenmemis: [sayi]
-Dosyalar: [olusturulan liste]
+=== API DOCUMENTATION SUMMARY ===
+Framework: [detected]
+Total Endpoints: [count]
+  GET/POST/PUT/DELETE: [counts]
+Undocumented: [count]
+Files: [created list]
 ===============================
 ```

--- a/.claude/commands-vault/api-test.md
+++ b/.claude/commands-vault/api-test.md
@@ -1,19 +1,19 @@
 HTTP API endpoint testing. Send GET/POST/PUT/DELETE requests, analyze status + response, assertions.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi dev api-test)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Basit GET
+### Step 1: Simple GET
 ```bash
 badi dev api-test https://api.example.com/users
 ```
 
-### Adim 2: Gelismis Kullanim
+### Step 2: Advanced Usage
 
 ```bash
-# POST body ile
+# POST with a body
 badi dev api-test https://api.example.com/users \
   --method POST \
   --body '{"name":"Ali","email":"a@b.com"}'
@@ -26,29 +26,29 @@ badi dev api-test https://api.example.com/me \
 badi dev api-test https://api.example.com/health \
   --expect 200
 
-# Coklu header
+# Multiple headers
 badi dev api-test https://api.example.com/data \
   --header "Authorization: Bearer X" \
   --header "X-Custom: Y"
 ```
 
-### Adim 3: Cikti
+### Step 3: Output
 
-- **Status + Sure** (ms)
-- **Boyut** (KB)
+- **Status + Duration** (ms)
+- **Size** (KB)
 - **Content-Type**
-- **Tum response headers**
-- **Body** (JSON pretty print veya text)
-- **Assertion sonucu** (--expect kullanildiysa)
+- **All response headers**
+- **Body** (JSON pretty print or text)
+- **Assertion result** (if --expect was used)
 
-### Adim 4: Kullanim Senaryolari
+### Step 4: Usage Scenarios
 
-**Saglik kontrolu:**
+**Health check:**
 ```bash
 badi dev api-test https://app.com/health --expect 200
 ```
 
-**Yeni endpoint test:**
+**New endpoint test:**
 ```bash
 badi dev api-test http://localhost:3000/api/users/1
 ```
@@ -64,11 +64,11 @@ done
 ```bash
 # Login
 badi dev api-test https://api.com/login --method POST --body '{"u":"x","p":"y"}'
-# Token'i al, kullan
+# Take the token, use it
 badi dev api-test https://api.com/me --header "Authorization: Bearer $TOKEN"
 ```
 
-### Adim 5: CI Entegrasyonu
+### Step 5: CI Integration
 
 ```yaml
 - name: API Smoke Test
@@ -77,7 +77,7 @@ badi dev api-test https://api.com/me --header "Authorization: Bearer $TOKEN"
     badi dev api-test ${{ env.API_URL }}/api/v1/version --expect 200
 ```
 
-# Ornek
+# Example
 
 ```
 /api-test https://api.github.com/users/octocat --expect 200

--- a/.claude/commands-vault/architect.md
+++ b/.claude/commands-vault/architect.md
@@ -1,26 +1,26 @@
 Project planning command. Turns vague project ideas into 5 structured documents: specification, implementation plan, task list, brand identity, and a kickoff prompt.
 
-# Gerekli Araclar
-- Read (referans dosyalari, mevcut proje bilgisi)
-- Write (5 dokuman + TaskBoard entegrasyonu)
-- Agent (project-architect ajani)
-- Bash (proje analizi)
+# Required Tools
+- Read (reference files, existing project info)
+- Write (5 documents + TaskBoard integration)
+- Agent (project-architect agent)
+- Bash (project analysis)
 
-# Prosedur (7 Adim)
+# Procedure (7 Steps)
 
-### Adim 1: Proje Fikrini Al
-Kullanicidan projeyi tanimlamasini iste:
-- Proje fikri (1-2 cumle yeterli, ham olabilir)
-- Proje boyutu tahmini: Kucuk (hafta sonu) / Orta / Buyuk
+### Step 1: Get the Project Idea
+Ask the user to describe the project:
+- The project idea (1-2 sentences is enough, raw is fine)
+- Size estimate: Small (weekend) / Medium / Large
 
-### Adim 2: Project-Architect Ajanini Etkinlestir
-Ajana devret:
-- Proje fikrini ilet
-- Boyut tahminine gore soru katmanini belirle
-- Interaktif kesif surecini baslat (Katman 1-3 sorular)
+### Step 2: Activate the Project-Architect Agent
+Delegate to the agent:
+- Pass the project idea
+- Pick the question layer by the size estimate
+- Start the interactive discovery (Layer 1-3 questions)
 
-### Adim 3: Referanslari Yukle
-Ajan su referans dosyalarini okur:
+### Step 3: Load the References
+The agent reads these reference files:
 - `.claude/references/design-patterns.md`
 - `.claude/references/specification-guide.md`
 - `.claude/references/implementation-guide.md`
@@ -28,52 +28,52 @@ Ajan su referans dosyalarini okur:
 - `.claude/references/tech-stacks.md`
 - `.claude/references/elicitation-guide.md`
 
-### Adim 4: Tech Stack Secimi
-Interaktif tech stack danismanligi:
-- 8 karar noktasinda secenek sun
-- Her secenek icin artilari/eksileri goster
-- Kullanicinin onayini al
+### Step 4: Tech Stack Selection
+Interactive tech-stack advisory:
+- Offer options at 8 decision points
+- Show pros/cons for each option
+- Get the user's approval
 
-### Adim 5: 5 Dokumani Olustur
-Sirali olarak olustur:
-1. `docs/SPECIFICATION.md` — Kapsam, ozellikler, kabul kriterleri
-2. `docs/IMPLEMENTATION.md` — Tech stack, kaliplar, dizin yapisi
-3. `docs/TASKS.md` — Sirali gorev listesi (faz bazli)
-4. `docs/BRANDING.md` — Gorsel kimlik (kullaniciya yonelik projelerde)
-5. `docs/PROMPT.md` — Tek seferlik calistirma prompt'u
+### Step 5: Create the 5 Documents
+Create in order:
+1. `docs/SPECIFICATION.md` — Scope, features, acceptance criteria
+2. `docs/IMPLEMENTATION.md` — Tech stack, patterns, directory structure
+3. `docs/TASKS.md` — Ordered task list (by phase)
+4. `docs/BRANDING.md` — Visual identity (user-facing projects)
+5. `docs/PROMPT.md` — A single-pass kickoff prompt
 
-### Adim 6: Badi Entegrasyonu
-Uretilen dokumanlarI Badi sistemine entegre et:
-- TASKS.md'den gorevleri `.claude/workspace/TaskBoard.md`'ye aktar
-- IMPLEMENTATION.md'den temel mimari kararlarI `knowledge-base.md`'ye aday goster
-- SPECIFICATION.md ozetini `memory.md`'ye ekle
+### Step 6: Badi Integration
+Integrate the produced documents into the Badi system:
+- Move tasks from TASKS.md into `.claude/workspace/TaskBoard.md`
+- Nominate the key architecture decisions from IMPLEMENTATION.md into `knowledge-base.md`
+- Add the SPECIFICATION.md summary to `memory.md`
 
-### Adim 7: Sonraki Adimlar
-Kullaniciya yonlendir:
-- `/scaffold` ile proje yapisini olustur (IMPLEMENTATION.md'den)
-- `/start` ile gelistirme oturumunu baslat
-- `/spec-check` ile uyum kontrolu yap (gelistirme sirasinda)
+### Step 7: Next Steps
+Point the user to:
+- `/scaffold` to build the project structure (from IMPLEMENTATION.md)
+- `/start` to begin the development session
+- `/spec-check` for conformance checks (during development)
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI PROJE MIMARISI ===
-Proje: [proje adi]
-Boyut: [kucuk/orta/buyuk]
-Tech Stack: [ana teknolojiler]
+=== BADI PROJECT ARCHITECTURE ===
+Project: [project name]
+Size: [small/medium/large]
+Tech Stack: [main technologies]
 
-Olusturulan Dokumanlar:
+Created Documents:
   + docs/SPECIFICATION.md
   + docs/IMPLEMENTATION.md
   + docs/TASKS.md
-  + docs/BRANDING.md (varsa)
+  + docs/BRANDING.md (if applicable)
   + docs/PROMPT.md
 
-Entegrasyon:
-  ~ TaskBoard.md guncellendi ([sayi] gorev eklendi)
-  ~ memory.md guncellendi (proje ozeti)
+Integration:
+  ~ TaskBoard.md updated ([count] tasks added)
+  ~ memory.md updated (project summary)
 
-Sonraki:
-  1. /scaffold — Proje yapisini olustur
-  2. /start — Gelistirmeye basla
+Next:
+  1. /scaffold — Build the project structure
+  2. /start — Start developing
 ==============================
 ```

--- a/.claude/commands-vault/aso.md
+++ b/.claude/commands-vault/aso.md
@@ -1,109 +1,109 @@
 App Store Optimization command. iOS app listing analysis via the iTunes API, keyword optimization, and competitor comparison.
 
-# Gerekli Araclar
-- Bash (badi aso komutlari)
+# Required Tools
+- Bash (badi aso commands)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Hedef Belirle
+### Step 1: Set the Target
 
-Kullaniciya sor: "Ne analiz etmek istiyorsunuz?"
-- **Kendi app'iniz** — Audit + keyword + review
-- **Rakip karsilastirma** — 2 app side-by-side
-- **Keyword arastirma** — Pazar kesif
-- **Yeni app metadata** — Listing hazirlama
+Ask the user: "What do you want to analyze?"
+- **Your own app** — Audit + keywords + reviews
+- **Competitor comparison** — 2 apps side-by-side
+- **Keyword research** — Market discovery
+- **New app metadata** — Listing preparation
 
-App ID gerekli: `https://apps.apple.com/app/id[APP_ID]` URL'sinden al.
+The App ID is required: take it from the `https://apps.apple.com/app/id[APP_ID]` URL.
 
-### Adim 2: Temel ASO Audit
+### Step 2: Basic ASO Audit
 
 ```bash
 badi aso audit [app-id]
 ```
 
-Olculen metrikler:
-- Title/Subtitle uzunlugu (30/30 karakter limit)
-- Description uzunlugu (500+ onerilir)
-- Screenshot sayisi (>= 3 zorunlu, >= 6 ideal)
+Measured metrics:
+- Title/Subtitle length (30/30 character limits)
+- Description length (500+ recommended)
+- Screenshot count (>= 3 mandatory, >= 6 ideal)
 - Supported languages
-- Rating count (>= 100 onerilir, >= 4.0 skor)
+- Rating count (>= 100 recommended, >= 4.0 score)
 
-ASO skoru 0-100 arasi verilir.
+An ASO score of 0-100 is given.
 
-### Adim 3: Keyword Analizi
+### Step 3: Keyword Analysis
 
 ```bash
 badi aso keywords [app-id]
 ```
 
-Gosterir:
-- Title keyword'leri
-- Subtitle keyword'leri
-- Description top 20 keyword
-- Frekans bazli siralama
+Shows:
+- Title keywords
+- Subtitle keywords
+- Description top-20 keywords
+- Frequency-based ranking
 
-### Adim 4: Rakip Karsilastirma
+### Step 4: Competitor Comparison
 
 ```bash
-badi aso compete [benim-app-id] [rakip-app-id]
+badi aso compete [my-app-id] [competitor-app-id]
 ```
 
-Yan yana:
-- Metadata uzunluklari
+Side by side:
+- Metadata lengths
 - Rating + count
-- Screenshot sayisi
+- Screenshot count
 - Language count
-- Ortak + farkli keywordler (rakipten ogrenmek icin)
+- Shared + differing keywords (to learn from the competitor)
 
-### Adim 5: Metadata Limit Rehberi
+### Step 5: Metadata Limit Guide
 
 ```bash
-badi aso metadata appstore      # iOS karakter limitleri
-badi aso metadata playstore     # Android karakter limitleri
+badi aso metadata appstore      # iOS character limits
+badi aso metadata playstore     # Android character limits
 ```
 
-### Adim 6: Review Yaniti
+### Step 6: Review Responses
 
 ```bash
 badi aso review [app-id]
 ```
-Pozitif/negatif/feature response sablonlari.
+Positive/negative/feature response templates.
 
-### Adim 7: Screenshot Rehberi
+### Step 7: Screenshot Guide
 
 ```bash
 badi aso screenshots
 ```
-iOS 4 zorunlu + 3 opsiyonel boyut, Android 4 kategori.
+iOS 4 mandatory + 3 optional sizes, Android 4 categories.
 
-### Adim 8: Pazar Arastirma
+### Step 8: Market Research
 
 ```bash
-badi aso search "sorgu" --country tr
+badi aso search "query" --country us
 ```
-Rakipleri kesfet, trending app'leri gor.
+Discover competitors, see trending apps.
 
-### Adim 9: Icerik Uretimi Entegrasyonu
+### Step 9: Content Production Integration
 
-Launch icin:
+For launch:
 ```bash
-badi content post "yeni urun lansman" --platform appstore
-badi content release-notes --platform ios --version X.Y.Z --lang tr,en
+badi content post "new product launch" --platform appstore
+badi content release-notes --platform ios --version X.Y.Z
 badi content visual "app store screenshot"
 ```
 
-### Adim 10: Detayli Strateji
+### Step 10: Detailed Strategy
 
-Claude Code'da derin analiz icin ajanlari cagir:
+In Claude Code, invoke the agents for deep analysis:
 - `aso-master` — Full strategy
 - `aso-research` — Market research
 - `aso-optimizer` — Metadata optimization
 - `aso-strategist` — Growth planning
 
-# Ornek Kullanim
+# Example Usage
 
 ```
-/aso 284882215              # Facebook app analizi
+/aso 284882215              # Facebook app analysis
 /aso compete 284882215 310633997   # Facebook vs WhatsApp
-/aso search "task manager" --country tr
+/aso search "task manager" --country us
 ```

--- a/.claude/commands-vault/brief.md
+++ b/.claude/commands-vault/brief.md
@@ -1,107 +1,107 @@
 Project briefing command. Turns raw project ideas into structured, actionable briefs.
 
-# Gerekli Araclar
-- Read (mevcut proje bilgileri)
-- Write (brifing dosyasi)
-- Grep (benzer proje arama)
-- Glob (kaynak tarama)
+# Required Tools
+- Read (existing project info)
+- Write (brief file)
+- Grep (similar project search)
+- Glob (resource scan)
 
-# Prosedur (7 Adim)
+# Procedure (7 Steps)
 
-### Adim 1: Fikir Yakala
-Kullanicidan su bilgileri topla (yapilandirilmamis bile olsa kabul et):
-- **Problem:** Hangi sorunu cozuyoruz?
-- **Cozum:** Nasil cozmeyi planliyoruz?
-- **Kullanicilar:** Kim kullanacak? (birincil ve ikincil hedef kitle)
-- **Basari Kriteri:** Basariyi nasil olcecegiz?
-- **Motivasyon:** Neden simdi? Tetikleyen olay nedir?
+### Step 1: Capture the Idea
+Collect from the user (accept it even unstructured):
+- **Problem:** What problem are we solving?
+- **Solution:** How do we plan to solve it?
+- **Users:** Who will use it? (primary and secondary audience)
+- **Success Criterion:** How will we measure success?
+- **Motivation:** Why now? What triggered it?
 
-Fikir ne kadar ham olursa olsun, yapilandirilmis formata donustur.
+However raw the idea, convert it into a structured format.
 
-### Adim 2: Kapsam Tanimla
-Net sinirlar ciz:
+### Step 2: Define the Scope
+Draw clear lines:
 
-**Dahil Olanlar:**
-- Birinci fazda teslim edilecek ozellikler
-- Temel kullanici akislari
-- Minimum teknik gereksinimler
+**In Scope:**
+- Features delivered in phase one
+- Core user flows
+- Minimum technical requirements
 
-**Haric Tutulanlar:**
-- Bilinçli olarak kapsam disinda birakilan ozellikler
-- Gelecek fazlara ertelenen isler
-- Sorumluluk sinirlari
+**Out of Scope:**
+- Features deliberately excluded
+- Work deferred to future phases
+- Responsibility boundaries
 
-**Varsayimlar:**
-- Teknik varsayimlar (altyapi, erisim, vb.)
-- Is varsayimlari (butce, zaman, kaynak)
-- Kullanici varsayimlari (beceri seviyesi, erisim, vb.)
+**Assumptions:**
+- Technical assumptions (infrastructure, access, etc.)
+- Business assumptions (budget, time, resources)
+- User assumptions (skill level, access, etc.)
 
-### Adim 3: Kullanici Hikayeleri (MoSCoW)
-5-10 kullanici hikayesi yaz, her biri icin:
-- Format: "Bir [rol] olarak, [amac] istiyorum, boylece [fayda]."
-- Kabul kriterleri (2-4 madde)
-- MoSCoW onceligi:
-  - **Must (Olmali):** Olmadan urun calisamaz
-  - **Should (Olmali):** Onemli ama ilk surumde olmasa da olur
-  - **Could (Olabilir):** Guzel olur ama oncelikli degil
-  - **Won't (Olmayacak):** Bu fazda bilinçli olarak yapilmayacak
+### Step 3: User Stories (MoSCoW)
+Write 5-10 user stories, each with:
+- Format: "As a [role], I want [goal], so that [benefit]."
+- Acceptance criteria (2-4 items)
+- MoSCoW priority:
+  - **Must:** The product cannot work without it
+  - **Should:** Important but can miss the first release
+  - **Could:** Nice to have, not a priority
+  - **Won't:** Deliberately not done in this phase
 
-### Adim 4: Teknik Degerlendirme
-- **Teknoloji Yigini:** Onerilen diller, frameworkler, araclar
-- **Entegrasyonlar:** Ucuncu parti servisler ve API'ler
-- **Veri Gereksinimleri:** Veritabani, depolama, veri akisi
-- **Altyapi:** Hosting, CI/CD, izleme
-- **Kisitlamalar:** Performans gereksinimleri, uyumluluk, olcek
-- **Teknik Borc Riski:** Bilinen kisa yollar veya gecici cozumler
-- **Build vs Buy Analizi:** Hangi bilesenleri gelistirmeli, hangilerini hazir kullanmali?
+### Step 4: Technical Assessment
+- **Tech Stack:** Suggested languages, frameworks, tools
+- **Integrations:** Third-party services and APIs
+- **Data Requirements:** Database, storage, data flow
+- **Infrastructure:** Hosting, CI/CD, monitoring
+- **Constraints:** Performance requirements, compliance, scale
+- **Technical Debt Risk:** Known shortcuts or workarounds
+- **Build vs Buy Analysis:** Which components to build, which to use off the shelf?
 
-### Adim 5: Risk Tespiti
-Risk matrisi olustur:
+### Step 5: Risk Identification
+Build a risk matrix:
 
-| Risk | Olasilik (1-5) | Etki (1-5) | Risk Skoru | Azaltma Stratejisi |
-|------|----------------|------------|------------|-------------------|
-| [risk tanimi] | [deger] | [deger] | [OxE] | [strateji] |
+| Risk | Likelihood (1-5) | Impact (1-5) | Risk Score | Mitigation Strategy |
+|------|------------------|--------------|------------|---------------------|
+| [risk description] | [value] | [value] | [LxI] | [strategy] |
 
-Risk kategorileri:
-- Teknik riskler (karmasiklik, bilinmeyen teknoloji)
-- Kaynak riskleri (zaman, butce, yetenek)
-- Dis bagimlilik riskleri (ucuncu parti, API)
-- Pazar riskleri (talep, rekabet)
+Risk categories:
+- Technical risks (complexity, unknown technology)
+- Resource risks (time, budget, talent)
+- External dependency risks (third parties, APIs)
+- Market risks (demand, competition)
 
-### Adim 6: Zaman Tahmini
-Faz bazli tahmin tablosu:
+### Step 6: Time Estimate
+A phase-based estimate table:
 
-| Faz | Aciklama | Tahmini Sure | Onkosusllar |
-|-----|----------|-------------|-------------|
-| Arastirma | ... | ... | ... |
-| Tasarim | ... | ... | ... |
-| Gelistirme | ... | ... | ... |
+| Phase | Description | Estimated Duration | Prerequisites |
+|-------|-------------|--------------------|---------------|
+| Research | ... | ... | ... |
+| Design | ... | ... | ... |
+| Development | ... | ... | ... |
 | Test | ... | ... | ... |
-| Lansman | ... | ... | ... |
+| Launch | ... | ... | ... |
 
-Not: Tahminlere %20 tampon ekle.
-Toplam tahmini sure ve bitiris tarihi belirt.
+Note: add a 20% buffer to estimates.
+State the total estimated duration and the end date.
 
-### Adim 7: Brifing Dosyasi Olustur
-`briefs/[proje-adi]-brief.md` dosyasina kaydet.
+### Step 7: Create the Brief File
+Save to `briefs/[project-name]-brief.md`.
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI PROJE BRIFINGI ===
-Proje: [proje adi]
-Tarih: [tarih]
-Durum: TASLAK
+=== BADI PROJECT BRIEF ===
+Project: [project name]
+Date: [date]
+Status: DRAFT
 
-Ozet: [tek paragraf]
-Oncelik: [YUKSEK/ORTA/DUSUK]
-Tahmini Sure: [sure]
-Risk Seviyesi: [YUKSEK/ORTA/DUSUK]
+Summary: [single paragraph]
+Priority: [HIGH/MEDIUM/LOW]
+Estimated Duration: [duration]
+Risk Level: [HIGH/MEDIUM/LOW]
 
-Must Have: [sayi] hikaye
-Should Have: [sayi] hikaye
-Could Have: [sayi] hikaye
-Won't Have: [sayi] hikaye
+Must Have: [count] stories
+Should Have: [count] stories
+Could Have: [count] stories
+Won't Have: [count] stories
 
-Dosya: briefs/[proje-adi]-brief.md
+File: briefs/[project-name]-brief.md
 ============================
 ```

--- a/.claude/commands-vault/changelog.md
+++ b/.claude/commands-vault/changelog.md
@@ -1,152 +1,152 @@
 Automatic changelog generation. Produces a structured changelog from commit history.
 
-## Badi CLI Komutu (v1.6+)
-Hizli uretim icin:
+## Badi CLI Command (v1.6+)
+For quick generation:
 ```bash
-badi changelog                    # Son tag'den HEAD'e onizleme
-badi changelog --from v1.0.0      # Belirli tag'den
-badi changelog --write --version 1.6.0  # CHANGELOG.md'ye yaz
+badi changelog                    # Preview from the latest tag to HEAD
+badi changelog --from v1.0.0      # From a specific tag
+badi changelog --write --version 1.6.0  # Write to CHANGELOG.md
 ```
 
-CLI conventional commit tipleriyle otomatik gruplar. Asagidaki manuel adimlar karmasik durumlar icin (non-conventional commit'ler, breaking change isaretleme vb.).
+The CLI groups automatically by conventional commit types. The manual steps below are for complex cases (non-conventional commits, breaking-change marking, etc.).
 
-# Gerekli Araclar
+# Required Tools
 - Bash (git log, git tag, git diff)
-- Read (mevcut CHANGELOG.md)
-- Write (changelog dosyasi olusturma/guncelleme)
-- Grep (commit mesaji arama)
+- Read (the existing CHANGELOG.md)
+- Write (creating/updating the changelog file)
+- Grep (commit message search)
 
-# Format Standardi
-Bu komut Keep-a-Changelog (keepachangelog.com) formatini kullanir.
-Conventional Commits (feat:, fix:, breaking:, vb.) mesajlari otomatik kategorize edilir.
-
----
-
-## Adim 1: Surum Araligini Belirle
-
-### 1a: Son Etiketi Bul
-- `git tag --sort=-version:refname` ile en son etiketi bul
-- Etiket yoksa ilk commit'i baslangic noktasi olarak kullan
-- Kullanicidan ozel aralik belirtmesini iste (istege bagli)
-
-### 1b: Aralik Dogrulama
-- Baslangic noktasi: [son etiket] veya [belirtilen commit]
-- Bitis noktasi: HEAD (veya belirtilen commit)
-- Aralikdaki toplam commit sayisini goster
-- `git log [baslangic]..HEAD --oneline` ile on izleme sun
+# Format Standard
+This command uses the Keep-a-Changelog (keepachangelog.com) format.
+Conventional Commits messages (feat:, fix:, breaking:, etc.) are categorized automatically.
 
 ---
 
-## Adim 2: Commit Mesajlarini Parse Et
+## Step 1: Define the Version Range
 
-### 2a: Commit Listesini Al
-- `git log [aralik] --format="%H|%s|%an|%ad" --date=short` calistir
-- Her commit icin: hash, mesaj, yazar, tarih bilgisi topla
-- Merge commit'leri ayir (istege bagli dahil et veya haric tut)
+### 1a: Find the Latest Tag
+- Find the latest tag with `git tag --sort=-version:refname`
+- If no tag exists, use the first commit as the starting point
+- Ask the user for a custom range (optional)
 
-### 2b: Conventional Commits Ayristirmasi
-Asagidaki on ekleri tani:
-- `feat:` veya `feature:` -> Ozellikler
-- `fix:` veya `bugfix:` -> Duzeltmeler
-- `breaking:` veya `BREAKING CHANGE:` -> Kirilma Degisiklikleri
-- `refactor:` -> Yeniden Duzenleme
-- `docs:` -> Dokumantasyon
-- `perf:` -> Performans
-- `test:` -> Test
-- `chore:` veya `ci:` -> Bakim
-
-### 2c: Conventional Olmayan Mesajlar
-- On eki olmayan commit'leri iceriklerne gore siniflandir
-- Siniflandirilamazsa "Diger" kategorisine ekle
-- Kullaniciya belirsiz commit'ler icin kategori sormay teklif et
+### 1b: Range Validation
+- Start point: [last tag] or [given commit]
+- End point: HEAD (or a given commit)
+- Show the total commit count in the range
+- Offer a preview with `git log [start]..HEAD --oneline`
 
 ---
 
-## Adim 3: Kategorize Et
+## Step 2: Parse the Commit Messages
 
-### 3a: Ana Kategoriler
-Bulgulari su siralamayla grupla:
-1. **Kirilma Degisiklikleri** (BREAKING CHANGES) - En uste, dikkat cekici
-2. **Ozellikler** (Features) - Yeni islevsellik
-3. **Duzeltmeler** (Bug Fixes) - Hata giderimleri
-4. **Performans** (Performance) - Performans iyilestirmeleri
-5. **Yeniden Duzenleme** (Refactoring) - Kod yapisi degisiklikleri
-6. **Dokumantasyon** (Documentation) - Belge degisiklikleri
-7. **Test** - Test degisiklikleri
-8. **Bakim** (Chores) - Yardimci degisiklikler
+### 2a: Get the Commit List
+- Run `git log [range] --format="%H|%s|%an|%ad" --date=short`
+- Per commit collect: hash, message, author, date
+- Separate merge commits (include or exclude on request)
 
-### 3b: Kapsam Bilgisi
-- Eger commit mesajinda kapsam varsa (ornek: `feat(auth):`) grupla
-- Kapsam bilgisini changelog girisi icinde goster
+### 2b: Conventional Commits Parsing
+Recognize these prefixes:
+- `feat:` or `feature:` -> Features
+- `fix:` or `bugfix:` -> Fixes
+- `breaking:` or `BREAKING CHANGE:` -> Breaking Changes
+- `refactor:` -> Refactoring
+- `docs:` -> Documentation
+- `perf:` -> Performance
+- `test:` -> Tests
+- `chore:` or `ci:` -> Maintenance
+
+### 2c: Non-Conventional Messages
+- Classify unprefixed commits by their content
+- If unclassifiable, add to the "Other" category
+- Offer to ask the user about ambiguous commits
 
 ---
 
-## Adim 4: Markdown Olustur
+## Step 3: Categorize
 
-### 4a: Changelog Formati
-Keep-a-Changelog formatinda olustur:
+### 3a: Main Categories
+Group the findings in this order:
+1. **Breaking Changes** - At the top, prominent
+2. **Features** - New functionality
+3. **Bug Fixes** - Error remediation
+4. **Performance** - Performance improvements
+5. **Refactoring** - Code structure changes
+6. **Documentation** - Doc changes
+7. **Tests** - Test changes
+8. **Chores** - Auxiliary changes
+
+### 3b: Scope Info
+- If the commit message has a scope (example: `feat(auth):`), group by it
+- Show the scope inside the changelog entry
+
+---
+
+## Step 4: Build the Markdown
+
+### 4a: Changelog Format
+Produce in Keep-a-Changelog format:
 
 ```markdown
-# Degisiklik Gunlugu
+# Changelog
 
-## [Yayinlanmamis] - YYYY-AA-GG
+## [Unreleased] - YYYY-MM-DD
 
-### Kirilma Degisiklikleri
-- **[kapsam]** Degisiklik aciklamasi ([hash])
+### Breaking Changes
+- **[scope]** Change description ([hash])
 
-### Ozellikler
-- **[kapsam]** Yeni ozellik aciklamasi ([hash])
+### Features
+- **[scope]** New feature description ([hash])
 
-### Duzeltmeler
-- Hata duzeltme aciklamasi ([hash])
+### Fixes
+- Bug fix description ([hash])
 
-### Yeniden Duzenleme
-- Refactoring aciklamasi ([hash])
+### Refactoring
+- Refactoring description ([hash])
 
-### Dokumantasyon
-- Dokumantasyon degisikligi ([hash])
+### Documentation
+- Documentation change ([hash])
 ```
 
-### 4b: Ek Bilgiler
-- Katki saglayanlari listele (yazarlar)
-- Toplam commit sayisini ekle
-- Karsilastirma baglantisi ekle: `[Yayinlanmamis]: [repo-url]/compare/[etiket]...HEAD`
+### 4b: Extra Info
+- List the contributors (authors)
+- Add the total commit count
+- Add a compare link: `[Unreleased]: [repo-url]/compare/[tag]...HEAD`
 
 ---
 
-## Adim 5: CHANGELOG.md Guncelle (Istege Bagli)
+## Step 5: Update CHANGELOG.md (Optional)
 
-### 5a: Mevcut Dosya Kontrolu
-- `CHANGELOG.md` mevcut mu kontrol et
-- Mevcutsa icerigi oku ve format uyumunu dogrula
+### 5a: Existing File Check
+- Check whether `CHANGELOG.md` exists
+- If it does, read the content and verify format compatibility
 
-### 5b: Kullanici Onay
-- Olusturulan changelog icerigini on izleme olarak goster
-- Kullaniciya sor: "CHANGELOG.md dosyasini guncelleyeyim mi?"
-- Onay alinrsa, yeni girisleri dosyanin ustune ekle (mevcut icerigi koru)
+### 5b: User Approval
+- Show the generated changelog content as a preview
+- Ask the user: "Shall I update CHANGELOG.md?"
+- On approval, prepend the new entries (preserve the existing content)
 
-### 5c: Dosya Yazimi
-- Yeni bolumu mevcut icergin ustune ekle
-- Baslik formatini koru
-- Tarih ve surum bilgisini dogru formatta ekle
+### 5c: File Write
+- Prepend the new section above the existing content
+- Preserve the heading format
+- Add the date and version in the correct format
 
 ---
 
-## Cikti Formati
+## Output Format
 
-### Adim 6: Ozet Rapor
+### Step 6: Summary Report
 ```
-=== CHANGELOG OZETI ===
-Aralik: [baslangic] -> [bitis]
-Toplam Commit: [sayi]
-Kategoriler:
-  Ozellikler:            [sayi]
-  Duzeltmeler:           [sayi]
-  Kirilma Degisiklikleri:[sayi]
-  Yeniden Duzenleme:     [sayi]
-  Dokumantasyon:         [sayi]
-  Diger:                 [sayi]
-Katki Saglayanlar: [yazar listesi]
-CHANGELOG.md: [GUNCELLENDI / GUNCELLENMEDI]
+=== CHANGELOG SUMMARY ===
+Range: [start] -> [end]
+Total Commits: [count]
+Categories:
+  Features:          [count]
+  Fixes:             [count]
+  Breaking Changes:  [count]
+  Refactoring:       [count]
+  Documentation:     [count]
+  Other:             [count]
+Contributors: [author list]
+CHANGELOG.md: [UPDATED / NOT UPDATED]
 ========================
 ```

--- a/.claude/commands-vault/debt-map.md
+++ b/.claude/commands-vault/debt-map.md
@@ -1,121 +1,121 @@
 Technical debt mapping command. Systematically detects and prioritizes technical debt in the codebase.
 
-# Gerekli Araclar
-- Grep (kod taramasi)
-- Glob (dosya bulma)
-- Read (dosya okuma)
-- Bash (karmasiklik analizi, git blame)
-- Write (rapor yazimi)
+# Required Tools
+- Grep (code scan)
+- Glob (file discovery)
+- Read (file reading)
+- Bash (complexity analysis, git blame)
+- Write (report writing)
 
-# Prosedur (4 Adim)
+# Procedure (4 Steps)
 
-### Adim 1: Kapsam Belirle
-Kullaniciya sor:
-- **Tum proje:** Komple kod tabanini tara
-- **Modul:** Belirli bir modul veya dizin
-- **Katman:** Belirli bir katman (API, UI, veritabani, vb.)
+### Step 1: Define the Scope
+Ask the user:
+- **Whole project:** Scan the complete codebase
+- **Module:** A specific module or directory
+- **Layer:** A specific layer (API, UI, database, etc.)
 
-Kapsam bilgisini kaydet:
-- Taranacak dizinler
-- Dahil edilecek dosya turleri
-- Haric tutulacak dizinler (node_modules, vendor, dist, build, vb.)
+Record the scope:
+- Directories to scan
+- File types to include
+- Directories to exclude (node_modules, vendor, dist, build, etc.)
 
-### Adim 2: 3 Paralel Tarama
+### Step 2: 3 Parallel Scans
 
-**Tarama A: TODO/FIXME Envanteri**
-- `TODO` etiketlerini tara ve kategorilere ayir
-- `FIXME` etiketlerini tara (acil mudahale gerektiren)
-- `HACK` etiketlerini tara (gecici cozumler)
-- `WORKAROUND` etiketlerini tara (bilinen sorun gecici cozumleri)
-- `DEPRECATED` etiketlerini tara (kullanilmamasi gereken)
-- `XXX` ve `BUG` etiketlerini tara
-- Her bulgu icin dosya yolu, satir numarasi ve baglamini kaydet
-- Git blame ile yaslarini tespit et ve eski olanlari vurgula
+**Scan A: TODO/FIXME Inventory**
+- Scan and categorize `TODO` tags
+- Scan `FIXME` tags (needing urgent attention)
+- Scan `HACK` tags (temporary fixes)
+- Scan `WORKAROUND` tags (known-issue workarounds)
+- Scan `DEPRECATED` tags (should no longer be used)
+- Scan `XXX` and `BUG` tags
+- For each finding record file path, line number, and context
+- Date them via git blame and highlight the old ones
 
-**Tarama B: Karmasiklik Analizi**
-- 500+ satirlik dosyalari tespit et (asiri buyuk)
-- 100+ satirlik fonksiyonlari bul (asiri uzun)
-- 3+ seviye ic ice gecen kosullari bul (derin nesting)
-- Cok fazla import/bagimlilik iceren dosyalar
-- Tekrarlayan kod bloklari (copy-paste tespiti)
-- 5+ parametreli fonksiyonlar
-- Derin miras hiyerarsileri (3+ seviye)
-- God class/God function tespiiti
+**Scan B: Complexity Analysis**
+- Detect 500+ line files (oversized)
+- Find 100+ line functions (overlong)
+- Find 3+ level nested conditionals (deep nesting)
+- Files with too many imports/dependencies
+- Duplicated code blocks (copy-paste detection)
+- Functions with 5+ parameters
+- Deep inheritance hierarchies (3+ levels)
+- God class / god function detection
 
-**Tarama C: Eskime ve Kullanilmama Tespiti**
-- Kullanilmayan export/fonksiyonlar
-- Deprecated API kullanimi (dil ve framework bazli)
-- Guncelligini yitirmis bagimliliklar
-- Uyumsuz versiyon eslemeleri
-- Kaldirilmis veya desteklenmeyen kutuphaneler
-- Eski konfigur asyon formatlari
-- Yoruma alinmis kod bloklari (zombi kod)
-- Olmeyen feature flag'ler
+**Scan C: Staleness and Dead Code Detection**
+- Unused exports/functions
+- Deprecated API usage (per language and framework)
+- Outdated dependencies
+- Incompatible version pairings
+- Removed or unsupported libraries
+- Old configuration formats
+- Commented-out code blocks (zombie code)
+- Undying feature flags
 
-### Adim 3: Skorlama
-Her teknik borc maddesi icin skor hesapla:
+### Step 3: Scoring
+Compute a score per debt item:
 
-**Etki Skoru (1-5):**
-- 5: Uretim kesintisi riski, guvenlik acigi
-- 4: Performans degradasyonu, veri tutarsizligi
-- 3: Gelistirme hizini onemli olcude yavaslatir
-- 2: Kod okunabilirligini ve bakim kolayligini azaltir
-- 1: Kozmetik sorun, minor tutarsizlik
+**Impact Score (1-5):**
+- 5: Production-outage risk, security vulnerability
+- 4: Performance degradation, data inconsistency
+- 3: Significantly slows development
+- 2: Reduces readability and maintainability
+- 1: Cosmetic issue, minor inconsistency
 
-**Efor Skoru (1-5):**
-- 1: Hizli duzeltme (< 1 saat)
-- 2: Kisa gorev (1-4 saat)
-- 3: Yarim gunluk is (4-8 saat)
-- 4: Tam gunluk is (1-2 gun)
-- 5: Cok gunluk refactoring (3+ gun)
+**Effort Score (1-5):**
+- 1: Quick fix (< 1 hour)
+- 2: Short task (1-4 hours)
+- 3: Half-day job (4-8 hours)
+- 4: Full-day job (1-2 days)
+- 5: Multi-day refactoring (3+ days)
 
-**Oncelik Hesabi:** Etki / Efor = Oncelik Skoru
-- **Yuksek oncelik:** skor >= 2.0 (yuksek etki, dusuk efor = hemen yap)
-- **Orta oncelik:** skor 1.0 - 1.99 (sprint icinde planla)
-- **Dusuk oncelik:** skor < 1.0 (arka planda birak)
+**Priority Calculation:** Impact / Effort = Priority Score
+- **High priority:** score >= 2.0 (high impact, low effort = do now)
+- **Medium priority:** score 1.0 - 1.99 (plan within the sprint)
+- **Low priority:** score < 1.0 (leave in the background)
 
-### Adim 4: Markdown Rapor Olustur
+### Step 4: Build the Markdown Report
 
-# Cikti Formati
+# Output Format
 ```markdown
-# Teknik Borc Haritasi - [tarih]
+# Technical Debt Map - [date]
 
-## Ozet Istatistikler
-- Toplam Borc Maddesi: [sayi]
-- Kritik (Yuksek Oncelik): [sayi]
-- Orta Oncelik: [sayi]
-- Dusuk Oncelik: [sayi]
-- Tahmini Toplam Efor: [saat/gun]
-- En Borclu Modul: [modul adi]
+## Summary Statistics
+- Total Debt Items: [count]
+- Critical (High Priority): [count]
+- Medium Priority: [count]
+- Low Priority: [count]
+- Estimated Total Effort: [hours/days]
+- Most Indebted Module: [module name]
 
-## TODO/FIXME Envanteri
-| # | Dosya | Satir | Tur | Yas | Etki | Efor | Oncelik | Aciklama |
-|---|-------|-------|-----|-----|------|------|---------|----------|
+## TODO/FIXME Inventory
+| # | File | Line | Type | Age | Impact | Effort | Priority | Description |
+|---|------|------|------|-----|--------|--------|----------|-------------|
 | 1 | ... | ... | TODO | ... | ... | ... | ... | ... |
 
-## Karmasiklik Sicak Noktalari
-| # | Dosya | Satir Sayisi | Karmasiklik | Etki | Efor | Sorun |
-|---|-------|-------------|-------------|------|------|-------|
+## Complexity Hot Spots
+| # | File | Line Count | Complexity | Impact | Effort | Issue |
+|---|------|------------|------------|--------|--------|-------|
 | 1 | ... | ... | ... | ... | ... | ... |
 
-## Eskimis Bilesenler
-| # | Bilesen | Tur | Risk | Efor | Oneri |
-|---|---------|-----|------|------|-------|
+## Stale Components
+| # | Component | Type | Risk | Effort | Suggestion |
+|---|-----------|------|------|--------|------------|
 | 1 | ... | ... | ... | ... | ... |
 
-## Oncelikli Eylem Plani
-### Hemen Yapilmali (Oncelik >= 2.0)
-1. [madde] - Etki: [skor] / Efor: [skor] = Oncelik: [skor]
+## Prioritized Action Plan
+### Do Now (Priority >= 2.0)
+1. [item] - Impact: [score] / Effort: [score] = Priority: [score]
 
-### Sprint Ici (Oncelik 1.0 - 1.99)
-1. [madde]
+### Within the Sprint (Priority 1.0 - 1.99)
+1. [item]
 
-### Arka Plan (Oncelik < 1.0)
-1. [madde]
+### Background (Priority < 1.0)
+1. [item]
 
-## Trend Analizi
-[onceki taramalarla karsilastirma, borc artisi/azalisi]
+## Trend Analysis
+[comparison with previous scans, debt growth/shrinkage]
 
-## Takip Metrikleri
-[sonraki tarama icin temel degerler]
+## Tracking Metrics
+[baseline values for the next scan]
 ```

--- a/.claude/commands-vault/deploy.md
+++ b/.claude/commands-vault/deploy.md
@@ -1,121 +1,121 @@
 Deployment checklist. Verifies all pre-deployment requirements and produces a readiness report.
 
 ## Badi CLI Pre-Deploy Checklist (v1.6+)
-Dagitim oncesi su kontrolleri MUTLAKA calistir:
-- `badi secret-scan` — Sir sizintisi olmamali (KRITIK — exit 1 ise deploy engelle)
-- `badi commit --check` — Son commit conventional format (changelog uretimi icin)
-- `badi changelog` — Son tag'den beri degisiklikler gozden gecirilmeli
-- `badi ssl [production-domain]` — SSL expire < 30 gun ise uyari
-- `badi dns [domain]` — DNS saglik (email guvenlik)
-- `badi lighthouse [url]` — Performance baseline (regression tespit icin)
+ALWAYS run these checks before deploying:
+- `badi secret-scan` — No secret leakage allowed (CRITICAL — block the deploy on exit 1)
+- `badi commit --check` — Last commit in conventional format (for changelog generation)
+- `badi changelog` — Review the changes since the last tag
+- `badi ssl [production-domain]` — Warn if SSL expires in < 30 days
+- `badi dns [domain]` — DNS health (email security)
+- `badi lighthouse [url]` — Performance baseline (for regression detection)
 
-# Gerekli Araclar
-- Bash (git komutlari, test calistirma, ortam degiskeni kontrolu)
-- Read (konfigur asyon dosyalari, changelog)
-- Grep (kod ve konfigur asyon taramasi)
+# Required Tools
+- Bash (git commands, running tests, env variable checks)
+- Read (configuration files, changelog)
+- Grep (code and configuration scan)
 - ...
 
-# Onemli Not
-Bu komut dagitimi kendisi YAPMAZ. Dagitima hazir olunup olunmadigini degerlendirir
-ve nihai karari kullaniciya birakir.
+# Important Note
+This command does NOT deploy by itself. It evaluates deployment readiness
+and leaves the final decision to the user.
 
 ---
 
-## Bolum 1: On Dagitim Dogrulama
+## Section 1: Pre-Deployment Validation
 
-### Adim 1: Test Suite Kontrolu
-- Tum test suite'ini calistir (veya son CI sonucunu kontrol et)
-- Basarisiz test var mi belirle
-- Test kapsam oranini raporla
+### Step 1: Test Suite Check
+- Run the full test suite (or check the latest CI result)
+- Determine whether any tests fail
+- Report the coverage ratio
 - ...
 
-### Adim 2: Kritik Denetim Bulgusu Kontrolu
-- `audit-trail.md` dosyasini oku (mevcutsa)
-- Son dagitimdan bu yana T0 (kritik) bulgu var mi kontrol et
-- Cozulmemis guvenlik uyarilari var mi tara
+### Step 2: Critical Audit Finding Check
+- Read `audit-trail.md` (if present)
+- Check for T0 (critical) findings since the last deploy
+- Scan for unresolved security warnings
 - ...
 
-### Adim 3: Changelog Dogrulamas i
-- `CHANGELOG.md` dosyasinin guncellenip guncellenmedigini kontrol et
-- Son commit'ten bu yana changelog giris i eklenmi s mi dogrula
-- Eksikse `/changelog` komutunun calistirilmasini oner
+### Step 3: Changelog Validation
+- Check whether `CHANGELOG.md` has been updated
+- Verify a changelog entry exists since the last commit
+- If missing, suggest running the `/changelog` command
 - ...
 
 ---
 
-## Bolum 2: Ortam Degiskeni Dogrulamas i
+## Section 2: Environment Variable Validation
 
-### Adim 4: Env Dosyalari Karsilastirmasi
-- `.env.example` veya `.env.template` dosyasini oku
-- Tanimlanmasi gereken degiskenleri listele
-- Produksiyon ortaminda eksik olabilecek degiskenleri tespit et
+### Step 4: Env File Comparison
+- Read `.env.example` or `.env.template`
+- List the variables that must be defined
+- Detect variables possibly missing in production
 
-### Adim 5: Hassas Deger Kontrolu
+### Step 5: Sensitive Value Check
 
-**Badi Secret Scanner Calistir:**
+**Run the Badi Secret Scanner:**
 ```bash
-badi secret-scan --git    # Working tree + son 100 commit
+badi secret-scan --git    # Working tree + last 100 commits
 ```
 
-Exit code 1 ise (kritik/yuksek sir bulundu) deploy **ENGELLENMELI**.
-- Kod icinde sabit kodlu ortam degeri olup olmadigini tara
-- `TODO` veya `FIXME` iceren ortam referanslarini bul
-- Debug modunun kapali oldugunu dogrula (NODE_ENV, DEBUG, vb.)
+If the exit code is 1 (critical/high secret found), the deploy **MUST BE BLOCKED**.
+- Scan for hardcoded environment values in the code
+- Find environment references containing `TODO` or `FIXME`
+- Verify debug mode is off (NODE_ENV, DEBUG, etc.)
 - ...
 
 ---
 
-## Bolum 3: Veritabani Goc Durumu
+## Section 3: Database Migration State
 
-### Adim 6: Migrasyon Kontrolu
-- Bekleyen migrasyon dosyalarini tespit et
-- Migrasyon sirasinin tutarli oldugunu dogrula
-- Geri alinabilir migrasyonlarin rollback dosyalarinin varligini kontrol et
+### Step 6: Migration Check
+- Detect pending migration files
+- Verify the migration order is consistent
+- Check rollback files exist for reversible migrations
 - ...
 
-### Adim 7: Sema Uyumlulugu
-- Kirilma potansiyeli olan sema degisikliklerini tespit et (sutun silme, tip degisikligi)
-- Geriye uyumluluk risklerini belirt
-- Sonuc: UYUMLU / RISKLI / UYGULANACAK_YOK
+### Step 7: Schema Compatibility
+- Detect schema changes with breaking potential (column drops, type changes)
+- Note backward-compatibility risks
+- Result: COMPATIBLE / RISKY / NOTHING_TO_APPLY
 
 ---
 
-## Bolum 4: Dagitim Manifesti
+## Section 4: Deployment Manifest
 
-### Adim 8: Degisiklik Ozeti Olustur
-Son dagitimdan (son etiket veya belirtilen commit) bu yana:
-- Degisen dosya sayisi: `git diff --stat [son-etiket]..HEAD`
-- Yeni eklenen dosyalar
-- Silinen dosyalar
+### Step 8: Build the Change Summary
+Since the last deploy (last tag or a given commit):
+- Changed file count: `git diff --stat [last-tag]..HEAD`
+- Newly added files
+- Deleted files
 - ...
 
-### Adim 9: Manifest Dosyasi Yaz
-`deploy-manifest-[tarih].md` dosyasi olustur:
+### Step 9: Write the Manifest File
+Create `deploy-manifest-[date].md`:
 ```
-[kisaltildi]
+[abridged]
 ```
 
 ---
 
-## Bolum 5: Dagitim Sonrasi Smoke Test Plani
+## Section 5: Post-Deployment Smoke Test Plan
 
-### Adim 10: Test Plani Olustur
-Degisikliklere gore smoke test kontrol listesi hazirla:
-- Kritik kullanici yollari (login, ana islevler)
-- Degisen API endpoint'leri
-- Veritabani baglantisi dogrulama
+### Step 10: Build the Test Plan
+Prepare a smoke-test checklist based on the changes:
+- Critical user paths (login, core functions)
+- Changed API endpoints
+- Database connectivity verification
 - ...
 
 ---
 
-## Cikti: Dagitim Hazirlik Raporu
+## Output: Deployment Readiness Report
 
-### Adim 11: Nihai Degerlendirme
+### Step 11: Final Assessment
 ```
-[kisaltildi]
+[abridged]
 ```
 
-### GIT/GITME Kriter Tablosu
-- GIT: Tum kontroller GECTI/TEMIZ/GUNCEL/GUVENLI/UYUMLU
-- GITME: Herhangi bir kontrol BASARISIZ/ENGEL_VAR/RISKLI
-- Istisnai GIT: Sadece EKSIK changelog veya UYARI ortam degiskeni varsa, kullanici onayiyla GIT verilebilir
+### GO/NO-GO Criteria Table
+- GO: All checks PASSED/CLEAN/CURRENT/SECURE/COMPATIBLE
+- NO-GO: Any check FAILED/BLOCKED/RISKY
+- Exceptional GO: Only with a MISSING changelog or a WARNING env variable, GO may be given with user approval

--- a/.claude/commands-vault/hotfix.md
+++ b/.claude/commands-vault/hotfix.md
@@ -1,127 +1,127 @@
 Emergency fix workflow. Manages a fast, safe patching process for production errors.
 
-# Gerekli Araclar
-- Bash (git islemleri, test calistirma)
-- Read (hata gunlukleri, stack trace analizi)
-- Write (duzeltme dosyalari)
-- Grep (hata kaynak tespiti)
-- Glob (ilgili dosya taramasi)
-- Agent (auditor: hizli T1 denetim)
+# Required Tools
+- Bash (git operations, running tests)
+- Read (error logs, stack trace analysis)
+- Write (fix files)
+- Grep (error source detection)
+- Glob (related file scan)
+- Agent (auditor: fast T1 audit)
 
-# Kapsam Korumasi
-ONEMLI: Bu is akisi sadece acil duzeltme icindir. Kapsam kaymasi kesinlikle reddedilir.
-Eger duzeltme sirasinda baska bir iyilestirme firsati gorulurse, not olarak kaydet ama UYGULAMADAN devam et.
-
----
-
-## Adim 1: Hotfix Dali Olustur
-
-### 1a: Mevcut Durumu Kontrol Et
-- `git status` ile temiz calisma dizini dogrula
-- Kaydedilmemis degisiklikler varsa stash'le
-
-### 1b: Dal Olustur
-- Ana dali tespit et: `main` veya `master`
-- `git checkout -b hotfix/[kisa-aciklama] [ana-dal]` komutuyla dal olustur
-- Dal adlandirmasi: `hotfix/fix-login-crash`, `hotfix/patch-api-timeout` gibi aciklayici isimler kullan
+# Scope Protection
+IMPORTANT: This workflow is for emergency fixes only. Scope creep is strictly rejected.
+If another improvement opportunity appears during the fix, record it as a note but continue WITHOUT applying it.
 
 ---
 
-## Adim 2: Hatayi Izole Et
+## Step 1: Create the Hotfix Branch
 
-### 2a: Hata Bilgilerini Topla
-- Kullanicidan hata gunlugunu veya stack trace'i iste
-- Varsa hata raporunu oku
-- Hatanin tekrarlanma kosullarini belirle
+### 1a: Check the Current State
+- Verify a clean working directory with `git status`
+- Stash uncommitted changes if any
 
-### 2b: Kaynak Tespiti
-- Stack trace'deki dosya ve satir numaralarini takip et
-- Grep ile hata mesajini kod tabaninda ara
-- Hatanin ilk kez ne zaman ortaya ciktigini git log ile kontrol et
-- `git bisect` onerisinde bulun (gerekirse)
-
-### 2c: Etki Analizi
-- Hatadan etkilenen modulleri belirle
-- Iliskili testlerin mevcut durumunu kontrol et
+### 1b: Create the Branch
+- Detect the main branch: `main` or `master`
+- Create it with `git checkout -b hotfix/[short-description] [main-branch]`
+- Branch naming: descriptive names like `hotfix/fix-login-crash`, `hotfix/patch-api-timeout`
 
 ---
 
-## Adim 3: Minimal Duzeltme Uygula
+## Step 2: Isolate the Bug
 
-### 3a: Kapsam Kontrolu
-- Duzeltme sadece hatanin kök nedenini hedeflemeli
-- Refactoring YAPMA
-- Yeni ozellik EKLEME
-- Iliskisiz kod DEGISTIRME
-- Her degisiklik icin sor: "Bu degisiklik hatanin cozumu icin zorunlu mu?"
+### 2a: Gather the Error Info
+- Ask the user for the error log or stack trace
+- Read the bug report if one exists
+- Determine the reproduction conditions
 
-### 3b: Duzeltmeyi Yaz
-- Mumkun olan en kucuk degisikligi yap
-- Degisikligin neden yapildigini yorum olarak ekle
-- Yan etkileri minimize et
+### 2b: Source Detection
+- Follow the files and line numbers in the stack trace
+- Grep the error message across the codebase
+- Check when the bug first appeared via git log
+- Suggest `git bisect` (if needed)
 
----
-
-## Adim 4: Hedefli Testleri Calistir
-
-### 4a: Mevcut Testleri Calistir
-- Hatanin iliskili oldugu modülun testlerini calistir
-- Regresyon testi olarak tum ilgili test suite'ini calistir
-- Test sonuclarini raporla
-
-### 4b: Duzeltme Dogrulama Testi
-- Hatanin artik olusmadigini dogrulayan bir test yazilmasini oner
-- Eger mevcut test hatanin kapsaminda degilse, yeni test ekle
+### 2c: Impact Analysis
+- Identify the modules affected by the bug
+- Check the current state of the related tests
 
 ---
 
-## Adim 5: Geri Alma Plani Olustur
+## Step 3: Apply the Minimal Fix
 
-### 5a: Revert Komutu Hazirla
-- `git revert` komutunu onceden hazirla ve kullaniciya sun:
+### 3a: Scope Check
+- The fix must target only the bug's root cause
+- NO refactoring
+- NO new features
+- NO touching unrelated code
+- For every change ask: "Is this change essential to fixing the bug?"
+
+### 3b: Write the Fix
+- Make the smallest possible change
+- Add a comment explaining why the change was made
+- Minimize side effects
+
+---
+
+## Step 4: Run the Targeted Tests
+
+### 4a: Run the Existing Tests
+- Run the tests of the module the bug relates to
+- Run the whole related test suite as a regression check
+- Report the test results
+
+### 4b: Fix Verification Test
+- Suggest writing a test that proves the bug no longer occurs
+- If existing tests do not cover the bug, add a new test
+
+---
+
+## Step 5: Build the Rollback Plan
+
+### 5a: Prepare the Revert Command
+- Prepare the `git revert` command in advance and present it:
 ```
-# Geri alma komutu (gerekirse hemen calistirilabilir):
+# Rollback command (runnable immediately if needed):
 git revert [commit-hash] --no-edit
 ```
 
-### 5b: Geri Alma Senaryosu
-- Hangi kosullarda geri alma yapilmasi gerektigini belirt
-- Geri almanin yan etkilerini acikla
-- Alternatif geri alma stratejilerini listele
+### 5b: Rollback Scenario
+- State the conditions under which a rollback should happen
+- Explain the side effects of rolling back
+- List alternative rollback strategies
 
 ---
 
-## Adim 6: PR Olustur
+## Step 6: Create the PR
 
-### 6a: Degisiklikleri Kaydet
-- `git add` ile sadece duzeltme dosyalarini ekle
-- Commit mesaji formati: `[HOTFIX] [kisa aciklama]`
-- Ornek: `[HOTFIX] Fix null pointer in user auth flow`
+### 6a: Commit the Changes
+- `git add` only the fix files
+- Commit message format: `[HOTFIX] [short description]`
+- Example: `[HOTFIX] Fix null pointer in user auth flow`
 
-### 6b: Auditor Denetimi
-- Agent(auditor) ile hizli T1 denetim baslat
-- Duzeltmenin kapsam disina cikmis olmadigini dogrula
-- Guvenlik etkisi degerlendirmesi yap
+### 6b: Auditor Review
+- Start a fast T1 audit via Agent(auditor)
+- Verify the fix has not drifted out of scope
+- Run a security-impact assessment
 
-### 6c: Pull Request Olustur
-- PR basligina `[HOTFIX]` on eki ekle
-- PR aciklamasina su bilgileri ekle:
-  - Hatanin aciklamasi
-  - Kok neden analizi
-  - Yapilan duzeltme
-  - Test sonuclari
-  - Geri alma plani
+### 6c: Create the Pull Request
+- Prefix the PR title with `[HOTFIX]`
+- Include in the PR description:
+  - The bug description
+  - Root cause analysis
+  - The applied fix
+  - Test results
+  - The rollback plan
 
-# Cikti Formati
+# Output Format
 ```
-=== HOTFIX OZET ===
-Dal: hotfix/[isim]
-Hata: [kisa aciklama]
-Kok Neden: [neden]
-Duzeltme: [ne yapildi]
-Degisiklik: [dosya sayisi] dosya, [satir sayisi] satir
-Testler: [GECTI/BASARISIZ]
-Geri Alma: git revert [hash]
+=== HOTFIX SUMMARY ===
+Branch: hotfix/[name]
+Bug: [short description]
+Root Cause: [cause]
+Fix: [what was done]
+Change: [file count] files, [line count] lines
+Tests: [PASSED/FAILED]
+Rollback: git revert [hash]
 PR: [PR URL]
 ===================
 ```

--- a/.claude/commands-vault/mobile.md
+++ b/.claude/commands-vault/mobile.md
@@ -1,60 +1,60 @@
 Mobile project management command. React Native/Flutter/Expo/Swift/Kotlin scaffolding, version sync, build and release guides.
 
-# Gerekli Araclar
-- Bash (badi mobile komutlari)
+# Required Tools
+- Bash (badi mobile commands)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Ne Yapmak Istiyor?
+### Step 1: What Do They Want?
 
-Kullaniciya sor:
-- **Yeni proje** — `init` ile iskelet
+Ask the user:
+- **New project** — scaffold with `init`
 - **Version bump** — iOS/Android/Flutter sync
 - **Build** — Release APK/IPA
-- **Release** — TestFlight/Play Store rehberi
-- **Asset uretimi** — Icon/Splash/Screenshots
+- **Release** — TestFlight/Play Store guide
+- **Asset production** — Icon/Splash/Screenshots
 
-### Adim 2: Yeni Proje (init)
+### Step 2: New Project (init)
 
 ```bash
 badi mobile init MyApp --framework [rn|flutter|expo|swift|kotlin]
 ```
 
-Framework'e gore:
+Per framework:
 - **react-native**: npx react-native init
 - **flutter**: flutter create
 - **expo**: create-expo-app
-- **swift**: Xcode manuel rehber
-- **kotlin**: Android Studio manuel rehber
+- **swift**: Xcode manual guide
+- **kotlin**: Android Studio manual guide
 
-Sonrasi:
+Afterwards:
 ```bash
 cd MyApp
-npx @fatihkan/badi init      # Badi konfigurasyonu
+npx @fatihkan/badi init      # Badi configuration
 ```
 
-### Adim 3: Version Bump
+### Step 3: Version Bump
 
 ```bash
 badi mobile version bump [major|minor|patch]
 ```
 
-Sync ettigi dosyalar (otomatik tespit):
+Files it syncs (auto-detected):
 - `package.json` (RN, Expo)
 - `ios/**/Info.plist` (iOS)
 - `android/app/build.gradle` (Android)
 - `pubspec.yaml` (Flutter)
 
-### Adim 4: Build
+### Step 4: Build
 
 ```bash
 badi mobile build ios        # iOS release (Xcode/xcodebuild)
 badi mobile build android    # Android AAB (Gradle)
 ```
 
-Proje turu otomatik tespit edilir (RN vs Flutter).
+The project type is auto-detected (RN vs Flutter).
 
-### Adim 5: Release Pipeline
+### Step 5: Release Pipeline
 
 ```bash
 badi mobile release testflight      # iOS beta
@@ -63,47 +63,47 @@ badi mobile release appstore        # iOS production
 badi mobile release play            # Android production
 ```
 
-Her hedef icin adim adim rehber gosterir. Otomatik deploy icin:
+Shows a step-by-step guide per target. For automated deploys:
 - fastlane (iOS + Android)
 - eas submit (Expo)
 
-### Adim 6: Asset Uretimi
+### Step 6: Asset Production
 
 ```bash
-badi mobile assets icon [source.png]      # 40+ boyut rehberi (iOS + Android)
-badi mobile assets splash                 # Splash screen boyutlari
-badi mobile assets screenshots            # App Store + Play screenshot boyutlari
+badi mobile assets icon [source.png]      # 40+ size guide (iOS + Android)
+badi mobile assets splash                 # Splash screen sizes
+badi mobile assets screenshots            # App Store + Play screenshot sizes
 ```
 
-ImageMagick kurulu ise otomatik uretim komutlari verir.
+If ImageMagick is installed, it provides automatic generation commands.
 
-### Adim 7: Release Notes
+### Step 7: Release Notes
 
 ```bash
-badi content release-notes --platform ios --version X.Y.Z --lang tr,en
+badi content release-notes --platform ios --version X.Y.Z
 badi content release-notes --platform android --version X.Y.Z
 ```
 
-### Adim 8: ASO Entegrasyonu
+### Step 8: ASO Integration
 
-Launch oncesi:
-- `/aso` — App Store listing optimizasyonu
-- `/aso-strategy` — Marketing plan
-- `/content-generate` — Lansman postlari
+Before launch:
+- `/aso` — App Store listing optimization
+- `aso-master` agent — Marketing plan / full strategy
+- `/content-generate` — Launch posts
 
-# Checklist: Yeni Surum Cikarma
+# Checklist: Shipping a New Version
 
 1. `badi mobile version bump minor`
 2. `badi mobile build ios && badi mobile build android`
-3. `badi content release-notes --platform ios --version X.Y.Z --lang tr,en`
-4. `badi secret-scan --git` (guvenlik)
-5. `badi mobile release testflight` (ios staging)
-6. `badi mobile release play-internal` (android staging)
+3. `badi content release-notes --platform ios --version X.Y.Z`
+4. `badi secret-scan --git` (security)
+5. `badi mobile release testflight` (iOS staging)
+6. `badi mobile release play-internal` (Android staging)
 7. Test + QA
 8. `badi mobile release appstore && badi mobile release play` (production)
-9. `badi aso audit [app-id]` (listing kontrol)
+9. `badi aso audit [app-id]` (listing check)
 
-# Ornek
+# Example
 ```
 /mobile init MyApp --framework react-native
 /mobile version bump minor

--- a/.claude/commands-vault/perf-check.md
+++ b/.claude/commands-vault/perf-check.md
@@ -1,112 +1,112 @@
 Performance profiling. Detects hot paths, bottlenecks, and optimization opportunities.
 
-## Badi CLI Komutlari (v1.6+)
-Production URL varsa:
+## Badi CLI Commands (v1.6+)
+If a production URL exists:
 - `badi lighthouse [url]` — Core Web Vitals (FCP, LCP, TBT, CLS, Speed Index)
-- `badi lighthouse [url] --desktop` — Desktop ayri olcum
-- `badi seo speed [url]` — Sayfa hizi + kaynak analizi (v1.4+)
+- `badi lighthouse [url] --desktop` — Separate desktop measurement
+- `badi seo speed [url]` — Page speed + resource analysis (v1.4+)
 
-Bu CLI araclari gercek-dunya metrikler verir (PageSpeed Insights). Kod bazli analizler (asagidaki adimlar) bunu tamamlar.
+These CLI tools give real-world metrics (PageSpeed Insights). The code-based analyses (steps below) complement them.
 
-# Gerekli Araclar
-- Bash (build komutlari, dosya boyut hesaplama)
-- Read (kaynak kod analizi)
-- Grep (kalip arama)
+# Required Tools
+- Bash (build commands, file size calculation)
+- Read (source code analysis)
+- Grep (pattern search)
 - ...
 
-# Ajan Delegasyonu
-Bu komut ana analiz isini performance-profiler ajanina devreder.
-Ajan bulunamazsa, asagidaki adimlari dogrudan uygula.
+# Agent Delegation
+This command delegates the main analysis to the performance-profiler agent.
+If the agent is unavailable, apply the steps below directly.
 
 ---
 
-## Bolum 1: Sicak Yol Tespiti
+## Section 1: Hot Path Detection
 
-### Adim 1: Sik Degistirilen Dosyalar
-- `git log --format=format: --name-only` ile son 50 commit'te en cok degisen dosyalari bul
-- En sik degisen 10 dosyayi listele
-- Bu dosyalarin karmasiklik ve boyut bilgisini ekle
+### Step 1: Frequently Changed Files
+- Find the most-changed files in the last 50 commits with `git log --format=format: --name-only`
+- List the 10 most frequently changed files
+- Add their complexity and size info
 - ...
 
-### Adim 2: Karmasik Fonksiyon Tespiti
-- Uzun fonksiyonlari tespit et (50+ satir)
-- Derin ic ice gecmis yapilari bul (4+ seviye girinti)
-- Coklu dongu iceren fonksiyonlari isaretl
+### Step 2: Complex Function Detection
+- Detect long functions (50+ lines)
+- Find deeply nested structures (4+ indent levels)
+- Flag functions with multiple loops
 - ...
 
-### Adim 3: Import/Bagimlilik Analizi
-- Cok fazla import iceren dosyalari tespit et
-- Dairesel bagimliliklari ara
-- Kullanilmayan import'lari bul
+### Step 3: Import/Dependency Analysis
+- Detect files with too many imports
+- Look for circular dependencies
+- Find unused imports
 
 ---
 
-## Bolum 2: Veritabani Sorgu Analizi
+## Section 2: Database Query Analysis
 
-### Adim 4: N+1 Sorgu Kalip Tespiti
-Asagidaki kaliplari kodda ara:
-- Dongu icindeki veritabani cagrilari
-- ORM iliskilerinde eager loading eksikligi
-- `forEach`/`map` icindeki `await` veritabani islemleri
+### Step 4: N+1 Query Pattern Detection
+Search the code for these patterns:
+- Database calls inside loops
+- Missing eager loading on ORM relations
+- `await`ed database operations inside `forEach`/`map`
 - ...
 
-### Adim 5: Sorgu Optimizasyon Onerileri
-- Index kullanimi onerileri
-- Toplu islem (batch) donusum firsatlari
-- Gereksiz sorgu tekrarlari
-- ...
-
----
-
-## Bolum 3: Paket ve Build Boyutlari
-
-### Adim 6: Build Boyut Analizi
-- `package.json` bagimlilik sayisini raporla
-- Varsa build ciktisinin boyutunu olc
-- `node_modules` toplam boyutunu kontrol et
-- ...
-
-### Adim 7: Bagimlilik Agirlik Analizi
-- En buyuk bagimliliklari boyutlarina gore sirala
-- Alternatifi olan agir kutuphaneleri tespit et
-  Ornek: moment.js -> date-fns, lodash -> lodash-es veya natif yontemler
-- Dev dependency'lerin production build'e sizmasini kontrol et
-- Duplicate paketleri tespit et
-
-### Adim 8: Asset Boyutlari
-- Resim dosyalarinin boyutlarini kontrol et
-- Sıkistırılmamis assetleri tespit et
-- Font dosya boyutlarini degerlendir
+### Step 5: Query Optimization Suggestions
+- Index usage suggestions
+- Batch-conversion opportunities
+- Needless query repetition
 - ...
 
 ---
 
-## Bolum 4: Onbellek Strateji Incelemesi
+## Section 3: Bundle and Build Sizes
 
-### Adim 9: Mevcut Onbellek Uygulamasi
-- Redis/Memcached kullanimi var mi kontrol et
-- HTTP onbellek basliklarini incele (Cache-Control, ETag)
-- CDN konfigurasyonunu degerlendir (mevcutsa)
+### Step 6: Build Size Analysis
+- Report the `package.json` dependency count
+- Measure the build output size if present
+- Check the total `node_modules` size
 - ...
 
-### Adim 10: Onbellek Optimizasyon Onerileri
-- Onbelleklenebilecek ama onbelleklenmeyen verileri tespit et
-- Onbellek gecersiz kilma (invalidation) stratejisini degerlendir
-- Yazma-okuma oranina gore onbellek katmani oner
+### Step 7: Dependency Weight Analysis
+- Rank the largest dependencies by size
+- Detect heavy libraries with lighter alternatives
+  Example: moment.js -> date-fns, lodash -> lodash-es or native methods
+- Check dev dependencies leaking into the production build
+- Detect duplicate packages
+
+### Step 8: Asset Sizes
+- Check image file sizes
+- Detect uncompressed assets
+- Evaluate font file sizes
 - ...
 
 ---
 
-## Bolum 5: Performans Raporu
+## Section 4: Caching Strategy Review
 
-### Adim 11: Bulgu Ozeti Olustur
+### Step 9: Current Cache Implementation
+- Check for Redis/Memcached usage
+- Review HTTP cache headers (Cache-Control, ETag)
+- Evaluate the CDN configuration (if present)
+- ...
+
+### Step 10: Cache Optimization Suggestions
+- Detect cacheable-but-uncached data
+- Evaluate the cache invalidation strategy
+- Suggest a cache layer based on the read/write ratio
+- ...
+
+---
+
+## Section 5: Performance Report
+
+### Step 11: Build the Findings Summary
 ```
-[kisaltildi]
+[abridged]
 ```
 
-### Adim 12: Etki Tahmini
-Her oneri icin:
-- Tahmini iyilesme yuzdesi veya suresi
-- Uygulama zorlugu: KOLAY / ORTA / ZOR
-- Oncelik: Etki/Efor oranina gore siralama
+### Step 12: Impact Estimate
+For each suggestion:
+- Estimated improvement percentage or time
+- Implementation difficulty: EASY / MEDIUM / HARD
+- Priority: ranked by impact/effort ratio
 - ...

--- a/.claude/commands-vault/playbook.md
+++ b/.claude/commands-vault/playbook.md
@@ -1,88 +1,88 @@
 Workflow-to-command command. Converts repetitive manual workflows into reusable Badi commands.
 
-# Gerekli Araclar
-- Read (mevcut komutlar) -- Write (yeni komut) -- Glob (mevcut komut listesi) -- Grep (kalip/referans)
+# Required Tools
+- Read (existing commands) -- Write (new command) -- Glob (existing command list) -- Grep (pattern/reference)
 
-# Prosedur (7 Adim)
+# Procedure (7 Steps)
 
-## 1. Isimlendir
-- Arguman verilmisse onu kullan -- verilmemisse aciklamadan turet
-- Kurallar: kebab-case (`hata-takip`, `sprint-plan`) -- kisa-akilda kalici (1-3 kelime) -- eylem yansitan (fiil/fiil-nesne) -- mevcutla cakismayan
+## 1. Name It
+- Use the argument if given -- otherwise derive it from the description
+- Rules: kebab-case (`bug-triage`, `sprint-plan`) -- short and memorable (1-3 words) -- action-reflecting (verb/verb-object) -- no collision with existing names
 
-Cakisma kontrolu: `.claude/commands/` tara -- ayni/benzer var mi -- alternatif oner.
+Collision check: scan `.claude/commands/` -- same/similar exists? -- suggest alternatives.
 
-## 2. Is Akisini Yakala
-Her adim icin: ne yapiliyor (eylem) -- nerede (dosya/dizin/sistem) -- neden (amac/baglam) -- girdiler -- ciktilar -- basari kriteri -- hata durumu
+## 2. Capture the Workflow
+For every step: what is done (action) -- where (file/directory/system) -- why (purpose/context) -- inputs -- outputs -- success criterion -- failure case
 
-Kronolojik sira + numaralandir.
+Chronological order + numbering.
 
-## 3. Kaliplari Tespit Et
-- **Paralellik:** bagimsiz adimlar -- paralel alt gorevler
-- **Kullanici giris:** insan karari -- onay bekleme -- veri alinacak noktalar
-- **Kosullu dallanma:** "Eger X ise Y, degilse Z" -- opsiyonel adim -- hata yonlendirme
-- **Arac gereksinimi:** Claude araclar (Read, Write, Bash, Grep, ...) -- dis arac (git, npm, docker, ...)
-- **Mevcut skill eslesmesi:** parcalari mevcut komutla ortusuyor mu -- alt adim olarak cagrilabilir mi
+## 3. Detect the Patterns
+- **Parallelism:** independent steps -- parallel subtasks
+- **User input:** human decisions -- approval waits -- data-collection points
+- **Conditional branching:** "If X then Y, else Z" -- optional steps -- error routing
+- **Tool needs:** Claude tools (Read, Write, Bash, Grep, ...) -- external tools (git, npm, docker, ...)
+- **Existing skill matches:** do parts overlap with an existing command -- can it be invoked as a substep
 
-## 4. Arguman Belirle
-Her calistirmada degisen girdileri tanimla:
-- Hangi degerler degisecek -- varsayilanlar -- zorunlu/opsiyonel ayrim -- `argument-hint` aciklamasi
+## 4. Define the Arguments
+Identify the inputs that change per run:
+- Which values vary -- defaults -- required/optional split -- the `argument-hint` description
 
 ```
-Arguman: [proje-adi]  Varsayilan: mevcut dizin  Aciklama: "Playbook olusturulacak projenin adi"
+Argument: [project-name]  Default: current directory  Description: "Name of the project the playbook targets"
 ```
 
-## 5. Komut Dosyasi
-`.claude/commands/[isim].md` standart formatta olustur:
+## 5. The Command File
+Create `.claude/commands/[name].md` in the standard format:
 
 ```markdown
-[Tek satirlik aciklama]
+[One-line description]
 
-# Gerekli Araclar
-- [Arac 1] ([ne icin])
-- [Arac 2] ([ne icin])
+# Required Tools
+- [Tool 1] ([for what])
+- [Tool 2] ([for what])
 
-# Prosedur ([adim sayisi] Adim)
+# Procedure ([step count] Steps)
 
-### Adim 1: [Ad]
-[talimat]
+### Step 1: [Name]
+[instruction]
 
-### Adim 2: [Ad]
-[talimat]
+### Step 2: [Name]
+[instruction]
 
-# Cikti Formati
+# Output Format
 ```
-[sablon]
+[template]
 ```
 ```
 
-Kurallar: Turkce yaz, acik-net -- her adim kendi basina anlasilir -- arac kullanimi acik -- hata durumlari -- net cikti formati.
+Rules: write in English, clear and direct -- every step understandable on its own -- tool usage explicit -- failure cases covered -- a crisp output format.
 
-## 6. Dogrula ve Iyilestir
-Kullaniciya sun: is akisini dogru yansitiyor mu -- eksik/yanlis adim -- ek kosul/ozel durum -- duzenlemeleri uygula -- nihai onay.
+## 6. Validate and Refine
+Present to the user: does it reflect the workflow correctly -- missing/wrong steps -- extra conditions/special cases -- apply the edits -- final approval.
 
-Teknik: referans araclar gecerli -- dosya yollari -- markdown -- cikti formati tutarli.
+Technical: referenced tools valid -- file paths -- markdown -- output format consistent.
 
-## 7. Indekse Ekle
-`command-index.md` (varsa): yeni komutu uygun kategoriye -- aciklama satiri -- iliskili komutlara capraz referans
+## 7. Add to the Index
+`command-index.md` (if present): the new command in the right category -- a description line -- cross-references to related commands
 
-`| /[isim] | [kisa aciklama] | [kategori] |`
+`| /[name] | [short description] | [category] |`
 
-# Cikti Formati
+# Output Format
 ```
 === BADI PLAYBOOK ===
-Komut: /[isim]
-Dosya: .claude/commands/[isim].md
-Adim Sayisi: [sayi]
-Arac Sayisi: [sayi]
-Arguman: [aciklama veya "yok"]
+Command: /[name]
+File: .claude/commands/[name].md
+Step Count: [count]
+Tool Count: [count]
+Argument: [description or "none"]
 
-Durum: OLUSTURULDU
-Indeks: GUNCELLENDI / INDEKS YOK
+Status: CREATED
+Index: UPDATED / NO INDEX
 
-> "[isim]" komutu `/[isim]` olarak kaydedildi.
-> Bu is akisini tekrarlamak icin istediginiz zaman calistirin.
+> The "[name]" command was registered as `/[name]`.
+> Run it any time to repeat this workflow.
 ======================
 ```
 
-# Ipuclari
-- Basit is akislarini gereksiz karmasiklastirma -- 3-7 adim ideal (10'u gecme) -- her komut tek amac (tek sorumluluk) -- karmasik akislari boyle -- mevcut komutlari alt adim referans et
+# Tips
+- Do not over-complicate simple workflows -- 3-7 steps ideal (never past 10) -- one purpose per command (single responsibility) -- split complex flows -- reference existing commands as substeps

--- a/.claude/commands-vault/release.md
+++ b/.claude/commands-vault/release.md
@@ -1,112 +1,112 @@
 Release notes command. Compiles changes into formats for 3 different audiences.
 
 ## Badi CLI Workflow (v1.6+)
-Release oncesi sira:
+Pre-release order:
 ```bash
-badi secret-scan --git                   # Kritik sir yokmu dogrula
-badi changelog --write --version X.Y.Z   # CHANGELOG.md guncelle
-badi commit --check                      # Son commit conventional mi
+badi secret-scan --git                   # Verify no critical secrets
+badi changelog --write --version X.Y.Z   # Update CHANGELOG.md
+badi commit --check                      # Is the last commit conventional
 git tag vX.Y.Z && git push origin vX.Y.Z
 gh release create vX.Y.Z --notes-file release-notes.md
 ```
 
-Bu komut 3 hedef kitleye (teknik/pazarlama/yonetici) ozel surum notu derler.
+This command compiles release notes tailored to 3 audiences (technical/marketing/executive).
 
-# Gerekli Araclar
+# Required Tools
 - Bash (git log, git tag, diff)
-- Read (commit mesajlari, PR aciklamalari)
-- Grep (degisiklik taramasi)
-- Write (surum notu dosyalari)
+- Read (commit messages, PR descriptions)
+- Grep (change scan)
+- Write (release note files)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Aralik Belirle
-- Son release tag'ini bul: `git describe --tags --abbrev=0`
-- Mevcut HEAD ile arasindaki farki hesapla
-- Commit araligini belirle: `git log [son-tag]..HEAD`
-- Etkilenen dosya ve modulleri listele
+### Step 1: Define the Range
+- Find the latest release tag: `git describe --tags --abbrev=0`
+- Compute the diff against the current HEAD
+- Define the commit range: `git log [last-tag]..HEAD`
+- List the affected files and modules
 
-### Adim 2: Veri Topla
-Her commit icin bilgi derle:
-- Commit mesaji ve aciklamasi
-- Iliskili PR numaralari
-- Degisen dosyalar ve satirlar
-- Yazar bilgisi
-- Iliskili issue veya gorev numaralari
+### Step 2: Gather Data
+Compile per commit:
+- Commit message and description
+- Related PR numbers
+- Changed files and lines
+- Author info
+- Related issue or task numbers
 
-### Adim 3: Degisiklikleri Siniflandir
-Conventional Commits veya proje kuralina gore kategorilere ayir:
+### Step 3: Classify the Changes
+Categorize by Conventional Commits or the project's convention:
 
-**Yeni Ozellikler (feat):**
-- Yeni eklenen islevler
-- Yeni API endpointleri
-- Yeni kullanici arayuzu bilesenleri
+**New Features (feat):**
+- Newly added functionality
+- New API endpoints
+- New UI components
 
-**Hata Duzeltmleri (fix):**
-- Cozulen hatalar
-- Performans duzeltmleri
-- Guvenlik yamalari
+**Bug Fixes (fix):**
+- Resolved bugs
+- Performance fixes
+- Security patches
 
-**Kirilma Degisiklikleri (BREAKING):**
-- API degisiklikleri
-- Veritabani sema degisiklikleri
-- Konfigur asyon degisiklikleri
-- Kaldirilmis ozellikler
+**Breaking Changes (BREAKING):**
+- API changes
+- Database schema changes
+- Configuration changes
+- Removed features
 
-**Iyilestirmeler (improve):**
-- Performans iyilestirmeleri
-- UX iyilestirmeleri
-- Kod kalitesi iyilestirmeleri
+**Improvements (improve):**
+- Performance improvements
+- UX improvements
+- Code quality improvements
 
-**Altyapi (infra):**
-- CI/CD degisiklikleri
-- Bagimlilik guncellemeleri
-- Dokumantasyon
+**Infrastructure (infra):**
+- CI/CD changes
+- Dependency updates
+- Documentation
 
-### Adim 4: 3 Versiyon Yaz
+### Step 4: Write 3 Versions
 
-**Versiyon A: Teknik Surum Notu**
-- Tam degisiklik listesi kategorilere gore
-- Kirilma degisiklikleri ve migrasyon talimatai
-- API degisiklikleri detayi
-- Bilinen sorunlar
-- Commit hashleri ve PR referanslari
+**Version A: Technical Release Notes**
+- The full change list by category
+- Breaking changes and migration instructions
+- API change details
+- Known issues
+- Commit hashes and PR references
 
-**Versiyon B: Pazarlama Surum Notu**
-- Kullanici odakli dilde yeni ozellikler
-- Fayda ve deger vurgusu
-- Ekran goruntuleri veya gorseller icin yer tutucular
-- Cagri aksiyonu (call to action)
+**Version B: Marketing Release Notes**
+- New features in user-focused language
+- Benefit and value emphasis
+- Placeholders for screenshots or visuals
+- A call to action
 
-**Versiyon C: Yonetici Ozeti**
-- 3-5 maddelik ust duzey ozet
-- Is etkisi vurgusu
-- Risk ve dikkat gerektiren maddeler
-- Sonraki surum planina bakis
+**Version C: Executive Summary**
+- A 3-5 item high-level summary
+- Business impact emphasis
+- Risks and items needing attention
+- A look at the next release plan
 
-### Adim 5: Dosyalari Kaydet
-`releases/` dizini altinda kaydet:
-- `releases/v[VERSIYON]-teknik.md`
-- `releases/v[VERSIYON]-pazarlama.md`
-- `releases/v[VERSIYON]-yonetici.md`
+### Step 5: Save the Files
+Save under `releases/`:
+- `releases/v[VERSION]-technical.md`
+- `releases/v[VERSION]-marketing.md`
+- `releases/v[VERSION]-executive.md`
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI SURUM NOTLARI ===
-Versiyon: v[VERSIYON]
-Onceki: v[ONCEKI]
-Aralik: [commit sayisi] commit
+=== BADI RELEASE NOTES ===
+Version: v[VERSION]
+Previous: v[PREVIOUS]
+Range: [commit count] commits
 
-Degisiklik Ozeti:
-- Yeni Ozellik: [sayi]
-- Hata Duzeltme: [sayi]
-- Kirilma Degisikligi: [sayi]
-- Iyilestirme: [sayi]
-- Altyapi: [sayi]
+Change Summary:
+- New Features: [count]
+- Bug Fixes: [count]
+- Breaking Changes: [count]
+- Improvements: [count]
+- Infrastructure: [count]
 
-Olusturulan Dosyalar:
-1. releases/v[VERSIYON]-teknik.md
-2. releases/v[VERSIYON]-pazarlama.md
-3. releases/v[VERSIYON]-yonetici.md
+Created Files:
+1. releases/v[VERSION]-technical.md
+2. releases/v[VERSION]-marketing.md
+3. releases/v[VERSION]-executive.md
 ============================
 ```

--- a/.claude/commands-vault/report.md
+++ b/.claude/commands-vault/report.md
@@ -1,153 +1,153 @@
 Professional report command. Turns raw data and findings into professional, audience-appropriate reports.
 
-# Gerekli Araclar
-- Read (veri kaynaklari)
-- Write (rapor dosyasi)
-- Grep (veri taramasi)
-- Glob (kaynak bulma)
-- Bash (veri isleme)
+# Required Tools
+- Read (data sources)
+- Write (report file)
+- Grep (data scan)
+- Glob (source discovery)
+- Bash (data processing)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Girdileri Netlestir
-Kullanicidan su bilgileri al:
+### Step 1: Clarify the Inputs
+Get from the user:
 
-- **Konu:** Rapor ne hakkinda?
-- **Veri Kaynaklari:** Hangi veriler kullanilacak? (dosyalar, metrikler, analizler)
-- **Hedef Kitle:** Kim okuyacak? (Yonetici / Teknik / Musteri)
-- **Amac:** Rapor ne icin kullanilacak? (karar destek, bilgilendirme, ikna)
-- **Format Tercihi:** Varsayilan: profesyonel, net, jargonsuz
-- **Uzunluk:** Kisa (1-2 sayfa) / Standart (3-5 sayfa) / Detayli (5+ sayfa)
-- **Aciliyet:** Normal / Acil (hizli taslak)
+- **Topic:** What is the report about?
+- **Data Sources:** Which data will be used? (files, metrics, analyses)
+- **Audience:** Who will read it? (Executive / Technical / Client)
+- **Purpose:** What will the report be used for? (decision support, information, persuasion)
+- **Format Preference:** Default: professional, clear, jargon-free
+- **Length:** Short (1-2 pages) / Standard (3-5 pages) / Detailed (5+ pages)
+- **Urgency:** Normal / Urgent (fast draft)
 
-### Adim 2: Kaynak Toplama
-Tum ilgili verileri derle:
+### Step 2: Source Collection
+Compile all relevant data:
 
-- **Nicel Veriler:** Metrikler, istatistikler, olcumler
-- **Nitel Veriler:** Gozlemler, geri bildirimler, degerlendirmeler
-- **Trendler:** Zaman serisi verileri, degisim oranlari
-- **Karsilastirmalar:** Hedefler vs gerceklesenler, onceki donem vs mevcut
-- **Anomaliler:** Normal disi durumlar ve aciklamalari
-- **Dissal Faktorler:** Sonuclari etkileyen dis etkenler
+- **Quantitative Data:** Metrics, statistics, measurements
+- **Qualitative Data:** Observations, feedback, assessments
+- **Trends:** Time-series data, change rates
+- **Comparisons:** Targets vs. actuals, previous period vs. current
+- **Anomalies:** Out-of-norm situations and their explanations
+- **External Factors:** Outside influences on the results
 
-Eksik veri varsa kullaniciya bildir ve ya topla ya da varsayim belirt.
+If data is missing, tell the user and either collect it or state the assumption.
 
-### Adim 3: Hedef Kitleye Gore Yapilandir
+### Step 3: Structure by Audience
 
-**Tip A: Yonetici Raporu**
-- Sonuc once, detay sonra (piramit yapisi)
-- Madde isaretleri ve kisa paragraflar
-- Karar metrikleri ve KPI'lar on planda
-- Maksimum 2 sayfa ana govde
-- Gorsel ozetler (tablo ve grafik aciklamalari)
-- Net oneriler ve sonraki adimlar
-- Jargon yok, is dili kullan
+**Type A: Executive Report**
+- Conclusion first, detail later (pyramid structure)
+- Bullets and short paragraphs
+- Decision metrics and KPIs up front
+- A 2-page main body maximum
+- Visual summaries (table and chart descriptions)
+- Clear recommendations and next steps
+- No jargon, business language
 
-**Tip B: Teknik Rapor**
-- Metodoloji ve veri kaynaklari detayli
-- Teknik terminoloji serbest
-- Veri tablolari ve detayli analizler
-- Uyarilar ve sinirliliklar bolumu
-- Kaynak referanslari ve atiflar
-- Yeniden uretilebilirlik bilgisi
-- Ek (appendix) bolumleri
+**Type B: Technical Report**
+- Methodology and data sources in detail
+- Technical terminology allowed
+- Data tables and detailed analyses
+- A caveats-and-limitations section
+- Source references and citations
+- Reproducibility information
+- Appendix sections
 
-**Tip C: Musteri Raporu**
-- Sonuclar ve ROI vurgusu
-- Baglamsal rakamlar (yuzde, karsilastirmali)
-- Gorsel formatlar (tablo, liste, on plana cikarilmis metrikler)
-- Basarilar ve deger gosterimi
-- Anlasilir dil, teknik detay minimum
-- Sonraki adimlar ve beklentiler
-- Profesyonel ve guven veren ton
+**Type C: Client Report**
+- Results and ROI emphasis
+- Contextualized numbers (percentages, comparatives)
+- Visual formats (tables, lists, highlighted metrics)
+- Wins and value demonstration
+- Plain language, minimal technical detail
+- Next steps and expectations
+- A professional, confidence-inspiring tone
 
-### Adim 4: Rapor Yaz
-Secilen tipe gore raporu olustur:
+### Step 4: Write the Report
+Build the report for the chosen type:
 
 ```markdown
-# [Rapor Basligi]
-**Tarih:** [tarih]
-**Hazirlayan:** [isim]
-**Donem:** [kapsam]
-**Gizlilik:** [seviye]
+# [Report Title]
+**Date:** [date]
+**Prepared by:** [name]
+**Period:** [scope]
+**Confidentiality:** [level]
 
-## Yonetici Ozeti
-[2-3 paragraf: temel bulgular, sonuclar, oneriler]
+## Executive Summary
+[2-3 paragraphs: key findings, conclusions, recommendations]
 
-## Temel Bulgular
-### Bulgu 1: [baslik]
-[detay, veri destegi, etki]
+## Key Findings
+### Finding 1: [title]
+[detail, data support, impact]
 
-### Bulgu 2: [baslik]
-[detay, veri destegi, etki]
+### Finding 2: [title]
+[detail, data support, impact]
 
-### Bulgu 3: [baslik]
-[detay, veri destegi, etki]
+### Finding 3: [title]
+[detail, data support, impact]
 
-## Detayli Analiz
-[konu bazli derinlemesine inceleme]
+## Detailed Analysis
+[in-depth review by topic]
 
-## Veriler ve Metrikler
-| Metrik | Onceki | Mevcut | Degisim | Hedef |
-|--------|--------|--------|---------|-------|
+## Data and Metrics
+| Metric | Previous | Current | Change | Target |
+|--------|----------|---------|--------|--------|
 | ... | ... | ... | ... | ... |
 
-## Oneriler
-### Kisa Vadeli
-1. [oneri ve beklenen etki]
+## Recommendations
+### Short Term
+1. [recommendation and expected impact]
 
-### Orta Vadeli
-1. [oneri ve beklenen etki]
+### Mid Term
+1. [recommendation and expected impact]
 
-### Uzun Vadeli
-1. [oneri ve beklenen etki]
+### Long Term
+1. [recommendation and expected impact]
 
-## Sonraki Adimlar
-1. [adim, sorumluluk, tarih]
-2. [adim, sorumluluk, tarih]
+## Next Steps
+1. [step, owner, date]
+2. [step, owner, date]
 
-## Ekler
-[ek tablolar, ham veriler, metodoloji detaylari]
+## Appendices
+[extra tables, raw data, methodology details]
 ```
 
-### Adim 5: Kalite Kontrol
-Raporu su kriterlerle degerlendir:
+### Step 5: Quality Control
+Evaluate the report against these criteria:
 
-**Icerik Kontrolu:**
-- [ ] Her iddia veri ile desteklenmis mi?
-- [ ] Varsayimlar acikca belirtilmis mi?
-- [ ] Sinirliliklar not edilmis mi?
-- [ ] Oneriler uygulanabilir ve somut mu?
+**Content Check:**
+- [ ] Is every claim backed by data?
+- [ ] Are the assumptions stated explicitly?
+- [ ] Are the limitations noted?
+- [ ] Are the recommendations actionable and concrete?
 
-**Format Kontrolu:**
-- [ ] Hedef kitleye uygun dil kullanilmis mi?
-- [ ] Yapi mantiksal sirayla akmis mi?
-- [ ] Tablolar ve listeler dogru formatli mi?
-- [ ] Baslik hiyerarsisi tutarli mi?
+**Format Check:**
+- [ ] Is the language right for the audience?
+- [ ] Does the structure flow logically?
+- [ ] Are tables and lists formatted correctly?
+- [ ] Is the heading hierarchy consistent?
 
-**Tutarlilik Kontrolu:**
-- [ ] Rakamlar tutarli mi? (yuzde, toplam, detay)
-- [ ] Ozet ile detay uyumlu mu?
-- [ ] Oneriler bulgularla desteklenmis mi?
-- [ ] Onceki raporlarla celisiyor mu?
+**Consistency Check:**
+- [ ] Are the numbers consistent? (percentages, totals, detail)
+- [ ] Do the summary and detail agree?
+- [ ] Are the recommendations backed by the findings?
+- [ ] Does it contradict previous reports?
 
-**Son Kontrol:**
-- [ ] Yazim ve dilbilgisi kontrol edildi mi?
-- [ ] Hassas bilgi uygun isaretlenmis mi?
-- [ ] Tarih ve donem bilgileri dogru mu?
+**Final Check:**
+- [ ] Spelling and grammar checked?
+- [ ] Sensitive information marked appropriately?
+- [ ] Dates and period info correct?
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI RAPOR ===
-Baslik: [rapor basligi]
-Tip: [Yonetici/Teknik/Musteri]
-Uzunluk: [sayfa sayisi]
-Tarih: [tarih]
+=== BADI REPORT ===
+Title: [report title]
+Type: [Executive/Technical/Client]
+Length: [page count]
+Date: [date]
 
-Temel Bulgular: [sayi]
-Oneriler: [sayi]
-Kalite Skoru: [yuzde]%
+Key Findings: [count]
+Recommendations: [count]
+Quality Score: [percent]%
 
-Dosya: [dosya yolu]
+File: [file path]
 ==================
 ```

--- a/.claude/commands-vault/retro.md
+++ b/.claude/commands-vault/retro.md
@@ -1,123 +1,123 @@
 Sprint retrospective command. Analyzes the past period and identifies improvement areas.
 
-# Gerekli Araclar
-- Read (gunluk notlar, gorev panosu, bellek)
-- Bash (git istatistikleri)
-- Grep (kalip arama)
-- Write (rapor yazimi)
+# Required Tools
+- Read (daily notes, task board, memory)
+- Bash (git statistics)
+- Grep (pattern search)
+- Write (report writing)
 
-# Prosedur (4 Adim)
+# Procedure (4 Steps)
 
-### Adim 1: Veri Toplama
-Retrospektif donemi icin verileri topla:
+### Step 1: Data Collection
+Gather the data for the retrospective period:
 
-**Git Verileri:**
-- Commit sayisi ve dagilimi (gune gore)
-- Degisen dosya sayisi
-- Satir ekleme/silme istatistikleri
-- Branch ve merge gecmisi
-- Revert edilen commitler
+**Git Data:**
+- Commit count and distribution (by day)
+- Changed file count
+- Line add/delete statistics
+- Branch and merge history
+- Reverted commits
 
-**Gorev Verileri:**
-- Tamamlanan gorevler ve sureleri
-- Ertelenen veya iptal edilen gorevler
-- Bloke kalan gorevler ve sureleri
-- Kapsam degisiklikleri
+**Task Data:**
+- Completed tasks and their durations
+- Deferred or cancelled tasks
+- Blocked tasks and their durations
+- Scope changes
 
-**Not Verileri:**
-- Gunluk notlardaki kararlar
-- Ogrenimler ve icegorular
-- Sorunlar ve cozumleri
-- Devir notlari
+**Note Data:**
+- Decisions in the daily notes
+- Learnings and insights
+- Problems and their solutions
+- Handoff notes
 
-### Adim 2: Kalip Analizi
-Toplanan verilerde kaliplari tespit et:
+### Step 2: Pattern Analysis
+Detect patterns in the collected data:
 
-**Uretkenlik Kaliplari:**
-- En verimli gunler/saatler
-- En cok commit yapilan alanlar
-- Tekrarlayan darbogazlar
-- Hiz degisimleri (yavaslamalar, hizlanmalar)
+**Productivity Patterns:**
+- Most productive days/hours
+- Areas with the most commits
+- Recurring bottlenecks
+- Velocity changes (slowdowns, speedups)
 
-**Sorun Kaliplari:**
-- Tekrarlayan hatalar
-- Sik bloke olan alanlar
-- Kapsam kaymasi ornekleri
-- Iletisim kopukluklari
+**Problem Patterns:**
+- Recurring errors
+- Frequently blocked areas
+- Scope-creep examples
+- Communication gaps
 
-**Basari Kaliplari:**
-- Iyi sonuclanan yaklasimlar
-- Etkili cozum stratejileri
-- Basarili isbirligi ornekleri
+**Success Patterns:**
+- Approaches that ended well
+- Effective solution strategies
+- Successful collaboration examples
 
-### Adim 3: Iyilestirme Kategorilendirme
-Bulgulari 4 kategoride siniflandir:
+### Step 3: Improvement Categorization
+Classify the findings into 4 categories:
 
-**Devam Etmeli (Iyi Giden):**
-- Etkili olan pratikler
-- Basarili yaklasimlar
-- Korunmasi gereken aliskanliklar
+**Keep Doing (Went Well):**
+- Practices that worked
+- Successful approaches
+- Habits worth keeping
 
-**Durdurulmali (Kotu Giden):**
-- Zaman kaybettiren pratikler
-- Etkisiz yaklasimlar
-- Tekrarlayan hatalar
+**Stop Doing (Went Badly):**
+- Time-wasting practices
+- Ineffective approaches
+- Recurring mistakes
 
-**Baslamali (Yeni Denemeler):**
-- Onerilen yeni pratikler
-- Denenmesi gereken araclar
-- Surec iyilestirmeleri
+**Start Doing (New Experiments):**
+- Suggested new practices
+- Tools worth trying
+- Process improvements
 
-**Arastirilmali (Belirsiz):**
-- Daha fazla veri gerektiren alanlar
-- Test edilmesi gereken hipotezler
-- Karar bekleyen konular
+**Investigate (Unclear):**
+- Areas needing more data
+- Hypotheses to test
+- Topics awaiting a decision
 
-### Adim 4: Yapilandirilmis Rapor
+### Step 4: Structured Report
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI RETROSPEKTIF ===
-Donem: [baslangic] - [bitis]
-Toplam Gun: [sayi]
+=== BADI RETROSPECTIVE ===
+Period: [start] - [end]
+Total Days: [count]
 
-## Metrikler
-- Commitler: [sayi] (gunluk ort: [sayi])
-- Tamamlanan Gorevler: [sayi]
-- Ertelenen: [sayi]
-- Bloke Kalan: [sayi]
-- Satir Degisikligi: +[eklenen] / -[silinen]
+## Metrics
+- Commits: [count] (daily avg: [count])
+- Completed Tasks: [count]
+- Deferred: [count]
+- Blocked: [count]
+- Line Changes: +[added] / -[removed]
 
-## Kaliplar
-### Uretkenlik
-[tespit edilen kaliplar]
+## Patterns
+### Productivity
+[detected patterns]
 
-### Tekrarlayan Sorunlar
-[sorun kaliplari]
+### Recurring Problems
+[problem patterns]
 
-### Basarilar
-[basari kaliplari]
+### Successes
+[success patterns]
 
-## Eylem Plani
+## Action Plan
 
-### Devam Etmeli
-- [pratik]
+### Keep Doing
+- [practice]
 
-### Durdurulmali
-- [pratik]
+### Stop Doing
+- [practice]
 
-### Baslamali
-- [yeni pratik]
+### Start Doing
+- [new practice]
 
-### Arastirilmali
-- [konu]
+### Investigate
+- [topic]
 
-## Sprint Notu
-[genel degerllendirme ve motivasyon notu]
+## Sprint Note
+[overall assessment and a motivational note]
 
-## Sonraki Sprint Hedefleri
-1. [hedef]
-2. [hedef]
-3. [hedef]
+## Next Sprint Goals
+1. [goal]
+2. [goal]
+3. [goal]
 ==========================
 ```

--- a/.claude/commands-vault/review.md
+++ b/.claude/commands-vault/review.md
@@ -1,170 +1,170 @@
 Deep code review command. Comprehensive code analysis across security, performance, and architecture.
 
-> **Argument formati (v1.31.0+)**: `/review [effort] [--comment] [--correctness-only]`
-> - `effort`: `low` | `medium` (default) | `high` — analiz derinligi
-> - `--comment`: bulgulari aktif PR'a inline yorum olarak post et (gh CLI gerekir)
-> - `--correctness-only`: yalniz correctness bug'larina odaklan (mimari/perf/guvenlik kanallarini atla)
+> **Argument format (v1.31.0+)**: `/review [effort] [--comment] [--correctness-only]`
+> - `effort`: `low` | `medium` (default) | `high` — analysis depth
+> - `--comment`: post findings as inline comments on the active PR (requires the gh CLI)
+> - `--correctness-only`: focus only on correctness bugs (skip the architecture/perf/security channels)
 
-> **Anthropic native `/code-review` (Claude Code 2.1.147+) farki:**
-> - `/code-review`: correctness bug + effort tuning + `--comment` (native English render)
-> - `/review` (badi): yukaridakilerin **superset**'i — 3 kanal (guvenlik+perf+mimari) + TR rapor + classification
-> - Kombine kullanim: `/code-review high --comment` (logic) sonra `/review high --comment` (mimari/perf/guvenlik)
+> **Difference vs. Anthropic's native `/code-review` (Claude Code 2.1.147+):**
+> - `/code-review`: correctness bugs + effort tuning + `--comment` (native English render)
+> - `/review` (badi): a **superset** of the above — 3 channels (security+perf+architecture) + structured report + classification
+> - Combined use: `/code-review high --comment` (logic) then `/review high --comment` (architecture/perf/security)
 
-# Gerekli Araclar
-- Read (kod okuma)
-- Grep (kalip arama)
-- Glob (dosya taramasi)
-- Bash (git diff, gh CLI inline PR comment, analiz araclari)
+# Required Tools
+- Read (code reading)
+- Grep (pattern search)
+- Glob (file scan)
+- Bash (git diff, gh CLI inline PR comments, analysis tools)
 
-# Prosedur (4 Adim + opsiyonel PR Comment)
+# Procedure (4 Steps + optional PR Comment)
 
-### Adim 0: Argument Parse + Effort & Mod Belirle (v1.31.0+)
+### Step 0: Argument Parse + Effort & Mode (v1.31.0+)
 
-> **Not**: Bu komut Claude tarafindan **prompt baglaminda yorumlanir** — kod-bazli
-> argument parsing yok. Asagidaki argumanlar Claude'a "review high --comment"
-> formatinda gelir, Claude prosedurde belirtilen davranisi uygular.
+> **Note**: This command is **interpreted by Claude in prompt context** — there is
+> no code-based argument parsing. The arguments arrive as "review high --comment"
+> and Claude applies the behavior described in this procedure.
 
 
-Komut argumanlari:
+Command arguments:
 - `effort` (positional): `low` | `medium` | `high`
-  - `low`: yalniz KRITIK + YUKSEK bulgu; performans/mimari kanallarini hizli tara
-  - `medium` (default): mevcut davranis — KRITIK + YUKSEK + ORTA siniflari
-  - `high`: tum siniflar (KRITIK/YUKSEK/ORTA/DUSUK) + olumlu gozlemler + alternative cozumler
-- `--comment`: Adim 5'i etkinlestir (PR inline comment)
-- `--correctness-only`: Adim 3'te yalniz Kanal A guvenlik + correctness bug'larina odaklan, Kanal B (performans) + Kanal C (mimari) atla
+  - `low`: only CRITICAL + HIGH findings; fast pass over the performance/architecture channels
+  - `medium` (default): current behavior — CRITICAL + HIGH + MEDIUM classes
+  - `high`: all classes (CRITICAL/HIGH/MEDIUM/LOW) + positive observations + alternative solutions
+- `--comment`: enables Step 5 (PR inline comments)
+- `--correctness-only`: in Step 3 focus only on Channel A security + correctness bugs, skip Channel B (performance) + Channel C (architecture)
 
-### Adim 1: Kapsam Tanimla
-Incelenecek kodu belirle:
-- **Aktif PR (auto-detect)**: `gh pr view --json number,baseRefName,headRefName` ile mevcut branch'in PR'i tespit edilir. Varsa scope otomatik PR diff'i (`gh pr diff <num>`).
-- **PR/Commit:** `git diff` ciktisini al (branch veya commit hash ile)
-- **Dosya:** Belirli dosya veya dosyalar
-- **Modul:** Bir ozellik veya modul dizini
-- **Degisiklik Kumesi:** Son N commitin degisiklikleri
+### Step 1: Define the Scope
+Determine the code to review:
+- **Active PR (auto-detect)**: detect the current branch's PR via `gh pr view --json number,baseRefName,headRefName`. If found, the scope is automatically the PR diff (`gh pr diff <num>`).
+- **PR/Commit:** take the `git diff` output (by branch or commit hash)
+- **File:** a specific file or files
+- **Module:** a feature or module directory
+- **Change Set:** the last N commits' changes
 
-Kapsam bilgisini kaydet:
-- Dosya sayisi
-- Degisen satir sayisi (eklenen/silinen)
-- Etkilenen moduller
+Record the scope:
+- File count
+- Changed line count (added/removed)
+- Affected modules
 
-### Adim 2: Kod Oku
-- Tum degisiklikleri dikkatli oku
-- Baglam icin cevredeki kodu da incele
-- Ilgili test dosyalarini bul ve oku
-- Etkilenen API'leri veya arayuzleri kontrol et
+### Step 2: Read the Code
+- Read all the changes carefully
+- Review the surrounding code for context
+- Find and read the related test files
+- Check the affected APIs or interfaces
 
-### Adim 3: Paralel Analiz (3 Kanal — `--correctness-only` ile Kanal B+C atlanir)
+### Step 3: Parallel Analysis (3 Channels — `--correctness-only` skips Channels B+C)
 
-**Kanal A: Guvenlik Analizi**
-- Girdi dogrulama eksiklikleri
-- SQL/NoSQL injection riskleri
-- XSS ve CSRF aciklari
-- Hassas veri sizintisi (loglamada, hata mesajlarinda)
-- Yetkilendirme kontrolleri
-- Kriptografik zayifliklar
-- Bagimlilik guvenlik aciklari
-- Hardcoded sirlar veya anahtarlar
+**Channel A: Security Analysis**
+- Missing input validation
+- SQL/NoSQL injection risks
+- XSS and CSRF holes
+- Sensitive data leakage (in logging, in error messages)
+- Authorization checks
+- Cryptographic weaknesses
+- Dependency vulnerabilities
+- Hardcoded secrets or keys
 
-**Kanal B: Performans Analizi**
-- N+1 sorgu kaliplari
-- Gereksiz hesaplamalar veya donguler
-- Bellek sizintisi riskleri
-- Indeks kullanimi (veritabani sorgulari)
-- Onbellekleme firsatlari
-- Asenkron islem gereksinimleri
-- Buyuk veri kumesi islemleri
-- API cagri optimizasyonlari
+**Channel B: Performance Analysis**
+- N+1 query patterns
+- Needless computation or loops
+- Memory-leak risks
+- Index usage (database queries)
+- Caching opportunities
+- Async-processing needs
+- Large dataset operations
+- API call optimizations
 
-**Kanal C: Mimari Analizi**
-- SOLID ilkeleriyle uyum
-- Katman ayrimina saygi (separation of concerns)
-- Bagimlilik yonu (dependency inversion)
-- Kod tekrari (DRY ihlalleri)
-- Isimlendirme tutarliligi
-- Hata yonetimi stratejisi
-- Test edilebilirlik
-- Genisletilebilirlik ve bakim kolayligi
+**Channel C: Architecture Analysis**
+- SOLID compliance
+- Separation of concerns
+- Dependency direction (dependency inversion)
+- Code duplication (DRY violations)
+- Naming consistency
+- Error-handling strategy
+- Testability
+- Extensibility and maintainability
 
-### Adim 4: Bulgulari Siniflandir
+### Step 4: Classify the Findings
 
-Her bulguyu su seviyelere ata:
+Assign every finding a level:
 
-**KRITIK** - Mutlaka duzeltilmeli (merge engelleyici)
-- Guvenlik aciklari
-- Veri kaybi/bozulma riski
-- Uretim ortamini kiracak hatalar
+**CRITICAL** - Must be fixed (merge blocker)
+- Security vulnerabilities
+- Data loss/corruption risk
+- Errors that will break production
 
-**YUKSEK** - Merge oncesi cozulmesi onerilen
-- Performans sorunlari
-- Hata yonetimi eksiklikleri
-- Test kapsami boslugu (kritik yollar)
+**HIGH** - Recommended to resolve before merge
+- Performance issues
+- Error-handling gaps
+- Test coverage holes (critical paths)
 
-**ORTA** - Iyilestirme firsati
-- Kod kalitesi
-- Okunabilirlik
+**MEDIUM** - Improvement opportunity
+- Code quality
+- Readability
 - Minor refactoring
 
-**DUSUK** - Oneri niteliginde
-- Stil tercihleri
-- Dokumantasyon iyilestirmeleri
-- Gelecek refactoring firsatlari
+**LOW** - Advisory
+- Style preferences
+- Documentation improvements
+- Future refactoring opportunities
 
-### Adim 5 (opsiyonel): PR Inline Comment (`--comment`)
+### Step 5 (optional): PR Inline Comments (`--comment`)
 
-`--comment` flag ile birlikte calistirildiginda, bulgular aktif PR'a inline yorum olarak post edilir. gh CLI gerekir.
+When run with the `--comment` flag, findings are posted as inline comments on the active PR. Requires the gh CLI.
 
-**On kontroller:**
-1. `gh` PATH'te mi: `which gh`
-2. Aktif branch'in PR'i var mi: `gh pr view --json number,headRefName` (yoksa hata: "PR bulunamadi. /review --comment yalniz PR icindeyken calisir")
-3. Yetki kontrolu: `gh auth status`
+**Pre-checks:**
+1. Is `gh` on the PATH: `which gh`
+2. Does the current branch have a PR: `gh pr view --json number,headRefName` (otherwise error: "No PR found. /review --comment only works inside a PR")
+3. Auth check: `gh auth status`
 
-**Yorum yazimi (her KRITIK + YUKSEK bulgu icin):**
+**Comment posting (for every CRITICAL + HIGH finding):**
 ```bash
 gh api repos/:owner/:repo/pulls/<num>/comments \
   --method POST \
-  --field body="<bulgu_aciklamasi>" \
-  --field path="<dosya_yolu>" \
-  --field line=<satir_no> \
+  --field body="<finding_description>" \
+  --field path="<file_path>" \
+  --field line=<line_no> \
   --field side="RIGHT"
 ```
 
-**Ozet yorum (PR description'a):**
+**Summary comment (on the PR):**
 ```bash
 gh pr comment <num> --body "$(badi review --format markdown-summary)"
 ```
 
-Cikti: KRITIK N | YUKSEK N | ORTA N | DUSUK N + onerilen action (merge OK / revize / red).
+Output: CRITICAL N | HIGH N | MEDIUM N | LOW N + the suggested action (merge OK / revise / reject).
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI KOD INCELEMESI ===
-Tarih: [tarih]
-Kapsam: [belirtilen kapsam]
-Dosya Sayisi: [sayi]
-Degisen Satir: +[eklenen] / -[silinen]
+=== BADI CODE REVIEW ===
+Date: [date]
+Scope: [specified scope]
+File Count: [count]
+Changed Lines: +[added] / -[removed]
 
-## Genel Degerlendirme
-[1-2 cumle ozet]
-Onay Durumu: ONAYLANDI / DEGISIKLIK GEREKLI / REDDEDILDI
+## Overall Assessment
+[1-2 sentence summary]
+Approval State: APPROVED / CHANGES REQUIRED / REJECTED
 
-## Kritik Bulgular ([sayi])
-### [Bulgu Basligi]
-- Dosya: [yol:satir]
-- Sorun: [aciklama]
-- Oneri: [cozum]
+## Critical Findings ([count])
+### [Finding Title]
+- File: [path:line]
+- Problem: [description]
+- Suggestion: [fix]
 
-## Yuksek Oncelikli ([sayi])
+## High Priority ([count])
 ...
 
-## Orta Oncelikli ([sayi])
+## Medium Priority ([count])
 ...
 
-## Dusuk Oncelikli ([sayi])
+## Low Priority ([count])
 ...
 
-## Olumlu Gozlemler
-- [iyi yapilmis seyler]
+## Positive Observations
+- [things done well]
 
-## Ozet
-- Kritik: [sayi] | Yuksek: [sayi] | Orta: [sayi] | Dusuk: [sayi]
+## Summary
+- Critical: [count] | High: [count] | Medium: [count] | Low: [count]
 ==============================
 ```

--- a/.claude/commands-vault/security-scan.md
+++ b/.claude/commands-vault/security-scan.md
@@ -1,141 +1,141 @@
 Security scan. Searches the codebase and dependencies for vulnerabilities and produces a severity-ranked report.
 
-> **Native komut (v1.31.0+)**: Claude Code 2.1.140+ ile `/security-review` artik **native** komut (built-in slash). Bu komut onun yaninda **deterministic baseline** (`badi security baseline`) + **post-scan triage** (`badi security triage`) saglar.
+> **Native command (v1.31.0+)**: With Claude Code 2.1.140+, `/security-review` is now a **native** command (built-in slash). This command complements it with a **deterministic baseline** (`badi security baseline`) + **post-scan triage** (`badi security triage`).
 >
-> **Onerilen akis**:
-> 1. `badi security baseline` — sirlar + bagimliliklar (deterministic)
+> **Recommended flow**:
+> 1. `badi security baseline` — secrets + dependencies (deterministic)
 > 2. `/security-review` — AI semantic vulnerability hunt (Anthropic native)
-> 3. `badi security triage` — rapor severity filtreleme
-> 4. CI: `badi security init --ci` — PR'larda otomatik review
+> 3. `badi security triage` — report severity filtering
+> 4. CI: `badi security init --ci` — automatic review on PRs
 
-## Badi CLI Komutlari (v1.6+)
-Bu komut ilk olarak su CLI araclarini cagirir:
-- `badi secret-scan` — 17 pattern sir/credential taramasi (AWS, GCP, GitHub, OpenAI, Stripe, DB URI'leri, private keys)
-- `badi secret-scan --git` — Son 100 commit'te de tarama
-- `badi a11y [url]` — Accessibility (guvenlik audit'in bir bolumu)
-Sonra security-scanner ajanina devredilir (kod kalip analizi).
+## Badi CLI Commands (v1.6+)
+This command first invokes these CLI tools:
+- `badi secret-scan` — 17-pattern secret/credential scan (AWS, GCP, GitHub, OpenAI, Stripe, DB URIs, private keys)
+- `badi secret-scan --git` — Also scan the last 100 commits
+- `badi a11y [url]` — Accessibility (part of the security audit)
+Then it delegates to the security-scanner agent (code pattern analysis).
 
-# Gerekli Araclar
-- Bash (npm audit, bagimlilik taramasi)
-- Read (konfigur asyon dosyalari)
-- Grep (kod kalip taramasi)
+# Required Tools
+- Bash (npm audit, dependency scan)
+- Read (configuration files)
+- Grep (code pattern scan)
 - ...
 
-# Ajan Delegasyonu
-Bu komut ana tarama isini security-scanner ajanina devreder.
-Ajan bulunamazsa, asagidaki adimlari dogrudan uygula.
+# Agent Delegation
+This command delegates the main scan to the security-scanner agent.
+If the agent is unavailable, apply the steps below directly.
 
 ---
 
-## Bolum 1: Bagimlilik Acigi Taramasi
+## Section 1: Dependency Vulnerability Scan
 
-### Adim 1: Paket Yoneticisi Tespiti ve Audit
-- npm: `npm audit --json` calistir
-- yarn: `yarn audit --json` calistir
-- pip: `pip audit` veya `safety check` calistir
+### Step 1: Package Manager Detection and Audit
+- npm: run `npm audit --json`
+- yarn: run `yarn audit --json`
+- pip: run `pip audit` or `safety check`
 - ...
 
-### Adim 2: Acik Siniflandirmasi
-Her bulunan acik icin kaydet:
-- Paket adi ve versiyonu
-- CVE numarasi (varsa)
-- Ciddiyet seviyesi: KRITIK / YUKSEK / ORTA / DUSUK
+### Step 2: Vulnerability Classification
+Record per finding:
+- Package name and version
+- CVE number (if any)
+- Severity: CRITICAL / HIGH / MEDIUM / LOW
 - ...
 
-### Adim 3: Bagimlilik Zinciri Analizi
-- Dogrudan bagimlilik mi yoksa gecisli bagimlilik mi belirle
-- Gecisli bagimliliklarda hangi ust paketin getirdigini goster
-- Lock dosyasinin guncel oldugunu dogrula
+### Step 3: Dependency Chain Analysis
+- Determine direct vs. transitive dependency
+- For transitive ones, show which parent package pulls it in
+- Verify the lock file is current
 
 ---
 
-## Bolum 2: Kod Kalip Analizi
+## Section 2: Code Pattern Analysis
 
-### Adim 4: Sabit Kodlu Sir Taramasi
+### Step 4: Hardcoded Secret Scan
 
-**Once `badi secret-scan` calistir** — 17 pattern ile hizli tarama:
+**Run `badi secret-scan` first** — a fast scan with 17 patterns:
 - AWS Access/Secret, GCP, GitHub PAT (classic + fine-grained), Slack, Stripe,
   OpenAI, Anthropic
-- npm, SendGrid, Twilio, MongoDB/Postgres URI
-- RSA/EC private keys, JWT token
-- Generic secret (20-64 char)
+- npm, SendGrid, Twilio, MongoDB/Postgres URIs
+- RSA/EC private keys, JWT tokens
+- Generic secrets (20-64 chars)
 
-Komut:
+Commands:
 ```bash
 badi secret-scan                                       # Working tree
-badi secret-scan --git                                 # + git history (son N commit)
-badi secret-scan --format json                         # JSON cikti
-badi secret-scan --exit-code strict                    # her bulguda exit 1
-badi secret-scan --max-commits 500 --git               # daha derin tarihce
-badi secret-scan --ignore jwt,github-pat               # belirli pattern'leri yoksay
-badi secret-scan --ignore-file .secretignore           # dosyadan oku
-badi secret-scan --patterns custom-org-patterns.json   # ek pattern yukle
+badi secret-scan --git                                 # + git history (last N commits)
+badi secret-scan --format json                         # JSON output
+badi secret-scan --exit-code strict                    # exit 1 on any finding
+badi secret-scan --max-commits 500 --git               # deeper history
+badi secret-scan --ignore jwt,github-pat               # ignore specific patterns
+badi secret-scan --ignore-file .secretignore           # read from a file
+badi secret-scan --patterns custom-org-patterns.json   # load extra patterns
 ```
 
-**Cikis kodlari (CI icin):**
-- `0`  Bulgu yok (veya --exit-code never, veya yalniz ORTA/DUSUK varsayilanda)
-- `1`  KRITIK veya YUKSEK bulgu — pipeline durdurulmali
+**Exit codes (for CI):**
+- `0`  No findings (or --exit-code never, or only MEDIUM/LOW by default)
+- `1`  CRITICAL or HIGH finding — the pipeline should stop
 
-**Kapsam disi (CI'da basaca bilinmesi gerekenler):**
-- `git stash`, `reflog`, packed-refs taranmaz — sadece reachable commit'ler
-- Sembolik link'ler atlanir (cycle + path traversal koruma)
-- Dosya boyut limiti: 2MB, dosya sayisi limiti: 5000 (--max-files ile ayarla)
+**Out of scope (worth knowing in CI):**
+- `git stash`, `reflog`, packed-refs are not scanned — only reachable commits
+- Symlinks are skipped (cycle + path traversal protection)
+- File size limit: 2MB, file count limit: 5000 (tune with --max-files)
 
-**Sonra ek kod kalip analizi** (CLI'in kacirmis olabilecekleri):
-- API anahtarlari: `api[_-]?key\s*[:=]`
-- Tokenlar: `token\s*[:=]\s*['"][A-Za-z0-9]`
-- Sifreler: `password\s*[:=]\s*['"]`
+**Then extra code pattern analysis** (what the CLI may have missed):
+- API keys: `api[_-]?key\s*[:=]`
+- Tokens: `token\s*[:=]\s*['"][A-Za-z0-9]`
+- Passwords: `password\s*[:=]\s*['"]`
 - ...
 
-### Adim 5: Enjeksiyon Vektoru Taramasi
-- SQL enjeksiyonu: Ham sorgu birlestireleri, parametresiz sorgular
-- XSS: `innerHTML`, `dangerouslySetInnerHTML`, filtresiz kullanici girdisi
-- Komut enjeksiyonu: `exec()`, `eval()`, `child_process` kullanimi
+### Step 5: Injection Vector Scan
+- SQL injection: raw query concatenation, non-parameterized queries
+- XSS: `innerHTML`, `dangerouslySetInnerHTML`, unfiltered user input
+- Command injection: `exec()`, `eval()`, `child_process` usage
 - ...
 
-### Adim 6: Kimlik Dogrulama ve Yetkilendirme Kaliplari
-- JWT implementasyonunu incele (algoritma sabitleme, sure asimi)
-- Sifre hashleme yontemi kontrol et (bcrypt/argon2 mi, MD5/SHA1 mi)
-- Rate limiting uygulamasi var mi kontrol et
+### Step 6: Authentication and Authorization Patterns
+- Review the JWT implementation (algorithm pinning, expiry)
+- Check the password hashing method (bcrypt/argon2 vs. MD5/SHA1)
+- Check whether rate limiting is in place
 - ...
 
 ---
 
-## Bolum 3: Konfigurasyon Incelemesi
+## Section 3: Configuration Review
 
-### Adim 7: CORS Politikasi
-- CORS konfigurasyonunu bul ve oku
-- Wildcard origin (`*`) kullanimi var mi kontrol et
-- Izin verilen originlerin kabul edilebilir oldugunu dogrula
+### Step 7: CORS Policy
+- Find and read the CORS configuration
+- Check for wildcard origin (`*`) usage
+- Verify the allowed origins are acceptable
 - ...
 
-### Adim 8: Guvenlik Basliklari
-Asagidaki basliklarin konfigure edildigini kontrol et:
+### Step 8: Security Headers
+Check that the following headers are configured:
 - Content-Security-Policy (CSP)
 - X-Content-Type-Options: nosniff
-- X-Frame-Options veya frame-ancestors
+- X-Frame-Options or frame-ancestors
 - ...
 
-### Adim 9: Auth Konfigurasyonu
-- Oturum yonetimi konfigurasyonunu incele
-- Cookie ayarlari: secure, httpOnly, sameSite
-- Token surelerini degerlendir
+### Step 9: Auth Configuration
+- Review the session management configuration
+- Cookie settings: secure, httpOnly, sameSite
+- Evaluate the token lifetimes
 - ...
 
 ---
 
-## Bolum 4: Bulgular Raporu
+## Section 4: Findings Report
 
-### Adim 10: Ciddiyet Siralamasi
-Tum bulgulari su siralama ile raporla:
+### Step 10: Severity Ranking
+Report all findings in this order:
 
 ```
-[kisaltildi]
+[abridged]
 ```
 
-### Adim 11: Duzeltme Onerileri
-Her bulgu icin:
-- Sorunun kisa aciklamasi
-- Onerien duzeltme yontemi
-- Ornek kod veya konfigurasyon degisikligi
+### Step 11: Remediation Suggestions
+For each finding:
+- A short description of the problem
+- The suggested fix
+- An example code or configuration change
 - ...

--- a/.claude/commands-vault/seo.md
+++ b/.claude/commands-vault/seo.md
@@ -1,80 +1,80 @@
 SEO audit command. Website SEO analysis, meta tag checks, sitemap validation, and speed assessment.
 
-# Gerekli Araclar
-- Bash (badi seo komutlari)
+# Required Tools
+- Bash (badi seo commands)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Kapsam Belirle
+### Step 1: Define the Scope
 
-Kullaniciya sor: "Hangi analizi yapalim?"
-- **Tam audit** — 20+ kontrol (tavsiye edilen baslangic)
-- **Meta taglar** — OG, Twitter Card detayi
+Ask the user: "Which analysis shall we run?"
+- **Full audit** — 20+ checks (recommended starting point)
+- **Meta tags** — OG, Twitter Card detail
 - **Sitemap + robots.txt** — Crawlability
-- **Hiz + kaynaklar** — Performance baslangici
+- **Speed + resources** — Performance starter
 
-### Adim 2: SEO Audit (Varsayilan)
+### Step 2: SEO Audit (Default)
 ```bash
 badi seo audit [url]
 ```
 
-Kontrol edilenler:
+What is checked:
 - Title, Description, OG tags, Twitter Card
-- H1 yapisi (tek olmali)
-- Gorsel alt taglari
+- H1 structure (must be single)
+- Image alt tags
 - Canonical URL, Viewport, lang, charset
 - HTTPS, Schema.org, robots meta
-- Kelime sayisi, link analizi
+- Word count, link analysis
 
-SEO skoru 0-100 arasi verilir.
+An SEO score of 0-100 is given.
 
-### Adim 3: Detayli Analizler
+### Step 3: Detailed Analyses
 
 ```bash
-badi seo meta [url]        # Meta tag analizi (eksik tespit)
+badi seo meta [url]        # Meta tag analysis (missing detection)
 badi seo sitemap [url]     # robots.txt + sitemap.xml
-badi seo speed [url]       # TTFB + HTML boyutu + compression
+badi seo speed [url]       # TTFB + HTML size + compression
 ```
 
-### Adim 4: Iyilestirme Onerileri
+### Step 4: Improvement Suggestions
 
-Skor < 80 ise bulgulara gore:
-- **Title eksik/uzun**: 30-60 karakter onerisi
-- **Description yok**: 120-160 karakter ornek
-- **H1 sorunu**: Sayfa yapisi onerisi
-- **Gorsel alt eksik**: WCAG + SEO birlesik fayda
-- **Canonical yok**: Duplicate content riski
-- **Schema.org yok**: Structured data firsati
+If the score < 80, based on the findings:
+- **Title missing/long**: 30-60 character suggestion
+- **No description**: 120-160 character example
+- **H1 problem**: page structure suggestion
+- **Missing image alts**: combined WCAG + SEO benefit
+- **No canonical**: duplicate-content risk
+- **No Schema.org**: structured-data opportunity
 
-### Adim 5: Lighthouse Derin Analiz
+### Step 5: Lighthouse Deep Analysis
 
-Daha derin metrikler icin:
+For deeper metrics:
 ```bash
 badi lighthouse [url]
 ```
-Core Web Vitals + Performance + Accessibility + Best Practices + SEO skoru.
+Core Web Vitals + Performance + Accessibility + Best Practices + SEO score.
 
-### Adim 6: AI Search Optimizasyonu
+### Step 6: AI Search Optimization
 
-Modern SEO'da GEO (Generative Engine Optimization) onemli:
-- ChatGPT/Perplexity tarafindan alintılanma
+GEO (Generative Engine Optimization) matters in modern SEO:
+- Being cited by ChatGPT/Perplexity
 - Schema.org structured data
-- llms.txt dosyasi (opsiyonel)
+- An llms.txt file (optional)
 
-Claude Code'da `ai-seo` veya `seo-geo` skill'ini cagirin (ileri seviye).
+In Claude Code, invoke the `ai-seo` or `seo-geo` skill (advanced).
 
-# Ornek Kullanim
+# Example Usage
 
 ```
 /seo https://example.com
 ```
 
 ```
-Kullanici: /seo blog.com
-Asistan: [badi seo audit calistirir]
-         SEO skoru: 72/100
-         Kritik sorunlar: 
-           - Meta description eksik
-           - 3 gorselde alt tag yok
-         Detay icin: /seo-audit ile devam edelim mi?
+User: /seo blog.com
+Assistant: [runs badi seo audit]
+         SEO score: 72/100
+         Critical issues:
+           - Meta description missing
+           - 3 images lack alt tags
+         For detail: shall we continue with /seo-audit?
 ```

--- a/.claude/commands-vault/wp.md
+++ b/.claude/commands-vault/wp.md
@@ -1,84 +1,84 @@
 WordPress site management command. Site status, plugin/theme management, security scan, and bulk updates.
 
-# Gerekli Araclar
-- Bash (badi wp komutlari)
+# Required Tools
+- Bash (badi wp commands)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Site Kaydi Kontrolu
+### Step 1: Check the Site Registry
 ```bash
 badi wp list
 ```
-Kullanicinin kayitli siteleri varsa goster, yoksa ekleme onerisi yap:
+If the user has registered sites, show them; otherwise suggest adding one:
 ```bash
 badi wp add [alias] [url] --method [wp-cli|rest]
 ```
 
-### Adim 2: Site Durumu
+### Step 2: Site Status
 ```bash
 badi wp status [alias]
 ```
-Gosterir:
-- WordPress surumu
-- Aktif tema
-- Eklenti sayisi + guncelleme bekleyen
-- Core guncelleme durumu
+Shows:
+- WordPress version
+- Active theme
+- Plugin count + pending updates
+- Core update status
 
-### Adim 3: Detayli Inceleme (istege bagli)
+### Step 3: Detailed Review (optional)
 
 ```bash
-badi wp plugins [alias]       # Eklenti listesi
-badi wp themes [alias]        # Tema listesi
+badi wp plugins [alias]       # Plugin list
+badi wp themes [alias]        # Theme list
 ```
 
-### Adim 4: Guvenlik Taramasi
+### Step 4: Security Scan
 ```bash
 badi wp security [alias]
 ```
-6 nokta kontrolu:
-- WP Core guncelligi
-- Eklenti guncellemeleri
-- Pasif eklenti (kaldirilabilir)
-- WP_DEBUG kapali mi
-- DISALLOW_FILE_EDIT tanimli mi
-- `admin` kullanicisi ve admin sayisi
+6-point check:
+- WP Core freshness
+- Plugin updates
+- Inactive plugins (removable)
+- Is WP_DEBUG off
+- Is DISALLOW_FILE_EDIT defined
+- The `admin` user and the admin count
 
-### Adim 5: Toplu Guncelleme (Dikkatli!)
+### Step 5: Bulk Update (Careful!)
 ```bash
-badi wp update [alias] all                  # Core + plugin + theme (120s timeout)
-badi wp update [alias] core                 # Sadece core
-badi wp update [alias] plugins              # Sadece plugins
-badi wp update [alias] themes               # Sadece themes
-badi wp update [alias] [plugin-name]        # Belirli eklenti
+badi wp update [alias] all                  # Core + plugins + themes (120s timeout)
+badi wp update [alias] core                 # Core only
+badi wp update [alias] plugins              # Plugins only
+badi wp update [alias] themes               # Themes only
+badi wp update [alias] [plugin-name]        # A specific plugin
 ```
 
-**Staging'de test et, production icin backup al.**
+**Test on staging; take a backup for production.**
 
-### Adim 6: Takip Aksiyonlari
+### Step 6: Follow-up Actions
 
-Guvenlik sorunu varsa:
-- `/secret-scan` — uygulama tarafinda da sir ara
-- `/ssl-check [domain]` — SSL durumu
-- `/dns-audit [domain]` — Email guvenlik
+If security issues exist:
+- `/secret-scan` — also search for secrets on the app side
+- `/ssl-check [domain]` — SSL state
+- `/dns-audit [domain]` — Email security
 
-# Baglanti Yontemleri
+# Connection Methods
 
-| Method | Senaryo |
-|--------|---------|
-| `--method wp-cli --path /var/www/` | Lokal WordPress kurulumu |
+| Method | Scenario |
+|--------|----------|
+| `--method wp-cli --path /var/www/` | Local WordPress install |
 | `--method wp-cli --ssh user@host` | SSH + remote WP-CLI |
-| `--method rest` | REST API (interactive password'li kisitli) |
+| `--method rest` | REST API (limited with an interactive password) |
 
-Application password icin: WP Admin → Users → Profile → Application Passwords
+For an application password: WP Admin → Users → Profile → Application Passwords
 
-# Ornek Kullanim
+# Example Usage
 
 ```
-Kullanici: /wp
-Asistan: Kayitli WP siteleriniz: [list]
-         Hangisinde calismak istersiniz?
+User: /wp
+Assistant: Your registered WP sites: [list]
+         Which one shall we work on?
 
-Kullanici: blog
-Asistan: [badi wp status blog calistirir]
-         [Sonuclari yorumlar, guvenlik taramasi onerir]
+User: blog
+Assistant: [runs badi wp status blog]
+         [Interprets the results, suggests a security scan]
 ```

--- a/.claude/commands/api-doc.md
+++ b/.claude/commands/api-doc.md
@@ -1,97 +1,97 @@
 API documentation generation. Scans route definitions and produces structured API docs.
 
-# Gerekli Araclar
-- Bash (dosya sistemi) -- Read (kaynak kod) -- Grep (route/endpoint) -- Glob (dosya tespiti) -- Write (dok dosyasi) -- Agent (api-designer: detayli API analiz)
+# Required Tools
+- Bash (filesystem) -- Read (source code) -- Grep (routes/endpoints) -- Glob (file detection) -- Write (doc file) -- Agent (api-designer: detailed API analysis)
 
-# Ajan Delegasyonu
-Ana is api-designer ajanina devredilir. Ajan yoksa asagidaki adimlari dogrudan uygula.
+# Agent Delegation
+The main work is delegated to the api-designer agent. If the agent is unavailable, apply the steps below directly.
 
-## 1. Framework Tespiti
-**1a — Proje yapisi:** `package.json` framework bagimliligi -- desteklenen: Express (`express`, `app.get/post/put/delete`), Fastify (`fastify`, `fastify.route`), NestJS (`@nestjs/core`, `@Controller`, `@Get/@Post`), Koa (`koa-router`, `router.get/post`), Next.js API (`pages/api/` veya `app/api/`), Django/Flask/FastAPI
+## 1. Framework Detection
+**1a — Project structure:** `package.json` framework dependency -- supported: Express (`express`, `app.get/post/put/delete`), Fastify (`fastify`, `fastify.route`), NestJS (`@nestjs/core`, `@Controller`, `@Get/@Post`), Koa (`koa-router`, `router.get/post`), Next.js API (`pages/api/` or `app/api/`), Django/Flask/FastAPI
 
-**1b — Route dosyalari:** framework'e gore tipik konumlar -- `routes/`, `controllers/`, `api/`, `endpoints/` -- middleware dosyalari
+**1b — Route files:** typical locations per framework -- `routes/`, `controllers/`, `api/`, `endpoints/` -- middleware files
 
-## 2. Endpoint Cikartma
-**2a — Route taramasi (grep):**
+## 2. Endpoint Extraction
+**2a — Route scan (grep):**
 - Express: `router\.(get|post|put|patch|delete)\(`
 - NestJS: `@(Get|Post|Put|Patch|Delete)\(`
 - Next.js: `export (async )?function (GET|POST|PUT|DELETE)`
-- Her esleme: dosya yolu + satir no + tam route ifadesi
+- Per match: file path + line number + the full route expression
 
-**2b — Endpoint bilgisi:** HTTP metod (GET/POST/PUT/PATCH/DELETE) -- URL yolu (path parametre dahil) -- middleware zinciri (auth, validation, rate-limit) -- controller fonksiyon adi
+**2b — Endpoint info:** HTTP method (GET/POST/PUT/PATCH/DELETE) -- URL path (including path params) -- middleware chain (auth, validation, rate-limit) -- controller function name
 
-**2c — Parametre:** URL (`:id`, `[slug]`) -- query (koddan cikar) -- body (TS tip, Zod, Joi) -- header (Authorization, Content-Type, vb.)
+**2c — Parameters:** URL (`:id`, `[slug]`) -- query (extract from code) -- body (TS types, Zod, Joi) -- headers (Authorization, Content-Type, etc.)
 
-## 3. Yanit Sekilleri
-**3a — Tip tespiti:** TS interface/type -- DTO siniflari -- ornek yanit nesneleri -- hata yanit formati
+## 3. Response Shapes
+**3a — Type detection:** TS interfaces/types -- DTO classes -- sample response objects -- error response format
 
-**3b — Durum kodlari:** her endpoint'in dondurdugu HTTP kodlari -- basarili (200, 201, 204) -- hata (400, 401, 403, 404, 500) -- ozel hata yanitlari
+**3b — Status codes:** the HTTP codes each endpoint returns -- success (200, 201, 204) -- errors (400, 401, 403, 404, 500) -- custom error responses
 
-## 4. OpenAPI/Swagger Iskeleti
+## 4. OpenAPI/Swagger Skeleton
 **4a — OpenAPI 3.0:**
 ```yaml
 openapi: "3.0.0"
 info:
-  title: "[Proje Adi] API"
-  version: "[surum]"
-  description: "[aciklama]"
+  title: "[Project Name] API"
+  version: "[version]"
+  description: "[description]"
 paths:
-  /api/[kaynak]:
+  /api/[resource]:
     get:
-      summary: "[aciklama]"
+      summary: "[description]"
       parameters: [...]
       responses:
         "200":
-          description: "[aciklama]"
+          description: "[description]"
           content:
             application/json:
               schema: [...]
 ```
 
-**4b — Sema:** tespit edilen modeller icin OpenAPI sema -- `$ref` ile tekrar kullanilabilir -- enum degerleri
+**4b — Schemas:** OpenAPI schemas for the detected models -- reusable via `$ref` -- enum values
 
-## 5. Belgelenmemis Endpoint
-**5a — Mevcut dok karsilastir:** mevcut API dok dosyasi -- Swagger/OpenAPI dosyasi -- README API bolumleri
+## 5. Undocumented Endpoints
+**5a — Compare with existing docs:** the existing API doc file -- a Swagger/OpenAPI file -- README API sections
 
-**5b — Eksik rapor:** belgelenmemis endpoint listesi -- eksik parametre aciklamasi -- yanit ornegi olmayan endpoint
+**5b — Gap report:** undocumented endpoint list -- missing parameter descriptions -- endpoints without response examples
 
-## 6. Cikti
+## 6. Output
 **6a — Markdown:**
 ```markdown
-## [HTTP Metodu] [Yol]
-[Aciklama]
+## [HTTP Method] [Path]
+[Description]
 
-**Yetkilendirme:** [Gerekli/Gereksiz] [Tip]
+**Authorization:** [Required/Not required] [Type]
 
-**Parametreler:**
-| Isim | Konum | Tip | Zorunlu | Aciklama |
-|------|--------|-----|---------|----------|
-| id   | path   | string | Evet | Kaynak kimlik numarasi |
+**Parameters:**
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| id   | path | string | Yes | The resource identifier |
 
-**Istek Govdesi:**
+**Request Body:**
 ```json
-{ "alan": "tip - aciklama" }
+{ "field": "type - description" }
 ```
 
-**Basarili Yanit (200):**
+**Success Response (200):**
 ```json
-{ "ornek": "yanit" }
+{ "example": "response" }
 ```
 
-**Hata Yanitlari:**
-- `401` - Yetkilendirme hatasi
-- `404` - Kaynak bulunamadi
+**Error Responses:**
+- `401` - Authorization error
+- `404` - Resource not found
 ```
 
-**6b — OpenAPI YAML (istege bagli):** kullaniciya sor -- onayla `openapi.yaml` yaz -- gecerlilik dogrula
+**6b — OpenAPI YAML (optional):** ask the user -- on approval write `openapi.yaml` -- validate it
 
-**6c — Ozet rapor:**
+**6c — Summary report:**
 ```
-=== API DOKUMANTASYON OZETI ===
-Framework: [tespit]
-Toplam Endpoint: [sayi]
-  GET/POST/PUT/DELETE: [sayilar]
-Belgelenmemis: [sayi]
-Dosyalar: [olusturulan liste]
+=== API DOCUMENTATION SUMMARY ===
+Framework: [detected]
+Total Endpoints: [count]
+  GET/POST/PUT/DELETE: [counts]
+Undocumented: [count]
+Files: [created list]
 ===============================
 ```

--- a/.claude/commands/api-test.md
+++ b/.claude/commands/api-test.md
@@ -1,19 +1,19 @@
 HTTP API endpoint testing. Send GET/POST/PUT/DELETE requests, analyze status + response, assertions.
 
-# Gerekli Araclar
+# Required Tools
 - Bash (badi dev api-test)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Basit GET
+### Step 1: Simple GET
 ```bash
 badi dev api-test https://api.example.com/users
 ```
 
-### Adim 2: Gelismis Kullanim
+### Step 2: Advanced Usage
 
 ```bash
-# POST body ile
+# POST with a body
 badi dev api-test https://api.example.com/users \
   --method POST \
   --body '{"name":"Ali","email":"a@b.com"}'
@@ -26,29 +26,29 @@ badi dev api-test https://api.example.com/me \
 badi dev api-test https://api.example.com/health \
   --expect 200
 
-# Coklu header
+# Multiple headers
 badi dev api-test https://api.example.com/data \
   --header "Authorization: Bearer X" \
   --header "X-Custom: Y"
 ```
 
-### Adim 3: Cikti
+### Step 3: Output
 
-- **Status + Sure** (ms)
-- **Boyut** (KB)
+- **Status + Duration** (ms)
+- **Size** (KB)
 - **Content-Type**
-- **Tum response headers**
-- **Body** (JSON pretty print veya text)
-- **Assertion sonucu** (--expect kullanildiysa)
+- **All response headers**
+- **Body** (JSON pretty print or text)
+- **Assertion result** (if --expect was used)
 
-### Adim 4: Kullanim Senaryolari
+### Step 4: Usage Scenarios
 
-**Saglik kontrolu:**
+**Health check:**
 ```bash
 badi dev api-test https://app.com/health --expect 200
 ```
 
-**Yeni endpoint test:**
+**New endpoint test:**
 ```bash
 badi dev api-test http://localhost:3000/api/users/1
 ```
@@ -64,11 +64,11 @@ done
 ```bash
 # Login
 badi dev api-test https://api.com/login --method POST --body '{"u":"x","p":"y"}'
-# Token'i al, kullan
+# Take the token, use it
 badi dev api-test https://api.com/me --header "Authorization: Bearer $TOKEN"
 ```
 
-### Adim 5: CI Entegrasyonu
+### Step 5: CI Integration
 
 ```yaml
 - name: API Smoke Test
@@ -77,7 +77,7 @@ badi dev api-test https://api.com/me --header "Authorization: Bearer $TOKEN"
     badi dev api-test ${{ env.API_URL }}/api/v1/version --expect 200
 ```
 
-# Ornek
+# Example
 
 ```
 /api-test https://api.github.com/users/octocat --expect 200

--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -1,26 +1,26 @@
 Project planning command. Turns vague project ideas into 5 structured documents: specification, implementation plan, task list, brand identity, and a kickoff prompt.
 
-# Gerekli Araclar
-- Read (referans dosyalari, mevcut proje bilgisi)
-- Write (5 dokuman + TaskBoard entegrasyonu)
-- Agent (project-architect ajani)
-- Bash (proje analizi)
+# Required Tools
+- Read (reference files, existing project info)
+- Write (5 documents + TaskBoard integration)
+- Agent (project-architect agent)
+- Bash (project analysis)
 
-# Prosedur (7 Adim)
+# Procedure (7 Steps)
 
-### Adim 1: Proje Fikrini Al
-Kullanicidan projeyi tanimlamasini iste:
-- Proje fikri (1-2 cumle yeterli, ham olabilir)
-- Proje boyutu tahmini: Kucuk (hafta sonu) / Orta / Buyuk
+### Step 1: Get the Project Idea
+Ask the user to describe the project:
+- The project idea (1-2 sentences is enough, raw is fine)
+- Size estimate: Small (weekend) / Medium / Large
 
-### Adim 2: Project-Architect Ajanini Etkinlestir
-Ajana devret:
-- Proje fikrini ilet
-- Boyut tahminine gore soru katmanini belirle
-- Interaktif kesif surecini baslat (Katman 1-3 sorular)
+### Step 2: Activate the Project-Architect Agent
+Delegate to the agent:
+- Pass the project idea
+- Pick the question layer by the size estimate
+- Start the interactive discovery (Layer 1-3 questions)
 
-### Adim 3: Referanslari Yukle
-Ajan su referans dosyalarini okur:
+### Step 3: Load the References
+The agent reads these reference files:
 - `.claude/references/design-patterns.md`
 - `.claude/references/specification-guide.md`
 - `.claude/references/implementation-guide.md`
@@ -28,52 +28,52 @@ Ajan su referans dosyalarini okur:
 - `.claude/references/tech-stacks.md`
 - `.claude/references/elicitation-guide.md`
 
-### Adim 4: Tech Stack Secimi
-Interaktif tech stack danismanligi:
-- 8 karar noktasinda secenek sun
-- Her secenek icin artilari/eksileri goster
-- Kullanicinin onayini al
+### Step 4: Tech Stack Selection
+Interactive tech-stack advisory:
+- Offer options at 8 decision points
+- Show pros/cons for each option
+- Get the user's approval
 
-### Adim 5: 5 Dokumani Olustur
-Sirali olarak olustur:
-1. `docs/SPECIFICATION.md` — Kapsam, ozellikler, kabul kriterleri
-2. `docs/IMPLEMENTATION.md` — Tech stack, kaliplar, dizin yapisi
-3. `docs/TASKS.md` — Sirali gorev listesi (faz bazli)
-4. `docs/BRANDING.md` — Gorsel kimlik (kullaniciya yonelik projelerde)
-5. `docs/PROMPT.md` — Tek seferlik calistirma prompt'u
+### Step 5: Create the 5 Documents
+Create in order:
+1. `docs/SPECIFICATION.md` — Scope, features, acceptance criteria
+2. `docs/IMPLEMENTATION.md` — Tech stack, patterns, directory structure
+3. `docs/TASKS.md` — Ordered task list (by phase)
+4. `docs/BRANDING.md` — Visual identity (user-facing projects)
+5. `docs/PROMPT.md` — A single-pass kickoff prompt
 
-### Adim 6: Badi Entegrasyonu
-Uretilen dokumanlarI Badi sistemine entegre et:
-- TASKS.md'den gorevleri `.claude/workspace/TaskBoard.md`'ye aktar
-- IMPLEMENTATION.md'den temel mimari kararlarI `knowledge-base.md`'ye aday goster
-- SPECIFICATION.md ozetini `memory.md`'ye ekle
+### Step 6: Badi Integration
+Integrate the produced documents into the Badi system:
+- Move tasks from TASKS.md into `.claude/workspace/TaskBoard.md`
+- Nominate the key architecture decisions from IMPLEMENTATION.md into `knowledge-base.md`
+- Add the SPECIFICATION.md summary to `memory.md`
 
-### Adim 7: Sonraki Adimlar
-Kullaniciya yonlendir:
-- `/scaffold` ile proje yapisini olustur (IMPLEMENTATION.md'den)
-- `/start` ile gelistirme oturumunu baslat
-- `/spec-check` ile uyum kontrolu yap (gelistirme sirasinda)
+### Step 7: Next Steps
+Point the user to:
+- `/scaffold` to build the project structure (from IMPLEMENTATION.md)
+- `/start` to begin the development session
+- `/spec-check` for conformance checks (during development)
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI PROJE MIMARISI ===
-Proje: [proje adi]
-Boyut: [kucuk/orta/buyuk]
-Tech Stack: [ana teknolojiler]
+=== BADI PROJECT ARCHITECTURE ===
+Project: [project name]
+Size: [small/medium/large]
+Tech Stack: [main technologies]
 
-Olusturulan Dokumanlar:
+Created Documents:
   + docs/SPECIFICATION.md
   + docs/IMPLEMENTATION.md
   + docs/TASKS.md
-  + docs/BRANDING.md (varsa)
+  + docs/BRANDING.md (if applicable)
   + docs/PROMPT.md
 
-Entegrasyon:
-  ~ TaskBoard.md guncellendi ([sayi] gorev eklendi)
-  ~ memory.md guncellendi (proje ozeti)
+Integration:
+  ~ TaskBoard.md updated ([count] tasks added)
+  ~ memory.md updated (project summary)
 
-Sonraki:
-  1. /scaffold — Proje yapisini olustur
-  2. /start — Gelistirmeye basla
+Next:
+  1. /scaffold — Build the project structure
+  2. /start — Start developing
 ==============================
 ```

--- a/.claude/commands/aso.md
+++ b/.claude/commands/aso.md
@@ -1,109 +1,109 @@
 App Store Optimization command. iOS app listing analysis via the iTunes API, keyword optimization, and competitor comparison.
 
-# Gerekli Araclar
-- Bash (badi aso komutlari)
+# Required Tools
+- Bash (badi aso commands)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Hedef Belirle
+### Step 1: Set the Target
 
-Kullaniciya sor: "Ne analiz etmek istiyorsunuz?"
-- **Kendi app'iniz** — Audit + keyword + review
-- **Rakip karsilastirma** — 2 app side-by-side
-- **Keyword arastirma** — Pazar kesif
-- **Yeni app metadata** — Listing hazirlama
+Ask the user: "What do you want to analyze?"
+- **Your own app** — Audit + keywords + reviews
+- **Competitor comparison** — 2 apps side-by-side
+- **Keyword research** — Market discovery
+- **New app metadata** — Listing preparation
 
-App ID gerekli: `https://apps.apple.com/app/id[APP_ID]` URL'sinden al.
+The App ID is required: take it from the `https://apps.apple.com/app/id[APP_ID]` URL.
 
-### Adim 2: Temel ASO Audit
+### Step 2: Basic ASO Audit
 
 ```bash
 badi aso audit [app-id]
 ```
 
-Olculen metrikler:
-- Title/Subtitle uzunlugu (30/30 karakter limit)
-- Description uzunlugu (500+ onerilir)
-- Screenshot sayisi (>= 3 zorunlu, >= 6 ideal)
+Measured metrics:
+- Title/Subtitle length (30/30 character limits)
+- Description length (500+ recommended)
+- Screenshot count (>= 3 mandatory, >= 6 ideal)
 - Supported languages
-- Rating count (>= 100 onerilir, >= 4.0 skor)
+- Rating count (>= 100 recommended, >= 4.0 score)
 
-ASO skoru 0-100 arasi verilir.
+An ASO score of 0-100 is given.
 
-### Adim 3: Keyword Analizi
+### Step 3: Keyword Analysis
 
 ```bash
 badi aso keywords [app-id]
 ```
 
-Gosterir:
-- Title keyword'leri
-- Subtitle keyword'leri
-- Description top 20 keyword
-- Frekans bazli siralama
+Shows:
+- Title keywords
+- Subtitle keywords
+- Description top-20 keywords
+- Frequency-based ranking
 
-### Adim 4: Rakip Karsilastirma
+### Step 4: Competitor Comparison
 
 ```bash
-badi aso compete [benim-app-id] [rakip-app-id]
+badi aso compete [my-app-id] [competitor-app-id]
 ```
 
-Yan yana:
-- Metadata uzunluklari
+Side by side:
+- Metadata lengths
 - Rating + count
-- Screenshot sayisi
+- Screenshot count
 - Language count
-- Ortak + farkli keywordler (rakipten ogrenmek icin)
+- Shared + differing keywords (to learn from the competitor)
 
-### Adim 5: Metadata Limit Rehberi
+### Step 5: Metadata Limit Guide
 
 ```bash
-badi aso metadata appstore      # iOS karakter limitleri
-badi aso metadata playstore     # Android karakter limitleri
+badi aso metadata appstore      # iOS character limits
+badi aso metadata playstore     # Android character limits
 ```
 
-### Adim 6: Review Yaniti
+### Step 6: Review Responses
 
 ```bash
 badi aso review [app-id]
 ```
-Pozitif/negatif/feature response sablonlari.
+Positive/negative/feature response templates.
 
-### Adim 7: Screenshot Rehberi
+### Step 7: Screenshot Guide
 
 ```bash
 badi aso screenshots
 ```
-iOS 4 zorunlu + 3 opsiyonel boyut, Android 4 kategori.
+iOS 4 mandatory + 3 optional sizes, Android 4 categories.
 
-### Adim 8: Pazar Arastirma
+### Step 8: Market Research
 
 ```bash
-badi aso search "sorgu" --country tr
+badi aso search "query" --country us
 ```
-Rakipleri kesfet, trending app'leri gor.
+Discover competitors, see trending apps.
 
-### Adim 9: Icerik Uretimi Entegrasyonu
+### Step 9: Content Production Integration
 
-Launch icin:
+For launch:
 ```bash
-badi content post "yeni urun lansman" --platform appstore
-badi content release-notes --platform ios --version X.Y.Z --lang tr,en
+badi content post "new product launch" --platform appstore
+badi content release-notes --platform ios --version X.Y.Z
 badi content visual "app store screenshot"
 ```
 
-### Adim 10: Detayli Strateji
+### Step 10: Detailed Strategy
 
-Claude Code'da derin analiz icin ajanlari cagir:
+In Claude Code, invoke the agents for deep analysis:
 - `aso-master` — Full strategy
 - `aso-research` — Market research
 - `aso-optimizer` — Metadata optimization
 - `aso-strategist` — Growth planning
 
-# Ornek Kullanim
+# Example Usage
 
 ```
-/aso 284882215              # Facebook app analizi
+/aso 284882215              # Facebook app analysis
 /aso compete 284882215 310633997   # Facebook vs WhatsApp
-/aso search "task manager" --country tr
+/aso search "task manager" --country us
 ```

--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -1,107 +1,107 @@
 Project briefing command. Turns raw project ideas into structured, actionable briefs.
 
-# Gerekli Araclar
-- Read (mevcut proje bilgileri)
-- Write (brifing dosyasi)
-- Grep (benzer proje arama)
-- Glob (kaynak tarama)
+# Required Tools
+- Read (existing project info)
+- Write (brief file)
+- Grep (similar project search)
+- Glob (resource scan)
 
-# Prosedur (7 Adim)
+# Procedure (7 Steps)
 
-### Adim 1: Fikir Yakala
-Kullanicidan su bilgileri topla (yapilandirilmamis bile olsa kabul et):
-- **Problem:** Hangi sorunu cozuyoruz?
-- **Cozum:** Nasil cozmeyi planliyoruz?
-- **Kullanicilar:** Kim kullanacak? (birincil ve ikincil hedef kitle)
-- **Basari Kriteri:** Basariyi nasil olcecegiz?
-- **Motivasyon:** Neden simdi? Tetikleyen olay nedir?
+### Step 1: Capture the Idea
+Collect from the user (accept it even unstructured):
+- **Problem:** What problem are we solving?
+- **Solution:** How do we plan to solve it?
+- **Users:** Who will use it? (primary and secondary audience)
+- **Success Criterion:** How will we measure success?
+- **Motivation:** Why now? What triggered it?
 
-Fikir ne kadar ham olursa olsun, yapilandirilmis formata donustur.
+However raw the idea, convert it into a structured format.
 
-### Adim 2: Kapsam Tanimla
-Net sinirlar ciz:
+### Step 2: Define the Scope
+Draw clear lines:
 
-**Dahil Olanlar:**
-- Birinci fazda teslim edilecek ozellikler
-- Temel kullanici akislari
-- Minimum teknik gereksinimler
+**In Scope:**
+- Features delivered in phase one
+- Core user flows
+- Minimum technical requirements
 
-**Haric Tutulanlar:**
-- Bilinçli olarak kapsam disinda birakilan ozellikler
-- Gelecek fazlara ertelenen isler
-- Sorumluluk sinirlari
+**Out of Scope:**
+- Features deliberately excluded
+- Work deferred to future phases
+- Responsibility boundaries
 
-**Varsayimlar:**
-- Teknik varsayimlar (altyapi, erisim, vb.)
-- Is varsayimlari (butce, zaman, kaynak)
-- Kullanici varsayimlari (beceri seviyesi, erisim, vb.)
+**Assumptions:**
+- Technical assumptions (infrastructure, access, etc.)
+- Business assumptions (budget, time, resources)
+- User assumptions (skill level, access, etc.)
 
-### Adim 3: Kullanici Hikayeleri (MoSCoW)
-5-10 kullanici hikayesi yaz, her biri icin:
-- Format: "Bir [rol] olarak, [amac] istiyorum, boylece [fayda]."
-- Kabul kriterleri (2-4 madde)
-- MoSCoW onceligi:
-  - **Must (Olmali):** Olmadan urun calisamaz
-  - **Should (Olmali):** Onemli ama ilk surumde olmasa da olur
-  - **Could (Olabilir):** Guzel olur ama oncelikli degil
-  - **Won't (Olmayacak):** Bu fazda bilinçli olarak yapilmayacak
+### Step 3: User Stories (MoSCoW)
+Write 5-10 user stories, each with:
+- Format: "As a [role], I want [goal], so that [benefit]."
+- Acceptance criteria (2-4 items)
+- MoSCoW priority:
+  - **Must:** The product cannot work without it
+  - **Should:** Important but can miss the first release
+  - **Could:** Nice to have, not a priority
+  - **Won't:** Deliberately not done in this phase
 
-### Adim 4: Teknik Degerlendirme
-- **Teknoloji Yigini:** Onerilen diller, frameworkler, araclar
-- **Entegrasyonlar:** Ucuncu parti servisler ve API'ler
-- **Veri Gereksinimleri:** Veritabani, depolama, veri akisi
-- **Altyapi:** Hosting, CI/CD, izleme
-- **Kisitlamalar:** Performans gereksinimleri, uyumluluk, olcek
-- **Teknik Borc Riski:** Bilinen kisa yollar veya gecici cozumler
-- **Build vs Buy Analizi:** Hangi bilesenleri gelistirmeli, hangilerini hazir kullanmali?
+### Step 4: Technical Assessment
+- **Tech Stack:** Suggested languages, frameworks, tools
+- **Integrations:** Third-party services and APIs
+- **Data Requirements:** Database, storage, data flow
+- **Infrastructure:** Hosting, CI/CD, monitoring
+- **Constraints:** Performance requirements, compliance, scale
+- **Technical Debt Risk:** Known shortcuts or workarounds
+- **Build vs Buy Analysis:** Which components to build, which to use off the shelf?
 
-### Adim 5: Risk Tespiti
-Risk matrisi olustur:
+### Step 5: Risk Identification
+Build a risk matrix:
 
-| Risk | Olasilik (1-5) | Etki (1-5) | Risk Skoru | Azaltma Stratejisi |
-|------|----------------|------------|------------|-------------------|
-| [risk tanimi] | [deger] | [deger] | [OxE] | [strateji] |
+| Risk | Likelihood (1-5) | Impact (1-5) | Risk Score | Mitigation Strategy |
+|------|------------------|--------------|------------|---------------------|
+| [risk description] | [value] | [value] | [LxI] | [strategy] |
 
-Risk kategorileri:
-- Teknik riskler (karmasiklik, bilinmeyen teknoloji)
-- Kaynak riskleri (zaman, butce, yetenek)
-- Dis bagimlilik riskleri (ucuncu parti, API)
-- Pazar riskleri (talep, rekabet)
+Risk categories:
+- Technical risks (complexity, unknown technology)
+- Resource risks (time, budget, talent)
+- External dependency risks (third parties, APIs)
+- Market risks (demand, competition)
 
-### Adim 6: Zaman Tahmini
-Faz bazli tahmin tablosu:
+### Step 6: Time Estimate
+A phase-based estimate table:
 
-| Faz | Aciklama | Tahmini Sure | Onkosusllar |
-|-----|----------|-------------|-------------|
-| Arastirma | ... | ... | ... |
-| Tasarim | ... | ... | ... |
-| Gelistirme | ... | ... | ... |
+| Phase | Description | Estimated Duration | Prerequisites |
+|-------|-------------|--------------------|---------------|
+| Research | ... | ... | ... |
+| Design | ... | ... | ... |
+| Development | ... | ... | ... |
 | Test | ... | ... | ... |
-| Lansman | ... | ... | ... |
+| Launch | ... | ... | ... |
 
-Not: Tahminlere %20 tampon ekle.
-Toplam tahmini sure ve bitiris tarihi belirt.
+Note: add a 20% buffer to estimates.
+State the total estimated duration and the end date.
 
-### Adim 7: Brifing Dosyasi Olustur
-`briefs/[proje-adi]-brief.md` dosyasina kaydet.
+### Step 7: Create the Brief File
+Save to `briefs/[project-name]-brief.md`.
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI PROJE BRIFINGI ===
-Proje: [proje adi]
-Tarih: [tarih]
-Durum: TASLAK
+=== BADI PROJECT BRIEF ===
+Project: [project name]
+Date: [date]
+Status: DRAFT
 
-Ozet: [tek paragraf]
-Oncelik: [YUKSEK/ORTA/DUSUK]
-Tahmini Sure: [sure]
-Risk Seviyesi: [YUKSEK/ORTA/DUSUK]
+Summary: [single paragraph]
+Priority: [HIGH/MEDIUM/LOW]
+Estimated Duration: [duration]
+Risk Level: [HIGH/MEDIUM/LOW]
 
-Must Have: [sayi] hikaye
-Should Have: [sayi] hikaye
-Could Have: [sayi] hikaye
-Won't Have: [sayi] hikaye
+Must Have: [count] stories
+Should Have: [count] stories
+Could Have: [count] stories
+Won't Have: [count] stories
 
-Dosya: briefs/[proje-adi]-brief.md
+File: briefs/[project-name]-brief.md
 ============================
 ```

--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -1,152 +1,152 @@
 Automatic changelog generation. Produces a structured changelog from commit history.
 
-## Badi CLI Komutu (v1.6+)
-Hizli uretim icin:
+## Badi CLI Command (v1.6+)
+For quick generation:
 ```bash
-badi changelog                    # Son tag'den HEAD'e onizleme
-badi changelog --from v1.0.0      # Belirli tag'den
-badi changelog --write --version 1.6.0  # CHANGELOG.md'ye yaz
+badi changelog                    # Preview from the latest tag to HEAD
+badi changelog --from v1.0.0      # From a specific tag
+badi changelog --write --version 1.6.0  # Write to CHANGELOG.md
 ```
 
-CLI conventional commit tipleriyle otomatik gruplar. Asagidaki manuel adimlar karmasik durumlar icin (non-conventional commit'ler, breaking change isaretleme vb.).
+The CLI groups automatically by conventional commit types. The manual steps below are for complex cases (non-conventional commits, breaking-change marking, etc.).
 
-# Gerekli Araclar
+# Required Tools
 - Bash (git log, git tag, git diff)
-- Read (mevcut CHANGELOG.md)
-- Write (changelog dosyasi olusturma/guncelleme)
-- Grep (commit mesaji arama)
+- Read (the existing CHANGELOG.md)
+- Write (creating/updating the changelog file)
+- Grep (commit message search)
 
-# Format Standardi
-Bu komut Keep-a-Changelog (keepachangelog.com) formatini kullanir.
-Conventional Commits (feat:, fix:, breaking:, vb.) mesajlari otomatik kategorize edilir.
-
----
-
-## Adim 1: Surum Araligini Belirle
-
-### 1a: Son Etiketi Bul
-- `git tag --sort=-version:refname` ile en son etiketi bul
-- Etiket yoksa ilk commit'i baslangic noktasi olarak kullan
-- Kullanicidan ozel aralik belirtmesini iste (istege bagli)
-
-### 1b: Aralik Dogrulama
-- Baslangic noktasi: [son etiket] veya [belirtilen commit]
-- Bitis noktasi: HEAD (veya belirtilen commit)
-- Aralikdaki toplam commit sayisini goster
-- `git log [baslangic]..HEAD --oneline` ile on izleme sun
+# Format Standard
+This command uses the Keep-a-Changelog (keepachangelog.com) format.
+Conventional Commits messages (feat:, fix:, breaking:, etc.) are categorized automatically.
 
 ---
 
-## Adim 2: Commit Mesajlarini Parse Et
+## Step 1: Define the Version Range
 
-### 2a: Commit Listesini Al
-- `git log [aralik] --format="%H|%s|%an|%ad" --date=short` calistir
-- Her commit icin: hash, mesaj, yazar, tarih bilgisi topla
-- Merge commit'leri ayir (istege bagli dahil et veya haric tut)
+### 1a: Find the Latest Tag
+- Find the latest tag with `git tag --sort=-version:refname`
+- If no tag exists, use the first commit as the starting point
+- Ask the user for a custom range (optional)
 
-### 2b: Conventional Commits Ayristirmasi
-Asagidaki on ekleri tani:
-- `feat:` veya `feature:` -> Ozellikler
-- `fix:` veya `bugfix:` -> Duzeltmeler
-- `breaking:` veya `BREAKING CHANGE:` -> Kirilma Degisiklikleri
-- `refactor:` -> Yeniden Duzenleme
-- `docs:` -> Dokumantasyon
-- `perf:` -> Performans
-- `test:` -> Test
-- `chore:` veya `ci:` -> Bakim
-
-### 2c: Conventional Olmayan Mesajlar
-- On eki olmayan commit'leri iceriklerne gore siniflandir
-- Siniflandirilamazsa "Diger" kategorisine ekle
-- Kullaniciya belirsiz commit'ler icin kategori sormay teklif et
+### 1b: Range Validation
+- Start point: [last tag] or [given commit]
+- End point: HEAD (or a given commit)
+- Show the total commit count in the range
+- Offer a preview with `git log [start]..HEAD --oneline`
 
 ---
 
-## Adim 3: Kategorize Et
+## Step 2: Parse the Commit Messages
 
-### 3a: Ana Kategoriler
-Bulgulari su siralamayla grupla:
-1. **Kirilma Degisiklikleri** (BREAKING CHANGES) - En uste, dikkat cekici
-2. **Ozellikler** (Features) - Yeni islevsellik
-3. **Duzeltmeler** (Bug Fixes) - Hata giderimleri
-4. **Performans** (Performance) - Performans iyilestirmeleri
-5. **Yeniden Duzenleme** (Refactoring) - Kod yapisi degisiklikleri
-6. **Dokumantasyon** (Documentation) - Belge degisiklikleri
-7. **Test** - Test degisiklikleri
-8. **Bakim** (Chores) - Yardimci degisiklikler
+### 2a: Get the Commit List
+- Run `git log [range] --format="%H|%s|%an|%ad" --date=short`
+- Per commit collect: hash, message, author, date
+- Separate merge commits (include or exclude on request)
 
-### 3b: Kapsam Bilgisi
-- Eger commit mesajinda kapsam varsa (ornek: `feat(auth):`) grupla
-- Kapsam bilgisini changelog girisi icinde goster
+### 2b: Conventional Commits Parsing
+Recognize these prefixes:
+- `feat:` or `feature:` -> Features
+- `fix:` or `bugfix:` -> Fixes
+- `breaking:` or `BREAKING CHANGE:` -> Breaking Changes
+- `refactor:` -> Refactoring
+- `docs:` -> Documentation
+- `perf:` -> Performance
+- `test:` -> Tests
+- `chore:` or `ci:` -> Maintenance
+
+### 2c: Non-Conventional Messages
+- Classify unprefixed commits by their content
+- If unclassifiable, add to the "Other" category
+- Offer to ask the user about ambiguous commits
 
 ---
 
-## Adim 4: Markdown Olustur
+## Step 3: Categorize
 
-### 4a: Changelog Formati
-Keep-a-Changelog formatinda olustur:
+### 3a: Main Categories
+Group the findings in this order:
+1. **Breaking Changes** - At the top, prominent
+2. **Features** - New functionality
+3. **Bug Fixes** - Error remediation
+4. **Performance** - Performance improvements
+5. **Refactoring** - Code structure changes
+6. **Documentation** - Doc changes
+7. **Tests** - Test changes
+8. **Chores** - Auxiliary changes
+
+### 3b: Scope Info
+- If the commit message has a scope (example: `feat(auth):`), group by it
+- Show the scope inside the changelog entry
+
+---
+
+## Step 4: Build the Markdown
+
+### 4a: Changelog Format
+Produce in Keep-a-Changelog format:
 
 ```markdown
-# Degisiklik Gunlugu
+# Changelog
 
-## [Yayinlanmamis] - YYYY-AA-GG
+## [Unreleased] - YYYY-MM-DD
 
-### Kirilma Degisiklikleri
-- **[kapsam]** Degisiklik aciklamasi ([hash])
+### Breaking Changes
+- **[scope]** Change description ([hash])
 
-### Ozellikler
-- **[kapsam]** Yeni ozellik aciklamasi ([hash])
+### Features
+- **[scope]** New feature description ([hash])
 
-### Duzeltmeler
-- Hata duzeltme aciklamasi ([hash])
+### Fixes
+- Bug fix description ([hash])
 
-### Yeniden Duzenleme
-- Refactoring aciklamasi ([hash])
+### Refactoring
+- Refactoring description ([hash])
 
-### Dokumantasyon
-- Dokumantasyon degisikligi ([hash])
+### Documentation
+- Documentation change ([hash])
 ```
 
-### 4b: Ek Bilgiler
-- Katki saglayanlari listele (yazarlar)
-- Toplam commit sayisini ekle
-- Karsilastirma baglantisi ekle: `[Yayinlanmamis]: [repo-url]/compare/[etiket]...HEAD`
+### 4b: Extra Info
+- List the contributors (authors)
+- Add the total commit count
+- Add a compare link: `[Unreleased]: [repo-url]/compare/[tag]...HEAD`
 
 ---
 
-## Adim 5: CHANGELOG.md Guncelle (Istege Bagli)
+## Step 5: Update CHANGELOG.md (Optional)
 
-### 5a: Mevcut Dosya Kontrolu
-- `CHANGELOG.md` mevcut mu kontrol et
-- Mevcutsa icerigi oku ve format uyumunu dogrula
+### 5a: Existing File Check
+- Check whether `CHANGELOG.md` exists
+- If it does, read the content and verify format compatibility
 
-### 5b: Kullanici Onay
-- Olusturulan changelog icerigini on izleme olarak goster
-- Kullaniciya sor: "CHANGELOG.md dosyasini guncelleyeyim mi?"
-- Onay alinrsa, yeni girisleri dosyanin ustune ekle (mevcut icerigi koru)
+### 5b: User Approval
+- Show the generated changelog content as a preview
+- Ask the user: "Shall I update CHANGELOG.md?"
+- On approval, prepend the new entries (preserve the existing content)
 
-### 5c: Dosya Yazimi
-- Yeni bolumu mevcut icergin ustune ekle
-- Baslik formatini koru
-- Tarih ve surum bilgisini dogru formatta ekle
+### 5c: File Write
+- Prepend the new section above the existing content
+- Preserve the heading format
+- Add the date and version in the correct format
 
 ---
 
-## Cikti Formati
+## Output Format
 
-### Adim 6: Ozet Rapor
+### Step 6: Summary Report
 ```
-=== CHANGELOG OZETI ===
-Aralik: [baslangic] -> [bitis]
-Toplam Commit: [sayi]
-Kategoriler:
-  Ozellikler:            [sayi]
-  Duzeltmeler:           [sayi]
-  Kirilma Degisiklikleri:[sayi]
-  Yeniden Duzenleme:     [sayi]
-  Dokumantasyon:         [sayi]
-  Diger:                 [sayi]
-Katki Saglayanlar: [yazar listesi]
-CHANGELOG.md: [GUNCELLENDI / GUNCELLENMEDI]
+=== CHANGELOG SUMMARY ===
+Range: [start] -> [end]
+Total Commits: [count]
+Categories:
+  Features:          [count]
+  Fixes:             [count]
+  Breaking Changes:  [count]
+  Refactoring:       [count]
+  Documentation:     [count]
+  Other:             [count]
+Contributors: [author list]
+CHANGELOG.md: [UPDATED / NOT UPDATED]
 ========================
 ```

--- a/.claude/commands/debt-map.md
+++ b/.claude/commands/debt-map.md
@@ -1,121 +1,121 @@
 Technical debt mapping command. Systematically detects and prioritizes technical debt in the codebase.
 
-# Gerekli Araclar
-- Grep (kod taramasi)
-- Glob (dosya bulma)
-- Read (dosya okuma)
-- Bash (karmasiklik analizi, git blame)
-- Write (rapor yazimi)
+# Required Tools
+- Grep (code scan)
+- Glob (file discovery)
+- Read (file reading)
+- Bash (complexity analysis, git blame)
+- Write (report writing)
 
-# Prosedur (4 Adim)
+# Procedure (4 Steps)
 
-### Adim 1: Kapsam Belirle
-Kullaniciya sor:
-- **Tum proje:** Komple kod tabanini tara
-- **Modul:** Belirli bir modul veya dizin
-- **Katman:** Belirli bir katman (API, UI, veritabani, vb.)
+### Step 1: Define the Scope
+Ask the user:
+- **Whole project:** Scan the complete codebase
+- **Module:** A specific module or directory
+- **Layer:** A specific layer (API, UI, database, etc.)
 
-Kapsam bilgisini kaydet:
-- Taranacak dizinler
-- Dahil edilecek dosya turleri
-- Haric tutulacak dizinler (node_modules, vendor, dist, build, vb.)
+Record the scope:
+- Directories to scan
+- File types to include
+- Directories to exclude (node_modules, vendor, dist, build, etc.)
 
-### Adim 2: 3 Paralel Tarama
+### Step 2: 3 Parallel Scans
 
-**Tarama A: TODO/FIXME Envanteri**
-- `TODO` etiketlerini tara ve kategorilere ayir
-- `FIXME` etiketlerini tara (acil mudahale gerektiren)
-- `HACK` etiketlerini tara (gecici cozumler)
-- `WORKAROUND` etiketlerini tara (bilinen sorun gecici cozumleri)
-- `DEPRECATED` etiketlerini tara (kullanilmamasi gereken)
-- `XXX` ve `BUG` etiketlerini tara
-- Her bulgu icin dosya yolu, satir numarasi ve baglamini kaydet
-- Git blame ile yaslarini tespit et ve eski olanlari vurgula
+**Scan A: TODO/FIXME Inventory**
+- Scan and categorize `TODO` tags
+- Scan `FIXME` tags (needing urgent attention)
+- Scan `HACK` tags (temporary fixes)
+- Scan `WORKAROUND` tags (known-issue workarounds)
+- Scan `DEPRECATED` tags (should no longer be used)
+- Scan `XXX` and `BUG` tags
+- For each finding record file path, line number, and context
+- Date them via git blame and highlight the old ones
 
-**Tarama B: Karmasiklik Analizi**
-- 500+ satirlik dosyalari tespit et (asiri buyuk)
-- 100+ satirlik fonksiyonlari bul (asiri uzun)
-- 3+ seviye ic ice gecen kosullari bul (derin nesting)
-- Cok fazla import/bagimlilik iceren dosyalar
-- Tekrarlayan kod bloklari (copy-paste tespiti)
-- 5+ parametreli fonksiyonlar
-- Derin miras hiyerarsileri (3+ seviye)
-- God class/God function tespiiti
+**Scan B: Complexity Analysis**
+- Detect 500+ line files (oversized)
+- Find 100+ line functions (overlong)
+- Find 3+ level nested conditionals (deep nesting)
+- Files with too many imports/dependencies
+- Duplicated code blocks (copy-paste detection)
+- Functions with 5+ parameters
+- Deep inheritance hierarchies (3+ levels)
+- God class / god function detection
 
-**Tarama C: Eskime ve Kullanilmama Tespiti**
-- Kullanilmayan export/fonksiyonlar
-- Deprecated API kullanimi (dil ve framework bazli)
-- Guncelligini yitirmis bagimliliklar
-- Uyumsuz versiyon eslemeleri
-- Kaldirilmis veya desteklenmeyen kutuphaneler
-- Eski konfigur asyon formatlari
-- Yoruma alinmis kod bloklari (zombi kod)
-- Olmeyen feature flag'ler
+**Scan C: Staleness and Dead Code Detection**
+- Unused exports/functions
+- Deprecated API usage (per language and framework)
+- Outdated dependencies
+- Incompatible version pairings
+- Removed or unsupported libraries
+- Old configuration formats
+- Commented-out code blocks (zombie code)
+- Undying feature flags
 
-### Adim 3: Skorlama
-Her teknik borc maddesi icin skor hesapla:
+### Step 3: Scoring
+Compute a score per debt item:
 
-**Etki Skoru (1-5):**
-- 5: Uretim kesintisi riski, guvenlik acigi
-- 4: Performans degradasyonu, veri tutarsizligi
-- 3: Gelistirme hizini onemli olcude yavaslatir
-- 2: Kod okunabilirligini ve bakim kolayligini azaltir
-- 1: Kozmetik sorun, minor tutarsizlik
+**Impact Score (1-5):**
+- 5: Production-outage risk, security vulnerability
+- 4: Performance degradation, data inconsistency
+- 3: Significantly slows development
+- 2: Reduces readability and maintainability
+- 1: Cosmetic issue, minor inconsistency
 
-**Efor Skoru (1-5):**
-- 1: Hizli duzeltme (< 1 saat)
-- 2: Kisa gorev (1-4 saat)
-- 3: Yarim gunluk is (4-8 saat)
-- 4: Tam gunluk is (1-2 gun)
-- 5: Cok gunluk refactoring (3+ gun)
+**Effort Score (1-5):**
+- 1: Quick fix (< 1 hour)
+- 2: Short task (1-4 hours)
+- 3: Half-day job (4-8 hours)
+- 4: Full-day job (1-2 days)
+- 5: Multi-day refactoring (3+ days)
 
-**Oncelik Hesabi:** Etki / Efor = Oncelik Skoru
-- **Yuksek oncelik:** skor >= 2.0 (yuksek etki, dusuk efor = hemen yap)
-- **Orta oncelik:** skor 1.0 - 1.99 (sprint icinde planla)
-- **Dusuk oncelik:** skor < 1.0 (arka planda birak)
+**Priority Calculation:** Impact / Effort = Priority Score
+- **High priority:** score >= 2.0 (high impact, low effort = do now)
+- **Medium priority:** score 1.0 - 1.99 (plan within the sprint)
+- **Low priority:** score < 1.0 (leave in the background)
 
-### Adim 4: Markdown Rapor Olustur
+### Step 4: Build the Markdown Report
 
-# Cikti Formati
+# Output Format
 ```markdown
-# Teknik Borc Haritasi - [tarih]
+# Technical Debt Map - [date]
 
-## Ozet Istatistikler
-- Toplam Borc Maddesi: [sayi]
-- Kritik (Yuksek Oncelik): [sayi]
-- Orta Oncelik: [sayi]
-- Dusuk Oncelik: [sayi]
-- Tahmini Toplam Efor: [saat/gun]
-- En Borclu Modul: [modul adi]
+## Summary Statistics
+- Total Debt Items: [count]
+- Critical (High Priority): [count]
+- Medium Priority: [count]
+- Low Priority: [count]
+- Estimated Total Effort: [hours/days]
+- Most Indebted Module: [module name]
 
-## TODO/FIXME Envanteri
-| # | Dosya | Satir | Tur | Yas | Etki | Efor | Oncelik | Aciklama |
-|---|-------|-------|-----|-----|------|------|---------|----------|
+## TODO/FIXME Inventory
+| # | File | Line | Type | Age | Impact | Effort | Priority | Description |
+|---|------|------|------|-----|--------|--------|----------|-------------|
 | 1 | ... | ... | TODO | ... | ... | ... | ... | ... |
 
-## Karmasiklik Sicak Noktalari
-| # | Dosya | Satir Sayisi | Karmasiklik | Etki | Efor | Sorun |
-|---|-------|-------------|-------------|------|------|-------|
+## Complexity Hot Spots
+| # | File | Line Count | Complexity | Impact | Effort | Issue |
+|---|------|------------|------------|--------|--------|-------|
 | 1 | ... | ... | ... | ... | ... | ... |
 
-## Eskimis Bilesenler
-| # | Bilesen | Tur | Risk | Efor | Oneri |
-|---|---------|-----|------|------|-------|
+## Stale Components
+| # | Component | Type | Risk | Effort | Suggestion |
+|---|-----------|------|------|--------|------------|
 | 1 | ... | ... | ... | ... | ... |
 
-## Oncelikli Eylem Plani
-### Hemen Yapilmali (Oncelik >= 2.0)
-1. [madde] - Etki: [skor] / Efor: [skor] = Oncelik: [skor]
+## Prioritized Action Plan
+### Do Now (Priority >= 2.0)
+1. [item] - Impact: [score] / Effort: [score] = Priority: [score]
 
-### Sprint Ici (Oncelik 1.0 - 1.99)
-1. [madde]
+### Within the Sprint (Priority 1.0 - 1.99)
+1. [item]
 
-### Arka Plan (Oncelik < 1.0)
-1. [madde]
+### Background (Priority < 1.0)
+1. [item]
 
-## Trend Analizi
-[onceki taramalarla karsilastirma, borc artisi/azalisi]
+## Trend Analysis
+[comparison with previous scans, debt growth/shrinkage]
 
-## Takip Metrikleri
-[sonraki tarama icin temel degerler]
+## Tracking Metrics
+[baseline values for the next scan]
 ```

--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,121 +1,121 @@
 Deployment checklist. Verifies all pre-deployment requirements and produces a readiness report.
 
 ## Badi CLI Pre-Deploy Checklist (v1.6+)
-Dagitim oncesi su kontrolleri MUTLAKA calistir:
-- `badi secret-scan` — Sir sizintisi olmamali (KRITIK — exit 1 ise deploy engelle)
-- `badi commit --check` — Son commit conventional format (changelog uretimi icin)
-- `badi changelog` — Son tag'den beri degisiklikler gozden gecirilmeli
-- `badi ssl [production-domain]` — SSL expire < 30 gun ise uyari
-- `badi dns [domain]` — DNS saglik (email guvenlik)
-- `badi lighthouse [url]` — Performance baseline (regression tespit icin)
+ALWAYS run these checks before deploying:
+- `badi secret-scan` — No secret leakage allowed (CRITICAL — block the deploy on exit 1)
+- `badi commit --check` — Last commit in conventional format (for changelog generation)
+- `badi changelog` — Review the changes since the last tag
+- `badi ssl [production-domain]` — Warn if SSL expires in < 30 days
+- `badi dns [domain]` — DNS health (email security)
+- `badi lighthouse [url]` — Performance baseline (for regression detection)
 
-# Gerekli Araclar
-- Bash (git komutlari, test calistirma, ortam degiskeni kontrolu)
-- Read (konfigur asyon dosyalari, changelog)
-- Grep (kod ve konfigur asyon taramasi)
+# Required Tools
+- Bash (git commands, running tests, env variable checks)
+- Read (configuration files, changelog)
+- Grep (code and configuration scan)
 - ...
 
-# Onemli Not
-Bu komut dagitimi kendisi YAPMAZ. Dagitima hazir olunup olunmadigini degerlendirir
-ve nihai karari kullaniciya birakir.
+# Important Note
+This command does NOT deploy by itself. It evaluates deployment readiness
+and leaves the final decision to the user.
 
 ---
 
-## Bolum 1: On Dagitim Dogrulama
+## Section 1: Pre-Deployment Validation
 
-### Adim 1: Test Suite Kontrolu
-- Tum test suite'ini calistir (veya son CI sonucunu kontrol et)
-- Basarisiz test var mi belirle
-- Test kapsam oranini raporla
+### Step 1: Test Suite Check
+- Run the full test suite (or check the latest CI result)
+- Determine whether any tests fail
+- Report the coverage ratio
 - ...
 
-### Adim 2: Kritik Denetim Bulgusu Kontrolu
-- `audit-trail.md` dosyasini oku (mevcutsa)
-- Son dagitimdan bu yana T0 (kritik) bulgu var mi kontrol et
-- Cozulmemis guvenlik uyarilari var mi tara
+### Step 2: Critical Audit Finding Check
+- Read `audit-trail.md` (if present)
+- Check for T0 (critical) findings since the last deploy
+- Scan for unresolved security warnings
 - ...
 
-### Adim 3: Changelog Dogrulamas i
-- `CHANGELOG.md` dosyasinin guncellenip guncellenmedigini kontrol et
-- Son commit'ten bu yana changelog giris i eklenmi s mi dogrula
-- Eksikse `/changelog` komutunun calistirilmasini oner
+### Step 3: Changelog Validation
+- Check whether `CHANGELOG.md` has been updated
+- Verify a changelog entry exists since the last commit
+- If missing, suggest running the `/changelog` command
 - ...
 
 ---
 
-## Bolum 2: Ortam Degiskeni Dogrulamas i
+## Section 2: Environment Variable Validation
 
-### Adim 4: Env Dosyalari Karsilastirmasi
-- `.env.example` veya `.env.template` dosyasini oku
-- Tanimlanmasi gereken degiskenleri listele
-- Produksiyon ortaminda eksik olabilecek degiskenleri tespit et
+### Step 4: Env File Comparison
+- Read `.env.example` or `.env.template`
+- List the variables that must be defined
+- Detect variables possibly missing in production
 
-### Adim 5: Hassas Deger Kontrolu
+### Step 5: Sensitive Value Check
 
-**Badi Secret Scanner Calistir:**
+**Run the Badi Secret Scanner:**
 ```bash
-badi secret-scan --git    # Working tree + son 100 commit
+badi secret-scan --git    # Working tree + last 100 commits
 ```
 
-Exit code 1 ise (kritik/yuksek sir bulundu) deploy **ENGELLENMELI**.
-- Kod icinde sabit kodlu ortam degeri olup olmadigini tara
-- `TODO` veya `FIXME` iceren ortam referanslarini bul
-- Debug modunun kapali oldugunu dogrula (NODE_ENV, DEBUG, vb.)
+If the exit code is 1 (critical/high secret found), the deploy **MUST BE BLOCKED**.
+- Scan for hardcoded environment values in the code
+- Find environment references containing `TODO` or `FIXME`
+- Verify debug mode is off (NODE_ENV, DEBUG, etc.)
 - ...
 
 ---
 
-## Bolum 3: Veritabani Goc Durumu
+## Section 3: Database Migration State
 
-### Adim 6: Migrasyon Kontrolu
-- Bekleyen migrasyon dosyalarini tespit et
-- Migrasyon sirasinin tutarli oldugunu dogrula
-- Geri alinabilir migrasyonlarin rollback dosyalarinin varligini kontrol et
+### Step 6: Migration Check
+- Detect pending migration files
+- Verify the migration order is consistent
+- Check rollback files exist for reversible migrations
 - ...
 
-### Adim 7: Sema Uyumlulugu
-- Kirilma potansiyeli olan sema degisikliklerini tespit et (sutun silme, tip degisikligi)
-- Geriye uyumluluk risklerini belirt
-- Sonuc: UYUMLU / RISKLI / UYGULANACAK_YOK
+### Step 7: Schema Compatibility
+- Detect schema changes with breaking potential (column drops, type changes)
+- Note backward-compatibility risks
+- Result: COMPATIBLE / RISKY / NOTHING_TO_APPLY
 
 ---
 
-## Bolum 4: Dagitim Manifesti
+## Section 4: Deployment Manifest
 
-### Adim 8: Degisiklik Ozeti Olustur
-Son dagitimdan (son etiket veya belirtilen commit) bu yana:
-- Degisen dosya sayisi: `git diff --stat [son-etiket]..HEAD`
-- Yeni eklenen dosyalar
-- Silinen dosyalar
+### Step 8: Build the Change Summary
+Since the last deploy (last tag or a given commit):
+- Changed file count: `git diff --stat [last-tag]..HEAD`
+- Newly added files
+- Deleted files
 - ...
 
-### Adim 9: Manifest Dosyasi Yaz
-`deploy-manifest-[tarih].md` dosyasi olustur:
+### Step 9: Write the Manifest File
+Create `deploy-manifest-[date].md`:
 ```
-[kisaltildi]
+[abridged]
 ```
 
 ---
 
-## Bolum 5: Dagitim Sonrasi Smoke Test Plani
+## Section 5: Post-Deployment Smoke Test Plan
 
-### Adim 10: Test Plani Olustur
-Degisikliklere gore smoke test kontrol listesi hazirla:
-- Kritik kullanici yollari (login, ana islevler)
-- Degisen API endpoint'leri
-- Veritabani baglantisi dogrulama
+### Step 10: Build the Test Plan
+Prepare a smoke-test checklist based on the changes:
+- Critical user paths (login, core functions)
+- Changed API endpoints
+- Database connectivity verification
 - ...
 
 ---
 
-## Cikti: Dagitim Hazirlik Raporu
+## Output: Deployment Readiness Report
 
-### Adim 11: Nihai Degerlendirme
+### Step 11: Final Assessment
 ```
-[kisaltildi]
+[abridged]
 ```
 
-### GIT/GITME Kriter Tablosu
-- GIT: Tum kontroller GECTI/TEMIZ/GUNCEL/GUVENLI/UYUMLU
-- GITME: Herhangi bir kontrol BASARISIZ/ENGEL_VAR/RISKLI
-- Istisnai GIT: Sadece EKSIK changelog veya UYARI ortam degiskeni varsa, kullanici onayiyla GIT verilebilir
+### GO/NO-GO Criteria Table
+- GO: All checks PASSED/CLEAN/CURRENT/SECURE/COMPATIBLE
+- NO-GO: Any check FAILED/BLOCKED/RISKY
+- Exceptional GO: Only with a MISSING changelog or a WARNING env variable, GO may be given with user approval

--- a/.claude/commands/hotfix.md
+++ b/.claude/commands/hotfix.md
@@ -1,127 +1,127 @@
 Emergency fix workflow. Manages a fast, safe patching process for production errors.
 
-# Gerekli Araclar
-- Bash (git islemleri, test calistirma)
-- Read (hata gunlukleri, stack trace analizi)
-- Write (duzeltme dosyalari)
-- Grep (hata kaynak tespiti)
-- Glob (ilgili dosya taramasi)
-- Agent (auditor: hizli T1 denetim)
+# Required Tools
+- Bash (git operations, running tests)
+- Read (error logs, stack trace analysis)
+- Write (fix files)
+- Grep (error source detection)
+- Glob (related file scan)
+- Agent (auditor: fast T1 audit)
 
-# Kapsam Korumasi
-ONEMLI: Bu is akisi sadece acil duzeltme icindir. Kapsam kaymasi kesinlikle reddedilir.
-Eger duzeltme sirasinda baska bir iyilestirme firsati gorulurse, not olarak kaydet ama UYGULAMADAN devam et.
-
----
-
-## Adim 1: Hotfix Dali Olustur
-
-### 1a: Mevcut Durumu Kontrol Et
-- `git status` ile temiz calisma dizini dogrula
-- Kaydedilmemis degisiklikler varsa stash'le
-
-### 1b: Dal Olustur
-- Ana dali tespit et: `main` veya `master`
-- `git checkout -b hotfix/[kisa-aciklama] [ana-dal]` komutuyla dal olustur
-- Dal adlandirmasi: `hotfix/fix-login-crash`, `hotfix/patch-api-timeout` gibi aciklayici isimler kullan
+# Scope Protection
+IMPORTANT: This workflow is for emergency fixes only. Scope creep is strictly rejected.
+If another improvement opportunity appears during the fix, record it as a note but continue WITHOUT applying it.
 
 ---
 
-## Adim 2: Hatayi Izole Et
+## Step 1: Create the Hotfix Branch
 
-### 2a: Hata Bilgilerini Topla
-- Kullanicidan hata gunlugunu veya stack trace'i iste
-- Varsa hata raporunu oku
-- Hatanin tekrarlanma kosullarini belirle
+### 1a: Check the Current State
+- Verify a clean working directory with `git status`
+- Stash uncommitted changes if any
 
-### 2b: Kaynak Tespiti
-- Stack trace'deki dosya ve satir numaralarini takip et
-- Grep ile hata mesajini kod tabaninda ara
-- Hatanin ilk kez ne zaman ortaya ciktigini git log ile kontrol et
-- `git bisect` onerisinde bulun (gerekirse)
-
-### 2c: Etki Analizi
-- Hatadan etkilenen modulleri belirle
-- Iliskili testlerin mevcut durumunu kontrol et
+### 1b: Create the Branch
+- Detect the main branch: `main` or `master`
+- Create it with `git checkout -b hotfix/[short-description] [main-branch]`
+- Branch naming: descriptive names like `hotfix/fix-login-crash`, `hotfix/patch-api-timeout`
 
 ---
 
-## Adim 3: Minimal Duzeltme Uygula
+## Step 2: Isolate the Bug
 
-### 3a: Kapsam Kontrolu
-- Duzeltme sadece hatanin kök nedenini hedeflemeli
-- Refactoring YAPMA
-- Yeni ozellik EKLEME
-- Iliskisiz kod DEGISTIRME
-- Her degisiklik icin sor: "Bu degisiklik hatanin cozumu icin zorunlu mu?"
+### 2a: Gather the Error Info
+- Ask the user for the error log or stack trace
+- Read the bug report if one exists
+- Determine the reproduction conditions
 
-### 3b: Duzeltmeyi Yaz
-- Mumkun olan en kucuk degisikligi yap
-- Degisikligin neden yapildigini yorum olarak ekle
-- Yan etkileri minimize et
+### 2b: Source Detection
+- Follow the files and line numbers in the stack trace
+- Grep the error message across the codebase
+- Check when the bug first appeared via git log
+- Suggest `git bisect` (if needed)
 
----
-
-## Adim 4: Hedefli Testleri Calistir
-
-### 4a: Mevcut Testleri Calistir
-- Hatanin iliskili oldugu modülun testlerini calistir
-- Regresyon testi olarak tum ilgili test suite'ini calistir
-- Test sonuclarini raporla
-
-### 4b: Duzeltme Dogrulama Testi
-- Hatanin artik olusmadigini dogrulayan bir test yazilmasini oner
-- Eger mevcut test hatanin kapsaminda degilse, yeni test ekle
+### 2c: Impact Analysis
+- Identify the modules affected by the bug
+- Check the current state of the related tests
 
 ---
 
-## Adim 5: Geri Alma Plani Olustur
+## Step 3: Apply the Minimal Fix
 
-### 5a: Revert Komutu Hazirla
-- `git revert` komutunu onceden hazirla ve kullaniciya sun:
+### 3a: Scope Check
+- The fix must target only the bug's root cause
+- NO refactoring
+- NO new features
+- NO touching unrelated code
+- For every change ask: "Is this change essential to fixing the bug?"
+
+### 3b: Write the Fix
+- Make the smallest possible change
+- Add a comment explaining why the change was made
+- Minimize side effects
+
+---
+
+## Step 4: Run the Targeted Tests
+
+### 4a: Run the Existing Tests
+- Run the tests of the module the bug relates to
+- Run the whole related test suite as a regression check
+- Report the test results
+
+### 4b: Fix Verification Test
+- Suggest writing a test that proves the bug no longer occurs
+- If existing tests do not cover the bug, add a new test
+
+---
+
+## Step 5: Build the Rollback Plan
+
+### 5a: Prepare the Revert Command
+- Prepare the `git revert` command in advance and present it:
 ```
-# Geri alma komutu (gerekirse hemen calistirilabilir):
+# Rollback command (runnable immediately if needed):
 git revert [commit-hash] --no-edit
 ```
 
-### 5b: Geri Alma Senaryosu
-- Hangi kosullarda geri alma yapilmasi gerektigini belirt
-- Geri almanin yan etkilerini acikla
-- Alternatif geri alma stratejilerini listele
+### 5b: Rollback Scenario
+- State the conditions under which a rollback should happen
+- Explain the side effects of rolling back
+- List alternative rollback strategies
 
 ---
 
-## Adim 6: PR Olustur
+## Step 6: Create the PR
 
-### 6a: Degisiklikleri Kaydet
-- `git add` ile sadece duzeltme dosyalarini ekle
-- Commit mesaji formati: `[HOTFIX] [kisa aciklama]`
-- Ornek: `[HOTFIX] Fix null pointer in user auth flow`
+### 6a: Commit the Changes
+- `git add` only the fix files
+- Commit message format: `[HOTFIX] [short description]`
+- Example: `[HOTFIX] Fix null pointer in user auth flow`
 
-### 6b: Auditor Denetimi
-- Agent(auditor) ile hizli T1 denetim baslat
-- Duzeltmenin kapsam disina cikmis olmadigini dogrula
-- Guvenlik etkisi degerlendirmesi yap
+### 6b: Auditor Review
+- Start a fast T1 audit via Agent(auditor)
+- Verify the fix has not drifted out of scope
+- Run a security-impact assessment
 
-### 6c: Pull Request Olustur
-- PR basligina `[HOTFIX]` on eki ekle
-- PR aciklamasina su bilgileri ekle:
-  - Hatanin aciklamasi
-  - Kok neden analizi
-  - Yapilan duzeltme
-  - Test sonuclari
-  - Geri alma plani
+### 6c: Create the Pull Request
+- Prefix the PR title with `[HOTFIX]`
+- Include in the PR description:
+  - The bug description
+  - Root cause analysis
+  - The applied fix
+  - Test results
+  - The rollback plan
 
-# Cikti Formati
+# Output Format
 ```
-=== HOTFIX OZET ===
-Dal: hotfix/[isim]
-Hata: [kisa aciklama]
-Kok Neden: [neden]
-Duzeltme: [ne yapildi]
-Degisiklik: [dosya sayisi] dosya, [satir sayisi] satir
-Testler: [GECTI/BASARISIZ]
-Geri Alma: git revert [hash]
+=== HOTFIX SUMMARY ===
+Branch: hotfix/[name]
+Bug: [short description]
+Root Cause: [cause]
+Fix: [what was done]
+Change: [file count] files, [line count] lines
+Tests: [PASSED/FAILED]
+Rollback: git revert [hash]
 PR: [PR URL]
 ===================
 ```

--- a/.claude/commands/mobile.md
+++ b/.claude/commands/mobile.md
@@ -1,60 +1,60 @@
 Mobile project management command. React Native/Flutter/Expo/Swift/Kotlin scaffolding, version sync, build and release guides.
 
-# Gerekli Araclar
-- Bash (badi mobile komutlari)
+# Required Tools
+- Bash (badi mobile commands)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Ne Yapmak Istiyor?
+### Step 1: What Do They Want?
 
-Kullaniciya sor:
-- **Yeni proje** — `init` ile iskelet
+Ask the user:
+- **New project** — scaffold with `init`
 - **Version bump** — iOS/Android/Flutter sync
 - **Build** — Release APK/IPA
-- **Release** — TestFlight/Play Store rehberi
-- **Asset uretimi** — Icon/Splash/Screenshots
+- **Release** — TestFlight/Play Store guide
+- **Asset production** — Icon/Splash/Screenshots
 
-### Adim 2: Yeni Proje (init)
+### Step 2: New Project (init)
 
 ```bash
 badi mobile init MyApp --framework [rn|flutter|expo|swift|kotlin]
 ```
 
-Framework'e gore:
+Per framework:
 - **react-native**: npx react-native init
 - **flutter**: flutter create
 - **expo**: create-expo-app
-- **swift**: Xcode manuel rehber
-- **kotlin**: Android Studio manuel rehber
+- **swift**: Xcode manual guide
+- **kotlin**: Android Studio manual guide
 
-Sonrasi:
+Afterwards:
 ```bash
 cd MyApp
-npx @fatihkan/badi init      # Badi konfigurasyonu
+npx @fatihkan/badi init      # Badi configuration
 ```
 
-### Adim 3: Version Bump
+### Step 3: Version Bump
 
 ```bash
 badi mobile version bump [major|minor|patch]
 ```
 
-Sync ettigi dosyalar (otomatik tespit):
+Files it syncs (auto-detected):
 - `package.json` (RN, Expo)
 - `ios/**/Info.plist` (iOS)
 - `android/app/build.gradle` (Android)
 - `pubspec.yaml` (Flutter)
 
-### Adim 4: Build
+### Step 4: Build
 
 ```bash
 badi mobile build ios        # iOS release (Xcode/xcodebuild)
 badi mobile build android    # Android AAB (Gradle)
 ```
 
-Proje turu otomatik tespit edilir (RN vs Flutter).
+The project type is auto-detected (RN vs Flutter).
 
-### Adim 5: Release Pipeline
+### Step 5: Release Pipeline
 
 ```bash
 badi mobile release testflight      # iOS beta
@@ -63,47 +63,47 @@ badi mobile release appstore        # iOS production
 badi mobile release play            # Android production
 ```
 
-Her hedef icin adim adim rehber gosterir. Otomatik deploy icin:
+Shows a step-by-step guide per target. For automated deploys:
 - fastlane (iOS + Android)
 - eas submit (Expo)
 
-### Adim 6: Asset Uretimi
+### Step 6: Asset Production
 
 ```bash
-badi mobile assets icon [source.png]      # 40+ boyut rehberi (iOS + Android)
-badi mobile assets splash                 # Splash screen boyutlari
-badi mobile assets screenshots            # App Store + Play screenshot boyutlari
+badi mobile assets icon [source.png]      # 40+ size guide (iOS + Android)
+badi mobile assets splash                 # Splash screen sizes
+badi mobile assets screenshots            # App Store + Play screenshot sizes
 ```
 
-ImageMagick kurulu ise otomatik uretim komutlari verir.
+If ImageMagick is installed, it provides automatic generation commands.
 
-### Adim 7: Release Notes
+### Step 7: Release Notes
 
 ```bash
-badi content release-notes --platform ios --version X.Y.Z --lang tr,en
+badi content release-notes --platform ios --version X.Y.Z
 badi content release-notes --platform android --version X.Y.Z
 ```
 
-### Adim 8: ASO Entegrasyonu
+### Step 8: ASO Integration
 
-Launch oncesi:
-- `/aso` — App Store listing optimizasyonu
-- `/aso-strategy` — Marketing plan
-- `/content-generate` — Lansman postlari
+Before launch:
+- `/aso` — App Store listing optimization
+- `aso-master` agent — Marketing plan / full strategy
+- `/content-generate` — Launch posts
 
-# Checklist: Yeni Surum Cikarma
+# Checklist: Shipping a New Version
 
 1. `badi mobile version bump minor`
 2. `badi mobile build ios && badi mobile build android`
-3. `badi content release-notes --platform ios --version X.Y.Z --lang tr,en`
-4. `badi secret-scan --git` (guvenlik)
-5. `badi mobile release testflight` (ios staging)
-6. `badi mobile release play-internal` (android staging)
+3. `badi content release-notes --platform ios --version X.Y.Z`
+4. `badi secret-scan --git` (security)
+5. `badi mobile release testflight` (iOS staging)
+6. `badi mobile release play-internal` (Android staging)
 7. Test + QA
 8. `badi mobile release appstore && badi mobile release play` (production)
-9. `badi aso audit [app-id]` (listing kontrol)
+9. `badi aso audit [app-id]` (listing check)
 
-# Ornek
+# Example
 ```
 /mobile init MyApp --framework react-native
 /mobile version bump minor

--- a/.claude/commands/perf-check.md
+++ b/.claude/commands/perf-check.md
@@ -1,112 +1,112 @@
 Performance profiling. Detects hot paths, bottlenecks, and optimization opportunities.
 
-## Badi CLI Komutlari (v1.6+)
-Production URL varsa:
+## Badi CLI Commands (v1.6+)
+If a production URL exists:
 - `badi lighthouse [url]` — Core Web Vitals (FCP, LCP, TBT, CLS, Speed Index)
-- `badi lighthouse [url] --desktop` — Desktop ayri olcum
-- `badi seo speed [url]` — Sayfa hizi + kaynak analizi (v1.4+)
+- `badi lighthouse [url] --desktop` — Separate desktop measurement
+- `badi seo speed [url]` — Page speed + resource analysis (v1.4+)
 
-Bu CLI araclari gercek-dunya metrikler verir (PageSpeed Insights). Kod bazli analizler (asagidaki adimlar) bunu tamamlar.
+These CLI tools give real-world metrics (PageSpeed Insights). The code-based analyses (steps below) complement them.
 
-# Gerekli Araclar
-- Bash (build komutlari, dosya boyut hesaplama)
-- Read (kaynak kod analizi)
-- Grep (kalip arama)
+# Required Tools
+- Bash (build commands, file size calculation)
+- Read (source code analysis)
+- Grep (pattern search)
 - ...
 
-# Ajan Delegasyonu
-Bu komut ana analiz isini performance-profiler ajanina devreder.
-Ajan bulunamazsa, asagidaki adimlari dogrudan uygula.
+# Agent Delegation
+This command delegates the main analysis to the performance-profiler agent.
+If the agent is unavailable, apply the steps below directly.
 
 ---
 
-## Bolum 1: Sicak Yol Tespiti
+## Section 1: Hot Path Detection
 
-### Adim 1: Sik Degistirilen Dosyalar
-- `git log --format=format: --name-only` ile son 50 commit'te en cok degisen dosyalari bul
-- En sik degisen 10 dosyayi listele
-- Bu dosyalarin karmasiklik ve boyut bilgisini ekle
+### Step 1: Frequently Changed Files
+- Find the most-changed files in the last 50 commits with `git log --format=format: --name-only`
+- List the 10 most frequently changed files
+- Add their complexity and size info
 - ...
 
-### Adim 2: Karmasik Fonksiyon Tespiti
-- Uzun fonksiyonlari tespit et (50+ satir)
-- Derin ic ice gecmis yapilari bul (4+ seviye girinti)
-- Coklu dongu iceren fonksiyonlari isaretl
+### Step 2: Complex Function Detection
+- Detect long functions (50+ lines)
+- Find deeply nested structures (4+ indent levels)
+- Flag functions with multiple loops
 - ...
 
-### Adim 3: Import/Bagimlilik Analizi
-- Cok fazla import iceren dosyalari tespit et
-- Dairesel bagimliliklari ara
-- Kullanilmayan import'lari bul
+### Step 3: Import/Dependency Analysis
+- Detect files with too many imports
+- Look for circular dependencies
+- Find unused imports
 
 ---
 
-## Bolum 2: Veritabani Sorgu Analizi
+## Section 2: Database Query Analysis
 
-### Adim 4: N+1 Sorgu Kalip Tespiti
-Asagidaki kaliplari kodda ara:
-- Dongu icindeki veritabani cagrilari
-- ORM iliskilerinde eager loading eksikligi
-- `forEach`/`map` icindeki `await` veritabani islemleri
+### Step 4: N+1 Query Pattern Detection
+Search the code for these patterns:
+- Database calls inside loops
+- Missing eager loading on ORM relations
+- `await`ed database operations inside `forEach`/`map`
 - ...
 
-### Adim 5: Sorgu Optimizasyon Onerileri
-- Index kullanimi onerileri
-- Toplu islem (batch) donusum firsatlari
-- Gereksiz sorgu tekrarlari
-- ...
-
----
-
-## Bolum 3: Paket ve Build Boyutlari
-
-### Adim 6: Build Boyut Analizi
-- `package.json` bagimlilik sayisini raporla
-- Varsa build ciktisinin boyutunu olc
-- `node_modules` toplam boyutunu kontrol et
-- ...
-
-### Adim 7: Bagimlilik Agirlik Analizi
-- En buyuk bagimliliklari boyutlarina gore sirala
-- Alternatifi olan agir kutuphaneleri tespit et
-  Ornek: moment.js -> date-fns, lodash -> lodash-es veya natif yontemler
-- Dev dependency'lerin production build'e sizmasini kontrol et
-- Duplicate paketleri tespit et
-
-### Adim 8: Asset Boyutlari
-- Resim dosyalarinin boyutlarini kontrol et
-- Sıkistırılmamis assetleri tespit et
-- Font dosya boyutlarini degerlendir
+### Step 5: Query Optimization Suggestions
+- Index usage suggestions
+- Batch-conversion opportunities
+- Needless query repetition
 - ...
 
 ---
 
-## Bolum 4: Onbellek Strateji Incelemesi
+## Section 3: Bundle and Build Sizes
 
-### Adim 9: Mevcut Onbellek Uygulamasi
-- Redis/Memcached kullanimi var mi kontrol et
-- HTTP onbellek basliklarini incele (Cache-Control, ETag)
-- CDN konfigurasyonunu degerlendir (mevcutsa)
+### Step 6: Build Size Analysis
+- Report the `package.json` dependency count
+- Measure the build output size if present
+- Check the total `node_modules` size
 - ...
 
-### Adim 10: Onbellek Optimizasyon Onerileri
-- Onbelleklenebilecek ama onbelleklenmeyen verileri tespit et
-- Onbellek gecersiz kilma (invalidation) stratejisini degerlendir
-- Yazma-okuma oranina gore onbellek katmani oner
+### Step 7: Dependency Weight Analysis
+- Rank the largest dependencies by size
+- Detect heavy libraries with lighter alternatives
+  Example: moment.js -> date-fns, lodash -> lodash-es or native methods
+- Check dev dependencies leaking into the production build
+- Detect duplicate packages
+
+### Step 8: Asset Sizes
+- Check image file sizes
+- Detect uncompressed assets
+- Evaluate font file sizes
 - ...
 
 ---
 
-## Bolum 5: Performans Raporu
+## Section 4: Caching Strategy Review
 
-### Adim 11: Bulgu Ozeti Olustur
+### Step 9: Current Cache Implementation
+- Check for Redis/Memcached usage
+- Review HTTP cache headers (Cache-Control, ETag)
+- Evaluate the CDN configuration (if present)
+- ...
+
+### Step 10: Cache Optimization Suggestions
+- Detect cacheable-but-uncached data
+- Evaluate the cache invalidation strategy
+- Suggest a cache layer based on the read/write ratio
+- ...
+
+---
+
+## Section 5: Performance Report
+
+### Step 11: Build the Findings Summary
 ```
-[kisaltildi]
+[abridged]
 ```
 
-### Adim 12: Etki Tahmini
-Her oneri icin:
-- Tahmini iyilesme yuzdesi veya suresi
-- Uygulama zorlugu: KOLAY / ORTA / ZOR
-- Oncelik: Etki/Efor oranina gore siralama
+### Step 12: Impact Estimate
+For each suggestion:
+- Estimated improvement percentage or time
+- Implementation difficulty: EASY / MEDIUM / HARD
+- Priority: ranked by impact/effort ratio
 - ...

--- a/.claude/commands/playbook.md
+++ b/.claude/commands/playbook.md
@@ -1,88 +1,88 @@
 Workflow-to-command command. Converts repetitive manual workflows into reusable Badi commands.
 
-# Gerekli Araclar
-- Read (mevcut komutlar) -- Write (yeni komut) -- Glob (mevcut komut listesi) -- Grep (kalip/referans)
+# Required Tools
+- Read (existing commands) -- Write (new command) -- Glob (existing command list) -- Grep (pattern/reference)
 
-# Prosedur (7 Adim)
+# Procedure (7 Steps)
 
-## 1. Isimlendir
-- Arguman verilmisse onu kullan -- verilmemisse aciklamadan turet
-- Kurallar: kebab-case (`hata-takip`, `sprint-plan`) -- kisa-akilda kalici (1-3 kelime) -- eylem yansitan (fiil/fiil-nesne) -- mevcutla cakismayan
+## 1. Name It
+- Use the argument if given -- otherwise derive it from the description
+- Rules: kebab-case (`bug-triage`, `sprint-plan`) -- short and memorable (1-3 words) -- action-reflecting (verb/verb-object) -- no collision with existing names
 
-Cakisma kontrolu: `.claude/commands/` tara -- ayni/benzer var mi -- alternatif oner.
+Collision check: scan `.claude/commands/` -- same/similar exists? -- suggest alternatives.
 
-## 2. Is Akisini Yakala
-Her adim icin: ne yapiliyor (eylem) -- nerede (dosya/dizin/sistem) -- neden (amac/baglam) -- girdiler -- ciktilar -- basari kriteri -- hata durumu
+## 2. Capture the Workflow
+For every step: what is done (action) -- where (file/directory/system) -- why (purpose/context) -- inputs -- outputs -- success criterion -- failure case
 
-Kronolojik sira + numaralandir.
+Chronological order + numbering.
 
-## 3. Kaliplari Tespit Et
-- **Paralellik:** bagimsiz adimlar -- paralel alt gorevler
-- **Kullanici giris:** insan karari -- onay bekleme -- veri alinacak noktalar
-- **Kosullu dallanma:** "Eger X ise Y, degilse Z" -- opsiyonel adim -- hata yonlendirme
-- **Arac gereksinimi:** Claude araclar (Read, Write, Bash, Grep, ...) -- dis arac (git, npm, docker, ...)
-- **Mevcut skill eslesmesi:** parcalari mevcut komutla ortusuyor mu -- alt adim olarak cagrilabilir mi
+## 3. Detect the Patterns
+- **Parallelism:** independent steps -- parallel subtasks
+- **User input:** human decisions -- approval waits -- data-collection points
+- **Conditional branching:** "If X then Y, else Z" -- optional steps -- error routing
+- **Tool needs:** Claude tools (Read, Write, Bash, Grep, ...) -- external tools (git, npm, docker, ...)
+- **Existing skill matches:** do parts overlap with an existing command -- can it be invoked as a substep
 
-## 4. Arguman Belirle
-Her calistirmada degisen girdileri tanimla:
-- Hangi degerler degisecek -- varsayilanlar -- zorunlu/opsiyonel ayrim -- `argument-hint` aciklamasi
+## 4. Define the Arguments
+Identify the inputs that change per run:
+- Which values vary -- defaults -- required/optional split -- the `argument-hint` description
 
 ```
-Arguman: [proje-adi]  Varsayilan: mevcut dizin  Aciklama: "Playbook olusturulacak projenin adi"
+Argument: [project-name]  Default: current directory  Description: "Name of the project the playbook targets"
 ```
 
-## 5. Komut Dosyasi
-`.claude/commands/[isim].md` standart formatta olustur:
+## 5. The Command File
+Create `.claude/commands/[name].md` in the standard format:
 
 ```markdown
-[Tek satirlik aciklama]
+[One-line description]
 
-# Gerekli Araclar
-- [Arac 1] ([ne icin])
-- [Arac 2] ([ne icin])
+# Required Tools
+- [Tool 1] ([for what])
+- [Tool 2] ([for what])
 
-# Prosedur ([adim sayisi] Adim)
+# Procedure ([step count] Steps)
 
-### Adim 1: [Ad]
-[talimat]
+### Step 1: [Name]
+[instruction]
 
-### Adim 2: [Ad]
-[talimat]
+### Step 2: [Name]
+[instruction]
 
-# Cikti Formati
+# Output Format
 ```
-[sablon]
+[template]
 ```
 ```
 
-Kurallar: Turkce yaz, acik-net -- her adim kendi basina anlasilir -- arac kullanimi acik -- hata durumlari -- net cikti formati.
+Rules: write in English, clear and direct -- every step understandable on its own -- tool usage explicit -- failure cases covered -- a crisp output format.
 
-## 6. Dogrula ve Iyilestir
-Kullaniciya sun: is akisini dogru yansitiyor mu -- eksik/yanlis adim -- ek kosul/ozel durum -- duzenlemeleri uygula -- nihai onay.
+## 6. Validate and Refine
+Present to the user: does it reflect the workflow correctly -- missing/wrong steps -- extra conditions/special cases -- apply the edits -- final approval.
 
-Teknik: referans araclar gecerli -- dosya yollari -- markdown -- cikti formati tutarli.
+Technical: referenced tools valid -- file paths -- markdown -- output format consistent.
 
-## 7. Indekse Ekle
-`command-index.md` (varsa): yeni komutu uygun kategoriye -- aciklama satiri -- iliskili komutlara capraz referans
+## 7. Add to the Index
+`command-index.md` (if present): the new command in the right category -- a description line -- cross-references to related commands
 
-`| /[isim] | [kisa aciklama] | [kategori] |`
+`| /[name] | [short description] | [category] |`
 
-# Cikti Formati
+# Output Format
 ```
 === BADI PLAYBOOK ===
-Komut: /[isim]
-Dosya: .claude/commands/[isim].md
-Adim Sayisi: [sayi]
-Arac Sayisi: [sayi]
-Arguman: [aciklama veya "yok"]
+Command: /[name]
+File: .claude/commands/[name].md
+Step Count: [count]
+Tool Count: [count]
+Argument: [description or "none"]
 
-Durum: OLUSTURULDU
-Indeks: GUNCELLENDI / INDEKS YOK
+Status: CREATED
+Index: UPDATED / NO INDEX
 
-> "[isim]" komutu `/[isim]` olarak kaydedildi.
-> Bu is akisini tekrarlamak icin istediginiz zaman calistirin.
+> The "[name]" command was registered as `/[name]`.
+> Run it any time to repeat this workflow.
 ======================
 ```
 
-# Ipuclari
-- Basit is akislarini gereksiz karmasiklastirma -- 3-7 adim ideal (10'u gecme) -- her komut tek amac (tek sorumluluk) -- karmasik akislari boyle -- mevcut komutlari alt adim referans et
+# Tips
+- Do not over-complicate simple workflows -- 3-7 steps ideal (never past 10) -- one purpose per command (single responsibility) -- split complex flows -- reference existing commands as substeps

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,112 +1,112 @@
 Release notes command. Compiles changes into formats for 3 different audiences.
 
 ## Badi CLI Workflow (v1.6+)
-Release oncesi sira:
+Pre-release order:
 ```bash
-badi secret-scan --git                   # Kritik sir yokmu dogrula
-badi changelog --write --version X.Y.Z   # CHANGELOG.md guncelle
-badi commit --check                      # Son commit conventional mi
+badi secret-scan --git                   # Verify no critical secrets
+badi changelog --write --version X.Y.Z   # Update CHANGELOG.md
+badi commit --check                      # Is the last commit conventional
 git tag vX.Y.Z && git push origin vX.Y.Z
 gh release create vX.Y.Z --notes-file release-notes.md
 ```
 
-Bu komut 3 hedef kitleye (teknik/pazarlama/yonetici) ozel surum notu derler.
+This command compiles release notes tailored to 3 audiences (technical/marketing/executive).
 
-# Gerekli Araclar
+# Required Tools
 - Bash (git log, git tag, diff)
-- Read (commit mesajlari, PR aciklamalari)
-- Grep (degisiklik taramasi)
-- Write (surum notu dosyalari)
+- Read (commit messages, PR descriptions)
+- Grep (change scan)
+- Write (release note files)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Aralik Belirle
-- Son release tag'ini bul: `git describe --tags --abbrev=0`
-- Mevcut HEAD ile arasindaki farki hesapla
-- Commit araligini belirle: `git log [son-tag]..HEAD`
-- Etkilenen dosya ve modulleri listele
+### Step 1: Define the Range
+- Find the latest release tag: `git describe --tags --abbrev=0`
+- Compute the diff against the current HEAD
+- Define the commit range: `git log [last-tag]..HEAD`
+- List the affected files and modules
 
-### Adim 2: Veri Topla
-Her commit icin bilgi derle:
-- Commit mesaji ve aciklamasi
-- Iliskili PR numaralari
-- Degisen dosyalar ve satirlar
-- Yazar bilgisi
-- Iliskili issue veya gorev numaralari
+### Step 2: Gather Data
+Compile per commit:
+- Commit message and description
+- Related PR numbers
+- Changed files and lines
+- Author info
+- Related issue or task numbers
 
-### Adim 3: Degisiklikleri Siniflandir
-Conventional Commits veya proje kuralina gore kategorilere ayir:
+### Step 3: Classify the Changes
+Categorize by Conventional Commits or the project's convention:
 
-**Yeni Ozellikler (feat):**
-- Yeni eklenen islevler
-- Yeni API endpointleri
-- Yeni kullanici arayuzu bilesenleri
+**New Features (feat):**
+- Newly added functionality
+- New API endpoints
+- New UI components
 
-**Hata Duzeltmleri (fix):**
-- Cozulen hatalar
-- Performans duzeltmleri
-- Guvenlik yamalari
+**Bug Fixes (fix):**
+- Resolved bugs
+- Performance fixes
+- Security patches
 
-**Kirilma Degisiklikleri (BREAKING):**
-- API degisiklikleri
-- Veritabani sema degisiklikleri
-- Konfigur asyon degisiklikleri
-- Kaldirilmis ozellikler
+**Breaking Changes (BREAKING):**
+- API changes
+- Database schema changes
+- Configuration changes
+- Removed features
 
-**Iyilestirmeler (improve):**
-- Performans iyilestirmeleri
-- UX iyilestirmeleri
-- Kod kalitesi iyilestirmeleri
+**Improvements (improve):**
+- Performance improvements
+- UX improvements
+- Code quality improvements
 
-**Altyapi (infra):**
-- CI/CD degisiklikleri
-- Bagimlilik guncellemeleri
-- Dokumantasyon
+**Infrastructure (infra):**
+- CI/CD changes
+- Dependency updates
+- Documentation
 
-### Adim 4: 3 Versiyon Yaz
+### Step 4: Write 3 Versions
 
-**Versiyon A: Teknik Surum Notu**
-- Tam degisiklik listesi kategorilere gore
-- Kirilma degisiklikleri ve migrasyon talimatai
-- API degisiklikleri detayi
-- Bilinen sorunlar
-- Commit hashleri ve PR referanslari
+**Version A: Technical Release Notes**
+- The full change list by category
+- Breaking changes and migration instructions
+- API change details
+- Known issues
+- Commit hashes and PR references
 
-**Versiyon B: Pazarlama Surum Notu**
-- Kullanici odakli dilde yeni ozellikler
-- Fayda ve deger vurgusu
-- Ekran goruntuleri veya gorseller icin yer tutucular
-- Cagri aksiyonu (call to action)
+**Version B: Marketing Release Notes**
+- New features in user-focused language
+- Benefit and value emphasis
+- Placeholders for screenshots or visuals
+- A call to action
 
-**Versiyon C: Yonetici Ozeti**
-- 3-5 maddelik ust duzey ozet
-- Is etkisi vurgusu
-- Risk ve dikkat gerektiren maddeler
-- Sonraki surum planina bakis
+**Version C: Executive Summary**
+- A 3-5 item high-level summary
+- Business impact emphasis
+- Risks and items needing attention
+- A look at the next release plan
 
-### Adim 5: Dosyalari Kaydet
-`releases/` dizini altinda kaydet:
-- `releases/v[VERSIYON]-teknik.md`
-- `releases/v[VERSIYON]-pazarlama.md`
-- `releases/v[VERSIYON]-yonetici.md`
+### Step 5: Save the Files
+Save under `releases/`:
+- `releases/v[VERSION]-technical.md`
+- `releases/v[VERSION]-marketing.md`
+- `releases/v[VERSION]-executive.md`
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI SURUM NOTLARI ===
-Versiyon: v[VERSIYON]
-Onceki: v[ONCEKI]
-Aralik: [commit sayisi] commit
+=== BADI RELEASE NOTES ===
+Version: v[VERSION]
+Previous: v[PREVIOUS]
+Range: [commit count] commits
 
-Degisiklik Ozeti:
-- Yeni Ozellik: [sayi]
-- Hata Duzeltme: [sayi]
-- Kirilma Degisikligi: [sayi]
-- Iyilestirme: [sayi]
-- Altyapi: [sayi]
+Change Summary:
+- New Features: [count]
+- Bug Fixes: [count]
+- Breaking Changes: [count]
+- Improvements: [count]
+- Infrastructure: [count]
 
-Olusturulan Dosyalar:
-1. releases/v[VERSIYON]-teknik.md
-2. releases/v[VERSIYON]-pazarlama.md
-3. releases/v[VERSIYON]-yonetici.md
+Created Files:
+1. releases/v[VERSION]-technical.md
+2. releases/v[VERSION]-marketing.md
+3. releases/v[VERSION]-executive.md
 ============================
 ```

--- a/.claude/commands/report.md
+++ b/.claude/commands/report.md
@@ -1,153 +1,153 @@
 Professional report command. Turns raw data and findings into professional, audience-appropriate reports.
 
-# Gerekli Araclar
-- Read (veri kaynaklari)
-- Write (rapor dosyasi)
-- Grep (veri taramasi)
-- Glob (kaynak bulma)
-- Bash (veri isleme)
+# Required Tools
+- Read (data sources)
+- Write (report file)
+- Grep (data scan)
+- Glob (source discovery)
+- Bash (data processing)
 
-# Prosedur (5 Adim)
+# Procedure (5 Steps)
 
-### Adim 1: Girdileri Netlestir
-Kullanicidan su bilgileri al:
+### Step 1: Clarify the Inputs
+Get from the user:
 
-- **Konu:** Rapor ne hakkinda?
-- **Veri Kaynaklari:** Hangi veriler kullanilacak? (dosyalar, metrikler, analizler)
-- **Hedef Kitle:** Kim okuyacak? (Yonetici / Teknik / Musteri)
-- **Amac:** Rapor ne icin kullanilacak? (karar destek, bilgilendirme, ikna)
-- **Format Tercihi:** Varsayilan: profesyonel, net, jargonsuz
-- **Uzunluk:** Kisa (1-2 sayfa) / Standart (3-5 sayfa) / Detayli (5+ sayfa)
-- **Aciliyet:** Normal / Acil (hizli taslak)
+- **Topic:** What is the report about?
+- **Data Sources:** Which data will be used? (files, metrics, analyses)
+- **Audience:** Who will read it? (Executive / Technical / Client)
+- **Purpose:** What will the report be used for? (decision support, information, persuasion)
+- **Format Preference:** Default: professional, clear, jargon-free
+- **Length:** Short (1-2 pages) / Standard (3-5 pages) / Detailed (5+ pages)
+- **Urgency:** Normal / Urgent (fast draft)
 
-### Adim 2: Kaynak Toplama
-Tum ilgili verileri derle:
+### Step 2: Source Collection
+Compile all relevant data:
 
-- **Nicel Veriler:** Metrikler, istatistikler, olcumler
-- **Nitel Veriler:** Gozlemler, geri bildirimler, degerlendirmeler
-- **Trendler:** Zaman serisi verileri, degisim oranlari
-- **Karsilastirmalar:** Hedefler vs gerceklesenler, onceki donem vs mevcut
-- **Anomaliler:** Normal disi durumlar ve aciklamalari
-- **Dissal Faktorler:** Sonuclari etkileyen dis etkenler
+- **Quantitative Data:** Metrics, statistics, measurements
+- **Qualitative Data:** Observations, feedback, assessments
+- **Trends:** Time-series data, change rates
+- **Comparisons:** Targets vs. actuals, previous period vs. current
+- **Anomalies:** Out-of-norm situations and their explanations
+- **External Factors:** Outside influences on the results
 
-Eksik veri varsa kullaniciya bildir ve ya topla ya da varsayim belirt.
+If data is missing, tell the user and either collect it or state the assumption.
 
-### Adim 3: Hedef Kitleye Gore Yapilandir
+### Step 3: Structure by Audience
 
-**Tip A: Yonetici Raporu**
-- Sonuc once, detay sonra (piramit yapisi)
-- Madde isaretleri ve kisa paragraflar
-- Karar metrikleri ve KPI'lar on planda
-- Maksimum 2 sayfa ana govde
-- Gorsel ozetler (tablo ve grafik aciklamalari)
-- Net oneriler ve sonraki adimlar
-- Jargon yok, is dili kullan
+**Type A: Executive Report**
+- Conclusion first, detail later (pyramid structure)
+- Bullets and short paragraphs
+- Decision metrics and KPIs up front
+- A 2-page main body maximum
+- Visual summaries (table and chart descriptions)
+- Clear recommendations and next steps
+- No jargon, business language
 
-**Tip B: Teknik Rapor**
-- Metodoloji ve veri kaynaklari detayli
-- Teknik terminoloji serbest
-- Veri tablolari ve detayli analizler
-- Uyarilar ve sinirliliklar bolumu
-- Kaynak referanslari ve atiflar
-- Yeniden uretilebilirlik bilgisi
-- Ek (appendix) bolumleri
+**Type B: Technical Report**
+- Methodology and data sources in detail
+- Technical terminology allowed
+- Data tables and detailed analyses
+- A caveats-and-limitations section
+- Source references and citations
+- Reproducibility information
+- Appendix sections
 
-**Tip C: Musteri Raporu**
-- Sonuclar ve ROI vurgusu
-- Baglamsal rakamlar (yuzde, karsilastirmali)
-- Gorsel formatlar (tablo, liste, on plana cikarilmis metrikler)
-- Basarilar ve deger gosterimi
-- Anlasilir dil, teknik detay minimum
-- Sonraki adimlar ve beklentiler
-- Profesyonel ve guven veren ton
+**Type C: Client Report**
+- Results and ROI emphasis
+- Contextualized numbers (percentages, comparatives)
+- Visual formats (tables, lists, highlighted metrics)
+- Wins and value demonstration
+- Plain language, minimal technical detail
+- Next steps and expectations
+- A professional, confidence-inspiring tone
 
-### Adim 4: Rapor Yaz
-Secilen tipe gore raporu olustur:
+### Step 4: Write the Report
+Build the report for the chosen type:
 
 ```markdown
-# [Rapor Basligi]
-**Tarih:** [tarih]
-**Hazirlayan:** [isim]
-**Donem:** [kapsam]
-**Gizlilik:** [seviye]
+# [Report Title]
+**Date:** [date]
+**Prepared by:** [name]
+**Period:** [scope]
+**Confidentiality:** [level]
 
-## Yonetici Ozeti
-[2-3 paragraf: temel bulgular, sonuclar, oneriler]
+## Executive Summary
+[2-3 paragraphs: key findings, conclusions, recommendations]
 
-## Temel Bulgular
-### Bulgu 1: [baslik]
-[detay, veri destegi, etki]
+## Key Findings
+### Finding 1: [title]
+[detail, data support, impact]
 
-### Bulgu 2: [baslik]
-[detay, veri destegi, etki]
+### Finding 2: [title]
+[detail, data support, impact]
 
-### Bulgu 3: [baslik]
-[detay, veri destegi, etki]
+### Finding 3: [title]
+[detail, data support, impact]
 
-## Detayli Analiz
-[konu bazli derinlemesine inceleme]
+## Detailed Analysis
+[in-depth review by topic]
 
-## Veriler ve Metrikler
-| Metrik | Onceki | Mevcut | Degisim | Hedef |
-|--------|--------|--------|---------|-------|
+## Data and Metrics
+| Metric | Previous | Current | Change | Target |
+|--------|----------|---------|--------|--------|
 | ... | ... | ... | ... | ... |
 
-## Oneriler
-### Kisa Vadeli
-1. [oneri ve beklenen etki]
+## Recommendations
+### Short Term
+1. [recommendation and expected impact]
 
-### Orta Vadeli
-1. [oneri ve beklenen etki]
+### Mid Term
+1. [recommendation and expected impact]
 
-### Uzun Vadeli
-1. [oneri ve beklenen etki]
+### Long Term
+1. [recommendation and expected impact]
 
-## Sonraki Adimlar
-1. [adim, sorumluluk, tarih]
-2. [adim, sorumluluk, tarih]
+## Next Steps
+1. [step, owner, date]
+2. [step, owner, date]
 
-## Ekler
-[ek tablolar, ham veriler, metodoloji detaylari]
+## Appendices
+[extra tables, raw data, methodology details]
 ```
 
-### Adim 5: Kalite Kontrol
-Raporu su kriterlerle degerlendir:
+### Step 5: Quality Control
+Evaluate the report against these criteria:
 
-**Icerik Kontrolu:**
-- [ ] Her iddia veri ile desteklenmis mi?
-- [ ] Varsayimlar acikca belirtilmis mi?
-- [ ] Sinirliliklar not edilmis mi?
-- [ ] Oneriler uygulanabilir ve somut mu?
+**Content Check:**
+- [ ] Is every claim backed by data?
+- [ ] Are the assumptions stated explicitly?
+- [ ] Are the limitations noted?
+- [ ] Are the recommendations actionable and concrete?
 
-**Format Kontrolu:**
-- [ ] Hedef kitleye uygun dil kullanilmis mi?
-- [ ] Yapi mantiksal sirayla akmis mi?
-- [ ] Tablolar ve listeler dogru formatli mi?
-- [ ] Baslik hiyerarsisi tutarli mi?
+**Format Check:**
+- [ ] Is the language right for the audience?
+- [ ] Does the structure flow logically?
+- [ ] Are tables and lists formatted correctly?
+- [ ] Is the heading hierarchy consistent?
 
-**Tutarlilik Kontrolu:**
-- [ ] Rakamlar tutarli mi? (yuzde, toplam, detay)
-- [ ] Ozet ile detay uyumlu mu?
-- [ ] Oneriler bulgularla desteklenmis mi?
-- [ ] Onceki raporlarla celisiyor mu?
+**Consistency Check:**
+- [ ] Are the numbers consistent? (percentages, totals, detail)
+- [ ] Do the summary and detail agree?
+- [ ] Are the recommendations backed by the findings?
+- [ ] Does it contradict previous reports?
 
-**Son Kontrol:**
-- [ ] Yazim ve dilbilgisi kontrol edildi mi?
-- [ ] Hassas bilgi uygun isaretlenmis mi?
-- [ ] Tarih ve donem bilgileri dogru mu?
+**Final Check:**
+- [ ] Spelling and grammar checked?
+- [ ] Sensitive information marked appropriately?
+- [ ] Dates and period info correct?
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI RAPOR ===
-Baslik: [rapor basligi]
-Tip: [Yonetici/Teknik/Musteri]
-Uzunluk: [sayfa sayisi]
-Tarih: [tarih]
+=== BADI REPORT ===
+Title: [report title]
+Type: [Executive/Technical/Client]
+Length: [page count]
+Date: [date]
 
-Temel Bulgular: [sayi]
-Oneriler: [sayi]
-Kalite Skoru: [yuzde]%
+Key Findings: [count]
+Recommendations: [count]
+Quality Score: [percent]%
 
-Dosya: [dosya yolu]
+File: [file path]
 ==================
 ```

--- a/.claude/commands/retro.md
+++ b/.claude/commands/retro.md
@@ -1,123 +1,123 @@
 Sprint retrospective command. Analyzes the past period and identifies improvement areas.
 
-# Gerekli Araclar
-- Read (gunluk notlar, gorev panosu, bellek)
-- Bash (git istatistikleri)
-- Grep (kalip arama)
-- Write (rapor yazimi)
+# Required Tools
+- Read (daily notes, task board, memory)
+- Bash (git statistics)
+- Grep (pattern search)
+- Write (report writing)
 
-# Prosedur (4 Adim)
+# Procedure (4 Steps)
 
-### Adim 1: Veri Toplama
-Retrospektif donemi icin verileri topla:
+### Step 1: Data Collection
+Gather the data for the retrospective period:
 
-**Git Verileri:**
-- Commit sayisi ve dagilimi (gune gore)
-- Degisen dosya sayisi
-- Satir ekleme/silme istatistikleri
-- Branch ve merge gecmisi
-- Revert edilen commitler
+**Git Data:**
+- Commit count and distribution (by day)
+- Changed file count
+- Line add/delete statistics
+- Branch and merge history
+- Reverted commits
 
-**Gorev Verileri:**
-- Tamamlanan gorevler ve sureleri
-- Ertelenen veya iptal edilen gorevler
-- Bloke kalan gorevler ve sureleri
-- Kapsam degisiklikleri
+**Task Data:**
+- Completed tasks and their durations
+- Deferred or cancelled tasks
+- Blocked tasks and their durations
+- Scope changes
 
-**Not Verileri:**
-- Gunluk notlardaki kararlar
-- Ogrenimler ve icegorular
-- Sorunlar ve cozumleri
-- Devir notlari
+**Note Data:**
+- Decisions in the daily notes
+- Learnings and insights
+- Problems and their solutions
+- Handoff notes
 
-### Adim 2: Kalip Analizi
-Toplanan verilerde kaliplari tespit et:
+### Step 2: Pattern Analysis
+Detect patterns in the collected data:
 
-**Uretkenlik Kaliplari:**
-- En verimli gunler/saatler
-- En cok commit yapilan alanlar
-- Tekrarlayan darbogazlar
-- Hiz degisimleri (yavaslamalar, hizlanmalar)
+**Productivity Patterns:**
+- Most productive days/hours
+- Areas with the most commits
+- Recurring bottlenecks
+- Velocity changes (slowdowns, speedups)
 
-**Sorun Kaliplari:**
-- Tekrarlayan hatalar
-- Sik bloke olan alanlar
-- Kapsam kaymasi ornekleri
-- Iletisim kopukluklari
+**Problem Patterns:**
+- Recurring errors
+- Frequently blocked areas
+- Scope-creep examples
+- Communication gaps
 
-**Basari Kaliplari:**
-- Iyi sonuclanan yaklasimlar
-- Etkili cozum stratejileri
-- Basarili isbirligi ornekleri
+**Success Patterns:**
+- Approaches that ended well
+- Effective solution strategies
+- Successful collaboration examples
 
-### Adim 3: Iyilestirme Kategorilendirme
-Bulgulari 4 kategoride siniflandir:
+### Step 3: Improvement Categorization
+Classify the findings into 4 categories:
 
-**Devam Etmeli (Iyi Giden):**
-- Etkili olan pratikler
-- Basarili yaklasimlar
-- Korunmasi gereken aliskanliklar
+**Keep Doing (Went Well):**
+- Practices that worked
+- Successful approaches
+- Habits worth keeping
 
-**Durdurulmali (Kotu Giden):**
-- Zaman kaybettiren pratikler
-- Etkisiz yaklasimlar
-- Tekrarlayan hatalar
+**Stop Doing (Went Badly):**
+- Time-wasting practices
+- Ineffective approaches
+- Recurring mistakes
 
-**Baslamali (Yeni Denemeler):**
-- Onerilen yeni pratikler
-- Denenmesi gereken araclar
-- Surec iyilestirmeleri
+**Start Doing (New Experiments):**
+- Suggested new practices
+- Tools worth trying
+- Process improvements
 
-**Arastirilmali (Belirsiz):**
-- Daha fazla veri gerektiren alanlar
-- Test edilmesi gereken hipotezler
-- Karar bekleyen konular
+**Investigate (Unclear):**
+- Areas needing more data
+- Hypotheses to test
+- Topics awaiting a decision
 
-### Adim 4: Yapilandirilmis Rapor
+### Step 4: Structured Report
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI RETROSPEKTIF ===
-Donem: [baslangic] - [bitis]
-Toplam Gun: [sayi]
+=== BADI RETROSPECTIVE ===
+Period: [start] - [end]
+Total Days: [count]
 
-## Metrikler
-- Commitler: [sayi] (gunluk ort: [sayi])
-- Tamamlanan Gorevler: [sayi]
-- Ertelenen: [sayi]
-- Bloke Kalan: [sayi]
-- Satir Degisikligi: +[eklenen] / -[silinen]
+## Metrics
+- Commits: [count] (daily avg: [count])
+- Completed Tasks: [count]
+- Deferred: [count]
+- Blocked: [count]
+- Line Changes: +[added] / -[removed]
 
-## Kaliplar
-### Uretkenlik
-[tespit edilen kaliplar]
+## Patterns
+### Productivity
+[detected patterns]
 
-### Tekrarlayan Sorunlar
-[sorun kaliplari]
+### Recurring Problems
+[problem patterns]
 
-### Basarilar
-[basari kaliplari]
+### Successes
+[success patterns]
 
-## Eylem Plani
+## Action Plan
 
-### Devam Etmeli
-- [pratik]
+### Keep Doing
+- [practice]
 
-### Durdurulmali
-- [pratik]
+### Stop Doing
+- [practice]
 
-### Baslamali
-- [yeni pratik]
+### Start Doing
+- [new practice]
 
-### Arastirilmali
-- [konu]
+### Investigate
+- [topic]
 
-## Sprint Notu
-[genel degerllendirme ve motivasyon notu]
+## Sprint Note
+[overall assessment and a motivational note]
 
-## Sonraki Sprint Hedefleri
-1. [hedef]
-2. [hedef]
-3. [hedef]
+## Next Sprint Goals
+1. [goal]
+2. [goal]
+3. [goal]
 ==========================
 ```

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,170 +1,170 @@
 Deep code review command. Comprehensive code analysis across security, performance, and architecture.
 
-> **Argument formati (v1.31.0+)**: `/review [effort] [--comment] [--correctness-only]`
-> - `effort`: `low` | `medium` (default) | `high` — analiz derinligi
-> - `--comment`: bulgulari aktif PR'a inline yorum olarak post et (gh CLI gerekir)
-> - `--correctness-only`: yalniz correctness bug'larina odaklan (mimari/perf/guvenlik kanallarini atla)
+> **Argument format (v1.31.0+)**: `/review [effort] [--comment] [--correctness-only]`
+> - `effort`: `low` | `medium` (default) | `high` — analysis depth
+> - `--comment`: post findings as inline comments on the active PR (requires the gh CLI)
+> - `--correctness-only`: focus only on correctness bugs (skip the architecture/perf/security channels)
 
-> **Anthropic native `/code-review` (Claude Code 2.1.147+) farki:**
-> - `/code-review`: correctness bug + effort tuning + `--comment` (native English render)
-> - `/review` (badi): yukaridakilerin **superset**'i — 3 kanal (guvenlik+perf+mimari) + TR rapor + classification
-> - Kombine kullanim: `/code-review high --comment` (logic) sonra `/review high --comment` (mimari/perf/guvenlik)
+> **Difference vs. Anthropic's native `/code-review` (Claude Code 2.1.147+):**
+> - `/code-review`: correctness bugs + effort tuning + `--comment` (native English render)
+> - `/review` (badi): a **superset** of the above — 3 channels (security+perf+architecture) + structured report + classification
+> - Combined use: `/code-review high --comment` (logic) then `/review high --comment` (architecture/perf/security)
 
-# Gerekli Araclar
-- Read (kod okuma)
-- Grep (kalip arama)
-- Glob (dosya taramasi)
-- Bash (git diff, gh CLI inline PR comment, analiz araclari)
+# Required Tools
+- Read (code reading)
+- Grep (pattern search)
+- Glob (file scan)
+- Bash (git diff, gh CLI inline PR comments, analysis tools)
 
-# Prosedur (4 Adim + opsiyonel PR Comment)
+# Procedure (4 Steps + optional PR Comment)
 
-### Adim 0: Argument Parse + Effort & Mod Belirle (v1.31.0+)
+### Step 0: Argument Parse + Effort & Mode (v1.31.0+)
 
-> **Not**: Bu komut Claude tarafindan **prompt baglaminda yorumlanir** — kod-bazli
-> argument parsing yok. Asagidaki argumanlar Claude'a "review high --comment"
-> formatinda gelir, Claude prosedurde belirtilen davranisi uygular.
+> **Note**: This command is **interpreted by Claude in prompt context** — there is
+> no code-based argument parsing. The arguments arrive as "review high --comment"
+> and Claude applies the behavior described in this procedure.
 
 
-Komut argumanlari:
+Command arguments:
 - `effort` (positional): `low` | `medium` | `high`
-  - `low`: yalniz KRITIK + YUKSEK bulgu; performans/mimari kanallarini hizli tara
-  - `medium` (default): mevcut davranis — KRITIK + YUKSEK + ORTA siniflari
-  - `high`: tum siniflar (KRITIK/YUKSEK/ORTA/DUSUK) + olumlu gozlemler + alternative cozumler
-- `--comment`: Adim 5'i etkinlestir (PR inline comment)
-- `--correctness-only`: Adim 3'te yalniz Kanal A guvenlik + correctness bug'larina odaklan, Kanal B (performans) + Kanal C (mimari) atla
+  - `low`: only CRITICAL + HIGH findings; fast pass over the performance/architecture channels
+  - `medium` (default): current behavior — CRITICAL + HIGH + MEDIUM classes
+  - `high`: all classes (CRITICAL/HIGH/MEDIUM/LOW) + positive observations + alternative solutions
+- `--comment`: enables Step 5 (PR inline comments)
+- `--correctness-only`: in Step 3 focus only on Channel A security + correctness bugs, skip Channel B (performance) + Channel C (architecture)
 
-### Adim 1: Kapsam Tanimla
-Incelenecek kodu belirle:
-- **Aktif PR (auto-detect)**: `gh pr view --json number,baseRefName,headRefName` ile mevcut branch'in PR'i tespit edilir. Varsa scope otomatik PR diff'i (`gh pr diff <num>`).
-- **PR/Commit:** `git diff` ciktisini al (branch veya commit hash ile)
-- **Dosya:** Belirli dosya veya dosyalar
-- **Modul:** Bir ozellik veya modul dizini
-- **Degisiklik Kumesi:** Son N commitin degisiklikleri
+### Step 1: Define the Scope
+Determine the code to review:
+- **Active PR (auto-detect)**: detect the current branch's PR via `gh pr view --json number,baseRefName,headRefName`. If found, the scope is automatically the PR diff (`gh pr diff <num>`).
+- **PR/Commit:** take the `git diff` output (by branch or commit hash)
+- **File:** a specific file or files
+- **Module:** a feature or module directory
+- **Change Set:** the last N commits' changes
 
-Kapsam bilgisini kaydet:
-- Dosya sayisi
-- Degisen satir sayisi (eklenen/silinen)
-- Etkilenen moduller
+Record the scope:
+- File count
+- Changed line count (added/removed)
+- Affected modules
 
-### Adim 2: Kod Oku
-- Tum degisiklikleri dikkatli oku
-- Baglam icin cevredeki kodu da incele
-- Ilgili test dosyalarini bul ve oku
-- Etkilenen API'leri veya arayuzleri kontrol et
+### Step 2: Read the Code
+- Read all the changes carefully
+- Review the surrounding code for context
+- Find and read the related test files
+- Check the affected APIs or interfaces
 
-### Adim 3: Paralel Analiz (3 Kanal — `--correctness-only` ile Kanal B+C atlanir)
+### Step 3: Parallel Analysis (3 Channels — `--correctness-only` skips Channels B+C)
 
-**Kanal A: Guvenlik Analizi**
-- Girdi dogrulama eksiklikleri
-- SQL/NoSQL injection riskleri
-- XSS ve CSRF aciklari
-- Hassas veri sizintisi (loglamada, hata mesajlarinda)
-- Yetkilendirme kontrolleri
-- Kriptografik zayifliklar
-- Bagimlilik guvenlik aciklari
-- Hardcoded sirlar veya anahtarlar
+**Channel A: Security Analysis**
+- Missing input validation
+- SQL/NoSQL injection risks
+- XSS and CSRF holes
+- Sensitive data leakage (in logging, in error messages)
+- Authorization checks
+- Cryptographic weaknesses
+- Dependency vulnerabilities
+- Hardcoded secrets or keys
 
-**Kanal B: Performans Analizi**
-- N+1 sorgu kaliplari
-- Gereksiz hesaplamalar veya donguler
-- Bellek sizintisi riskleri
-- Indeks kullanimi (veritabani sorgulari)
-- Onbellekleme firsatlari
-- Asenkron islem gereksinimleri
-- Buyuk veri kumesi islemleri
-- API cagri optimizasyonlari
+**Channel B: Performance Analysis**
+- N+1 query patterns
+- Needless computation or loops
+- Memory-leak risks
+- Index usage (database queries)
+- Caching opportunities
+- Async-processing needs
+- Large dataset operations
+- API call optimizations
 
-**Kanal C: Mimari Analizi**
-- SOLID ilkeleriyle uyum
-- Katman ayrimina saygi (separation of concerns)
-- Bagimlilik yonu (dependency inversion)
-- Kod tekrari (DRY ihlalleri)
-- Isimlendirme tutarliligi
-- Hata yonetimi stratejisi
-- Test edilebilirlik
-- Genisletilebilirlik ve bakim kolayligi
+**Channel C: Architecture Analysis**
+- SOLID compliance
+- Separation of concerns
+- Dependency direction (dependency inversion)
+- Code duplication (DRY violations)
+- Naming consistency
+- Error-handling strategy
+- Testability
+- Extensibility and maintainability
 
-### Adim 4: Bulgulari Siniflandir
+### Step 4: Classify the Findings
 
-Her bulguyu su seviyelere ata:
+Assign every finding a level:
 
-**KRITIK** - Mutlaka duzeltilmeli (merge engelleyici)
-- Guvenlik aciklari
-- Veri kaybi/bozulma riski
-- Uretim ortamini kiracak hatalar
+**CRITICAL** - Must be fixed (merge blocker)
+- Security vulnerabilities
+- Data loss/corruption risk
+- Errors that will break production
 
-**YUKSEK** - Merge oncesi cozulmesi onerilen
-- Performans sorunlari
-- Hata yonetimi eksiklikleri
-- Test kapsami boslugu (kritik yollar)
+**HIGH** - Recommended to resolve before merge
+- Performance issues
+- Error-handling gaps
+- Test coverage holes (critical paths)
 
-**ORTA** - Iyilestirme firsati
-- Kod kalitesi
-- Okunabilirlik
+**MEDIUM** - Improvement opportunity
+- Code quality
+- Readability
 - Minor refactoring
 
-**DUSUK** - Oneri niteliginde
-- Stil tercihleri
-- Dokumantasyon iyilestirmeleri
-- Gelecek refactoring firsatlari
+**LOW** - Advisory
+- Style preferences
+- Documentation improvements
+- Future refactoring opportunities
 
-### Adim 5 (opsiyonel): PR Inline Comment (`--comment`)
+### Step 5 (optional): PR Inline Comments (`--comment`)
 
-`--comment` flag ile birlikte calistirildiginda, bulgular aktif PR'a inline yorum olarak post edilir. gh CLI gerekir.
+When run with the `--comment` flag, findings are posted as inline comments on the active PR. Requires the gh CLI.
 
-**On kontroller:**
-1. `gh` PATH'te mi: `which gh`
-2. Aktif branch'in PR'i var mi: `gh pr view --json number,headRefName` (yoksa hata: "PR bulunamadi. /review --comment yalniz PR icindeyken calisir")
-3. Yetki kontrolu: `gh auth status`
+**Pre-checks:**
+1. Is `gh` on the PATH: `which gh`
+2. Does the current branch have a PR: `gh pr view --json number,headRefName` (otherwise error: "No PR found. /review --comment only works inside a PR")
+3. Auth check: `gh auth status`
 
-**Yorum yazimi (her KRITIK + YUKSEK bulgu icin):**
+**Comment posting (for every CRITICAL + HIGH finding):**
 ```bash
 gh api repos/:owner/:repo/pulls/<num>/comments \
   --method POST \
-  --field body="<bulgu_aciklamasi>" \
-  --field path="<dosya_yolu>" \
-  --field line=<satir_no> \
+  --field body="<finding_description>" \
+  --field path="<file_path>" \
+  --field line=<line_no> \
   --field side="RIGHT"
 ```
 
-**Ozet yorum (PR description'a):**
+**Summary comment (on the PR):**
 ```bash
 gh pr comment <num> --body "$(badi review --format markdown-summary)"
 ```
 
-Cikti: KRITIK N | YUKSEK N | ORTA N | DUSUK N + onerilen action (merge OK / revize / red).
+Output: CRITICAL N | HIGH N | MEDIUM N | LOW N + the suggested action (merge OK / revise / reject).
 
-# Cikti Formati
+# Output Format
 ```
-=== BADI KOD INCELEMESI ===
-Tarih: [tarih]
-Kapsam: [belirtilen kapsam]
-Dosya Sayisi: [sayi]
-Degisen Satir: +[eklenen] / -[silinen]
+=== BADI CODE REVIEW ===
+Date: [date]
+Scope: [specified scope]
+File Count: [count]
+Changed Lines: +[added] / -[removed]
 
-## Genel Degerlendirme
-[1-2 cumle ozet]
-Onay Durumu: ONAYLANDI / DEGISIKLIK GEREKLI / REDDEDILDI
+## Overall Assessment
+[1-2 sentence summary]
+Approval State: APPROVED / CHANGES REQUIRED / REJECTED
 
-## Kritik Bulgular ([sayi])
-### [Bulgu Basligi]
-- Dosya: [yol:satir]
-- Sorun: [aciklama]
-- Oneri: [cozum]
+## Critical Findings ([count])
+### [Finding Title]
+- File: [path:line]
+- Problem: [description]
+- Suggestion: [fix]
 
-## Yuksek Oncelikli ([sayi])
+## High Priority ([count])
 ...
 
-## Orta Oncelikli ([sayi])
+## Medium Priority ([count])
 ...
 
-## Dusuk Oncelikli ([sayi])
+## Low Priority ([count])
 ...
 
-## Olumlu Gozlemler
-- [iyi yapilmis seyler]
+## Positive Observations
+- [things done well]
 
-## Ozet
-- Kritik: [sayi] | Yuksek: [sayi] | Orta: [sayi] | Dusuk: [sayi]
+## Summary
+- Critical: [count] | High: [count] | Medium: [count] | Low: [count]
 ==============================
 ```

--- a/.claude/commands/security-scan.md
+++ b/.claude/commands/security-scan.md
@@ -1,141 +1,141 @@
 Security scan. Searches the codebase and dependencies for vulnerabilities and produces a severity-ranked report.
 
-> **Native komut (v1.31.0+)**: Claude Code 2.1.140+ ile `/security-review` artik **native** komut (built-in slash). Bu komut onun yaninda **deterministic baseline** (`badi security baseline`) + **post-scan triage** (`badi security triage`) saglar.
+> **Native command (v1.31.0+)**: With Claude Code 2.1.140+, `/security-review` is now a **native** command (built-in slash). This command complements it with a **deterministic baseline** (`badi security baseline`) + **post-scan triage** (`badi security triage`).
 >
-> **Onerilen akis**:
-> 1. `badi security baseline` — sirlar + bagimliliklar (deterministic)
+> **Recommended flow**:
+> 1. `badi security baseline` — secrets + dependencies (deterministic)
 > 2. `/security-review` — AI semantic vulnerability hunt (Anthropic native)
-> 3. `badi security triage` — rapor severity filtreleme
-> 4. CI: `badi security init --ci` — PR'larda otomatik review
+> 3. `badi security triage` — report severity filtering
+> 4. CI: `badi security init --ci` — automatic review on PRs
 
-## Badi CLI Komutlari (v1.6+)
-Bu komut ilk olarak su CLI araclarini cagirir:
-- `badi secret-scan` — 17 pattern sir/credential taramasi (AWS, GCP, GitHub, OpenAI, Stripe, DB URI'leri, private keys)
-- `badi secret-scan --git` — Son 100 commit'te de tarama
-- `badi a11y [url]` — Accessibility (guvenlik audit'in bir bolumu)
-Sonra security-scanner ajanina devredilir (kod kalip analizi).
+## Badi CLI Commands (v1.6+)
+This command first invokes these CLI tools:
+- `badi secret-scan` — 17-pattern secret/credential scan (AWS, GCP, GitHub, OpenAI, Stripe, DB URIs, private keys)
+- `badi secret-scan --git` — Also scan the last 100 commits
+- `badi a11y [url]` — Accessibility (part of the security audit)
+Then it delegates to the security-scanner agent (code pattern analysis).
 
-# Gerekli Araclar
-- Bash (npm audit, bagimlilik taramasi)
-- Read (konfigur asyon dosyalari)
-- Grep (kod kalip taramasi)
+# Required Tools
+- Bash (npm audit, dependency scan)
+- Read (configuration files)
+- Grep (code pattern scan)
 - ...
 
-# Ajan Delegasyonu
-Bu komut ana tarama isini security-scanner ajanina devreder.
-Ajan bulunamazsa, asagidaki adimlari dogrudan uygula.
+# Agent Delegation
+This command delegates the main scan to the security-scanner agent.
+If the agent is unavailable, apply the steps below directly.
 
 ---
 
-## Bolum 1: Bagimlilik Acigi Taramasi
+## Section 1: Dependency Vulnerability Scan
 
-### Adim 1: Paket Yoneticisi Tespiti ve Audit
-- npm: `npm audit --json` calistir
-- yarn: `yarn audit --json` calistir
-- pip: `pip audit` veya `safety check` calistir
+### Step 1: Package Manager Detection and Audit
+- npm: run `npm audit --json`
+- yarn: run `yarn audit --json`
+- pip: run `pip audit` or `safety check`
 - ...
 
-### Adim 2: Acik Siniflandirmasi
-Her bulunan acik icin kaydet:
-- Paket adi ve versiyonu
-- CVE numarasi (varsa)
-- Ciddiyet seviyesi: KRITIK / YUKSEK / ORTA / DUSUK
+### Step 2: Vulnerability Classification
+Record per finding:
+- Package name and version
+- CVE number (if any)
+- Severity: CRITICAL / HIGH / MEDIUM / LOW
 - ...
 
-### Adim 3: Bagimlilik Zinciri Analizi
-- Dogrudan bagimlilik mi yoksa gecisli bagimlilik mi belirle
-- Gecisli bagimliliklarda hangi ust paketin getirdigini goster
-- Lock dosyasinin guncel oldugunu dogrula
+### Step 3: Dependency Chain Analysis
+- Determine direct vs. transitive dependency
+- For transitive ones, show which parent package pulls it in
+- Verify the lock file is current
 
 ---
 
-## Bolum 2: Kod Kalip Analizi
+## Section 2: Code Pattern Analysis
 
-### Adim 4: Sabit Kodlu Sir Taramasi
+### Step 4: Hardcoded Secret Scan
 
-**Once `badi secret-scan` calistir** — 17 pattern ile hizli tarama:
+**Run `badi secret-scan` first** — a fast scan with 17 patterns:
 - AWS Access/Secret, GCP, GitHub PAT (classic + fine-grained), Slack, Stripe,
   OpenAI, Anthropic
-- npm, SendGrid, Twilio, MongoDB/Postgres URI
-- RSA/EC private keys, JWT token
-- Generic secret (20-64 char)
+- npm, SendGrid, Twilio, MongoDB/Postgres URIs
+- RSA/EC private keys, JWT tokens
+- Generic secrets (20-64 chars)
 
-Komut:
+Commands:
 ```bash
 badi secret-scan                                       # Working tree
-badi secret-scan --git                                 # + git history (son N commit)
-badi secret-scan --format json                         # JSON cikti
-badi secret-scan --exit-code strict                    # her bulguda exit 1
-badi secret-scan --max-commits 500 --git               # daha derin tarihce
-badi secret-scan --ignore jwt,github-pat               # belirli pattern'leri yoksay
-badi secret-scan --ignore-file .secretignore           # dosyadan oku
-badi secret-scan --patterns custom-org-patterns.json   # ek pattern yukle
+badi secret-scan --git                                 # + git history (last N commits)
+badi secret-scan --format json                         # JSON output
+badi secret-scan --exit-code strict                    # exit 1 on any finding
+badi secret-scan --max-commits 500 --git               # deeper history
+badi secret-scan --ignore jwt,github-pat               # ignore specific patterns
+badi secret-scan --ignore-file .secretignore           # read from a file
+badi secret-scan --patterns custom-org-patterns.json   # load extra patterns
 ```
 
-**Cikis kodlari (CI icin):**
-- `0`  Bulgu yok (veya --exit-code never, veya yalniz ORTA/DUSUK varsayilanda)
-- `1`  KRITIK veya YUKSEK bulgu — pipeline durdurulmali
+**Exit codes (for CI):**
+- `0`  No findings (or --exit-code never, or only MEDIUM/LOW by default)
+- `1`  CRITICAL or HIGH finding — the pipeline should stop
 
-**Kapsam disi (CI'da basaca bilinmesi gerekenler):**
-- `git stash`, `reflog`, packed-refs taranmaz — sadece reachable commit'ler
-- Sembolik link'ler atlanir (cycle + path traversal koruma)
-- Dosya boyut limiti: 2MB, dosya sayisi limiti: 5000 (--max-files ile ayarla)
+**Out of scope (worth knowing in CI):**
+- `git stash`, `reflog`, packed-refs are not scanned — only reachable commits
+- Symlinks are skipped (cycle + path traversal protection)
+- File size limit: 2MB, file count limit: 5000 (tune with --max-files)
 
-**Sonra ek kod kalip analizi** (CLI'in kacirmis olabilecekleri):
-- API anahtarlari: `api[_-]?key\s*[:=]`
-- Tokenlar: `token\s*[:=]\s*['"][A-Za-z0-9]`
-- Sifreler: `password\s*[:=]\s*['"]`
+**Then extra code pattern analysis** (what the CLI may have missed):
+- API keys: `api[_-]?key\s*[:=]`
+- Tokens: `token\s*[:=]\s*['"][A-Za-z0-9]`
+- Passwords: `password\s*[:=]\s*['"]`
 - ...
 
-### Adim 5: Enjeksiyon Vektoru Taramasi
-- SQL enjeksiyonu: Ham sorgu birlestireleri, parametresiz sorgular
-- XSS: `innerHTML`, `dangerouslySetInnerHTML`, filtresiz kullanici girdisi
-- Komut enjeksiyonu: `exec()`, `eval()`, `child_process` kullanimi
+### Step 5: Injection Vector Scan
+- SQL injection: raw query concatenation, non-parameterized queries
+- XSS: `innerHTML`, `dangerouslySetInnerHTML`, unfiltered user input
+- Command injection: `exec()`, `eval()`, `child_process` usage
 - ...
 
-### Adim 6: Kimlik Dogrulama ve Yetkilendirme Kaliplari
-- JWT implementasyonunu incele (algoritma sabitleme, sure asimi)
-- Sifre hashleme yontemi kontrol et (bcrypt/argon2 mi, MD5/SHA1 mi)
-- Rate limiting uygulamasi var mi kontrol et
+### Step 6: Authentication and Authorization Patterns
+- Review the JWT implementation (algorithm pinning, expiry)
+- Check the password hashing method (bcrypt/argon2 vs. MD5/SHA1)
+- Check whether rate limiting is in place
 - ...
 
 ---
 
-## Bolum 3: Konfigurasyon Incelemesi
+## Section 3: Configuration Review
 
-### Adim 7: CORS Politikasi
-- CORS konfigurasyonunu bul ve oku
-- Wildcard origin (`*`) kullanimi var mi kontrol et
-- Izin verilen originlerin kabul edilebilir oldugunu dogrula
+### Step 7: CORS Policy
+- Find and read the CORS configuration
+- Check for wildcard origin (`*`) usage
+- Verify the allowed origins are acceptable
 - ...
 
-### Adim 8: Guvenlik Basliklari
-Asagidaki basliklarin konfigure edildigini kontrol et:
+### Step 8: Security Headers
+Check that the following headers are configured:
 - Content-Security-Policy (CSP)
 - X-Content-Type-Options: nosniff
-- X-Frame-Options veya frame-ancestors
+- X-Frame-Options or frame-ancestors
 - ...
 
-### Adim 9: Auth Konfigurasyonu
-- Oturum yonetimi konfigurasyonunu incele
-- Cookie ayarlari: secure, httpOnly, sameSite
-- Token surelerini degerlendir
+### Step 9: Auth Configuration
+- Review the session management configuration
+- Cookie settings: secure, httpOnly, sameSite
+- Evaluate the token lifetimes
 - ...
 
 ---
 
-## Bolum 4: Bulgular Raporu
+## Section 4: Findings Report
 
-### Adim 10: Ciddiyet Siralamasi
-Tum bulgulari su siralama ile raporla:
+### Step 10: Severity Ranking
+Report all findings in this order:
 
 ```
-[kisaltildi]
+[abridged]
 ```
 
-### Adim 11: Duzeltme Onerileri
-Her bulgu icin:
-- Sorunun kisa aciklamasi
-- Onerien duzeltme yontemi
-- Ornek kod veya konfigurasyon degisikligi
+### Step 11: Remediation Suggestions
+For each finding:
+- A short description of the problem
+- The suggested fix
+- An example code or configuration change
 - ...

--- a/.claude/commands/seo.md
+++ b/.claude/commands/seo.md
@@ -1,80 +1,80 @@
 SEO audit command. Website SEO analysis, meta tag checks, sitemap validation, and speed assessment.
 
-# Gerekli Araclar
-- Bash (badi seo komutlari)
+# Required Tools
+- Bash (badi seo commands)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Kapsam Belirle
+### Step 1: Define the Scope
 
-Kullaniciya sor: "Hangi analizi yapalim?"
-- **Tam audit** — 20+ kontrol (tavsiye edilen baslangic)
-- **Meta taglar** — OG, Twitter Card detayi
+Ask the user: "Which analysis shall we run?"
+- **Full audit** — 20+ checks (recommended starting point)
+- **Meta tags** — OG, Twitter Card detail
 - **Sitemap + robots.txt** — Crawlability
-- **Hiz + kaynaklar** — Performance baslangici
+- **Speed + resources** — Performance starter
 
-### Adim 2: SEO Audit (Varsayilan)
+### Step 2: SEO Audit (Default)
 ```bash
 badi seo audit [url]
 ```
 
-Kontrol edilenler:
+What is checked:
 - Title, Description, OG tags, Twitter Card
-- H1 yapisi (tek olmali)
-- Gorsel alt taglari
+- H1 structure (must be single)
+- Image alt tags
 - Canonical URL, Viewport, lang, charset
 - HTTPS, Schema.org, robots meta
-- Kelime sayisi, link analizi
+- Word count, link analysis
 
-SEO skoru 0-100 arasi verilir.
+An SEO score of 0-100 is given.
 
-### Adim 3: Detayli Analizler
+### Step 3: Detailed Analyses
 
 ```bash
-badi seo meta [url]        # Meta tag analizi (eksik tespit)
+badi seo meta [url]        # Meta tag analysis (missing detection)
 badi seo sitemap [url]     # robots.txt + sitemap.xml
-badi seo speed [url]       # TTFB + HTML boyutu + compression
+badi seo speed [url]       # TTFB + HTML size + compression
 ```
 
-### Adim 4: Iyilestirme Onerileri
+### Step 4: Improvement Suggestions
 
-Skor < 80 ise bulgulara gore:
-- **Title eksik/uzun**: 30-60 karakter onerisi
-- **Description yok**: 120-160 karakter ornek
-- **H1 sorunu**: Sayfa yapisi onerisi
-- **Gorsel alt eksik**: WCAG + SEO birlesik fayda
-- **Canonical yok**: Duplicate content riski
-- **Schema.org yok**: Structured data firsati
+If the score < 80, based on the findings:
+- **Title missing/long**: 30-60 character suggestion
+- **No description**: 120-160 character example
+- **H1 problem**: page structure suggestion
+- **Missing image alts**: combined WCAG + SEO benefit
+- **No canonical**: duplicate-content risk
+- **No Schema.org**: structured-data opportunity
 
-### Adim 5: Lighthouse Derin Analiz
+### Step 5: Lighthouse Deep Analysis
 
-Daha derin metrikler icin:
+For deeper metrics:
 ```bash
 badi lighthouse [url]
 ```
-Core Web Vitals + Performance + Accessibility + Best Practices + SEO skoru.
+Core Web Vitals + Performance + Accessibility + Best Practices + SEO score.
 
-### Adim 6: AI Search Optimizasyonu
+### Step 6: AI Search Optimization
 
-Modern SEO'da GEO (Generative Engine Optimization) onemli:
-- ChatGPT/Perplexity tarafindan alintılanma
+GEO (Generative Engine Optimization) matters in modern SEO:
+- Being cited by ChatGPT/Perplexity
 - Schema.org structured data
-- llms.txt dosyasi (opsiyonel)
+- An llms.txt file (optional)
 
-Claude Code'da `ai-seo` veya `seo-geo` skill'ini cagirin (ileri seviye).
+In Claude Code, invoke the `ai-seo` or `seo-geo` skill (advanced).
 
-# Ornek Kullanim
+# Example Usage
 
 ```
 /seo https://example.com
 ```
 
 ```
-Kullanici: /seo blog.com
-Asistan: [badi seo audit calistirir]
-         SEO skoru: 72/100
-         Kritik sorunlar: 
-           - Meta description eksik
-           - 3 gorselde alt tag yok
-         Detay icin: /seo-audit ile devam edelim mi?
+User: /seo blog.com
+Assistant: [runs badi seo audit]
+         SEO score: 72/100
+         Critical issues:
+           - Meta description missing
+           - 3 images lack alt tags
+         For detail: shall we continue with /seo-audit?
 ```

--- a/.claude/commands/wp.md
+++ b/.claude/commands/wp.md
@@ -1,84 +1,84 @@
 WordPress site management command. Site status, plugin/theme management, security scan, and bulk updates.
 
-# Gerekli Araclar
-- Bash (badi wp komutlari)
+# Required Tools
+- Bash (badi wp commands)
 
-# Prosedur
+# Procedure
 
-### Adim 1: Site Kaydi Kontrolu
+### Step 1: Check the Site Registry
 ```bash
 badi wp list
 ```
-Kullanicinin kayitli siteleri varsa goster, yoksa ekleme onerisi yap:
+If the user has registered sites, show them; otherwise suggest adding one:
 ```bash
 badi wp add [alias] [url] --method [wp-cli|rest]
 ```
 
-### Adim 2: Site Durumu
+### Step 2: Site Status
 ```bash
 badi wp status [alias]
 ```
-Gosterir:
-- WordPress surumu
-- Aktif tema
-- Eklenti sayisi + guncelleme bekleyen
-- Core guncelleme durumu
+Shows:
+- WordPress version
+- Active theme
+- Plugin count + pending updates
+- Core update status
 
-### Adim 3: Detayli Inceleme (istege bagli)
+### Step 3: Detailed Review (optional)
 
 ```bash
-badi wp plugins [alias]       # Eklenti listesi
-badi wp themes [alias]        # Tema listesi
+badi wp plugins [alias]       # Plugin list
+badi wp themes [alias]        # Theme list
 ```
 
-### Adim 4: Guvenlik Taramasi
+### Step 4: Security Scan
 ```bash
 badi wp security [alias]
 ```
-6 nokta kontrolu:
-- WP Core guncelligi
-- Eklenti guncellemeleri
-- Pasif eklenti (kaldirilabilir)
-- WP_DEBUG kapali mi
-- DISALLOW_FILE_EDIT tanimli mi
-- `admin` kullanicisi ve admin sayisi
+6-point check:
+- WP Core freshness
+- Plugin updates
+- Inactive plugins (removable)
+- Is WP_DEBUG off
+- Is DISALLOW_FILE_EDIT defined
+- The `admin` user and the admin count
 
-### Adim 5: Toplu Guncelleme (Dikkatli!)
+### Step 5: Bulk Update (Careful!)
 ```bash
-badi wp update [alias] all                  # Core + plugin + theme (120s timeout)
-badi wp update [alias] core                 # Sadece core
-badi wp update [alias] plugins              # Sadece plugins
-badi wp update [alias] themes               # Sadece themes
-badi wp update [alias] [plugin-name]        # Belirli eklenti
+badi wp update [alias] all                  # Core + plugins + themes (120s timeout)
+badi wp update [alias] core                 # Core only
+badi wp update [alias] plugins              # Plugins only
+badi wp update [alias] themes               # Themes only
+badi wp update [alias] [plugin-name]        # A specific plugin
 ```
 
-**Staging'de test et, production icin backup al.**
+**Test on staging; take a backup for production.**
 
-### Adim 6: Takip Aksiyonlari
+### Step 6: Follow-up Actions
 
-Guvenlik sorunu varsa:
-- `/secret-scan` — uygulama tarafinda da sir ara
-- `/ssl-check [domain]` — SSL durumu
-- `/dns-audit [domain]` — Email guvenlik
+If security issues exist:
+- `/secret-scan` — also search for secrets on the app side
+- `/ssl-check [domain]` — SSL state
+- `/dns-audit [domain]` — Email security
 
-# Baglanti Yontemleri
+# Connection Methods
 
-| Method | Senaryo |
-|--------|---------|
-| `--method wp-cli --path /var/www/` | Lokal WordPress kurulumu |
+| Method | Scenario |
+|--------|----------|
+| `--method wp-cli --path /var/www/` | Local WordPress install |
 | `--method wp-cli --ssh user@host` | SSH + remote WP-CLI |
-| `--method rest` | REST API (interactive password'li kisitli) |
+| `--method rest` | REST API (limited with an interactive password) |
 
-Application password icin: WP Admin → Users → Profile → Application Passwords
+For an application password: WP Admin → Users → Profile → Application Passwords
 
-# Ornek Kullanim
+# Example Usage
 
 ```
-Kullanici: /wp
-Asistan: Kayitli WP siteleriniz: [list]
-         Hangisinde calismak istersiniz?
+User: /wp
+Assistant: Your registered WP sites: [list]
+         Which one shall we work on?
 
-Kullanici: blog
-Asistan: [badi wp status blog calistirir]
-         [Sonuclari yorumlar, guvenlik taramasi onerir]
+User: blog
+Assistant: [runs badi wp status blog]
+         [Interprets the results, suggests a security scan]
 ```


### PR DESCRIPTION
## Summary

**Increment 5 — completes the command-body migration.** The 19 larger dev-profile bodies (vault + active = 38 files): `architect`, `seo`, `api-test`, `wp`, `playbook`, `api-doc`, `brief`, `aso`, `mobile`, `perf-check`, `release`, `debt-map`, `deploy`, `retro`, `hotfix`, `security-scan`, `changelog`, `report`, `review`.

**All 84 vault commands are now fully English** (broad vault-wide scan: zero Turkish structural markers).

### Caught en route
- `playbook`: the command-authoring rule **"write in Turkish" → "write in English"** — behavior-defining for every command /playbook generates from now on
- `aso` + `mobile`: dead `--lang tr,en` dropped from release-notes examples (no-op since v1.32)
- `mobile`: dangling `/aso-strategy` slash ref → the `aso-master` agent
- `review`: stale "TR rapor" claim in the `/code-review` comparison → structured report

## Test plan
- [x] `npm test` — **1161 pass / 0 fail** · biome clean · doctor healthy
- [x] Vault-wide Turkish scan (84 commands): **clean**

## Remaining (last family)
3f-h: skills vault — 59 SKILL.md (genel 22 / pentest 25 / expo 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)