### PR TITLE
feat(i18n): Phase 3f — English skills vault, general family (22 SKILL.md)

### DIFF
--- a/.claude/skills-vault/ai-automation/SKILL.md
+++ b/.claude/skills-vault/ai-automation/SKILL.md
@@ -10,300 +10,299 @@ metadata:
   badi-version: ">=1.14.0"
   category: ai-automation
 ---
-# AI Otomasyon Becerileri
-> 59 yapilandirilmis prosedur
-## Beceri Listesi
+# AI Automation Skills
+> 59 structured procedures
+## Skill List
 
-### chatbot-tasarimi
-Kullanici ihtiyaclarina uygun, dogal dil isleme tabanli sohbet botu tasarlama ve uygulama becerisi. Konusma akislari, niyet tanima ve baglam yonetimi dahil uclararasi chatbot mimarisi olusturur.
-
----
-
-### prompt-muhendisligi
-Buyuk dil modellerinden en iyi sonuclari almak icin etkili prompt tasarlama, test etme ve optimize etme becerisi. Sistem promptlari, few-shot ornekler ve zincirleme dusunme teknikleri icerir.
+### chatbot-design
+The skill of designing and building NLP-based chatbots fitting user needs. Builds end-to-end chatbot architecture including conversation flows, intent recognition, and context management.
 
 ---
 
-### rag-sistemi-kurulumu
-Retrieval-Augmented Generation (RAG) sistemi tasarlama ve uygulama becerisi. Belge indeksleme, vektor veritabani entegrasyonu ve sorgu optimizasyonu dahil eksiksiz RAG pipeline kurulumu saglar.
+### prompt-engineering
+The skill of designing, testing, and optimizing effective prompts for the best LLM results. Covers system prompts, few-shot examples, and chain-of-thought techniques.
+
+---
+
+### rag-system-setup
+The skill of designing and building Retrieval-Augmented Generation (RAG) systems. Delivers a complete RAG pipeline including document indexing, vector-database integration, and query optimization.
 
 ---
 
 ### llm-fine-tuning
-Buyuk dil modellerini belirli kullanim alanlarina uygun sekilde ince ayar yapma becerisi. Veri hazirlama, egitim sureci yonetimi ve model degerlendirme adimlarini kapsar.
+The skill of fine-tuning large language models for specific use cases. Covers data preparation, training-process management, and model evaluation.
 
 ---
 
-### otomasyon-is-akisi
-Tekrarlayan is sureclerini otomatiklestirmek icin is akisi tasarlama ve uygulama becerisi. Tetikleyiciler, kosullar ve eylemler zinciri ile verimli otomasyon sistemleri kurar.
+### automation-workflow
+The skill of designing and building workflows that automate repetitive processes. Builds efficient automation systems with triggers, conditions, and action chains.
 
 ---
 
-### ai-asistan-gelistirme
-Ozellestirilmis yapay zeka asistani gelistirme becerisi. Kullanici arayuzu, arka plan servisleri ve AI model entegrasyonu ile uclararasi asistan uygulamasi olusturur.
+### ai-assistant-development
+The skill of building customized AI assistants. Builds end-to-end assistant applications with UI, backend services, and AI-model integration.
 
 ---
 
-### veri-etiketleme
-Makine ogrenimi modelleri icin veri etiketleme sureci tasarlama ve yonetme becerisi. Etiketleme kilavuzlari, kalite kontrol ve etiketciler arasi uyum olcumu icerir.
+### data-labeling
+The skill of designing and managing the data-labeling process for ML models. Covers labeling guidelines, quality control, and inter-annotator agreement measurement.
 
 ---
 
-### model-degerlendirme
-AI modellerinin performansini sistematik olarak degerlendirme becerisi. Dogruluk, hassasiyet, geri cagirma ve alan-spesifik metriklerle kapsamli model analizi yapar.
+### model-evaluation
+The skill of systematically evaluating AI model performance. Runs comprehensive model analysis with accuracy, precision, recall, and domain-specific metrics.
 
 ---
 
-### ai-etik-cerceve
-Yapay zeka uygulamalari icin etik ilkeler ve sorumluluk cercevesi olusturma becerisi. Yanlilik tespiti, seffaflik ve hesap verebilirlik mekanizmalarini kapsar.
+### ai-ethics-framework
+The skill of building ethical principles and an accountability framework for AI applications. Covers bias detection, transparency, and accountability mechanisms.
 
 ---
 
-### konusma-tanima
-Ses verisini metne donusturme sistemleri tasarlama ve uygulama becerisi. ASR modelleri, ses on isleme ve gercek zamanli transkripsiyon pipeline'i olusturur.
+### speech-recognition
+The skill of designing and building speech-to-text systems. Builds ASR models, audio preprocessing, and real-time transcription pipelines.
 
 ---
 
-### goruntu-siniflandirma
-Goruntu siniflandirma modelleri gelistirme ve dagitma becerisi. Transfer ogrenme, veri artirma ve model optimizasyonu ile yuksek dogruluklu siniflandirici olusturur.
+### image-classification
+The skill of building and deploying image-classification models. Builds high-accuracy classifiers with transfer learning, data augmentation, and model optimization.
 
 ---
 
-### duygu-analizi
-Metin verilerinden duygu ve his durumunu otomatik olarak tespit etme becerisi. Olumlu, olumsuz ve notr siniflandirmanin yanisira ince taneli duygu analizi yapar.
+### sentiment-analysis
+The skill of automatically detecting sentiment and emotion in text data. Runs fine-grained sentiment analysis beyond positive, negative, and neutral classification.
 
 ---
 
-### oneri-motoru
-Kullanicilara kisisellestirilmis onerilerde bulunan sistem tasarlama becerisi. Isbirligi filtreleme, icerik tabanli filtreleme ve hibrit yaklasimlari icerir.
+### recommendation-engine
+The skill of designing systems that give users personalized recommendations. Covers collaborative filtering, content-based filtering, and hybrid approaches.
 
 ---
 
-### belge-isleme
-Yapilandirilmamis belgelerden bilgi cikarma ve otomatik isleme becerisi. OCR, tablo cikarma ve belge siniflandirma islemlerini kapsar.
+### document-processing
+The skill of extracting information from unstructured documents and processing it automatically. Covers OCR, table extraction, and document classification.
 
 ---
 
-### ai-api-entegrasyonu
-Ticari ve acik kaynakli AI API'lerini mevcut sistemlere entegre etme becerisi. OpenAI, Anthropic, Google AI ve diger saglayicilarin API'lerini guvenli ve verimli sekilde kullanir.
+### ai-api-integration
+The skill of integrating commercial and open-source AI APIs into existing systems. Uses OpenAI, Anthropic, Google AI, and other providers' APIs securely and efficiently.
 
 ---
 
-### otomatik-ozet
-Uzun metinleri otomatik olarak ozetleme becerisi. Cikarmali ve uretici ozetleme teknikleriyle belge, toplanti ve icerik ozetleri olusturur.
+### automatic-summarization
+The skill of summarizing long texts automatically. Builds document, meeting, and content summaries with extractive and generative techniques.
 
 ---
 
-### icerik-uretimi-ai
-AI destekli icerik uretim pipeline'i tasarlama ve yonetme becerisi. Blog, sosyal medya, pazarlama materyali ve diger icerik turlerini olcekli sekilde uretir.
+### ai-content-generation
+The skill of designing and managing AI-assisted content pipelines. Produces blogs, social media, marketing materials, and other content types at scale.
 
 ---
 
-### ceviri-otomasyonu
-Otomatik dil cevirisi pipeline'i kurma ve yonetme becerisi. Makine cevirisi, ceviri bellegi entegrasyonu ve kalite guvence sureclerini kapsar.
+### translation-automation
+The skill of building and managing automatic translation pipelines. Covers machine translation, translation-memory integration, and quality assurance.
 
 ---
 
-### anomali-tespiti
-Veri akislarinda anormal oruntuleri ve sapmalari otomatik olarak tespit etme becerisi. Istatistiksel ve makine ogrenimi tabanli yontemlerle anomali algilama sistemi kurar.
+### anomaly-detection
+The skill of automatically detecting abnormal patterns and deviations in data streams. Builds detection systems with statistical and ML-based methods.
 
 ---
 
-### tahmin-modeli
-Gelecek olaylari ve degerleri tahmin etmek icin istatistiksel ve ML tabanli modeller gelistirme becerisi. Regresyon, siniflandirma ve zaman serisi tahmin yontemlerini kapsar.
+### prediction-models
+The skill of building statistical and ML models to predict future events and values. Covers regression, classification, and time-series forecasting.
 
 ---
 
-### ai-test-otomasyonu
-AI modelleri ve sistemleri icin otomatik test surecleri tasarlama becerisi. Birim testleri, entegrasyon testleri ve regresyon testleri ile AI kalite guvencesi saglar.
+### ai-test-automation
+The skill of designing automated test processes for AI models and systems. Delivers AI quality assurance with unit, integration, and regression tests.
 
 ---
 
-### ses-sentezi
-Metinden konusmaya (TTS) donusum sistemleri tasarlama ve uygulama becerisi. Dogal ses uretimi, ses klonlama ve duygusal konusma sentezi icerir.
+### speech-synthesis
+The skill of designing and building text-to-speech (TTS) systems. Covers natural voice generation, voice cloning, and emotional speech synthesis.
 
 ---
 
-### yuz-tanima
-Yuz tespit ve tanima sistemleri gelistirme becerisi. Yuz algilama, ozellik cikarma ve kimlik dogrulama pipeline'lari icerir.
+### face-recognition
+The skill of building face detection and recognition systems. Covers face detection, feature extraction, and identity-verification pipelines.
 
 ---
 
-### metin-siniflandirma
-Metin belgelerini otomatik olarak kategorilere ayirma becerisi. Konu siniflandirma, spam tespiti ve icerik moderasyonu gibi gorevler icin model gelistirir.
+### text-classification
+The skill of automatically categorizing text documents. Builds models for tasks like topic classification, spam detection, and content moderation.
 
 ---
 
-### bilgi-cikarma
-Yapilandirilmamis metinlerden yapilandirilmis bilgi cikarma becerisi. Varlik tanima (NER), iliski cikarma ve olay cikarma islemlerini kapsar.
+### information-extraction
+The skill of extracting structured information from unstructured text. Covers named-entity recognition (NER), relation extraction, and event extraction.
 
 ---
 
-### ai-pipeline-tasarimi
-Uclararasi AI veri ve model pipeline'lari tasarlama becerisi. Veri toplama, isleme, model egitim, degerlendirme ve dagitim adimlarini orkestre eder.
+### ai-pipeline-design
+The skill of designing end-to-end AI data and model pipelines. Orchestrates data collection, processing, training, evaluation, and deployment.
 
 ---
 
-### embedding-stratejisi
-Metin, goruntu ve diger veri turleri icin etkin embedding stratejisi tasarlama becerisi. Model secimi, boyut optimizasyonu ve benzerlik arama yapilandirmasini kapsar.
+### embedding-strategy
+The skill of designing effective embedding strategies for text, images, and other data types. Covers model selection, dimension optimization, and similarity-search configuration.
 
 ---
 
-### vektordb-yonetimi
-Vektor veritabani secimi, yapilandirmasi ve yonetimi becerisi. Pinecone, Weaviate, Qdrant ve diger vektor DB cozumlerinin kurulumu ve optimizasyonunu kapsar.
+### vectordb-management
+The vector-database selection, configuration, and management skill. Covers setup and optimization of Pinecone, Weaviate, Qdrant, and other vector DB solutions.
 
 ---
 
-### agent-orkestrasyonu
-Birden fazla AI ajanini koordineli calistirma ve yonetme becerisi. Gorev dagitimi, ajanslar arasi iletisim ve sonuc birlestirme mekanizmalarini kapsar.
+### agent-orchestration
+The skill of running and managing multiple AI agents in coordination. Covers task distribution, inter-agent communication, and result merging.
 
 ---
 
 ### function-calling
-LLM'lerin harici fonksiyonlari ve araclari cagirma yeteneklerini tasarlama becerisi. Fonksiyon tanimlari, parametre dogrulama ve hata yonetimi ile guvenli arac kullanimi saglar.
+The skill of designing LLMs' external function- and tool-calling capabilities. Delivers safe tool use with function definitions, parameter validation, and error handling.
 
 ---
 
-### ai-guvenlik
-AI sistemlerinin guvenligini saglama becerisi. Prompt injection, veri zehirlenmesi, model calmasi ve diger AI-spesifik guvenik tehditlerini onleme stratejileri icerir.
+### ai-security
+The skill of securing AI systems. Covers strategies preventing prompt injection, data poisoning, model theft, and other AI-specific threats.
 
 ---
 
-### model-izleme
-Uretim ortamindaki AI modellerinin performansini surekli izleme becerisi. Model kayma tespiti, performans metrikleri ve otomatik alarm mekanizmalari kurar.
+### model-monitoring
+The skill of continuously monitoring production AI models. Builds drift detection, performance metrics, and automatic alerting.
 
 ---
 
-### ai-maliyet-optimizasyonu
-AI operasyonlarinin maliyetini analiz etme ve optimize etme becerisi. API kullanimi, hesaplama kaynaklari ve model secimi acisindan maliyet-performans dengesini saglar.
+### ai-cost-optimization
+The skill of analyzing and optimizing AI operation costs. Balances cost and performance across API usage, compute resources, and model selection.
 
 ---
 
-### prompt-sablonu
-Yeniden kullanilabilir ve parametrik prompt sablonlari olusturma becerisi. Degisken yerlestirme, kosullu mantik ve sablon versiyonlama ile olcekli prompt yonetimi saglar.
+### prompt-templates
+The skill of building reusable, parameterized prompt templates. Delivers scalable prompt management with variable interpolation, conditional logic, and template versioning.
 
 ---
 
-### ai-prototipleme
-AI fikirlerini hizla prototip haline getirme becerisi. Minimum uygulanabilir urun (MVP) yaklasimi ile AI konseptlerini test edilebilir prototiplere donusturur.
+### ai-prototyping
+The skill of prototyping AI ideas fast. Turns AI concepts into testable prototypes with an MVP approach.
 
 ---
 
 ### multimodal-ai
-Birden fazla veri turunu (metin, goruntu, ses, video) birlikte isleme becerisi. Multimodal modellerin entegrasyonu ve coklu modalite pipeline'lari olusturur.
+The skill of processing multiple data types (text, image, audio, video) together. Builds multimodal model integrations and multi-modality pipelines.
 
 ---
 
-### ai-rapor-otomasyonu
-Veri kaynaklarindan otomatik rapor uretme becerisi. AI ile veri analizi, gorsellesirme ve dogal dil raporlama pipeline'i olusturur.
+### ai-report-automation
+The skill of generating reports automatically from data sources. Builds the AI pipeline for data analysis, visualization, and natural-language reporting.
 
 ---
 
-### ai-veri-temizleme
-AI destekli veri temizleme ve kalite iyilestirme becerisi. Eksik deger tespiti, yinelenen kayit birlestirme ve format standartlasirma islemlerini otomatiklestirir.
+### ai-data-cleaning
+The AI-assisted data cleaning and quality improvement skill. Automates missing-value detection, duplicate merging, and format standardization.
 
 ---
 
 ### ai-dashboard
-AI model ve sistem metriklerini gorselleyen interaktif dashboard tasarlama becerisi. Gercek zamanli izleme, performans grafikleri ve uyari panelleri icerir.
+The skill of designing interactive dashboards visualizing AI model and system metrics. Covers real-time monitoring, performance charts, and alert panels.
 
 ---
 
-### zaman-serisi-tahmini
-Zamansal veri oruntularini analiz ederek gelecek degerleri tahmin etme becerisi. ARIMA, Prophet, LSTM ve transformer tabanli zaman serisi modellerini kapsar.
+### time-series-forecasting
+The skill of predicting future values by analyzing temporal patterns. Covers ARIMA, Prophet, LSTM, and transformer-based time-series models.
 
 ---
 
-### ai-musteri-segmentasyonu
-AI ile musteri segmentasyonu yapma becerisi. Kumeleme algoritmalari ve davranissal analiz ile musteri gruplarini otomatik belirler.
+### ai-customer-segmentation
+The AI customer-segmentation skill. Automatically determines customer groups with clustering algorithms and behavioral analysis.
 
 ---
 
-### ai-icerik-moderasyonu
-AI ile icerik moderasyon sistemi kurma becerisi. Uygunsuz icerik tespiti, siniflandirma ve otomatik aksiyon alma mekanizmalari olusturur.
+### ai-content-moderation
+The skill of building an AI content-moderation system. Builds inappropriate-content detection, classification, and automatic-action mechanisms.
 
 ---
 
-### ai-kod-inceleme
-AI destekli otomatik kod inceleme sistemi kurma becerisi. Kod kalitesi, guvenlik aciklari ve en iyi pratiklere uyum kontrollerini otomatiklestirir.
+### ai-code-review
+The skill of building an AI-assisted automatic code-review system. Automates checks for code quality, vulnerabilities, and best-practice compliance.
 
 ---
 
-### ai-test-uretimi
-AI ile otomatik test kodu uretme becerisi. Birim testleri, entegrasyon testleri ve edge case testi icin AI destekli test senaryolari olusturur.
+### ai-test-generation
+The skill of generating test code with AI. Builds AI-assisted test scenarios for unit tests, integration tests, and edge cases.
 
 ---
 
-### ai-dokumantasyon
-AI destekli otomatik dokumantasyon uretme becerisi. Kod dokumantasyonu, API referanslari ve kullanici kilavuzlarini AI ile olusturur.
+### ai-documentation
+The AI-assisted automatic documentation skill. Produces code documentation, API references, and user guides with AI.
 
 ---
 
-### ai-sunum-hazirla
-AI destekli sunum hazirlama becerisi. Icerik uretimi, slayt tasarimi ve konusma notlari ile profesyonel sunumlar olusturur.
+### ai-presentation-prep
+The AI-assisted presentation skill. Builds professional decks with content generation, slide design, and speaker notes.
 
 ---
 
-### ai-toplanti-ozeti
-Toplanti kayitlarindan otomatik ozet ve aksiyon maddeleri cikarma becerisi. Transkripsiyon, ozutleme ve gorev atama islemlerini otomatiklestirir.
+### ai-meeting-summary
+The skill of extracting automatic summaries and action items from meeting recordings. Automates transcription, summarization, and task assignment.
 
 ---
 
-### ai-e-posta-yazimi
-AI destekli e-posta taslak olusturma becerisi. Baglama, aliciya ve amaca uygun profesyonel e-postalar yazar ve ton ayarlamasi yapar.
+### ai-email-writing
+The AI-assisted email drafting skill. Writes professional emails fitting the context, recipient, and goal, with tone adjustment.
 
 ---
 
-### ai-sosyal-medya
-AI ile sosyal medya icerik uretimi ve yonetimi becerisi. Platform-spesifik icerikler, hashtag onerileri ve yayinlama takvimi olusturur.
+### ai-social-media
+The AI social content production and management skill. Builds platform-specific content, hashtag suggestions, and publishing calendars.
 
 ---
 
-### ai-seo-optimizasyonu
-AI destekli SEO icerik optimizasyonu becerisi. Anahtar kelime analizi, icerik optimizasyonu ve teknik SEO onerilerini AI ile otomatiklestirir.
+### ai-seo-optimization
+The AI-assisted SEO content-optimization skill. Automates keyword analysis, content optimization, and technical-SEO suggestions with AI.
 
 ---
 
-### ai-fiyat-optimizasyonu
-AI ile dinamik fiyatlandirma ve fiyat optimizasyonu becerisi. Talep tahmini, rakip analizi ve fiyat elastikiyeti modellemesi ile optimal fiyat noktalarini belirler.
+### ai-price-optimization
+The AI dynamic-pricing and price-optimization skill. Finds optimal price points with demand forecasting, competitor analysis, and price-elasticity modeling.
 
 ---
 
-### ai-envanter-tahmini
-AI ile envanter seviyelerini tahmin etme ve stok yonetimini optimize etme becerisi. Talep tahmini ve tedarik sureci optimizasyonu ile stok maliyetlerini azaltir.
+### ai-inventory-forecasting
+The skill of forecasting inventory levels and optimizing stock with AI. Cuts inventory costs with demand forecasting and supply-process optimization.
 
 ---
 
-### ai-risk-degerlendirmesi
-AI ile risk analizi ve degerlendirme becerisi. Olasilik modellemesi, etki analizi ve risk azaltma stratejileri ile kapsamli risk yonetimi saglar.
+### ai-risk-assessment
+The AI risk-analysis and assessment skill. Delivers comprehensive risk management with probability modeling, impact analysis, and mitigation strategies.
 
 ---
 
-### ai-hukuk-analizi
-AI destekli hukuki belge analizi ve inceleme becerisi. Sozlesme analizi, uyumluluk kontrolu ve hukuki risk tespiti islemlerini hizlandirir.
+### ai-legal-analysis
+The AI-assisted legal-document analysis and review skill. Speeds up contract analysis, compliance checks, and legal-risk detection.
 
 ---
 
-### ai-rekabet-istihbarati
-AI ile rakip analizi ve rekabet istihbarati toplama becerisi. Otomatik veri toplama, trend analizi ve stratejik icgoru uretimi saglar.
+### ai-competitive-intelligence
+The AI competitor-analysis and intelligence-gathering skill. Delivers automated data collection, trend analysis, and strategic insight generation.
 
 ---
 
-### ai-musteri-sesi
-AI ile musteri geri bildirimlerini analiz etme becerisi. Duygu analizi, konu modelleme ve musteri icerik analizi ile musteri sesini anlama saglar.
+### ai-voice-of-customer
+The skill of analyzing customer feedback with AI. Understands the voice of the customer with sentiment analysis, topic modeling, and content analysis.
 
 ---
 
-### ai-trend-analizi
-AI ile pazar ve sektor trendlerini analiz etme becerisi. Veri madenciligi, sinyal tespiti ve tahminsel analiz ile gelecek trendleri belirler.
+### ai-trend-analysis
+The skill of analyzing market and industry trends with AI. Identifies future trends with data mining, signal detection, and predictive analysis.
 
 ---
 
 ### ai-workflow-builder
-Gorsel suretukleme birakilma arayuzu ile AI is akisi olusturma becerisi. Kod yazmadan AI pipeline'lari ve otomasyon akislari tasarlama imkani saglar.
+The skill of building AI workflows with a visual drag-and-drop interface. Enables designing AI pipelines and automation flows without writing code.
 
 ---
 
 ### ai-data-enrichment
-AI ile mevcut verileri zenginlestirme becerisi. Eksik alanlari doldurma, ek bilgi ekleme ve veri kalitesini artirma islemlerini otomatiklestirir.
-
+The skill of enriching existing data with AI. Automates filling missing fields, adding extra information, and raising data quality.

--- a/.claude/skills-vault/consulting/SKILL.md
+++ b/.claude/skills-vault/consulting/SKILL.md
@@ -10,275 +10,274 @@ metadata:
   badi-version: ">=1.14.0"
   category: consulting
 ---
-# Danismanlik Becerileri
-> 54 yapilandirilmis prosedur
-## Beceri Listesi
+# Consulting Skills
+> 54 structured procedures
+## Skill List
 
-### stratejik-planlama
-Organizasyonlar icin uzun vadeli stratejik plan olusturma becerisi. Vizyon, misyon, hedefler ve stratejik girisimler dogrultusunda kapsamli yol haritasi hazirlar.
-
----
-
-### is-analizi
-Is sureclerini, gereksinimlerini ve firsatlari sistematik olarak analiz etme becerisi. Paydas gorusmeleri, veri analizi ve gap analizi ile mevcut durumu degerlendirip iyilestirme onerileri sunar.
+### strategic-planning
+The skill of building long-term strategic plans for organizations. Prepares a comprehensive roadmap along vision, mission, goals, and strategic initiatives.
 
 ---
 
-### degisim-yonetimi
-Organizasyonel degisim sureclerini planlama ve yonetme becerisi. Degisime direnci azaltma, iletisim plani ve gecis stratejileri ile basarili donusum saglar.
+### business-analysis
+The skill of systematically analyzing business processes, requirements, and opportunities. Assesses the current state via stakeholder interviews, data analysis, and gap analysis, and proposes improvements.
 
 ---
 
-### proje-yonetimi
-Danismanlik projelerini basindan sonuna yonetme becerisi. Kapsam, zaman, maliyet ve kalite boyutlarinda projeyi planlama, yurutme ve kapatma sureclerini kapsar.
+### change-management
+The skill of planning and managing organizational change. Delivers successful transformation through resistance reduction, communication plans, and transition strategies.
 
 ---
 
-### stakeholder-yonetimi
-Paydas analizini ve yonetimini sistematik olarak yapma becerisi. Paydas haritalama, beklenti yonetimi ve iletisim stratejileri ile etkili paydas iliskileri kurar.
+### project-management
+The skill of managing consulting projects end to end. Covers planning, execution, and closing across scope, time, cost, and quality.
 
 ---
 
-### risk-degerlendirmesi
-Is ve proje risklerini sistematik olarak belirleme ve degerlendirme becerisi. Risk tanimlama, olcme ve azaltma stratejileri ile proaktif risk yonetimi saglar.
+### stakeholder-management
+The skill of running stakeholder analysis and management systematically. Builds effective relationships through stakeholder mapping, expectation management, and communication strategies.
 
 ---
 
-### sunum-hazirlama
-Profesyonel danismanlik sunumlari hazirlama becerisi. Veri odakli, ikna edici ve gorsel acidan etkili sunumlar ile bulgulari ve onerileri paylasar.
+### risk-assessment
+The skill of systematically identifying and assessing business and project risks. Delivers proactive risk management through identification, measurement, and mitigation strategies.
 
 ---
 
-### musteri-iliskisi
-Danismanlik musterileriyle guclu ve surekli iliskiler kurma becerisi. Guven insasi, beklenti yonetimi ve deger gosterimi ile uzun vadeli is birlikleri olusturur.
+### presentation-preparation
+The skill of preparing professional consulting presentations. Shares findings and recommendations through data-driven, persuasive, visually effective decks.
 
 ---
 
-### sozlesme-yonetimi
-Danismanlik sozlesmelerini hazirlama ve yonetme becerisi. Kapsam, fiyatlandirma, teslim sureci ve hukuki maddeler dahil eksiksiz sozlesme yonetimi saglar.
+### client-relationship
+The skill of building strong, lasting relationships with consulting clients. Builds long-term partnerships through trust, expectation management, and value demonstration.
 
 ---
 
-### fiyatlandirma-stratejisi
-Danismanlik hizmetleri icin fiyatlandirma stratejisi belirleme becerisi. Deger bazli, zaman bazli ve proje bazli fiyatlandirma modelleri ile karlilik optimizasyonu yapar.
+### contract-management
+The skill of preparing and managing consulting contracts. Covers scope, pricing, delivery process, and legal clauses for complete contract management.
 
 ---
 
-### teklif-hazirlama
-Musteri ihaleleri ve talepleri icin profesyonel is teklifi hazirlama becerisi. Deger oneisi, metodoloji ve maliyet tablolari ile ikna edici teklifler yazar.
+### pricing-strategy
+The skill of setting the pricing strategy for consulting services. Optimizes profitability with value-based, time-based, and project-based pricing models.
 
 ---
 
-### workshop-kolaylastirma
-Atolye calismalarini planlama ve kolaylastirma becerisi. Katilimci yonetimi, etkinlik tasarimi ve sonuc cikarma ile etkili calustaylar duzenler.
+### proposal-preparation
+The skill of preparing professional business proposals for tenders and requests. Writes persuasive proposals with value propositions, methodology, and cost tables.
 
 ---
 
-### raporlama
-Danismanlik projesi bulgu ve onerilerini profesyonel rapor formatinda sunma becerisi. Yonetici ozeti, analiz bulgulari ve aksiyon onerileri ile karar vericilere deger saglar.
+### workshop-facilitation
+The skill of planning and facilitating workshops. Runs effective sessions through participant management, activity design, and outcome capture.
 
 ---
 
-### benchmark-analizi
-En iyi uygulamalari ve sektör standartlarini karsilastirmali olarak analiz etme becerisi. Ic ve dis kiyaslama ile performans bosluklerini belirler ve hedef seviyeler koyar.
+### reporting
+The skill of presenting project findings and recommendations in a professional report format. Delivers value to decision-makers with executive summaries, analysis findings, and action recommendations.
 
 ---
 
-### swot-analizi
-Organizasyonun guclu yonleri, zayif yonleri, firsatlari ve tehditlerini sistematik olarak analiz etme becerisi. Stratejik karar alma sureclerine girdi saglar.
+### benchmark-analysis
+The skill of comparatively analyzing best practices and industry standards. Finds performance gaps and sets target levels via internal and external benchmarking.
 
 ---
 
-### porter-analizi
-Porter'in Bes Gucu modeli ile sektor ve rekabet analizi yapma becerisi. Rekabet yogunlugu, tedarikci ve alici gucu, ikame urun ve yeni giris tehditlerini degerlendirir.
+### swot-analysis
+The skill of systematically analyzing the organization's strengths, weaknesses, opportunities, and threats. Feeds strategic decision processes.
 
 ---
 
-### deger-zinciri
-Organizasyonun deger zincirini analiz ederek rekabet avantaji kaynaklarini belirleme becerisi. Birincil ve destekleyici faaliyetleri inceleyerek verimlilik ve deger artisi firsatlarini tespit eder.
+### porter-analysis
+The skill of industry and competition analysis with Porter's Five Forces. Assesses competitive intensity, supplier and buyer power, substitutes, and new-entrant threats.
 
 ---
 
-### organizasyon-tasarimi
-Organizasyon yapisini, rolleri ve raporlama hatlarini tasarlama becerisi. Is stratejisine uyumlu, verimli ve etkin organizasyonel yapi olusturur.
+### value-chain
+The skill of finding competitive-advantage sources by analyzing the value chain. Examines primary and supporting activities to spot efficiency and value-creation opportunities.
 
 ---
 
-### yetenek-yonetimi
-Organizasyondaki yetenekleri degerlendirme ve gelistirme stratejisi olusturma becerisi. Yetenek envanter, gecis planlama ve gelisim programlari icerir.
+### organizational-design
+The skill of designing the org structure, roles, and reporting lines. Builds an efficient, effective structure aligned with the business strategy.
 
 ---
 
-### performans-olcumu
-Organizasyonel performansi olcmek icin metrik ve gosterge sistemi tasarlama becerisi. Dengeli skor karti ve performans yonetim sistemi olusturur.
+### talent-management
+The skill of building the strategy for assessing and developing organizational talent. Covers talent inventory, succession planning, and development programs.
 
 ---
 
-### kpi-tanimlama
-Temel performans gostergelerini (KPI) tanimlama ve izleme becerisi. SMART kriterlerine uygun, olculebilir ve aksiyona donusturulebilir KPI'lar olusturur.
+### performance-measurement
+The skill of designing the metric and indicator system measuring organizational performance. Builds the balanced scorecard and performance-management system.
 
 ---
 
-### dashboard-tasarimi
-Yonetici ve operasyonel dashboard'lar tasarlama becerisi. Veri gorsellesirme ilkeleri ve kullanici ihtiyaclarina uygun etkili gosterge panelleri olusturur.
+### kpi-definition
+The skill of defining and tracking key performance indicators (KPIs). Builds SMART, measurable, actionable KPIs.
 
 ---
 
-### veri-gorsellesirme
-Verileri etkili ve anlasilir gorsellere donusturme becerisi. Grafik secimi, renk kullanimi ve hikaye anlatimi ile veri destekli iletisim saglar.
+### dashboard-design
+The skill of designing executive and operational dashboards. Builds effective panels fitting data-visualization principles and user needs.
 
 ---
 
-### is-sureci-iyilestirme
-Mevcut is sureclerini analiz ederek verimlilik ve etkililik artisi saglama becerisi. Surec haritalama, dar bogaz tespiti ve yeniden tasarim ile surec optimizasyonu yapar.
+### data-visualization
+The skill of turning data into effective, clear visuals. Delivers data-backed communication through chart selection, color use, and storytelling.
 
 ---
 
-### lean-danismanlik
-Yalin (Lean) ilkelerini is sureclerine uygulama becerisi. Israf eliminasyonu, deger akisi haritalama ve surekli iyilestirme kulturunu yayginlastirir.
+### process-improvement
+The skill of raising efficiency and effectiveness by analyzing existing processes. Optimizes through process mapping, bottleneck detection, and redesign.
 
 ---
 
-### alti-sigma
-Alti Sigma metodolojisi ile surec iyilestirme becerisi. DMAIC dongusu uygulayarak surec degiskenligini azaltir ve kalite seviyesini arttirir.
+### lean-consulting
+The skill of applying Lean principles to business processes. Spreads waste elimination, value-stream mapping, and continuous-improvement culture.
 
 ---
 
-### dijital-donusum
-Organizasyonlarin dijital donusum yolculugunu planlama ve yonetme becerisi. Teknoloji, surec ve kultur boyutlarinda dijital olgunluk artisi saglar.
+### six-sigma
+The skill of process improvement with Six Sigma methodology. Reduces process variance and raises quality by applying the DMAIC cycle.
 
 ---
 
-### bulut-strateji
-Organizasyonlar icin bulut bilisim stratejisi olusturma becerisi. Bulut gecis planlama, saglayici secimi ve maliyet optimizasyonu danismanligi saglar.
+### digital-transformation
+The skill of planning and managing organizations' digital transformation journeys. Raises digital maturity across technology, process, and culture.
 
 ---
 
-### siber-guvenlik-danismanlik
-Siber guvenlik stratejisi ve uyumluluk danismanligi becerisi. Risk degerlendirmesi, guvenlik mimarisi ve olay mudahale planlama hizmetleri sunar.
+### cloud-strategy
+The skill of building the cloud-computing strategy for organizations. Advises on migration planning, provider selection, and cost optimization.
 
 ---
 
-### uyumluluk-danismanlik
-Yasal ve regulatif uyumluluk danismanligi becerisi. KVKK, GDPR ve sektor spesifik duzenlemelere uyum saglama rehberligi sunar.
+### cybersecurity-consulting
+The cybersecurity strategy and compliance consulting skill. Offers risk assessment, security architecture, and incident-response planning services.
+
+---
+
+### compliance-consulting
+The legal and regulatory compliance consulting skill. Guides compliance with KVKK, GDPR, and industry-specific regulations.
 
 ---
 
 ### m-and-a-due-diligence
-Birlesme ve satin alma sureclerinde due diligence (ozen incelemesi) becerisi. Mali, hukuki, operasyonel ve teknolojik boyutlarda kapsamli inceleme yapar.
+The due-diligence skill in mergers and acquisitions. Runs comprehensive reviews across financial, legal, operational, and technological dimensions.
 
 ---
 
-### pazar-giris-stratejisi
-Yeni pazarlara giris stratejisi gelistirme becerisi. Pazar analizi, giris modu secimi ve lokalizasyon planlama ile basarili pazar girisi saglar.
+### market-entry-strategy
+The skill of developing new-market entry strategies. Delivers successful entry through market analysis, entry-mode selection, and localization planning.
 
 ---
 
-### urunlestirme
-Danismanlik hizmetlerini olceklenebilir urun haline getirme becerisi. Tekrarlanabilir metodolojiler, araclari ve sablonlari urun formatinda paketler.
+### productization
+The skill of turning consulting services into scalable products. Packages repeatable methodologies, tools, and templates in a product format.
 
 ---
 
-### hizmet-tasarimi
-Musteri deneyimini merkeze alan hizmet tasarimi becerisi. Hizmet plani, temas noktalari ve deneyim haritasi ile bütünsel hizmet kurgusu olusturur.
+### service-design
+The customer-experience-centered service-design skill. Builds the holistic service construct with service blueprints, touchpoints, and experience maps.
 
 ---
 
-### musteri-deneyimi
-Musteri deneyimi (CX) strateji ve iyilestirme becerisi. Musteri yolculugu boyunca tutarli ve olumlu deneyimler tasarlama rehberligi sunar.
+### customer-experience
+The customer experience (CX) strategy and improvement skill. Guides the design of consistent, positive experiences across the customer journey.
 
 ---
 
-### nps-olcumu
-Net Tavsiye Skoru (NPS) programi tasarlama ve yonetme becerisi. Anket tasarimi, veri toplama ve analiz ile musteri sadakatini olcer ve iyilestirme firsatlari belirler.
+### nps-measurement
+The skill of designing and managing a Net Promoter Score (NPS) program. Measures loyalty and finds improvement opportunities via survey design, data collection, and analysis.
 
 ---
 
-### musteri-yolculugu
-Musteri yolculugu haritasi olusturma becerisi. Temas noktalari, duygusal durumlar ve firsat alanlari ile uclararasi musteri deneyimini gorsellestirir.
+### customer-journey
+The skill of building customer journey maps. Visualizes the end-to-end experience with touchpoints, emotional states, and opportunity areas.
 
 ---
 
-### is-modeli-tasarimi
-Yeni is modeli tasarlama veya mevcut is modelini donusturme becerisi. Business Model Canvas ve diger araclari kullanarak kapsamli is modeli olusturur.
+### business-model-design
+The skill of designing a new business model or transforming the current one. Builds a comprehensive model using the Business Model Canvas and other tools.
 
 ---
 
-### gelir-modeli
-Surdurulebilir gelir modeli tasarlama becerisi. Fiyatlandirma stratejileri, gelir akislari ve monetizasyon yontemlerini optimize eder.
+### revenue-model
+The skill of designing a sustainable revenue model. Optimizes pricing strategies, revenue streams, and monetization methods.
 
 ---
 
-### maliyet-optimizasyonu
-Organizasyonel maliyetleri analiz ederek optimizasyon saglama becerisi. Maliyet kalemleri, verimlilik firsatlari ve tasarruf potansiyelini belirler.
+### cost-optimization
+The skill of optimizing by analyzing organizational costs. Identifies cost items, efficiency opportunities, and savings potential.
 
 ---
 
-### tedarik-zinciri
-Tedarik zinciri analizi ve optimizasyonu becerisi. Tedarikci yonetimi, lojistik ve envanter optimizasyonu ile operasyonel verimlilik artisi saglar.
+### supply-chain
+The supply-chain analysis and optimization skill. Raises operational efficiency through supplier management, logistics, and inventory optimization.
 
 ---
 
-### operasyon-iyilestirme
-Operasyonel sureclerin verimliligini ve etkiligini artirma becerisi. Surec analizi, kaynak optimizasyonu ve otomasyon firsatlari ile operasyonel mukemmellik saglar.
+### operations-improvement
+The skill of raising operational process efficiency and effectiveness. Delivers operational excellence through process analysis, resource optimization, and automation opportunities.
 
 ---
 
-### kalite-yonetimi
-Kalite yonetim sistemi tasarlama ve uyguama becerisi. ISO standartlari, kalite kontrol ve surekli iyilestirme mekanizmalari ile kalite kulturunu yayginlastirir.
+### quality-management
+The skill of designing and implementing a quality management system. Spreads quality culture through ISO standards, quality control, and continuous-improvement mechanisms.
 
 ---
 
-### cevresel-danismanlik
-Cevre yonetimi ve uyumluluk danismanligi becerisi. Cevre etki degerlendirmesi, atik yonetimi ve cevresel uyumluluk rehberligi sunar.
+### environmental-consulting
+The environmental management and compliance consulting skill. Offers environmental-impact assessment, waste management, and compliance guidance.
 
 ---
 
-### surdurulebilirlik
-Kurumsal surdurulebilirlik stratejisi ve raporlama becerisi. ESG cercevesi, karbon ayak izi hesaplama ve surdurulebilirlik yol haritasi olusturur.
+### sustainability
+The corporate sustainability strategy and reporting skill. Builds the ESG framework, carbon-footprint calculation, and the sustainability roadmap.
 
 ---
 
-### kurumsal-egitim
-Kurumsal egitim programlari tasarlama ve yurutme becerisi. Ihtiyac analizi, mufredat tasarimi ve egitim etkililik olcumu ile degisim yaratan egitimler olusturur.
+### corporate-training
+The skill of designing and running corporate training programs. Builds change-making training via needs analysis, curriculum design, and effectiveness measurement.
 
 ---
 
-### liderlik-kocluk
-Yonetici ve lider adaylarina kocluk hizmeti sunma becerisi. Bireysel gelisim, liderlik yetkinlikleri ve performans artisi odakli kocluk seanslari planlar.
+### leadership-coaching
+The skill of coaching executives and leadership candidates. Plans coaching sessions focused on individual growth, leadership competencies, and performance gains.
 
 ---
 
-### takim-gelistirme
-Takim performansi ve isbirligini gelistirme becerisi. Takim dinamikleri, iletisim ve hedef uyumu calismalari ile yuksek performansli takimlar olusturur.
+### team-development
+The skill of growing team performance and collaboration. Builds high-performing teams through team dynamics, communication, and goal-alignment work.
 
 ---
 
-### inovasyon-yonetimi
-Organizasyonda inovasyon yonetimi sistemi kurma becerisi. Fikir uretme, degerlendirme, prototipleme ve olcekleme sureclerini yapilandirir.
+### innovation-management
+The skill of building the organization's innovation-management system. Structures ideation, evaluation, prototyping, and scaling processes.
 
 ---
 
-### tasarim-odakli-dusunme
-Design Thinking metodolojisini uygulama becerisi. Empati, tanimlama, fikir uretme, prototipleme ve test etme asamalari ile insan odakli cozumler olusturur.
+### design-thinking
+The skill of applying the Design Thinking methodology. Builds human-centered solutions through empathize, define, ideate, prototype, and test stages.
 
 ---
 
-### cevik-donusum
-Organizasyonu cevik (Agile) calisma yontemlerine gecirme becerisi. Scrum, Kanban ve SAFe gibi cevik cercevelerin uygulanmasi ve yayginlastirilmasi rehberligi sunar.
+### agile-transformation
+The skill of transitioning the organization to agile ways of working. Guides the adoption and spread of agile frameworks like Scrum, Kanban, and SAFe.
 
 ---
 
-### devops-danismanlik
-DevOps pratiklerinin organizasyona entegrasyonu icin danismanlik becerisi. CI/CD, otomasyon ve isbirligi kulturu ile yazilim teslim sureclerini iyilestirir.
+### devops-consulting
+The consulting skill for integrating DevOps practices into the organization. Improves software delivery through CI/CD, automation, and a collaboration culture.
 
 ---
 
-### veri-stratejisi
-Organizasyonel veri stratejisi olusturma becerisi. Veri yonetisimi, kalite, mimari ve veri kulturu boyutlarinda kapsamli strateji gelistirir.
+### data-strategy
+The skill of building the organizational data strategy. Develops a comprehensive strategy across governance, quality, architecture, and data culture.
 
 ---
 
-### ai-danismanlik
-Yapay zeka strateji ve uygulama danismanligi becerisi. AI firsat tespiti, olcek degerlendirmesi ve uygulama yol haritasi ile organizasyonlara AI yolculugunda rehberlik eder.
-
+### ai-consulting
+The AI strategy and implementation consulting skill. Guides organizations on their AI journey through opportunity detection, scale assessment, and an implementation roadmap.

--- a/.claude/skills-vault/content/SKILL.md
+++ b/.claude/skills-vault/content/SKILL.md
@@ -10,505 +10,504 @@ metadata:
   badi-version: ">=1.14.0"
   category: content
 ---
-# Icerik Uretimi Becerileri
-> 102 yapilandirilmis prosedur
-## Beceri Listesi
+# Content Production Skills
+> 102 structured procedures
+## Skill List
 
-### blog-yazimi
-SEO uyumlu, hedef kitleye yonelik blog yazilari olusturma becerisi. Arastirma, yapilandirma ve optimizasyon adimlariyla deger katan blog icerikleri uretir.
+### blog-writing
+The skill of creating SEO-friendly, audience-targeted blog posts. Produces value-adding blog content through research, structuring, and optimization steps.
 
 ---
 
-### makale-yazimi
-Derinlemesine arastirma ve analiz iceren uzun format makale yazma becerisi. Akademik ve profesyonel standartlarda kaynak destekli makaleler olusturur.
+### article-writing
+The long-form article writing skill with deep research and analysis. Builds source-backed articles at academic and professional standards.
 
 ---
 
-### teknik-yazim
-Teknik konulari anlasilir ve yapilandirilmis sekilde yazma becerisi. Kullanici kilavuzlari, teknik belgeler ve API dokumantasyonu olusturur.
+### technical-writing
+The skill of writing technical topics clearly and in a structured way. Builds user guides, technical documents, and API documentation.
 
 ---
 
-### seo-icerik
-Arama motoru optimizasyonuna uygun icerik uretme becerisi. Anahtar kelime stratejisi, on-page SEO ve icerik yapilandirmasi ile organik trafik artisi saglar.
+### seo-content
+The skill of producing search-engine-optimized content. Drives organic traffic with keyword strategy, on-page SEO, and content structuring.
 
 ---
 
-### landing-page-metin
-Donusum odakli landing page metinleri yazma becerisi. Deger onerisi, sosyal kanit ve harekete gecirici mesajlarla yuksek donusum oranli sayfalar olusturur.
+### landing-page-copy
+The conversion-focused landing-page copy skill. Builds high-conversion pages with value propositions, social proof, and calls to action.
 
 ---
 
-### e-posta-kopya
-E-posta pazarlama kampanyalari icin etkili metin yazma becerisi. Konu satiri, on izleme, govde metni ve CTA ile yuksek acilma ve tiklanma oranli e-postalar olusturur.
+### email-copy
+The skill of writing effective copy for email campaigns. Builds high-open, high-click emails with subject lines, preheaders, body copy, and CTAs.
 
 ---
 
-### sosyal-medya-icerik
-Platform-spesifik sosyal medya icerikleri uretme becerisi. Her platforma uygun format, ton ve gorsel stratejisi ile etkilesim odakli icerikler olusturur.
+### social-media-content
+The platform-specific social content skill. Builds engagement-driven content with the right format, tone, and visual strategy per platform.
 
 ---
 
-### video-senaryo
-Video icerikleri icin senaryo ve cekme plani hazirlama becerisi. Hikaye yapisi, sahne planlama ve diyalog yazimi ile profesyonel video senaryolari olusturur.
+### video-scripts
+The skill of preparing scripts and shoot plans for video content. Builds professional scripts with story structure, scene planning, and dialogue.
 
 ---
 
-### podcast-planlama
-Podcast icerigi planlama ve hazirlama becerisi. Bolum yapisi, konu secimi, konuk hazirlik ve yayinlama stratejisi ile profesyonel podcast produksiyonu saglar.
+### podcast-planning
+The podcast content planning and preparation skill. Delivers professional production with episode structure, topic selection, guest prep, and publishing strategy.
 
 ---
 
-### infografik-tasarim
-Veri ve bilgileri gorsel infografik formatinda sunma becerisi. Veri gorsellesirme, gorsel hiyerarsi ve bilgi akisi ile etkili infografikler olusturur.
+### infographic-design
+The skill of presenting data and information as visual infographics. Builds effective infographics with data visualization, visual hierarchy, and information flow.
 
 ---
 
-### e-kitap-olusturma
-Dijital kitap icerigi planlama ve olusturma becerisi. Konu arastirmasi, icerik yapilandirma ve tasarim yonergeleri ile profesyonel e-kitaplar hazirlar.
+### ebook-creation
+The digital-book planning and creation skill. Prepares professional e-books with topic research, content structuring, and design guidelines.
 
 ---
 
-### beyaz-kagit
-Teknik veya stratejik konularda detayli beyaz kagit (whitepaper) yazma becerisi. Arastirma destekli, ikna edici ve profesyonel B2B icerikler olusturur.
+### whitepapers
+The skill of writing detailed whitepapers on technical or strategic topics. Builds research-backed, persuasive, professional B2B content.
 
 ---
 
-### vaka-calismasi
-Musteri basari hikayelerini vaka calismasi formatinda yazma becerisi. Problem, cozum ve sonuc yapisiyla ikna edici referans icerikleri olusturur.
+### case-studies
+The skill of writing customer success stories in case-study format. Builds persuasive reference content with the problem-solution-result structure.
 
 ---
 
-### basari-hikayesi
-Musteri basari hikayelerini ikna edici anlatim formatinda yazma becerisi. Duygusal baglanti ve somut sonuclarla etkili referans icerikleri olusturur.
+### success-stories
+The skill of writing customer wins in a persuasive narrative format. Builds effective reference content with emotional connection and concrete outcomes.
 
 ---
 
-### basin-bulteni
-Medya icin profesyonel basin bulteni yazma becerisi. Haber degeri, ters piramit yapisi ve gazetecilik standartlari ile etkili medya iletisimi saglar.
+### press-releases
+The professional press-release writing skill. Delivers effective media communication with news value, the inverted pyramid, and journalism standards.
 
 ---
 
-### haber-yazimi
-Haber metni yazma becerisi. Gazetecilik ilkeleri, tarafsizlik ve dogruluk standartlarinda haber icerikleri uretir.
+### news-writing
+The news-writing skill. Produces news content at journalistic standards of objectivity and accuracy.
 
 ---
 
-### roportaj-hazirlama
-Roportaj planlama, soru hazirlama ve metin yazma becerisi. Hedef odakli sorular ve akici anlatim ile etkileyici roportajlar olusturur.
+### interviews
+The interview planning, question preparation, and writing skill. Builds compelling interviews with goal-driven questions and fluent narrative.
 
 ---
 
-### icerik-takvimi
-Icerik yayinlama takvimi olusturma ve yonetme becerisi. Kanal, tur ve tema bazinda planlama ile tutarli ve stratejik icerik akisi saglar.
+### content-calendar
+The skill of building and managing the content publishing calendar. Delivers a consistent, strategic content flow with channel, type, and theme planning.
 
 ---
 
-### icerik-stratejisi
-Kapsamli icerik stratejisi olusturma becerisi. Is hedefleri, hedef kitle ve kanal stratejisi ile bütünsel icerik planlamasi yapar.
+### content-strategy
+The comprehensive content-strategy skill. Runs holistic content planning with business goals, audience, and channel strategy.
 
 ---
 
-### icerik-denetimi
-Mevcut icerik varliklarini denetleme ve degerlendirme becerisi. Icerik envanter, performans analizi ve iyilestirme firsatlari ile icerik portfoyunu optimize eder.
+### content-audit
+The skill of auditing and evaluating existing content assets. Optimizes the portfolio with content inventory, performance analysis, and improvement opportunities.
 
 ---
 
-### anahtar-kelime-arastirma
-SEO icin anahtar kelime arastirmasi yapma becerisi. Arama hacmi, zorluk ve niyet analizi ile icerik stratejisine girdi saglayan kelime listeleri olusturur.
+### keyword-research
+The SEO keyword-research skill. Builds keyword lists feeding the content strategy with volume, difficulty, and intent analysis.
 
 ---
 
-### baslik-yazimi
-Dikkat cekici ve tiklama oranini artiran baslik yazma becerisi. A/B test uygun, SEO uyumlu ve psikolojik tetikleyiciler kullanan basliklar olusturur.
+### headline-writing
+The skill of writing attention-grabbing, CTR-lifting headlines. Builds A/B-testable, SEO-friendly headlines using psychological triggers.
 
 ---
 
-### meta-aciklama
-Arama sonuclarinda gorunen meta aciklama metinleri yazma becerisi. Karakter limiti, anahtar kelime ve harekete gecirici mesajlarla tiklama oranini arttirir.
+### meta-descriptions
+The skill of writing the meta descriptions shown in search results. Lifts CTR with character limits, keywords, and calls to action.
 
 ---
 
-### icerik-yeniden-kullanim
-Mevcut icerikleri farkli formatlara ve kanallara uyarlama becerisi. Bir icerik parcasindan birden fazla format ureterek icerik ROI'sini arttirir.
+### content-repurposing
+The skill of adapting existing content to other formats and channels. Raises content ROI by producing multiple formats from a single piece.
 
 ---
 
-### coklu-kanal-icerik
-Birden fazla kanal icin tutarli icerik uretme becerisi. Kanal-spesifik optimizasyonla birlikte marka tutarliligi saglayarak omni-channel icerik stratejisi uygular.
+### multi-channel-content
+The skill of producing consistent content for multiple channels. Applies an omni-channel strategy keeping brand consistency with channel-specific optimization.
 
 ---
 
-### icerik-kisisellistirme
-Kullanici segmenti ve davranisina gore kisisellestirilmis icerik uretme becerisi. Dinamik icerik, segment bazli mesajlasma ve kisisellesirme kurallarini tanimlar.
+### content-personalization
+The skill of producing personalized content per user segment and behavior. Defines dynamic content, segment-based messaging, and personalization rules.
 
 ---
 
-### ab-test-kopya
-A/B test icin icerik varyasyonlari olusturma becerisi. Baslik, CTA, govde metni ve deger onerisi alternatiflerini sistematik olarak test eder.
+### ab-test-copy
+The skill of building content variations for A/B tests. Systematically tests headline, CTA, body, and value-proposition alternatives.
 
 ---
 
-### donusum-odakli-kopya
-Donusum oranini artirmaya odaklanan metin yazma becerisi. Psikolojik tetikleyiciler, ikna teknikleri ve kullanici odakli mesajlasma ile aksiyona yonlendiren metinler yazar.
+### conversion-copy
+The conversion-focused copywriting skill. Writes action-driving copy with psychological triggers, persuasion techniques, and user-focused messaging.
 
 ---
 
-### hikaye-anlatimi
-Marka hikayesi ve icerik pazarlama icin hikaye anlatim teknikleri uygulama becerisi. Duygusal baglanti, karakter gelisimi ve cati yapisi ile akilda kalici hikayeler olusturur.
+### storytelling
+The skill of applying storytelling techniques for brand stories and content marketing. Builds memorable stories with emotional connection, character development, and arc.
 
 ---
 
-### marka-sesi
-Marka ses tonu ve kisilik tanimlama becerisi. Tutarli marka iletisimi icin ses tonu kilavuzu, kelime secimi kurallari ve iletisim standartlari olusturur.
+### brand-voice
+The brand voice and personality definition skill. Builds the tone guide, word-choice rules, and communication standards for consistent brand communication.
 
 ---
 
-### stil-kilavuzu
-Icerik uretim standartlarini tanimlayan stil kilavuzu olusturma becerisi. Yazim kurallari, terminoloji, formatlama ve gorsel standartlari icerir.
+### style-guide
+The skill of building the style guide defining content-production standards. Covers writing rules, terminology, formatting, and visual standards.
 
 ---
 
-### editoryal-standart
-Editoryal kalite standartlarini tanimlama ve uygulama becerisi. Icerik inceleme sureci, kalite kontrol listeleri ve editoryal is akisi olusturur.
+### editorial-standards
+The skill of defining and applying editorial quality standards. Builds the review process, quality checklists, and editorial workflow.
 
 ---
 
-### kelime-secimi
-Etkili ve dogru kelime secimi yapma becerisi. Hedef kitleye, kanala ve amaca uygun kelime dagarcigi ile net ve etkili iletisim saglar.
+### word-choice
+The effective, precise word-choice skill. Delivers clear, effective communication with vocabulary fitting the audience, channel, and purpose.
 
 ---
 
-### ton-ayarlama
-Icerik tonunu hedef kitle ve baglama gore ayarlama becerisi. Resmiyet, sicaklik, otorite ve samimiyet boyutlarinda ince ayar yapar.
+### tone-adjustment
+The skill of tuning content tone to the audience and context. Fine-tunes along formality, warmth, authority, and friendliness.
 
 ---
 
-### hedef-kitle-analizi
-Icerik hedef kitlesini derinlemesine analiz etme becerisi. Demografik, psikografik ve davranissal ozellikler ile icerik stratejisine girdi saglar.
+### audience-analysis
+The skill of analyzing the content audience deeply. Feeds the strategy with demographic, psychographic, and behavioral traits.
 
 ---
 
-### persona-bazli-icerik
-Farkli muster personlari icin ozellesmis icerik uretme becerisi. Her persona'nin ihtiyaclari, aci noktalari ve motivasyonlarina uygun mesajlar olusturur.
+### persona-based-content
+The skill of producing specialized content per customer persona. Builds messages fitting each persona's needs, pain points, and motivations.
 
 ---
 
-### uzun-form-icerik
-2000+ kelimelik derinlemesine uzun form icerikler olusturma becerisi. Kapsamli arastirma, detayli analiz ve SEO optimizasyonu ile otorite icerikleri uretir.
+### long-form-content
+The skill of building 2000+ word in-depth long-form content. Produces authority content with thorough research, detailed analysis, and SEO optimization.
 
 ---
 
-### kisa-form-icerik
-Kisa ve etkili icerikler olusturma becerisi. Sosyal medya gonderileri, mikro bloglar ve kisa mesajlar ile hizli tuketim icin optimize edilmis icerikler yazar.
+### short-form-content
+The skill of building short, effective content. Writes consumption-optimized social posts, micro-blogs, and short messages.
 
 ---
 
-### mikro-kopya
-Kullanici arayuzlerindeki kisa metin parcalarini yazma becerisi. Buton, etiket, hata mesaji ve bildirim gibi UI metin elemanlariini kullanici dostu sekilde olusturur.
+### microcopy
+The skill of writing the small text pieces in user interfaces. Builds user-friendly UI text elements like buttons, labels, error messages, and notifications.
 
 ---
 
-### ui-ux-yazimi
-Kullanici deneyimi odakli arayuz metinleri yazma becerisi. Kullanici yolculugu boyunca tutarli, yardimci ve marka uyumlu UI metinleri olusturur.
+### ui-ux-writing
+The UX-focused interface writing skill. Builds consistent, helpful, brand-aligned UI copy across the user journey.
 
 ---
 
-### hata-mesaji-yazimi
-Kullanici dostu hata mesajlari yazma becerisi. Teknik hatayalari anlasilir, yardimci ve cozum odakli mesajlara donusturur.
+### error-message-writing
+The user-friendly error-message skill. Turns technical errors into clear, helpful, solution-oriented messages.
 
 ---
 
-### bildirim-metni
-Uygulama ve e-posta bildirimleri icin metin yazma becerisi. Push bildirimi, in-app mesaj ve sistem uyarilari icin kisa, net ve aksiyona yonelik metinler olusturur.
+### notification-copy
+The skill of writing copy for app and email notifications. Builds short, clear, action-oriented texts for push, in-app, and system alerts.
 
 ---
 
-### cta-yazimi
-Harekete gecirici mesaj (CTA) metinleri yazma becerisi. Buton metinleri, kayit cagirilari ve satin alma tetikleyicileri ile donusum artisi saglar.
+### cta-writing
+The call-to-action (CTA) writing skill. Drives conversion with button copy, signup prompts, and purchase triggers.
 
 ---
 
-### urun-aciklamasi
-Urun aciklamasi metinleri yazma becerisi. Ozellik-fayda donusumu, duyusal dil ve ikna teknikleri ile satin almayi tesvik eden aciklamalar olusturur.
+### product-descriptions
+The product-description skill. Builds purchase-encouraging descriptions with feature-to-benefit conversion, sensory language, and persuasion techniques.
 
 ---
 
-### kategori-aciklamasi
-E-ticaret ve web sitesi kategori sayfalari icin aciklama metinleri yazma becerisi. SEO uyumlu ve kullanici yonlendirici kategori icerikleriii olusturur.
+### category-descriptions
+The skill of writing descriptions for e-commerce and website category pages. Builds SEO-friendly, user-guiding category content.
 
 ---
 
-### faq-olusturma
-Sikca sorulan sorular sayfasi icerigi olusturma becerisi. Kullanici ihtiyaclari ve arama verilerine dayali kapsamli SSS icerikleri hazirlar.
+### faq-creation
+The FAQ-page content skill. Prepares comprehensive FAQ content grounded in user needs and search data.
 
 ---
 
-### bilgi-tabani-yazimi
-Self-servis bilgi tabani icerikkleri yazma becerisi. Yardim makaleleri, rehberler ve sorun giderme kilavuzlari ile musteri destek yukunu azaltir.
+### knowledge-base-writing
+The self-service knowledge-base writing skill. Reduces support load with help articles, guides, and troubleshooting documentation.
 
 ---
 
-### kullanici-kilavuzu
-Urun veya hizmet kullanici kilavuzu yazma becerisi. Baslangic rehberi, detayli kullanim talimatlari ve sorun giderme bolumlerini icerir.
+### user-guides
+The product or service user-guide skill. Covers getting-started guides, detailed usage instructions, and troubleshooting sections.
 
 ---
 
-### api-dokumantasyonu
-API referans dokumantasyonu yazma becerisi. Endpoint aciklamalari, istek/yanit ornekleri ve kimlik dogrulama bilgileri ile gelistirici dostu API belgeleri olusturur.
+### api-documentation
+The API reference documentation skill. Builds developer-friendly docs with endpoint descriptions, request/response examples, and auth details.
 
 ---
 
-### degisiklik-gunlugu
-Yazilim degisiklik gunlugu (changelog) yazma becerisi. Versiyon bazli degisiklikleri, yeni ozellikleri ve hata duzeltmelerini dokumante eder.
+### changelogs
+The software changelog writing skill. Documents per-version changes, new features, and bug fixes.
 
 ---
 
-### surum-notu
-Yazilim surum notlari yazma becerisi. Teknik ve kullanici odakli surum bilgilerini profesyonel formatta iletir.
+### release-notes
+The software release-notes skill. Communicates technical and user-facing release information in a professional format.
 
 ---
 
-### readme-yazimi
-Proje README dosyasi yazma becerisi. Proje tanimi, kurulum talimatlari, kullanim ornekleri ve katki rehberi ile etkili README icerikleri olusturur.
+### readme-writing
+The project README skill. Builds effective READMEs with project descriptions, install instructions, usage examples, and contribution guides.
 
 ---
 
-### commit-mesaji
-Git commit mesajlari yazma becerisi. Conventional Commits standartlari ve takim kurallarina uygun, aciklayici commit mesajlari olusturur.
+### commit-messages
+The git commit-message skill. Builds descriptive messages following Conventional Commits standards and team rules.
 
 ---
 
-### pr-aciklamasi
-Pull request aciklamasi yazma becerisi. Degisiklik ozeti, test plani ve inceleme talimatlari ile etkili PR aciklamalari olusturur.
+### pr-descriptions
+The pull-request description skill. Builds effective PR descriptions with change summaries, test plans, and review instructions.
 
 ---
 
-### kod-yorumu
-Kod icindeki yorum ve dokumantasyon yazma becerisi. JSDoc, docstring ve satir ici yorumlar ile okunakli ve bakimi kolay kodlar olusturur.
+### code-comments
+The in-code comment and documentation skill. Builds readable, maintainable code with JSDoc, docstrings, and inline comments.
 
 ---
 
-### egitim-materyali
-Egitim icerikleri ve materyalleri olusturma becerisi. Ders plani, sunum, alistirma ve degerlendirme materyalleri ile etkili ogrenme deneyimleri tasarlar.
+### training-materials
+The training content and materials skill. Designs effective learning experiences with lesson plans, decks, exercises, and assessments.
 
 ---
 
-### kurs-icerigi
-Online kurs icerigi planlama ve olusturma becerisi. Modul yapisi, video senaryolari, quizler ve proje odevleri ile kapsamli kurs paketleri hazirlar.
+### course-content
+The online-course content planning and creation skill. Prepares complete course packages with module structure, video scripts, quizzes, and project assignments.
 
 ---
 
-### webinar-planla
-Webinar planlama ve icerik hazirlama becerisi. Konu secimi, sunum akisi, katilimci etkilesimi ve tanitim stratejisi ile etkili webinarlar duzenler.
+### webinar-planning
+The webinar planning and content skill. Runs effective webinars with topic selection, presentation flow, participant interaction, and promotion strategy.
 
 ---
 
-### sunum-slaydi
-Etkili sunum slaytlari icin icerik hazirlama becerisi. Gorsel hiyerarsi, mesaj netligi ve hikaye akisi ile profesyonel sunum icerikleri olusturur.
+### presentation-slides
+The skill of preparing content for effective presentation slides. Builds professional deck content with visual hierarchy, message clarity, and story flow.
 
 ---
 
-### konusma-metni
-Sahne, konferans ve toplantillar icin konusma metni yazma becerisi. Acilis, gelisme ve kapanis yapisiyla akici ve ikna edici konusma metinleri olusturur.
+### speech-writing
+The skill of writing speeches for stages, conferences, and meetings. Builds fluent, persuasive speeches with opening, development, and closing structure.
 
 ---
 
-### teklif-metni
-Is teklifi ve proje onerisi metinleri yazma becerisi. Ikna edici, profesyonel ve yapilandirilmis teklif dokumanlari olusturur.
+### proposal-copy
+The business proposal and project-pitch writing skill. Builds persuasive, professional, structured proposal documents.
 
 ---
 
-### rapor-yazimi
-Profesyonel is raporlari yazma becerisi. Analiz raporlari, durum raporlari ve degerlendirme raporlarini yapilandirilmis formatta olusturur.
+### report-writing
+The professional business-report skill. Builds analysis, status, and evaluation reports in structured formats.
 
 ---
 
-### ozet-hazirlama
-Uzun belge ve raporlarin ozetini hazirlama becerisi. Temel bilgileri koruyarak kisa ve ozlu ozetler olusturur.
+### summarization
+The skill of summarizing long documents and reports. Builds short, tight summaries preserving the essential information.
 
 ---
 
-### meeting-notu
-Toplanti notlari yazma becerisi. Gundem, tartismalar, kararlar ve aksiyon maddelerini yapilandirilmis formatta dokumante eder.
+### meeting-notes
+The meeting-notes skill. Documents agendas, discussions, decisions, and action items in a structured format.
 
 ---
 
-### brief-olusturma
-Proje ve icerik brief'i hazirlama becerisi. Hedefler, gereksinimler, kisitlamalar ve beklentileri net formatta tanimlayan brief dokumanlari olusturur.
+### brief-creation
+The project and content brief skill. Builds brief documents defining goals, requirements, constraints, and expectations clearly.
 
 ---
 
-### yaratici-yazim
-Yaratici icerikler uretme becerisi. Hikaye, senaryo, siir ve deneme gibi yaratici formatlarda ozgun ve etkileyici metinler yazar.
+### creative-writing
+The creative-content skill. Writes original, compelling texts in creative formats like stories, scripts, poetry, and essays.
 
 ---
 
-### slogan-uretimi
-Marka ve kampanya sloganlari olusturma becerisi. Akilda kalici, ozgun ve marka degerlerini yansitan kisa mesajlar uretir.
+### slogan-creation
+The brand and campaign slogan skill. Produces memorable, original short messages reflecting brand values.
 
 ---
 
-### reklam-metni
-Reklam metin yazarligi becerisi. Basili, dijital ve sosyal medya reklamlari icin dikkat cekici, ikna edici ve aksiyona yonlendiren reklam metinleri olusturur.
+### ad-copy
+The advertising copywriting skill. Builds attention-grabbing, persuasive, action-driving ad copy for print, digital, and social.
 
 ---
 
-### kampanya-konsepti
-Pazarlama kampanyasi konsepti gelistirme becerisi. Kampanya temasi, mesajlama cercevesi ve kanal stratejisi ile bütünsel kampanya fikirleri olusturur.
+### campaign-concepts
+The marketing-campaign concept skill. Builds holistic campaign ideas with themes, messaging frameworks, and channel strategy.
 
 ---
 
-### gorsel-yonetmenlik
-Gorsel icerik yonetim becerisi. Fotograf, illustrasyon ve grafik tasarim projeleri icin gorsel yonerge ve brief'ler hazirlar.
+### art-direction
+The visual content direction skill. Prepares visual guidelines and briefs for photography, illustration, and graphic-design projects.
 
 ---
 
-### icerik-lokalizasyonu
-Icerikleri farkli pazar ve kulturlere uyarlama becerisi. Ceviri otesinde kulturel uyum, yerel referanslar ve pazar-spesifik optimizasyon yapar.
+### content-localization
+The skill of adapting content to different markets and cultures. Goes beyond translation with cultural fit, local references, and market-specific optimization.
 
 ---
 
-### cevirmenlik
-Profesyonel metin ceviri becerisi. Kaynak ve hedef dil arasinda dogru, akici ve baglama uygun ceviriler yapar.
+### translation
+The professional text-translation skill. Produces accurate, fluent, context-appropriate translations between source and target languages.
 
 ---
 
-### dil-inceleme
-Metin dil kalitesi inceleme becerisi. Dilbilgisi, yazim, noktalama ve uslup kontrolu ile kusursuz metinler olusturur.
+### language-review
+The text language-quality review skill. Builds flawless texts with grammar, spelling, punctuation, and style checks.
 
 ---
 
-### duzeltme-okuma
-Son asama metin duzeltme okuma becerisi. Yazim, noktalama, formatlama ve tutarlilik hatallarini yakalayarak yayina hazir metinler olusturur.
+### proofreading
+The final-stage proofreading skill. Builds publication-ready texts by catching spelling, punctuation, formatting, and consistency errors.
 
 ---
 
-### bicim-kontrolu
-Icerik bicimlendirme ve format standartlarina uyumluluk kontrolu becerisi. Baslik hiyerarsisi, paragraf yapisi ve gorsel yerllesimi standartlarini denetler.
+### format-checking
+The content formatting and standards-compliance skill. Audits heading hierarchy, paragraph structure, and visual-layout standards.
 
 ---
 
-### seslendirme-metni
-Seslendirme projeleri icin metin yazma becerisi. Video, reklam, podcast ve IVR seslendirmeleri icin okunabilir ve kulaga hos gelen metinler olusturur.
+### voiceover-scripts
+The skill of writing scripts for voiceover projects. Builds readable, pleasant-sounding texts for video, ads, podcasts, and IVR.
 
 ---
 
-### altyazi-yazimi
-Video icerikleri icin altyazi ve kapal altyazi yazma becerisi. Zamanlama senkronizasyonu, okuma hizi ve erisilebilirlik standartlarinda altyazilar olusturur.
+### subtitle-writing
+The subtitle and closed-caption skill for video content. Builds subtitles at timing-sync, reading-speed, and accessibility standards.
 
 ---
 
-### podcast-transkripti
-Podcast bolumlerini metin formatina donusturme becerisi. Konusmaci tanimla, zaman damgalari ve konu basliklari ile yaplandrilmis transkript olusturur.
+### podcast-transcripts
+The skill of converting podcast episodes to text. Builds structured transcripts with speaker labels, timestamps, and topic headings.
 
 ---
 
-### icerik-geri-donusum
-Eski ve dusuk performansli icerikleri guncelleyip yeniden deger kazandirma becerisi. Icerik gunerlleme, birlestirme ve yeniden optimizasyon ile icerik ROI'sini arttirir.
+### content-recycling
+The skill of refreshing old, low-performing content back to value. Raises content ROI with updates, merges, and re-optimization.
 
 ---
 
-### evergreen-icerik
-Zaman asimina ugramayan, surekli deger ureten icerikler olusturma becerisi. Uzun omurlu, referans niteliginde icerikler ile surekli organik trafik saglar.
+### evergreen-content
+The skill of building timeless, continuously valuable content. Delivers steady organic traffic with long-lived, reference-grade content.
 
 ---
 
-### trend-icerik
-Guncel trend ve olaylara hizla tepki veren icerikler olusturma becerisi. Viral potansiyeli yuksek, zamaninda ve ilgili iceriklerle anlik gorünürlük saglar.
+### trend-content
+The skill of building content reacting fast to current trends and events. Delivers instant visibility with high-viral-potential, timely, relevant content.
 
 ---
 
-### mevsimsel-icerik
-Mevsim, tatil ve ozel gunlere yonelik planlanan icerikler olusturma becerisi. Onceden planlanan kampanya ve icerik takvimleri ile zamaninda yayinlama saglar.
+### seasonal-content
+The skill of building planned content for seasons, holidays, and special days. Delivers on-time publishing with pre-planned campaigns and calendars.
 
 ---
 
-### kriz-iletisimi
-Kriz donemlerinde etkili iletisim yonetimi becerisi. Kriz iletisim plani, mesaj sablonlari ve paydas iletisimi ile kriz surecini yonetir.
+### crisis-communications
+The effective crisis-period communications skill. Manages the crisis with a communication plan, message templates, and stakeholder outreach.
 
 ---
 
-### ic-iletisim
-Kurum ici iletisim icerikleri olusturma becerisi. Duyurular, bültenler, CEO mesajlari ve calisan iletisimi ile etkili ic iletisim saglar.
+### internal-communications
+The internal-communications content skill. Delivers effective internal comms with announcements, newsletters, CEO messages, and employee communication.
 
 ---
 
-### dis-iletisim
-Kurum disi iletisim icerikleri olusturma becerisi. Medya iliskileri, partner iletisimi ve kamuoyu bilgilendirmesi icin profesyonel iletisim materyalleri hazirlar.
+### external-communications
+The external-communications content skill. Prepares professional materials for media relations, partner communication, and public information.
 
 ---
 
-### kurumsal-iletisim
-Kurumsal duzeyde iletisim stratejisi ve icerik olusturma becerisi. Yillik rapor, surdurulebilirlik raporu ve kurumsal kimlik icerikleri hazirlama.
+### corporate-communications
+The corporate-level communications strategy and content skill. Prepares annual reports, sustainability reports, and corporate-identity content.
 
 ---
 
-### yatirimci-iletisimi
-Yatirimci iliskileri icin iletisim icerikleri olusturma becerisi. Yatirimci sunumlari, faaliyet raporlari ve basari metrikleri ile seffaf yatirimci iletisimi saglar.
+### investor-communications
+The investor-relations content skill. Delivers transparent investor communication with decks, activity reports, and success metrics.
 
 ---
 
-### sosyal-sorumluluk-iletisimi
-Kurumsal sosyal sorumluluk projelerini iletisim acisindan yonetme becerisi. CSR kampanyalari, etki raporlari ve paydas iletisimi ile toplumsal katki mesajini etkili sekilde iletir.
+### csr-communications
+The corporate social responsibility communications skill. Conveys the social-contribution message effectively with CSR campaigns, impact reports, and stakeholder outreach.
 
 ---
 
-### mimari-karar-kaydi
-Architecture Decision Record (ADR) yazma becerisi. Teknik kararlari baglam, alternatifler ve sonuclariyla belgeler, gelecek ekiplere "neden boyle?" sorusunun cevabini birakir.
+### architecture-decision-records
+The Architecture Decision Record (ADR) writing skill. Documents technical decisions with context, alternatives, and consequences, leaving future teams the answer to "why this way?"
 
 ---
 
-### olay-sonrasi-rapor
-Post-mortem / incident report yazma becerisi. Uretim olaylarini suclamayan, ogrenme odakli dil ile belgeler.
+### post-incident-reports
+The post-mortem / incident-report writing skill. Documents production incidents in blameless, learning-focused language.
 
 ---
 
-### operasyonel-runbook
-Operasyonel runbook yazma becerisi. On-call muhendisler icin adim adim olay mudahale ve bakim kilavuzlari olusturur.
+### operational-runbooks
+The operational-runbook writing skill. Builds step-by-step incident-response and maintenance guides for on-call engineers.
 
 ---
 
-### teknik-rfc
-Technical RFC (Request for Comments) yazma becerisi. Buyuk teknik degisiklikler icin takim tartismasina acilan tasarim onerileri olusturur.
+### technical-rfcs
+The Technical RFC (Request for Comments) writing skill. Builds design proposals opened for team discussion before big technical changes.
 
 ---
 
-### sdk-dokumantasyonu
-SDK ve kutuphane dokumantasyonu yazma becerisi. Gelistiricilerin hizla entegre olabilecegi baslangic kilavuzlari, API referanslari ve ornekler olusturur.
+### sdk-documentation
+The SDK and library documentation skill. Builds getting-started guides, API references, and examples developers can integrate fast.
 
 ---
 
-### api-hata-dokumantasyonu
-API hata kodlari ve mesajlari dokumantasyonu. Gelistiricilerin hatalari hizla teshis edip cozebilecegi referans belgesi olusturur.
+### api-error-documentation
+The API error code and message documentation skill. Builds the reference letting developers diagnose and fix errors fast.
 
 ---
 
-### migration-kilavuzu
-API/SDK versiyon gecis kilavuzu yazma becerisi. Kirilma degisikliklerini acik adimlarla belgeler, gelismiticilerin yukseltme surecini kolaylastirir.
+### migration-guides
+The API/SDK version migration-guide skill. Documents breaking changes in clear steps, easing developers' upgrade path.
 
 ---
 
-### deprecation-bildirimi
-API/ozellik kullanimdan kaldirma bildirimi yazma becerisi. Kullanicilari erken bilgilendirir, gecis sureci icin net zaman cizelgesi sunar.
+### deprecation-notices
+The API/feature deprecation-notice skill. Informs users early and offers a clear timeline for the transition.
 
 ---
 
-### erislebilir-icerik
-Erisilebilir (accessible) icerik yazma becerisi. Sade dil, okunabilirlik ve kapsayicilik ilkeleriyle herkesin anlayabilecegi icerik uretir.
+### accessible-content
+The accessible-content writing skill. Produces content everyone can understand with plain language, readability, and inclusivity principles.
 
 ---
 
-### kod-ornegi-yazimi
-Teknik dokumantasyon icin etkili kod ornegi yazma becerisi. Kopyala-yapistir'a uygun, aciklamali, calisir ornekler uretir.
+### code-example-writing
+The skill of writing effective code examples for technical docs. Produces copy-paste-ready, annotated, working examples.
 
 ---
 
-### sorun-giderme-kilavuzu
-Troubleshooting guide yazma becerisi. Yaygin hata ve sorunlar icin sistematik teshis ve cozum adimlari olusturur.
+### troubleshooting-guides
+The troubleshooting-guide skill. Builds systematic diagnosis and resolution steps for common errors and problems.
 
 ---
 
-### topluluk-kurallari
-Community guidelines yazma becerisi. Acik kaynak projeler ve topluluk platformlari icin katilim kurallari, moderasyon politikalari ve karsilama mesajlari olusturur.
-
+### community-guidelines
+The community-guidelines skill. Builds participation rules, moderation policies, and welcome messages for open-source projects and community platforms.

--- a/.claude/skills-vault/customer-success/SKILL.md
+++ b/.claude/skills-vault/customer-success/SKILL.md
@@ -10,245 +10,244 @@ metadata:
   badi-version: ">=1.14.0"
   category: customer-success
 ---
-# Musteri Basarisi Becerileri
-> 48 yapilandirilmis prosedur
-## Beceri Listesi
+# Customer Success Skills
+> 48 structured procedures
+## Skill List
 
-### musteri-oryantasyonu
-Yeni musterileri urun ve hizmete basarili sekilde alistiirma becerisi. Hosgeldin sureci, ilk deger gosterimi ve erken benimseme ile musteri kayip oranini azaltir.
-
----
-
-### musteri-saglik-skoru
-Musteri saglik skorlama sistemi tasarlama becerisi. Kullanim, memnuniyet ve etkilesim verilerinden bilesik skor hesaplayarak risk ve firsat tespit eder.
+### customer-onboarding
+The skill of successfully ramping new customers onto the product and service. Reduces churn through a welcome flow, first-value demonstration, and early adoption.
 
 ---
 
-### kayip-onleme
-Musteri kayip riskini erken tespit edip onleme becerisi. Kayip sinyalleri, proaktif mudahale ve geri kazanma stratejileri ile musteri yasam suresini uzatir.
+### customer-health-scoring
+The skill of designing a customer health scoring system. Detects risk and opportunity by computing a composite score from usage, satisfaction, and engagement data.
 
 ---
 
-### musteri-genisleme
-Mevcut musterilerde upsell ve cross-sell firsatlarini belirleme ve degerlendirme becerisi. Musteri buyume stratejileri ile gelir artisi saglar.
+### churn-prevention
+The skill of detecting and preventing churn risk early. Extends customer lifetime through churn signals, proactive intervention, and win-back strategies.
 
 ---
 
-### musteri-savunuculugu
-Memnun musterileri marka savunucularina donusturme becerisi. Referans programi, vaka calismasi ve musteri toplulugu ile organik buyume saglar.
+### customer-expansion
+The skill of identifying and evaluating upsell and cross-sell opportunities in existing customers. Drives revenue growth through customer-growth strategies.
 
 ---
 
-### csr-toplantisi-planlama
-Musteri basari temsilcisi (CSR) toplantisi planlama becerisi. Duzenli inceleme toplantilari ile musteri iliskisini guclendirme ve deger gosterimi yapar.
+### customer-advocacy
+The skill of turning happy customers into brand advocates. Drives organic growth through referral programs, case studies, and customer community.
 
 ---
 
-### musteri-geri-bildirim
-Musteri geri bildirim toplama ve yonetme becerisi. Anketler, gorusmeler ve geri bildirim kanallari ile musterib sesini sistematik olarak dinler.
+### csr-meeting-planning
+The skill of planning customer success representative (CSR) meetings. Strengthens the customer relationship and demonstrates value through regular review meetings.
 
 ---
 
-### musteri-egitimi
-Musterilere urun ve hizmet egitimi saglama becerisi. Egitim materyalleri, webinarlar ve self-servis kaynaklar ile musteri yetkinligini arttirir.
+### customer-feedback
+The skill of collecting and managing customer feedback. Listens to the voice of the customer systematically through surveys, interviews, and feedback channels.
 
 ---
 
-### qbr-hazirlama
-Ceyrek bazli is inceleme (QBR) toplantisi hazirlama becerisi. Performans ozeti, deger gosterimi ve sonraki donem planlama ile stratejik musteri iliskisi yonetir.
+### customer-education
+The skill of delivering product and service education to customers. Raises customer competence through training materials, webinars, and self-service resources.
 
 ---
 
-### musteri-segmentasyonu-cs
-Musteri basarisi perspektifinden musteri segmentasyonu becerisi. Hizmet modeli, temas sikligi ve kaynak tahsisini segment bazli optimize eder.
+### qbr-preparation
+The skill of preparing quarterly business review (QBR) meetings. Manages the strategic customer relationship through performance summaries, value demonstration, and next-period planning.
 
 ---
 
-### yenileme-yonetimi
-Musteri sozlesme yenileme surecini yonetme becerisi. Yenileme takvimi, risk degerlendirmesi ve muzakere stratejileri ile yenileme oranini arttirir.
+### customer-segmentation-cs
+The skill of customer segmentation from a customer-success perspective. Optimizes the service model, touch frequency, and resource allocation per segment.
 
 ---
 
-### musteri-yolculugu-cs
-Musteri basarisi perspektifinden musteri yolculugu haritalama becerisi. Yasam dongusu boyunca temas noktalari ve deneyim optimizasyonu ile musteri memnuniyetini arttirir.
+### renewal-management
+The skill of managing the contract renewal process. Raises the renewal rate through a renewal calendar, risk assessment, and negotiation strategies.
 
 ---
 
-### eskalasyon-yonetimi
-Musteri sorunlarini etkin sekilde eskalasyon sureciyle yonetme becerisi. Eskalasyon seviyeleri, mudahale surerleri ve cozum protokolleri ile hizli sorun cozumu saglar.
+### customer-journey-cs
+The skill of mapping the customer journey from a customer-success perspective. Raises satisfaction through touchpoints and experience optimization across the lifecycle.
 
 ---
 
-### musteri-memnuniyet-anketi
-Musteri memnuniyet anketi tasarlama ve uygulama becerisi. CSAT, CES ve NPS anketleri ile musteri deneyimini sistematik olarak olcer.
+### escalation-management
+The skill of managing customer issues effectively through an escalation process. Delivers fast resolution via escalation levels, response times, and resolution protocols.
 
 ---
 
-### musteri-portfoyu-yonetimi
-CSM (Musteri Basari Yoneticisi) portfoy yonetimi becerisi. Musteri portfoyunu dengeleme, onceliklendirme ve kaynak tahsisi ile verimli portfoy yonetimi saglar.
+### customer-satisfaction-survey
+The skill of designing and running customer satisfaction surveys. Measures the customer experience systematically with CSAT, CES, and NPS surveys.
 
 ---
 
-### playbook-olusturma
-Musteri basarisi is surecleri icin standart playbook olusturma becerisi. Tekrarlanabilir ve olceklenebilir surec kilavuzlari ile ekip verimliligini arttirir.
+### customer-portfolio-management
+The CSM (Customer Success Manager) portfolio management skill. Delivers efficient portfolio management through balancing, prioritization, and resource allocation.
 
 ---
 
-### risk-yonetimi-cs
-Musteri riski belirleme ve yonetme becerisi. Risk gostergeleri, erken uyari mekanizmalari ve mudahale planlari ile musteri kayiplarini minimize eder.
+### playbook-creation
+The skill of creating standard playbooks for customer-success processes. Raises team efficiency with repeatable, scalable process guides.
 
 ---
 
-### deger-gosterimi
-Musterilere saglanan degeri somut olarak gosterme becerisi. ROI hesaplama, basari metrikleri ve karsilastirmali analiz ile musteri icin deger kanitlari olusturur.
+### risk-management-cs
+The skill of identifying and managing customer risk. Minimizes customer losses through risk indicators, early-warning mechanisms, and intervention plans.
 
 ---
 
-### musteri-veri-analizi
-Musteri kullanim ve etkilesim verilerini analiz etme becerisi. Kullanim oruntuleri, benimseme metrikleri ve saglik gostergeleri ile veri odakli musteri yonetimi saglar.
+### value-demonstration
+The skill of showing customers the value delivered, concretely. Builds proof of value through ROI calculation, success metrics, and comparative analysis.
 
 ---
 
-### self-servis-strateji
-Musteri self-servis kaynaklari stratejisi olusturma becerisi. Bilgi tabani, video kilavuzlar ve topluluk forumu ile musteri bagamsizligini arttirir.
+### customer-data-analysis
+The skill of analyzing customer usage and engagement data. Enables data-driven customer management through usage patterns, adoption metrics, and health indicators.
 
 ---
 
-### musteri-toplulugu
-Musteri toplulugu kurma ve yonetme becerisi. Forum, etkinlik ve icerik stratejisi ile musteri bagliligi ve peer-to-peer destek saglar.
+### self-service-strategy
+The skill of building a customer self-service resource strategy. Raises customer independence through a knowledge base, video guides, and a community forum.
 
 ---
 
-### otomatik-bildirim-sistemi
-Musteri yasam dongusu bildirimleri tasarlama becerisi. Otomatik e-posta, in-app mesaj ve push bildirimleri ile zamaninda musteri iletisimi saglar.
+### customer-community
+The skill of building and managing a customer community. Delivers loyalty and peer-to-peer support through forums, events, and a content strategy.
 
 ---
 
-### musteri-basari-metrikleri
-Musteri basarisi KPI'larini tanimlama ve izleme becerisi. GRR, NRR, kayip orani ve benimseme metrikleri ile ekip performansini yonetir.
+### automated-notification-system
+The skill of designing customer lifecycle notifications. Delivers timely customer communication through automated email, in-app messages, and push notifications.
 
 ---
 
-### musteri-iletisim-plani
-Musteri yasam dongusu boyunca iletisim planı olusturma becerisi. Temas sikligi, kanal secimi ve mesaj icerikleri ile proaktif musteri iletisimi saglar.
+### customer-success-metrics
+The skill of defining and tracking customer-success KPIs. Manages team performance with GRR, NRR, churn rate, and adoption metrics.
 
 ---
 
-### musteri-geri-kazanma
-Kaybedilmis musterileri geri kazanma becerisi. Kayip nedeni analizi, geri kazanma kampanyasi ve ozel teklif stratejileri ile musterileri geri getirir.
+### customer-communication-plan
+The skill of building a communication plan across the customer lifecycle. Delivers proactive communication through touch frequency, channel selection, and message content.
 
 ---
 
-### musteri-basari-ekip-yonetimi
-Musteri basarisi ekibini yonetme ve gelistirme becerisi. Isve alimi, egitim, performans yonetimi ve kariyer gelisimi ile yuksek performansli CS ekibi olusturur.
+### customer-win-back
+The skill of winning back lost customers. Brings customers back through churn-reason analysis, win-back campaigns, and special-offer strategies.
 
 ---
 
-### musteri-benimseme-izleme
-Urun ozellik benimseme durumunu izleme becerisi. Kullanim metrikleri, ozellik aktivasyonu ve derinlesme analizi ile urun degerini maksimize eder.
+### cs-team-management
+The skill of managing and growing the customer-success team. Builds a high-performing CS team through hiring, training, performance management, and career development.
 
 ---
 
-### musteri-sesi-programi
-Sistematik musteri sesi (VoC) programi olusturma becerisi. Coklu kanal geri bildirim toplama, analiz ve aksiyona donusmturme ile musteri odakli karar alma saglar.
+### adoption-tracking
+The skill of tracking product feature adoption. Maximizes product value through usage metrics, feature activation, and depth analysis.
 
 ---
 
-### teknik-destek-eskalasyon
-Teknik destek taleplerini etkin sekilde yonetme ve eskalasyon becerisi. Sorun siniflandirma, mudahale surecleri ve cozum izleme ile musteri teknik memnuniyetini saglar.
+### voice-of-customer-program
+The skill of building a systematic voice-of-customer (VoC) program. Enables customer-centric decisions through multi-channel feedback collection, analysis, and action conversion.
 
 ---
 
-### musteri-basari-plani
-Bireysel musteri bazinda basari plani olusturma becerisi. Musteri hedefleri, basari metrikleri ve eylem plani ile kisisellestirilmis musteri yonetimi saglar.
+### technical-support-escalation
+The skill of managing and escalating technical support requests effectively. Secures technical satisfaction through issue classification, response processes, and resolution tracking.
 
 ---
 
-### musteri-segmenti-playbook
-Her musteri segmenti icin ozellestirilmis playbook olusturma becerisi. Segment ihtiyaclarina gore farklilastirilmis hizmet modelleri tanimlar.
+### customer-success-plan
+The skill of building a success plan per individual customer. Delivers personalized management through customer goals, success metrics, and an action plan.
 
 ---
 
-### musteri-basari-teknoloji
-Musteri basarisi teknoloji yiginini seeme ve yapilandirma becerisi. CRM, CS platformu ve otomasyon araclari ile verimli musteri yonetimi altyapisi kurar.
+### segment-playbooks
+The skill of building customized playbooks per customer segment. Defines differentiated service models by segment needs.
 
 ---
 
-### musteri-saglik-incelemesi
-Musteri portfoyunun genel saglik durumunu inceleme becerisi. Portfoy genelinde risk, firsat ve trend analizleri ile stratejik karar alma saglar.
+### cs-technology-stack
+The skill of selecting and configuring the customer-success technology stack. Builds an efficient management infrastructure with CRM, a CS platform, and automation tools.
 
 ---
 
-### musteri-iliskisi-gecisi
-CSM degisikliklerinde musteri iliskisi gecis yonetimi becerisi. Bilgi aktarimi, tanitim sureci ve sureklilik guvencesi ile sorunsuz gecis saglar.
+### portfolio-health-review
+The skill of reviewing the overall health of the customer portfolio. Enables strategic decisions through portfolio-wide risk, opportunity, and trend analyses.
 
 ---
 
-### musteri-referans-programi
-Musteri referans programi tasarlama ve yonetme becerisi. Referans tesviikleri, izleme ve odullendirme ile organik musteri kazanmi saglar.
+### relationship-transition
+The skill of managing customer relationship transitions during CSM changes. Delivers a smooth handover through knowledge transfer, introductions, and continuity assurance.
 
 ---
 
-### musteri-etkilesim-analizi
-Musteri etkilesim verilerini analiz etme becerisi. E-posta acilma, toplanti katilim, urun kullanim ve destek talep verileri ile etkilesim sagligini degerlendirir.
+### customer-referral-program
+The skill of designing and managing a customer referral program. Drives organic acquisition through referral incentives, tracking, and rewards.
 
 ---
 
-### musteri-beklenti-yonetimi
-Musteri beklentilerini etkin sekilde yonetme becerisi. Net iletisim, gercekci hedefler ve seffaf surec yonetimi ile musteri memnuniyetini korur.
+### engagement-analysis
+The skill of analyzing customer engagement data. Assesses engagement health through email opens, meeting attendance, product usage, and support-request data.
 
 ---
 
-### musteri-yasam-degeri
-Musteri yasam boyu degerini (CLV) hesaplama ve artirma becerisi. Gelir tahminleri, kayip olasiligi ve genisleme potansiyeli ile CLV optimizasyonu yapar.
+### expectation-management
+The skill of managing customer expectations effectively. Protects satisfaction through clear communication, realistic goals, and transparent process management.
 
 ---
 
-### musteri-gorus-toplantisi
-Musteri gorüsme ve derinlemesine mulakat becerisi. Yapilandirilmis gorusme teknikleri ile musteri ihtiyaclari, sorunlari ve beklentilerini derinlemesine anlar.
+### customer-lifetime-value
+The skill of calculating and growing customer lifetime value (CLV). Optimizes CLV through revenue forecasts, churn probability, and expansion potential.
 
 ---
 
-### musteri-basari-raporu
-Musteri basarisi ekibi ve portfoy performans raporu hazirlama becerisi. KPI'lar, trendler ve basari hikayeleri ile kapsamli raporlama saglar.
+### customer-interview
+The skill of customer interviews and in-depth conversations. Understands needs, problems, and expectations deeply through structured interview techniques.
 
 ---
 
-### musteri-kurtarma-operasyonu
-Kritik risk altindaki musterileri kurtarma becerisi. Acil mudahale, kok neden analizi ve duzeltici aksiyon plani ile musteri iliskisini onarır.
+### cs-reporting
+The skill of preparing CS team and portfolio performance reports. Delivers comprehensive reporting with KPIs, trends, and success stories.
 
 ---
 
-### musteri-basarisi-otomasyonu
-Musteri basarisi sureclerini otomatiklestirme becerisi. Tetikleyici bazli aksiyonlar, otomatik bildirimler ve is akislari ile CS operasyonlarini olceklendirir.
+### customer-rescue-operation
+The skill of rescuing customers under critical risk. Repairs the relationship through emergency response, root-cause analysis, and a corrective action plan.
 
 ---
 
-### musteri-deneyim-haritalama
-Musteri deneyimini uclararasi olarak haritalama becerisi. Duygusal yolculuk, sorun noktalari ve memnuniyet tepeleri ile butunsel deneyim gorunumu olusturur.
+### cs-automation
+The skill of automating customer-success processes. Scales CS operations through trigger-based actions, automated notifications, and workflows.
 
 ---
 
-### musteri-basari-sureci-tasarimi
-Musteri basarisi operasyonel sureclerini tasarlama becerisi. Is akislari, roller ve sorumluluklar ile olceklenebilir CS operasyonu olusturur.
+### experience-mapping
+The skill of mapping the customer experience end to end. Builds a holistic experience view through the emotional journey, pain points, and satisfaction peaks.
 
 ---
 
-### musteri-basari-kulturü
-Organizasyon genelinde musteri basarisi kulturunu yayginlastirma becerisi. Egitim, metrik paylasimi ve departmanlar arasi isbirligi ile musteri odakli kültür olusturur.
+### cs-process-design
+The skill of designing CS operational processes. Builds a scalable CS operation through workflows, roles, and responsibilities.
 
 ---
 
-### musteri-onceliklendirme
-Musteri taleplerini ve ihtiyaclarini onceliklendirme becerisi. Aciliyet, etki ve stratejik deger kriterlerine gore musteri eylemleriini siralama yapar.
+### cs-culture
+The skill of spreading a customer-success culture across the organization. Builds customer-centricity through training, metric sharing, and cross-department collaboration.
 
 ---
 
-### musteri-basari-benchmark
-Musteri basarisi metriklerini sektor benchmarklariyla karsilastirma becerisi. En iyi uygulamalar ve sektör standartlari ile performans degerlendirmesi yapar.
+### customer-prioritization
+The skill of prioritizing customer requests and needs. Ranks customer actions by urgency, impact, and strategic value.
 
 ---
 
-### musteri-basari-olcekleme
-Musteri basarisi operasyonunu büyüme ile birlikte olcekleme becerisi. Otomasyon, segmentasyon ve surec optimizasyonu ile verimli buyume saglar.
+### cs-benchmarking
+The skill of comparing CS metrics against industry benchmarks. Evaluates performance against best practices and industry standards.
 
+---
+
+### cs-scaling
+The skill of scaling the CS operation alongside growth. Delivers efficient growth through automation, segmentation, and process optimization.

--- a/.claude/skills-vault/data-analytics/SKILL.md
+++ b/.claude/skills-vault/data-analytics/SKILL.md
@@ -10,256 +10,255 @@ metadata:
   badi-version: ">=1.14.0"
   category: data-analytics
 ---
-# Veri Analitigi Becerileri
-Bu dosya, veri toplama, analiz, gorselestirme, makine ogrenmesi, is zekasi ve veri muhendisligi alanlarindaki tum becerileri icerir.
+# Data Analytics Skills
+This file contains all the skills across data collection, analysis, visualization, machine learning, business intelligence, and data engineering.
 
 ---
 
-### veri-strateji-tasarimi
-Organizasyon icin kapsamli veri stratejisi olusturarak veri odakli karar almayi saglar.
+### data-strategy-design
+Enables data-driven decision making by building a comprehensive data strategy for the organization.
 
 ---
 
-### veri-toplama-tasarimi
-Veri toplama mekanizmalarini tasarlayarak dogru ve eksiksiz veri akisi saglar.
+### data-collection-design
+Designs data collection mechanisms to ensure an accurate, complete data flow.
 
 ---
 
-### olay-izleme-tasarimi
-Uygulama ve web sitesi olay izleme (event tracking) altyapisini tasarlar.
+### event-tracking-design
+Designs the event-tracking infrastructure for applications and websites.
 
 ---
 
-### veri-ambari-tasarimi
-Veri ambari (data warehouse) mimarisini tasarlayarak analitik altyapisini kurar.
+### data-warehouse-design
+Builds the analytics foundation by designing the data warehouse architecture.
 
 ---
 
-### etl-pipeline-tasarimi
-ETL/ELT veri pipeline'larini tasarlayarak veri donusumu ve yukleme surecini otomatiklestirir.
+### etl-pipeline-design
+Automates data transformation and loading by designing ETL/ELT pipelines.
 
 ---
 
-### veri-golu-mimarisi
-Data lake mimarisi tasarlayarak yapisal ve yapisal olmayan verilerin depolanmasini saglar.
+### data-lake-architecture
+Enables storage of structured and unstructured data by designing a data lake architecture.
 
 ---
 
-### sql-analiz-sorulari
-Is sorularina yanit veren SQL analiz sorgulari yazar ve optimize eder.
+### sql-analysis-queries
+Writes and optimizes SQL analysis queries that answer business questions.
 
 ---
 
-### dashboard-tasarimi
-Is kullanicilari icin etkili ve aksiyona donusturulebilir dashboard'lar tasarlar.
+### dashboard-design
+Designs effective, actionable dashboards for business users.
 
 ---
 
-### veri-gorsellestirme
-Veriyi anlasilir ve etkili gorsellerle sunmak icin grafik turu secimi ve tasarim ilkeleri uygular.
+### data-visualization
+Applies chart-type selection and design principles to present data clearly and effectively.
 
 ---
 
-### kohort-analizi
-Kullanici kohortlari uzerinde zaman bazli davranis analizleri yaparak trendleri ortaya cikarir.
+### cohort-analysis
+Surfaces trends through time-based behavior analyses over user cohorts.
 
 ---
 
-### huni-analizi
-Kullanici donusum hunisini analiz ederek kayip noktalarini ve optimizasyon firsatlarini belirler.
+### funnel-analysis
+Identifies drop-off points and optimization opportunities by analyzing the user conversion funnel.
 
 ---
 
-### segmentasyon-analizi
-Kullanicilari veya musterileri anlamli gruplara ayiran segmentasyon analizi yapar.
+### segmentation-analysis
+Runs segmentation analyses that split users or customers into meaningful groups.
 
 ---
 
-### a-b-test-analizi
-A/B test sonuclarini istatistiksel olarak analiz ederek guvenilir kararlara yonlendirir.
+### a-b-test-analysis
+Drives reliable decisions by analyzing A/B test results statistically.
 
 ---
 
-### tahminleme-modeli
-Gecmis veriye dayali tahminleme modelleri olusturarak gelecek trendleri ongoru eder.
+### forecasting-model
+Anticipates future trends by building forecasting models on historical data.
 
 ---
 
-### musteri-yasam-boyu-degeri
-Musteri yasam boyu degerini (LTV/CLV) hesaplayan model ve analiz olusturur.
+### customer-lifetime-value
+Builds models and analyses that compute customer lifetime value (LTV/CLV).
 
 ---
 
-### kayip-analizi
-Musteri/kullanici kaybini (churn) analiz ederek kayip nedenlerini ve onleme stratejilerini belirler.
+### churn-analysis
+Determines churn causes and prevention strategies by analyzing customer/user loss.
 
 ---
 
-### rfm-analizi
-RFM (Recency, Frequency, Monetary) analizi ile musterileri segmentlere ayirarak pazarlama stratejisi belirler.
+### rfm-analysis
+Shapes marketing strategy by segmenting customers with RFM (Recency, Frequency, Monetary) analysis.
 
 ---
 
-### atribusyon-modelleme
-Pazarlama kanallarinin donusum uzerindeki etkisini olcen atribusyon modeli olusturur.
+### attribution-modeling
+Builds attribution models measuring marketing channels' impact on conversion.
 
 ---
 
-### pazar-sepeti-analizi
-Birliktelik kurallari analiizi ile urun satin alma kaliplarini kesfeder.
+### market-basket-analysis
+Discovers purchase patterns through association-rule analysis.
 
 ---
 
-### anomali-tespiti
-Verilerdeki normal disi kaliplari ve anomalileri otomatik tespit eden sistem kurar.
+### anomaly-detection
+Builds systems that automatically detect abnormal patterns and anomalies in data.
 
 ---
 
-### duygu-analizi-nlp
-Metin verilerinde duygu analizi yaparak musteri goruslerini ve pazar algisini olcer.
+### sentiment-analysis-nlp
+Measures customer opinion and market perception through sentiment analysis on text data.
 
 ---
 
-### veri-kalite-yonetimi
-Veri kalitesini olcen, izleyen ve iyilestiren sistematik surecler olusturur.
+### data-quality-management
+Builds systematic processes that measure, monitor, and improve data quality.
 
 ---
 
-### veri-yonetisimi
-Organizasyonel veri yonetisim (data governance) cercevesini olusturarak veri varliklarini yonetir.
+### data-governance
+Manages data assets by building an organizational data governance framework.
 
 ---
 
-### veri-katalogu
-Veri katalogu olusturarak organizasyondaki veri varliklarini kesfedilebilir hale getirir.
+### data-catalog
+Makes the organization's data assets discoverable by building a data catalog.
 
 ---
 
-### veri-gizliligi-uyumu
-Veri analitik sureclerinde gizlilik ve uyumluluk gereksinimlerini saglar.
+### data-privacy-compliance
+Meets privacy and compliance requirements in analytics processes.
 
 ---
 
-### is-zekasi-platformu
-Is zekasi (BI) platform secimi ve yapilandirmasini yaparak self-servis analitik saglar.
+### bi-platform
+Enables self-service analytics through BI platform selection and configuration.
 
 ---
 
-### otomatik-raporlama
-Periyodik raporlari otomatik olusturup dagtitan raporlama sistemi kurar.
+### automated-reporting
+Builds a reporting system that generates and distributes periodic reports automatically.
 
 ---
 
-### kpi-tanimlama
-Is hedeflerine uygun KPI'lar tanimlayarak performans izleme cercevesi olusturur.
+### kpi-definition
+Builds a performance-tracking framework by defining KPIs aligned with business goals.
 
 ---
 
-### istatistiksel-analiz
-Istatistiksel yontemler ile veri setlerinden anlamli icgorular cikarir.
+### statistical-analysis
+Extracts meaningful insights from datasets with statistical methods.
 
 ---
 
-### zaman-serisi-analizi
-Zaman serileri verilerini analiz ederek trend, mevsimsellik ve tahmin modelleri olusturur.
+### time-series-analysis
+Builds trend, seasonality, and forecasting models by analyzing time-series data.
 
 ---
 
-### veri-muhendisligi-altyapisi
-Veri muhendisligi altyapisini tasarlayarak olceklenebilir veri isleme kapasitesi olusturur.
+### data-engineering-infrastructure
+Builds scalable data-processing capacity by designing the data engineering infrastructure.
 
 ---
 
-### gercek-zamanli-analitik
-Gercek zamanli veri akisini ve analizini saglayan streaming analitik altyapisi kurar.
+### real-time-analytics
+Builds streaming analytics infrastructure enabling real-time data flow and analysis.
 
 ---
 
-### makine-ogrenmesi-projesi
-Makine ogrenmesi projesini basindan sonuna yoneten is akisi ve metodoloji olusturur.
+### machine-learning-project
+Builds the workflow and methodology that manages an ML project end to end.
 
 ---
 
-### ozellik-muhendisligi
-Makine ogrenmesi modelleri icin etkili ozellikler olusturma sureci tasarlar.
+### feature-engineering
+Designs the process of building effective features for machine-learning models.
 
 ---
 
-### model-degerlendirme
-ML model performansini kapsamli olarak degerlendiren metrik ve yontemler uygular.
+### model-evaluation
+Applies metrics and methods that evaluate ML model performance comprehensively.
 
 ---
 
-### model-dagitimi
-ML modelini uretim ortamina dagitarak surekli tahmin hizmeti saglar.
+### model-deployment
+Delivers a continuous prediction service by deploying the ML model to production.
 
 ---
 
-### model-izleme
-Uretim ortamindaki ML model performansini surekli izleyerek bozulmalari tespit eder.
+### model-monitoring
+Detects degradation by continuously monitoring ML model performance in production.
 
 ---
 
-### deneysel-tasarim
-Veri odakli deney tasarimi yaparak dogru nedensellik cikarimlarini saglar.
+### experimental-design
+Ensures correct causal inference through data-driven experiment design.
 
 ---
 
-### veri-hikayecilik
-Veri analizlerini ikna edici hikayeler seklinde sunarak aksiyona yonlendirir.
+### data-storytelling
+Drives action by presenting data analyses as persuasive stories.
 
 ---
 
-### self-servis-analitik
-Teknik olmayan kullanicilarin kendi analizlerini yapabilecegi self-servis altyapi kurar.
+### self-service-analytics
+Builds self-service infrastructure so non-technical users can run their own analyses.
 
 ---
 
-### veri-modelleme
-Analitik amacli veri modellerini tasarlayarak sorgu performansi ve kullanim kolayligi saglar.
+### data-modeling
+Delivers query performance and ease of use by designing analytics-oriented data models.
 
 ---
 
-### dbt-donusumleri
-dbt ile veri ambarinda donusum katmanini olusturarak analitik hazir veri saglar.
+### dbt-transformations
+Provides analytics-ready data by building the transformation layer in the warehouse with dbt.
 
 ---
 
-### python-veri-analizi
-Python ile veri analizi yaparak icgoru uretemek icin kod ve is akislari olusturur.
+### python-data-analysis
+Builds code and workflows for producing insights through data analysis in Python.
 
 ---
 
-### ab-test-platformu
-Organizasyonel A/B test platformu ve sureci kurarak deney kulturunu gelisitirir.
+### ab-test-platform
+Grows the experimentation culture by building the organizational A/B testing platform and process.
 
 ---
 
-### veri-ekibi-kurulumu
-Veri analitik ekibini kurma, roller tanimlama ve calisma modelini tasarlama stratejisi olusturur.
+### data-team-setup
+Builds the strategy for forming the data analytics team, defining roles, and designing the working model.
 
 ---
 
-### metrik-agaci
-Is metrikleri arasindaki iliskileri haritalayan metrik agaci (metric tree) olusturur.
+### metric-tree
+Builds a metric tree mapping the relationships between business metrics.
 
 ---
 
-### veri-migrsyonu
-Veri kaynak sistemlerinden hedef sistemlere guvenli ve eksiksiz veri gocunu planlar.
+### data-migration
+Plans safe, complete data migration from source systems to target systems.
 
 ---
 
-### veri-okuryazarligi
-Organizasyonda veri okuryazarligini gelistiren egitim ve kultur degisimi programi olusturur.
+### data-literacy
+Builds the training and culture-change program that grows data literacy across the organization.
 
 ---
 
-### elde-tutma-analizi
-Kullanici elde tutma (retention) oranlarini cohort bazli analiz ederek kayip trendlerini ortaya cikarir.
+### retention-analysis
+Surfaces churn trends by analyzing user retention rates per cohort.
 
 ---
 
-### veri-pipeli-izleme
-Veri pipeline'larinin sagligini ve veri kalitesini surekli izleyen sistem kurar.
-
+### data-pipeline-monitoring
+Builds systems that continuously monitor pipeline health and data quality.

--- a/.claude/skills-vault/design/SKILL.md
+++ b/.claude/skills-vault/design/SKILL.md
@@ -10,275 +10,274 @@ metadata:
   badi-version: ">=1.14.0"
   category: design
 ---
-# Tasarim Becerileri
-> 54 yapilandirilmis prosedur
-## Beceri Listesi
+# Design Skills
+> 54 structured procedures
+## Skill List
 
-### ui-tasarim
-Kullanici arayuzu tasarlama becerisi. Gorsel hiyerarsi, renk teorisi ve tipografi ilkeleriyle kullanici dostu ve estetik arayuzler olusturur.
-
----
-
-### ux-arastirma
-Kullanici deneyimi arastirma becerisi. Kullanici mulakatlarim, kullanilabilirlik testleri ve anketler ile veri odakli tasarim kararlari alir.
+### ui-design
+The user-interface design skill. Builds user-friendly, aesthetic interfaces with visual hierarchy, color theory, and typography principles.
 
 ---
 
-### wireframe-olusturma
-Sayfa ve ekran wireframe'leri olusturma becerisi. Icerik yerlesimi, navigasyon yapisi ve islevsel akim ile temel tasarim iskeletini tanismlar.
+### ux-research
+The user-experience research skill. Drives data-backed design decisions with user interviews, usability tests, and surveys.
 
 ---
 
-### prototipleme
-Etkiiesimli prototip olusturma becerisi. Tiklanabilir prototipler ile tasarim konseptlerini kullanici testi oncesinde canlandirir.
+### wireframing
+The skill of building page and screen wireframes. Defines the core design skeleton with content placement, navigation structure, and functional flow.
 
 ---
 
-### tasarim-sistemi
-Tasarim sistemi olusturma ve yonetme becerisi. Bilesen kitapligi, tokenlar ve tasarim ilkeleri ile tutarli ve olceklenebilir tasarim altyapisi kurar.
+### prototyping
+The skill of building interactive prototypes. Brings design concepts to life with clickable prototypes before user testing.
 
 ---
 
-### renk-paleti-olusturma
-Marka ve proje icin renk paleti tasarlama becerisi. Renk teorisi, kontrast kurallari ve erisilebilirlik standartlari ile etkili renk sistemleri olusturur.
+### design-system
+The skill of building and managing a design system. Builds consistent, scalable design infrastructure with a component library, tokens, and design principles.
 
 ---
 
-### tipografi-secimi
-Proje icin tipografi sistemi olusturma becerisi. Font eslestirme, boyut olcegi ve okunabilirlik optimizasyonu ile etkili tipografik hiyerarsi saglar.
+### color-palette-creation
+The skill of designing color palettes for brands and projects. Builds effective color systems with color theory, contrast rules, and accessibility standards.
 
 ---
 
-### ikonografi-tasarim
-Ikon seti tasarlama ve yonetme becerisi. Tutarli stil, olcu ve kullanim kurallariyla kapsamli ikon kitapligi olusturur.
+### typography-selection
+The skill of building the project's typography system. Delivers effective typographic hierarchy through font pairing, size scales, and readability optimization.
 
 ---
 
-### responsive-tasarim
-Farkli ekran boyutlarina uyumlu tasarim becerisi. Mobil, tablet ve masaustu icin optimize edilmis duyarli yerlesimler olusturur.
+### iconography-design
+The skill of designing and managing icon sets. Builds a comprehensive icon library with consistent style, sizing, and usage rules.
 
 ---
 
-### kullanilabilirlik-testi
-Kullanilabilirlik testi planlama ve yurutme becerisi. Gorev bazli testler, gozlem ve analiz ile tasarim sorunlarini tespit eder.
+### responsive-design
+The skill of designing across screen sizes. Builds responsive layouts optimized for mobile, tablet, and desktop.
 
 ---
 
-### erisilebilirlik-tasarim
-WCAG standartlarina uygun erisieblir tasarim becerisi. Renk kontrastı, klavye navigasyonu ve ekran okuyucu uyumlulugu ile herkes icin kullanilabilir tasarimlar olusturur.
+### usability-testing
+The skill of planning and running usability tests. Detects design problems through task-based tests, observation, and analysis.
 
 ---
 
-### animasyon-tasarim
-UI animasyon ve mikro-etkilesim tasarlama becerisi. Gecis efektleri, yukleme animasyonlari ve geri bildirim animasyonlari ile zengin kullanici deneyimi saglar.
+### accessibility-design
+The skill of accessible design per WCAG standards. Builds designs usable by everyone via color contrast, keyboard navigation, and screen-reader compatibility.
 
 ---
 
-### marka-kimligi
-Marka gorsel kimligi tasarlama becerisi. Logo, renk, tipografi ve gorsel dil ile tutarli marka deneyimi olusturur.
+### animation-design
+The skill of designing UI animation and micro-interactions. Delivers a rich experience through transitions, loading animations, and feedback animations.
 
 ---
 
-### logo-tasarim
-Logo tasarimi becerisi. Marka temsili, olceklenebilirlik ve farkli ortamlarda kullanim icin profesyonel logolar olusturur.
+### brand-identity
+The skill of designing the brand's visual identity. Builds a consistent brand experience with logo, color, typography, and visual language.
 
 ---
 
-### gorsel-hiyerarsi
-Gorsel hiyerarsi tasarlama becerisi. Boyut, renk, konum ve bosluk kullranarak bilgi onceliklendirmesi ve gorsel yonlendirme saglar.
+### logo-design
+The logo design skill. Builds professional logos for brand representation, scalability, and multi-context use.
 
 ---
 
-### dashboard-ui-tasarim
-Veri dashboard arayuzleri tasarlama becerisi. Bilgi yogunlugu, gorsellesirme bilesenleri ve kullanici etkilesimi ile etkili veri gosterge panelleri olusturur.
+### visual-hierarchy
+The skill of designing visual hierarchy. Delivers information prioritization and visual guidance using size, color, position, and space.
 
 ---
 
-### form-tasarimi
-Kullanici dostu form tasarlama becerisi. Alan siralamasii, dogrulama mesajlari ve adim adim formlar ile yuksek tamamlama oranli formlar olusturur.
+### dashboard-ui-design
+The skill of designing data-dashboard interfaces. Builds effective panels through information density, visualization components, and user interaction.
 
 ---
 
-### mobil-ui-tasarim
-Mobil uygulama arayuzu tasarlama becerisi. iOS ve Android platformu kilavuzlarina uygun, parmark dostu ve performansli mobil tasarimlar olusturur.
+### form-design
+The skill of designing user-friendly forms. Builds high-completion forms with field ordering, validation messages, and step-by-step flows.
 
 ---
 
-### web-tasarim
-Web sitesi tasarlama becerisi. Gorsel tasarim, icerik yerlesimi ve kullanici akisi ile etkili ve estetik web sayfalari olusturur.
+### mobile-ui-design
+The skill of designing mobile app interfaces. Builds thumb-friendly, performant designs following the iOS and Android platform guidelines.
 
 ---
 
-### sunum-tasarim
-Profesyonel sunum slaytlari tasarlama becerisi. Gorsel etki, bilgi netiligi ve marka tutarliligi ile etkili sunum materyalleri olusturur.
+### web-design
+The website design skill. Builds effective, aesthetic web pages with visual design, content placement, and user flow.
 
 ---
 
-### email-tasarim
-E-posta tasarimi becerisi. HTML e-posta sablonlari, mobil uyumluluk ve e-posta istemci uyumlulugu ile etkili e-posta tasarimlari olusturur.
+### presentation-design
+The skill of designing professional presentation slides. Builds effective materials with visual impact, information clarity, and brand consistency.
 
 ---
 
-### sosyal-medya-gorsel
-Sosyal medya gorselleri tasarlama becerisi. Platform boyut standartlari, gorsel trendler ve marka uyumu ile dikkat cekici sosyal icerikler olusturur.
+### email-design
+The email design skill. Builds effective designs with HTML templates, mobile compatibility, and email-client compatibility.
 
 ---
 
-### infografik-gorsel-tasarim
-Infografik gorsel tasarim becerisi. Veri gorsellesirme, bilgi akisi ve gorsel hiyerarsi ile karmasik bilgileri anlasilir gorsellere donusturur.
+### social-media-visuals
+The skill of designing social media visuals. Builds attention-grabbing social content with platform size standards, visual trends, and brand fit.
 
 ---
 
-### ux-yazimi
-UX odakli arayuz metinleri tasarlama becerisi. Mikro kopya, yonlendirme metinleri ve hata mesajlari ile kullanici deneyimini iyilestiren metinler olusturur.
+### infographic-design
+The infographic design skill. Turns complex information into clear visuals through data visualization, information flow, and visual hierarchy.
 
 ---
 
-### tasarim-inceleme
-Tasarim calismalarini inceleme ve geri bildirim verme becerisi. Yapici kritik, tutarlilik kontrolu ve iyilestirme onerileri ile tasarim kalitesini arttirir.
+### ux-writing
+The skill of designing UX-focused interface copy. Builds copy that improves the experience via microcopy, guidance text, and error messages.
 
 ---
 
-### kullanici-akisi-tasarim
-Kullanici akislari ve is akisi diyagramlari tasarlama becerisi. Ekranlar arasi gezinme, karar noktalari ve alternatif yollarla kapsamli kullanici yolculugu gorsellestirir.
+### design-review
+The skill of reviewing design work and giving feedback. Raises design quality with constructive critique, consistency checks, and improvement suggestions.
 
 ---
 
-### tasarim-teslim
-Tasarim dosyalarini gelistirme ekibine teslim etme becerisi. Olcu, renk, asset ve etkilesim spesifikasyonlari ile sorunsuz tasarim-gelistirme gecisi saglar.
+### user-flow-design
+The skill of designing user flows and workflow diagrams. Visualizes the full journey with screen-to-screen navigation, decision points, and alternative paths.
 
 ---
 
-### gorsel-tutarlilik
-Tasarim tutarliligini saglama becerisi. Bilesenler, stiller ve oruntular arasinda gorsel tutarlilik denetimi yapar.
+### design-handoff
+The skill of handing design files to the development team. Delivers a smooth design-to-dev transition with size, color, asset, and interaction specs.
 
 ---
 
-### landing-page-tasarim
-Donusum odakli landing page tasarlama becerisi. Gorsel hiyerarsi, CTA vurgusu ve guven elemanlari ile yuksek donusum oranli sayfalar tasarlar.
+### visual-consistency
+The skill of maintaining design consistency. Audits visual consistency across components, styles, and patterns.
 
 ---
 
-### e-ticaret-ui-tasarim
-E-ticaret arayuzleri tasarlama becerisi. Urun listesi, urun detay, sepet ve odeme akislari ile satin alma deneyimini optimize eder.
+### landing-page-design
+The skill of designing conversion-focused landing pages. Designs high-conversion pages with visual hierarchy, CTA emphasis, and trust elements.
 
 ---
 
-### tasarim-token
-Tasarim token sistemi olusturma becerisi. Renk, tipografi, bosluk ve golge tokenlarini tanimlayarak tasarim-kod tutarliligi saglar.
+### ecommerce-ui-design
+The skill of designing e-commerce interfaces. Optimizes the purchase experience across product lists, product detail, cart, and checkout flows.
 
 ---
 
-### empati-haritasi
-Kullanici empati haritasi olusturma becerisi. Kullanicinin dusundugu, hissettigi, gordugu ve yaptigi boyutlariyla derinlemesine kullanici anlayisi saglar.
+### design-tokens
+The skill of building a design-token system. Delivers design-code consistency by defining color, typography, spacing, and shadow tokens.
 
 ---
 
-### persona-tasarimi
-Kullanici persona profilleri olusturma becerisi. Demografik, davranissal ve motivasyonel ozelliklerle temsili kullanici profilleri tasarlar.
+### empathy-mapping
+The skill of building user empathy maps. Delivers deep user understanding across what users think, feel, see, and do.
 
 ---
 
-### bilgi-mimarisi
-Web ve uygulama bilgi mimarisi tasarlama becerisi. Icerik organizasyonu, navigasyon yapisi ve etiketleme sistemi ile kullanicinin bilgiye erisimini kolaylastirir.
+### persona-design
+The skill of building user persona profiles. Designs representative profiles with demographic, behavioral, and motivational traits.
 
 ---
 
-### gorsel-arastirma
-Tasarim ilham ve referans arastirmasi becerisi. Mood board, trend analizi ve rakip tasarim incelemesi ile tasarim yonu belirler.
+### information-architecture
+The skill of designing web and app information architecture. Eases access to information with content organization, navigation structure, and labeling.
 
 ---
 
-### baskilat-tasarimi
-Baski materyalleri tasarlama becerisi. Kartvizit, brosur, poster ve katalog gibi fiziksel materyallerin profesyonel tasarimini yapar.
+### visual-research
+The design inspiration and reference research skill. Sets the design direction with mood boards, trend analysis, and competitor design review.
 
 ---
 
-### illustrasyon
-Dijital illustrasyon olusturma becerisi. Marka uyumlu, ozgun ve iletisim amacli illustrasyonlar cizer.
+### print-design
+The skill of designing print materials. Produces professional designs for physical materials like business cards, brochures, posters, and catalogs.
 
 ---
 
-### hareket-tasarimi
-Hareket grafikleri (motion graphics) tasarlama becerisi. Video intro, animasyonlu icerik ve UI mikro-animasyonlari ile dinamik gorsel deneyimler olusturur.
+### illustration
+The digital illustration skill. Draws brand-aligned, original, communication-driven illustrations.
 
 ---
 
-### veri-gorsellesirme-tasarim
-Veri gorsellesirme tasarlama becerisi. Grafik turu secimi, renk kodlamasi ve etkilesim tasarimi ile veriden anlan cikaran gorseller olusturur.
+### motion-design
+The motion-graphics design skill. Builds dynamic visual experiences with video intros, animated content, and UI micro-animations.
 
 ---
 
-### oyun-arayuzu-tasarim
-Oyun kullanici arayuzu tasarlama becerisi. HUD, menu, envanter ve diyalog sistemleri ile oyuncuu deneyimini optimize eden arayuzler olusturur.
+### data-visualization-design
+The data-visualization design skill. Builds meaning-extracting visuals through chart selection, color coding, and interaction design.
 
 ---
 
-### ar-vr-tasarim
-Artirilmis ve sanal gerceklik deneyimi tasarlama becerisi. 3B arayuz, mekansal etkilesim ve bakmak gecici navigasyon ile immersif deneyimler olusturur.
+### game-ui-design
+The game UI design skill. Builds interfaces optimizing the player experience across HUD, menus, inventory, and dialog systems.
 
 ---
 
-### karanlilk-mod-tasarim
-Karanlik mod arayuz tasarlama becerisi. Renk donusumu, kontrast ayarlari ve gorsel konfor ile etkili karanlik tema tasarimlari olusturur.
+### ar-vr-design
+The skill of designing augmented and virtual reality experiences. Builds immersive experiences with 3D interfaces, spatial interaction, and gaze-based navigation.
 
 ---
 
-### mikro-etkilesim
-Mikro-etkilesim tasarlama becerisi. Buton hover, yukleme durumu, basari geri bildirimi gibi kucuk ama etkili etkilesimlerle kullanici deneyimini zenginlestirir.
+### dark-mode-design
+The dark-mode interface design skill. Builds effective dark themes through color conversion, contrast tuning, and visual comfort.
 
 ---
 
-### tasarim-sprint
-Tasarim sprint sureci planlama ve yurutme becerisi. Google Ventures Design Sprint metodolojisi ile 5 gunde problem cozme ve prototipleme yapar.
+### micro-interactions
+The micro-interaction design skill. Enriches the experience with small but effective interactions like button hovers, loading states, and success feedback.
 
 ---
 
-### kullanici-testi-plani
-Kullanici testi planlama ve yurutme becerisi. Test senaryolari, katilimci profili ve analiz yontemleri ile sistematik kullanici arastirmasi yapar.
+### design-sprint
+The skill of planning and running design sprints. Solves problems and prototypes in 5 days with the Google Ventures Design Sprint methodology.
 
 ---
 
-### tasarim-versiyon-yonetimi
-Tasarim dosyalarinin versiyonlama ve yonetim becerisi. Dosya adlandirma, dallanma stratejisi ve inceleme sureci ile duzenli tasarim is akisi saglar.
+### user-testing-plan
+The skill of planning and running user tests. Runs systematic research with test scenarios, participant profiles, and analysis methods.
 
 ---
 
-### cok-dilli-tasarim
-Birden fazla dili destekleyen arayuz tasarlama becerisi. Metin uzamalari, RTL destegi ve kulturel uyum ile uluslararasi tasarimlar olusturur.
+### design-version-management
+The skill of versioning and managing design files. Delivers an orderly workflow with file naming, branching strategy, and a review process.
 
 ---
 
-### tasarim-qA
-Tasarim uygulama kalitesini kontrol etme becerisi. Gelistirilen urun ile tasarim dosyasi arasindaki farklari tespit eder ve duzeltme saglar.
+### multilingual-design
+The skill of designing interfaces supporting multiple languages. Builds international designs with text expansion, RTL support, and cultural fit.
 
 ---
 
-### tasarim-sistemi-yonetimi
-Mevcut tasarim sistemini yonetme ve gelistirme becerisi. Bilesen guncellemeleri, yeni eklemeler ve kullanim izleme ile canli tasarim sistemi yonetir.
+### design-qa
+The skill of checking design implementation quality. Detects and fixes gaps between the built product and the design files.
 
 ---
 
-### urun-fotograf-yonlendirme
-Urun fotograflari icin gorsel yonlendirme becerisi. Cekim acisi, isik, arka plan ve stilizasyon talimatlari ile profesyonel urun gorselleri planlar.
+### design-system-management
+The skill of managing and evolving an existing design system. Runs a living system through component updates, additions, and usage tracking.
 
 ---
 
-### kullanici-arastirma-plani
-Kapsamli kullanici arastirma programi planlama becerisi. Arastirma yontem secimi, takvim ve kaynak planlama ile sistematik kullanici arastirmasi yonetir.
+### product-photo-direction
+The visual direction skill for product photos. Plans professional product imagery with shot angle, light, background, and styling instructions.
 
 ---
 
-### gorsel-stil-kesfı
-Proje icin gorsel stil ve estetik yon belirleme becerisi. Farkli gorsel yaklasimlari kesfederek projeye en uygun tasarim dilini tanımlar.
+### user-research-plan
+The skill of planning a comprehensive user research program. Manages systematic research with method selection, scheduling, and resource planning.
 
 ---
 
-### tasarim-prensipleri
-Proje bazli tasarim prensipleri olusturma becerisi. Tasarim kararlarina rehberlik eden ilkeler tanimlayarak ekip icinde tutarli karar alma saglar.
+### visual-style-exploration
+The skill of setting the project's visual style and aesthetic direction. Defines the best-fitting design language by exploring different visual approaches.
 
 ---
 
-### tasarim-atolyesi
-Tasarim atolyesi (workshop) planlama ve yurutme becerisi. Katilimci etkinlikleri, beyin firtinasi ve co-creation ile isbirligi icerisinde tasarim fikirleri olusturur.
+### design-principles
+The skill of building project-level design principles. Enables consistent team decisions by defining principles that guide design choices.
 
+---
+
+### design-workshop
+The skill of planning and running design workshops. Builds design ideas collaboratively with participatory activities, brainstorming, and co-creation.

--- a/.claude/skills-vault/development/SKILL.md
+++ b/.claude/skills-vault/development/SKILL.md
@@ -10,490 +10,489 @@ metadata:
   badi-version: ">=1.14.0"
   category: development
 ---
-# Yazilim Gelistirme Becerileri
-> 98 yapilandirilmis prosedur
-## Beceri Listesi
+# Software Development Skills
+> 98 structured procedures
+## Skill List
 
-### frontend-gelistirme
-Modern frontend uygulama gelistirme becerisi. React, Vue, Angular gibi cercevelerle performansli ve kullanici dostu web uygulamalari olusturur.
-
----
-
-### backend-gelistirme
-Sunucu tarafli uygulama gelistirme becerisi. API tasarimi, veritabani entegrasyonu ve is mantigi ile saglam backend sistemleri olusturur.
+### frontend-development
+The modern frontend development skill. Builds performant, user-friendly web apps with frameworks like React, Vue, and Angular.
 
 ---
 
-### rest-api-tasarimi
-RESTful API tasarlama ve dokumante etme becerisi. Kaynak modelleme, HTTP metotlari ve hata yonetimi ile standartlara uygun API'ler olusturur.
+### backend-development
+The server-side development skill. Builds solid backend systems with API design, database integration, and business logic.
+
+---
+
+### rest-api-design
+The RESTful API design and documentation skill. Builds standards-compliant APIs with resource modeling, HTTP methods, and error handling.
 
 ---
 
 ### graphql-api
-GraphQL API tasarlama ve gelistirme becerisi. Sema tanimlama, resolver'lar ve performans optimizasyonu ile esnek veri sorgulama katmani olusturur.
+The GraphQL API design and development skill. Builds a flexible data-query layer with schema definitions, resolvers, and performance optimization.
 
 ---
 
-### veritabani-tasarimi
-Veritabani sema ve mimari tasarlama becerisi. Iliskisel ve NoSQL veritabanlari icin normalizasyon, indeksleme ve performans optimizasyonu yapar.
+### database-design
+The database schema and architecture design skill. Runs normalization, indexing, and performance optimization for relational and NoSQL databases.
 
 ---
 
-### mikro-servis-mimari
-Mikro servis mimarisi tasarlama ve uygulama becerisi. Servis ayrimi, iletisim kaliplari ve orkestrasyon ile olceklenebilir sistemler kurar.
+### microservice-architecture
+The microservice architecture design and implementation skill. Builds scalable systems with service decomposition, communication patterns, and orchestration.
 
 ---
 
 ### ci-cd-pipeline
-Surekli entegrasyon ve surekli dagitim pipeline'i kurma becerisi. Otomatik build, test ve dagitim adimlari ile hizli ve guvenli yazilim tesliimi saglar.
+The CI/CD pipeline setup skill. Delivers fast, safe software delivery with automated build, test, and deploy steps.
 
 ---
 
-### docker-container
-Docker container'lari ile uygulama paketleme ve dagitim becerisi. Dockerfile olusturma, imaj optimizasyonu ve container orkestrasyon yapar.
+### docker-containers
+The app packaging and deployment skill with Docker containers. Runs Dockerfile authoring, image optimization, and container orchestration.
 
 ---
 
-### kubernetes-yonetimi
-Kubernetes cluster yonetimi ve uygulama dagitimi becerisi. Pod, servis, deployment ve ingress yapilandirmalarilyla container orkestrasyon saglar.
+### kubernetes-management
+The Kubernetes cluster management and app deployment skill. Delivers container orchestration with pod, service, deployment, and ingress configuration.
 
 ---
 
-### git-is-akisi
-Git versiyon kontrol is akisi tasarlama becerisi. Dallanma stratejisi, inceleme sureci ve birlestirme politikalari ile etkili takim is birligi saglar.
+### git-workflow
+The git version-control workflow design skill. Delivers effective team collaboration with branching strategy, review process, and merge policies.
 
 ---
 
-### kod-inceleme
-Kod inceleme sureci tasarlama ve uygulama becerisi. Inceleme kontrol listesi, geri bildirim kaliplari ve kalite standartlari ile etkili kod incelemeleri yapar.
+### code-review
+The code-review process design and execution skill. Runs effective reviews with checklists, feedback patterns, and quality standards.
 
 ---
 
-### birim-test
-Birim test yazma ve yonetme becerisi. Test stratejisi, test kaliplari ve kapsam olcumu ile guvenilir test suite olusturur.
+### unit-testing
+The unit-test writing and management skill. Builds a reliable test suite with test strategy, test patterns, and coverage measurement.
 
 ---
 
-### entegrasyon-testi
-Entegrasyon testi tasarlama ve uygulama becerisi. Bilesenler arasi etkilesim, API ve veritabani testleri ile sistem butünlügünü dogrulamar.
+### integration-testing
+The integration-test design and execution skill. Verifies system integrity with inter-component, API, and database tests.
 
 ---
 
-### performans-optimizasyonu
-Uygulama performans analizi ve optimizasyon becerisi. Profilleme, darbogazs tespiti ve optimizasyon teknikleri ile uygulama hizini arttirir.
+### performance-optimization
+The application performance analysis and optimization skill. Raises app speed with profiling, bottleneck detection, and optimization techniques.
 
 ---
 
-### guvenlik-kodlama
-Guvenli kodlama pratikleri uygulama becerisi. OWASP Top 10, girdi dogrulama ve yetkilendirme kaliplari ile guvenli yazilim gelistirir.
+### secure-coding
+The secure-coding practices skill. Develops secure software with OWASP Top 10, input validation, and authorization patterns.
 
 ---
 
-### api-entegrasyon
-Ucuncu parti API'leri entegre etme becerisi. Kimlik dogrulama, hata yonetimi ve veri donusumu ile güvenilir dis servis entegrasyonlari yapar.
+### api-integration
+The third-party API integration skill. Builds reliable external integrations with authentication, error handling, and data transformation.
 
 ---
 
-### veritabani-goc
-Veritabani sema degisikliklerini yonetme becerisi. Goc dosyalari, versiyon kontrol ve geri dondurmem ile güvenli veritabani evrimi saglar.
+### database-migrations
+The database schema-change management skill. Delivers safe database evolution with migration files, version control, and rollbacks.
 
 ---
 
-### hata-yonetimi
-Uygulama hata yonetimi stratejisi tasarlama becerisi. Hata siniflandirma, loglama ve kullanici bilgilendirme ile saglamm hata islelme mekanizmalari kurar.
+### error-handling
+The application error-handling strategy skill. Builds robust handling mechanisms with error classification, logging, and user communication.
 
 ---
 
-### onbellekleme-stratejisi
-Uygulama onbellekleme stratejisi tasarlama becerisi. Redis, CDN ve uygulama ici onbellek ile yanit surelerini azaltir ve sunucu yukunu hafifletir.
+### caching-strategy
+The application caching-strategy skill. Cuts response times and server load with Redis, CDN, and in-app caches.
 
 ---
 
-### websocket-gelistirme
-Gercek zamanli WebSocket iletisimi gelistirme becerisi. Cift yonlu baglanti, oda yonetimi ve mesaj protokolu ile canli veri akisi saglar.
+### websocket-development
+The real-time WebSocket development skill. Delivers live data flow with bidirectional connections, room management, and message protocols.
 
 ---
 
-### oturum-yonetimi
-Kullanici oturm ve kimlik dogrulama sistemi gelistirme becerisi. JWT, OAuth ve oturum yonetim kaliplari ile guvenli kimlik dogrulama saglar.
+### session-management
+The user session and authentication system skill. Delivers secure auth with JWT, OAuth, and session-management patterns.
 
 ---
 
-### dosya-yukleme-sistemi
-Dosya yukleme ve yonetim sistemi gelistirme becerisi. Boyut siniri, tip dogrulama, depolama ve CDN entegrasyonu ile guvenli dosya isleme saglar.
+### file-upload-system
+The file upload and management system skill. Delivers safe file handling with size limits, type validation, storage, and CDN integration.
 
 ---
 
-### arama-motoru-entegrasyonu
-Uygulama ici arama islevseligi gelistirme becerisi. Elasticsearch, Algolia veya Meilisearch ile hizli ve ilgili arama sonuclari saglar.
+### search-integration
+The in-app search functionality skill. Delivers fast, relevant results with Elasticsearch, Algolia, or Meilisearch.
 
 ---
 
-### bildirim-sistemi
-Uygulama bildirim sistemi gelistirme becerisi. E-posta, push, SMS ve in-app bildirimler ile cok kanalli bildirim altyapisi kurar.
+### notification-system
+The application notification-system skill. Builds multi-channel infrastructure with email, push, SMS, and in-app notifications.
 
 ---
 
-### odeme-entegrasyonu
-Odeme sistemi entegrasyonu geclistirme becerisi. Stripe, PayPal ve yerel odeme yontemleri ile guvenli odeme isleme altyapisi kurar.
+### payment-integration
+The payment-system integration skill. Builds secure payment-processing infrastructure with Stripe, PayPal, and local methods.
 
 ---
 
-### e-posta-servisi
-E-posta gonderim servisi gelistirme becerisi. Transaksiyonel ve pazarlama e-postalari icin guvenilir e-posta altyapisi kurar.
+### email-service
+The email-delivery service skill. Builds reliable email infrastructure for transactional and marketing mail.
 
 ---
 
-### log-yonetimi
-Uygulama log yonetim sistemi tasarlama becerisi. Yapilandirilmis loglama, toplama ve analiz ile etkili hata ayiklama ve izleme saglar.
+### log-management
+The application log-management design skill. Delivers effective debugging and observability with structured logging, aggregation, and analysis.
 
 ---
 
-### izleme-ve-alarm
-Uygulama ve altyapi izleme sistemi kurma becerisi. Metrik toplama, gorsellesirme ve alarm mekanizmalari ile proaktif sorun tespiti saglar.
+### monitoring-alerting
+The application and infrastructure monitoring skill. Delivers proactive problem detection with metric collection, visualization, and alerting.
 
 ---
 
-### kod-kalite-araci
-Kod kalite arac ve surec kurulumu becerisi. Linter, formatter ve statik analiz araclari ile tutarli ve kaliteli kod tabani saglar.
+### code-quality-tooling
+The code-quality tool and process setup skill. Delivers a consistent, high-quality codebase with linters, formatters, and static analysis.
 
 ---
 
-### teknik-borc-yonetimi
-Teknik borcu belirleme, onceliklendirme ve azaltma becerisi. Kod saglik metrikleri ve refactoring stratejisi ile surdurulebilir kod tabani yonetir.
+### tech-debt-management
+The skill of identifying, prioritizing, and reducing technical debt. Manages a sustainable codebase with code-health metrics and a refactoring strategy.
 
 ---
 
-### monorepo-yonetimi
-Monorepo yapiis tasarlama ve yonetme becerisi. Paylasilam bagimlliklar, workspace'ler ve secici build stratejileri ile verimli monorepo operasyonu saglar.
+### monorepo-management
+The monorepo design and management skill. Delivers efficient monorepo operations with shared dependencies, workspaces, and selective build strategies.
 
 ---
 
-### state-yonetimi
-Uygulama durum yonetimi stratejisi tasarlama becerisi. Yerel ve global durum, sunucu durumu ve URL durumu ile etkili veri yonetimi saglar.
+### state-management
+The application state-management strategy skill. Delivers effective data management across local, global, server, and URL state.
 
 ---
 
-### serverless-gelistirme
-Serverless mimari ile uygulama gelistirme becerisi. AWS Lambda, Vercel Functions veya Cloudflare Workers ile sunucu yonetimi gerektirmeyen uygulamalar olusturur.
+### serverless-development
+The serverless development skill. Builds apps requiring no server management with AWS Lambda, Vercel Functions, or Cloudflare Workers.
 
 ---
 
 ### progressive-web-app
-Progressive Web App (PWA) gelistirme becerisi. Service worker, cevrimdisi destek ve push bildirim ile yerele benzer web uygulamalari olusturur.
+The Progressive Web App (PWA) skill. Builds native-like web apps with service workers, offline support, and push notifications.
 
 ---
 
-### accessibility-gelistirme
-Web erisilebilirlik gelistirme becerisi. ARIA rolleri, klavye navigasyonu ve ekran okuyucu uyumlulugu ile herkes icin eriselebilir uygulamalar gelisitrir.
+### accessibility-development
+The web-accessibility development skill. Builds apps usable by everyone with ARIA roles, keyboard navigation, and screen-reader compatibility.
 
 ---
 
-### internasyonalizasyon
-Cok dilli uygulama gelistirme (i18n) becerisi. Dil dosyalari, format lokalizasyonu ve RTL destegi ile uluslararasi kullanim icin uygun uygulamalar olusturur.
+### internationalization
+The multi-language app development (i18n) skill. Builds apps fit for international use with language files, format localization, and RTL support.
 
 ---
 
-### web-performans
-Web uygulama performans optimizasyonu becerisi. Core Web Vitals, yukleme hizi ve calisma zamanli performans ile hizli web deneyimleri saglar.
+### web-performance
+The web performance optimization skill. Delivers fast experiences via Core Web Vitals, load speed, and runtime performance.
 
 ---
 
-### test-stratejisi
-Kapsamli test stratejisi tasarlama becerisi. Test piramidi, otomasyon seviyesi ve arac secimi ile etkili kalite guvence sureci olusturur.
+### test-strategy
+The comprehensive test-strategy design skill. Builds an effective QA process with the test pyramid, automation level, and tool selection.
 
 ---
 
-### veritabani-optimizasyonu
-Veritabani sorgu ve performans optimizasyonu becerisi. Yavas sorgu analizi, indeks optimizasyonu ve sema iyilestirme ile veritabani performansini arttirir.
+### database-optimization
+The database query and performance optimization skill. Raises database performance with slow-query analysis, index optimization, and schema improvement.
 
 ---
 
-### devops-pratikleri
-DevOps kulturunu ve pratiklerini uygulama becerisi. Altyapi kodu (IaC), otomasyon ve isbirligi ile hizli ve guvenilir yazilim teslimi saglar.
+### devops-practices
+The DevOps culture and practices skill. Delivers fast, reliable delivery with infrastructure as code, automation, and collaboration.
 
 ---
 
 ### refactoring
-Kod refactoring stratejisi ve uygulamasi becerisi. Kod kokularinin tespiti, refactoring kaliplari ve guvenli donusum ile kod kalitesini arttirir.
+The code-refactoring strategy and execution skill. Raises code quality with smell detection, refactoring patterns, and safe transformation.
 
 ---
 
-### yazilim-mimari
-Yazilim mimarisi tasarlama becerisi. Mimari kaliplar, bilesen yapisi ve teknik kararlar ile saglam ve surudrülebilir sistemler tasarlar.
+### software-architecture
+The software-architecture design skill. Designs solid, sustainable systems with architectural patterns, component structure, and technical decisions.
 
 ---
 
 ### mobile-backend
-Mobil uygulama backend servisleri gelistirme becerisi. Push bildirim, cevrimdisi senkronizasyon ve mobil-spesifik API'ler ile mobil destek altyapisi kurar.
+The mobile-app backend services skill. Builds the mobile support infrastructure with push, offline sync, and mobile-specific APIs.
 
 ---
 
-### task-kuyruk-sistemi
-Arka plan gorev kuyrugu sistemi gelistirme becerisi. Asenkron is isleme, onceliklendirme ve yeniden deneme mekanizmalari ile guvenilir gorev isleme saglar.
+### task-queue-system
+The background task-queue system skill. Delivers reliable job processing with async work, prioritization, and retry mechanisms.
 
 ---
 
-### event-driven-mimari
-Olay guddumlu mimari tasarlama becerisi. Olay yayinlama, abonelik ve isleme kaliplari ile gevseek bagli ve olceklenebilir sistemler olusturur.
+### event-driven-architecture
+The event-driven architecture design skill. Builds loosely coupled, scalable systems with event publishing, subscription, and processing patterns.
 
 ---
 
-### api-versiyonlama
-API versiyonlama stratejisi tasarlama becerisi. Geri uyumluluk, kullanim disi birakma surecleri ve goc kilavuzlari ile surdurulebilir API evrimi saglar.
+### api-versioning
+The API versioning strategy skill. Delivers sustainable API evolution with backward compatibility, deprecation processes, and migration guides.
 
 ---
 
-### veritabani-replikasyonu
-Veritabani replikasyon ve yuksek erisilebirlik becerisi. Master-slave, multi-master ve read replica yapilandirmalari ile veri dayanikliligi saglar.
+### database-replication
+The database replication and high-availability skill. Delivers data durability with master-slave, multi-master, and read-replica setups.
 
 ---
 
 ### api-gateway
-API gateway tasarlama ve yapilandirma becerisi. Yonlendirme, kimlik dogrulama, rate limiting ve transformasyon ile merkezi API yonetimi saglar.
+The API gateway design and configuration skill. Delivers centralized API management with routing, auth, rate limiting, and transformation.
 
 ---
 
-### feature-flag
-Ozellik bayrak (feature flag) sistemi tasarlama becerisi. Kontrollü yayinlama, A/B test ve acil kapatma ile guvenli ozellik yonetimi saglar.
+### feature-flags
+The feature-flag system design skill. Delivers safe feature management with controlled rollout, A/B tests, and kill switches.
 
 ---
 
-### e2e-test
-Uclarasi (end-to-end) test otomasyon becerisi. Kullanici senaryolarini basindan sonuna test ederek sistem butunlugunu dogrular.
+### e2e-testing
+The end-to-end test automation skill. Verifies system integrity by testing user scenarios from start to finish.
 
 ---
 
-### oauth-entegrasyon
-OAuth 2.0 ve sosyal giris entegrasyonu becerisi. Google, GitHub, Apple giris saglayicilari ile guvenli ucuncu parti kimlik dogrulama saglar.
+### oauth-integration
+The OAuth 2.0 and social-login integration skill. Delivers secure third-party auth with Google, GitHub, and Apple sign-in providers.
 
 ---
 
 ### rate-limiting
-API rate limiting ve kotlama sistemi gelistirme becerisi. Istek siniri, pencere stratejisi ve kullanici bazli kota ile API korumasii saglar.
+The API rate limiting and quota system skill. Protects the API with request limits, window strategies, and per-user quotas.
 
 ---
 
-### ssl-tls-yapilandirma
-SSL/TLS sertifika yonetimi ve yapilandirma becerisi. Sertifika temini, yenileme ve guvenlik yapilandirmasi ile sifrelenmis iletisim saglar.
+### ssl-tls-configuration
+The SSL/TLS certificate management and configuration skill. Delivers encrypted communication with certificate provisioning, renewal, and security tuning.
 
 ---
 
-### multi-tenant-mimari
-Cok kiraciili (multi-tenant) uygulama mimarisi tasarlama becerisi. Veri izolasyonu, kimlik yonetimi ve kiracii bazli yapilandirma ile SaaS uygulamalar olusturur.
+### multi-tenant-architecture
+The multi-tenant application architecture skill. Builds SaaS apps with data isolation, identity management, and per-tenant configuration.
 
 ---
 
-### webhook-sistemi
-Webhook tasarlama ve uygulama becerisi. Olay bildirimi, guvenlik dogrulama ve yeniden deneme mekanizmalari ile guvenilir webhook altyapisi olusturur.
+### webhook-system
+The webhook design and implementation skill. Builds reliable webhook infrastructure with event notification, security verification, and retries.
 
 ---
 
-### cdn-yapilandirma
-CDN yapilandirma ve optimizasyon becerisi. Statik icerik dagiitmi, onbellekleme kurallari ve guvenlik ayarlari ile hizli icerik teslimi saglar.
+### cdn-configuration
+The CDN configuration and optimization skill. Delivers fast content with static distribution, caching rules, and security settings.
 
 ---
 
-### migration-stratejisi
-Uygulama ve platform goc stratejisi tasarlama becerisi. Eski sistemden yeni sisteme guvenli ve kesintisiz gecis planlmasi yapar.
+### migration-strategy
+The application and platform migration strategy skill. Plans safe, seamless transitions from the old system to the new one.
 
 ---
 
-### teknik-dokumantasyon
-Teknik dokumantasyon olusturma ve yonetme becerisi. Mimari belgeler, API referanslari ve gelistirici kilavuzlari ile bilgi paylasimi saglar.
+### technical-documentation
+The technical documentation creation and management skill. Delivers knowledge sharing with architecture docs, API references, and developer guides.
 
 ---
 
 ### disaster-recovery
-Felaket kurtarma plani tasarlama becerisi. Yedekleme, geri yukleme ve is surekliligi stratejileri ile veri ve hizmet kaybi riskini minimize eder.
+The disaster-recovery planning skill. Minimizes data- and service-loss risk with backup, restore, and business-continuity strategies.
 
 ---
 
 ### load-testing
-Yuk testi planlama ve yurutme becerisi. Kapasite, dayaniklilk ve stres testleri ile sistemin yuk altindaki davranisini olcer.
+The load-test planning and execution skill. Measures the system's behavior under load with capacity, endurance, and stress tests.
 
 ---
 
 ### error-tracking
-Hata izleme sistemi kurma becerisi. Sentry, Bugsnag veya ozel cozumlerle uretim hatalarini yakalama, gruplama ve bildirim saglar.
+The error-tracking system skill. Delivers production error capture, grouping, and notification with Sentry, Bugsnag, or custom solutions.
 
 ---
 
 ### security-audit
-Yazilim guvenlik denetimi becerisi. Kod taramasi, bagimlilik kontrolu ve penetrasyon testi ile guvenlik aciklari tespit eder ve duzeltir.
+The software security audit skill. Finds and fixes vulnerabilities with code scanning, dependency checks, and penetration testing.
 
 ---
 
-### uygulama-olcekleme
-Uygulama olcekleme stratejisi tasarlama becerisi. Yatay ve dikey olcekleme, otomatik olcekleme ve yuk dengeleme ile trafik artisina hazirlkli olmak saglar.
+### application-scaling
+The application scaling strategy skill. Prepares for traffic growth with horizontal and vertical scaling, auto-scaling, and load balancing.
 
 ---
 
-### altyapi-kodlama
-Altyapi kodu (Infrastructure as Code) ile bulut kaynaklarini yonetme becerisi. Terraform, Pulumi veya CDK ile tekrarlanabilir altyapi provizyon saglar.
+### infrastructure-as-code
+The skill of managing cloud resources with Infrastructure as Code. Delivers repeatable provisioning with Terraform, Pulumi, or CDK.
 
 ---
 
-### veri-yedekleme
-Veri yedekleme ve geri yukleme sistemi tasarlama becerisi. Otomatik yedekleme, depolama yonetimi ve geri yukleme testi ile veri guvenligi saglar.
+### data-backup
+The data backup and restore system design skill. Delivers data safety with automated backups, storage management, and restore testing.
 
 ---
 
-### api-dokumantasyon-gelistirme
-API dokumantasyon aracilari kurma ve yonetme becerisi. Swagger UI, Redoc veya ozel portal ile gelistirici dostu API belgeleri yayinlar.
+### api-documentation-tooling
+The API documentation tooling skill. Publishes developer-friendly API docs with Swagger UI, Redoc, or a custom portal.
 
 ---
 
-### dependency-yonetimi
-Proje bagimlilik yonetimi becerisi. Bagimlilik guncelleme, guvenlik taramasi ve versiyon politikasi ile saglikli bagimlilik yonetimi saglar.
+### dependency-management
+The project dependency-management skill. Delivers healthy dependencies with updates, security scans, and version policies.
 
 ---
 
-### gelistirici-deneyimi
-Gelistirici deneyimi (DX) iyilestirme becerisi. Aracc, surec ve dokumantasyon optimizasyonu ile gelistirici verimliligi ve memnuniyetini arttirir.
+### developer-experience
+The developer experience (DX) improvement skill. Raises developer productivity and satisfaction by optimizing tools, processes, and docs.
 
 ---
 
-### grpc-gelistirme
-gRPC servis gelistirme becerisi. Protocol Buffer tanimlari, streaming ve hata yonetimi ile yuksek performansli RPC servisleri olusturur.
+### grpc-development
+The gRPC service development skill. Builds high-performance RPC services with Protocol Buffer definitions, streaming, and error handling.
 
 ---
 
-### graphql-subscription
-GraphQL subscription ve gercek zamanli veri akisi gelistirme becerisi. WebSocket tabanli abonelikler ile canli veri guncelemeleri saglar.
+### graphql-subscriptions
+The GraphQL subscription and real-time data skill. Delivers live updates with WebSocket-based subscriptions.
 
 ---
 
-### cqrs-mimari
-CQRS (Command Query Responsibility Segregation) mimari kalibini uygulama becerisi. Okuma ve yazma islemlerini ayirarak olceklenebilirlik ve performans saglar.
+### cqrs-architecture
+The CQRS (Command Query Responsibility Segregation) pattern skill. Delivers scalability and performance by separating reads and writes.
 
 ---
 
 ### saga-pattern
-Dagitik islem yonetimi icin Saga kalibini uygulama becerisi. Mikro servisler arasi tutarlilik ve telafi islemleri ile veri butunlugu saglar.
+The Saga pattern skill for distributed transaction management. Delivers data integrity with cross-microservice consistency and compensation.
 
 ---
 
 ### full-text-search
-Tam metin arama sistemi gelistirme becerisi. Indeksleme, tokenizasyon ve relevans puanlama ile gelismis metin arama yetenklerli saglar.
+The full-text search system skill. Delivers advanced text-search capabilities with indexing, tokenization, and relevance scoring.
 
 ---
 
-### idempotentlik-tasarimi
-API ve islem idempotentligi tasarlama becerisi. Tekrarlanan isteklerin guvenli sekilde islenmesini saglayarak veri tutarliligi korur.
+### idempotency-design
+The API and operation idempotency design skill. Protects data consistency by handling repeated requests safely.
 
 ---
 
 ### circuit-breaker
-Circuit breaker kalibini uygulama becerisi. Hata toleransi, gecici devre kesme ve otomatik kurtarma ile dayanikli servis cagrilari saglar.
+The circuit-breaker pattern skill. Delivers resilient service calls with fault tolerance, temporary circuit opening, and auto-recovery.
 
 ---
 
 ### database-connection-pooling
-Veritabani baglanti havuzu yonetimi becerisi. Baglanti sayisi, zaman asimi ve saglik kontrolu ayarlariyla veritabani performansini optimize eder.
+The database connection-pool management skill. Optimizes database performance with connection counts, timeouts, and health checks.
 
 ---
 
 ### blue-green-deployment
-Blue-green dagitim stratejisi uygulama becerisi. Sifir kesinti ile uretim guncellemesi ve aninda geri dondurme yetenlegi saglar.
+The blue-green deployment strategy skill. Delivers zero-downtime production updates with instant rollback capability.
 
 ---
 
 ### canary-release
-Canary surum stratejisi uygulama becerisi. Kademeli trafik yonlendirme ve metrik izleme ile dusuk riskli uretim guncellemeleri saglar.
+The canary release strategy skill. Delivers low-risk production updates with gradual traffic shifting and metric monitoring.
 
 ---
 
-### tasarim-kaliplari-olusum
-Creational tasarim kaliplarini uygulama becerisi. Factory Method, Abstract Factory, Builder, Singleton ve Prototype kaliplarini projede dogru yerlerde kullanmayi saglar.
+### design-patterns-creational
+The creational design-pattern skill. Applies Factory Method, Abstract Factory, Builder, Singleton, and Prototype in the right places.
 
 ---
 
-### tasarim-kaliplari-yapisal
-Structural tasarim kaliplarini uygulama becerisi. Adapter, Bridge, Composite, Decorator, Facade, Proxy kaliplarini var olan sistemlere entegre etmeyi saglar.
+### design-patterns-structural
+The structural design-pattern skill. Integrates Adapter, Bridge, Composite, Decorator, Facade, and Proxy into existing systems.
 
 ---
 
-### tasarim-kaliplari-davranissal
-Behavioral tasarim kaliplarini uygulama becerisi. Observer, Strategy, Command, State, Chain of Responsibility kaliplarini is mantigi icin kullanmayi saglar.
+### design-patterns-behavioral
+The behavioral design-pattern skill. Uses Observer, Strategy, Command, State, and Chain of Responsibility for business logic.
 
 ---
 
-### ddd-tasarim
-Domain-Driven Design kaliplarini uygulama becerisi. Aggregate, Entity, Value Object, Domain Event, Repository, Bounded Context kaliplarini is alanina uygun modellemede kullanir.
+### ddd-design
+The Domain-Driven Design pattern skill. Uses Aggregate, Entity, Value Object, Domain Event, Repository, and Bounded Context for domain-fit modeling.
 
 ---
 
 ### clean-architecture
-Clean Architecture / Hexagonal Architecture uygulama becerisi. Katmanli mimari ile is mantigini altyapidan izole eder, test edilebilirligi arttirir.
+The Clean Architecture / Hexagonal Architecture skill. Isolates business logic from infrastructure with layered architecture, raising testability.
 
 ---
 
-### kod-kokusu-tespiti
-Sistematik kod kokusu tespit ve duzeltme becerisi. Martin Fowler'in katalogunu temel alarak uzun metod, buyuk sinif, kiskanclik gibi kokulari tespit eder.
+### code-smell-detection
+The systematic code-smell detection and fixing skill. Finds long methods, large classes, feature envy, and more, based on Martin Fowler's catalog.
 
 ---
 
 ### guard-clause-refactoring
-Guard clause ile ic ice kosul sadselestirme becerisi. Derin nesting'i early return kaliplariyla okunabilir hale getirir.
+The guard-clause conditional simplification skill. Makes deep nesting readable with early-return patterns.
 
 ---
 
-### retry-ve-dayaniklilik
-Retry, circuit breaker ve graceful degradation kaliplarini uygulama becerisi. Dagilmis sistemlerde hata toleransini arttirir.
+### retry-and-resilience
+The retry, circuit-breaker, and graceful-degradation pattern skill. Raises fault tolerance in distributed systems.
 
 ---
 
-### veritabani-sharding
-Veritabani sharding stratejisi tasarlama becerisi. Buyuk veri setlerini yatay bolumleyerek olceklendirir.
+### database-sharding
+The database-sharding strategy skill. Scales by partitioning large datasets horizontally.
 
 ---
 
-### event-sourcing-uygulama
-Event sourcing mimarisini uygulama becerisi. Durum degisikliklerini olay akisi olarak kaydeder, zaman yolculugu ve denetim izi saglar.
+### event-sourcing
+The event-sourcing architecture skill. Records state changes as an event stream, enabling time travel and an audit trail.
 
 ---
 
-### gozlemlenebilirlik-mimari
-Metrics, traces ve logs'un korelasyonuyla tam gozlemlenebilirlik mimarisi kurma becerisi.
+### observability-architecture
+The skill of building full observability through correlated metrics, traces, and logs.
 
 ---
 
 ### contract-testing
-API sozlesme testi uygulama becerisi. Servisler arasi sozlesme uyumunu surekli dogrular, kirilma degisikliklerini erken yakalar.
+The API contract-testing skill. Continuously verifies inter-service contract compliance, catching breaking changes early.
 
 ---
 
 ### mutation-testing
-Mutation testing ile test kalitesini olcme becerisi. Testlerin gercekten hata yakalayip yakalamadini dogrular.
+The mutation-testing skill for measuring test quality. Verifies whether tests actually catch faults.
 
 ---
 
 ### zero-downtime-deployment
-Sifir kesinti ile dagitim stratejileri uygulama becerisi. Blue-green, canary, rolling update kaliplarini kapsar.
+The zero-downtime deployment strategies skill. Covers blue-green, canary, and rolling-update patterns.
 
 ---
 
 ### secret-management
-Gizli bilgi yonetimi becerisi. API anahtarlari, sertifikalar ve parolalarin guvenli depolanmasi, dagitilmasi ve rotasyonunu kapsar.
+The secrets-management skill. Covers secure storage, distribution, and rotation of API keys, certificates, and passwords.
 
 ---
 
-### kod-uretimi-openapi
-OpenAPI/Swagger semasindan kod uretimi becerisi. API istemci ve sunucu stublari, tip tanimlari ve validator'lar uretir.
+### code-generation-openapi
+The code generation from OpenAPI/Swagger schemas skill. Produces API client and server stubs, type definitions, and validators.
 
 ---
 
-### adr-yazimi
-Architecture Decision Record yazma becerisi. Onemli teknik kararlari baglamlari ve alternatifleriyle birlikte belgeler.
+### adr-writing
+The Architecture Decision Record writing skill. Documents important technical decisions with their context and alternatives.
 
 ---
 
-### postmortem-yazimi
-Olay sonrasi analiz raporu yazma becerisi. Suclamayan, ogrenme odakli dil ile kok neden analizi ve aksiyon maddelerini belgeler.
+### postmortem-writing
+The post-incident analysis report skill. Documents root-cause analysis and action items in blameless, learning-focused language.
 
 ---
 
-### runbook-olusturma
-Operasyonel runbook yazma becerisi. Tekrarlayan operasyon gorevleri ve olay mudahalesi icin adim adim kilavuzlar olusturur.
-
+### runbook-creation
+The operational runbook writing skill. Builds step-by-step guides for recurring operational tasks and incident response.

--- a/.claude/skills-vault/devops/SKILL.md
+++ b/.claude/skills-vault/devops/SKILL.md
@@ -10,256 +10,255 @@ metadata:
   badi-version: ">=1.14.0"
   category: devops
 ---
-# DevOps Becerileri
-Bu dosya, CI/CD, container yonetimi, bulut mimarisi, izleme, guvenlik ve altyapi otomasyonu alanlarindaki tum becerileri icerir.
+# DevOps Skills
+This file contains all the skills across CI/CD, container management, cloud architecture, monitoring, security, and infrastructure automation.
 
 ---
 
-### ci-cd-tasarimi
-Surekli entegrasyon ve surekli dagitim (CI/CD) pipeline mimarisini tasarlar ve uygular.
+### ci-cd-design
+Designs and implements the continuous integration and continuous deployment (CI/CD) pipeline architecture.
 
 ---
 
-### pipeline-optimizasyonu
-Mevcut CI/CD pipeline performansini analiz ederek hiz ve guvenilirlik optimizasyonu yapar.
+### pipeline-optimization
+Optimizes speed and reliability by analyzing existing CI/CD pipeline performance.
 
 ---
 
-### container-orkestrasyonu
-Container'lari olcekli ortamlarda yonetmek icin orkestrasyon stratejisi ve altyapisi kurar.
+### container-orchestration
+Builds the orchestration strategy and infrastructure for managing containers at scale.
 
 ---
 
-### kubernetes-yonetimi
-Kubernetes cluster kurulumu, yapilandirmasi ve gunluk operasyonlarini yonetir.
+### kubernetes-management
+Manages Kubernetes cluster setup, configuration, and day-to-day operations.
 
 ---
 
-### docker-en-iyi-uygulamalar
-Docker image olusturma, boyut optimizasyonu ve guvenlik en iyi uygulamalarini uygular.
+### docker-best-practices
+Applies best practices for Docker image building, size optimization, and security.
 
 ---
 
-### altyapi-kod-olarak
-Infrastructure as Code (IaC) yaklasimiyla altyapi yonetimini kod tabanli hale getirir.
+### infrastructure-as-code
+Makes infrastructure management code-based with the Infrastructure as Code (IaC) approach.
 
 ---
 
-### terraform-moduller
-Yeniden kullanilabilir Terraform modulleri tasarlayarak altyapi standardizasyonu saglar.
+### terraform-modules
+Standardizes infrastructure by designing reusable Terraform modules.
 
 ---
 
-### ansible-playbook
-Ansible playbook'lar ile sunucu yapilandirma ve uygulama dagitim otomasyonu olusturur.
+### ansible-playbooks
+Builds server configuration and app deployment automation with Ansible playbooks.
 
 ---
 
-### bulut-mimarisi
-Olceklenebilir, guvenli ve maliyet-etkin bulut mimarisi tasarlar.
+### cloud-architecture
+Designs scalable, secure, cost-effective cloud architecture.
 
 ---
 
-### aws-optimizasyonu
-AWS hizmetlerinin maliyet, performans ve guvenlik optimizasyonunu yapar.
+### aws-optimization
+Optimizes AWS services for cost, performance, and security.
 
 ---
 
-### azure-yonetimi
-Microsoft Azure platformundaki kaynaklari etkili yonetir ve optimize eder.
+### azure-management
+Manages and optimizes resources on the Microsoft Azure platform effectively.
 
 ---
 
-### gcp-mimarisi
-Google Cloud Platform uzerinde olceklenebilir ve maliyet-etkin mimari tasarlar.
+### gcp-architecture
+Designs scalable, cost-effective architecture on Google Cloud Platform.
 
 ---
 
-### coklu-bulut
-Birden fazla bulut saglayicisi ile coklu bulut (multi-cloud) stratejisi tasarlar.
+### multi-cloud
+Designs a multi-cloud strategy across multiple cloud providers.
 
 ---
 
-### sunucusuz-mimari
-Serverless mimarisi ile olceklenebilir ve maliyet-etkin uygulamalar tasarlar.
+### serverless-architecture
+Designs scalable, cost-effective applications with serverless architecture.
 
 ---
 
-### mikroservis-dagitimi
-Mikroservis mimarisinde dagitim stratejileri ve orkestrasyonu yonetir.
+### microservice-deployment
+Manages deployment strategies and orchestration in a microservice architecture.
 
 ---
 
-### servis-mesh
-Service mesh altyapisi kurarak mikroservisler arasi iletisimi, guvenligi ve gozlemlenebilirligi saglar.
+### service-mesh
+Provides inter-microservice communication, security, and observability by building service-mesh infrastructure.
 
 ---
 
 ### api-gateway
-API Gateway yapilandirmasi ile API trafik yonetimi, guvenlik ve rate limiting uygular.
+Applies API traffic management, security, and rate limiting through API Gateway configuration.
 
 ---
 
 ### load-balancing
-Yuk dengeleme stratejisi tasarlayarak trafigi sunucular arasinda optimal dagitir.
+Distributes traffic optimally across servers by designing the load-balancing strategy.
 
 ---
 
-### otomatik-olceklendirme
-Otoomatik olceklendirme (auto-scaling) politikalari tasarlayarak kaynak verimliligi saglar.
+### auto-scaling
+Delivers resource efficiency by designing auto-scaling policies.
 
 ---
 
-### izleme-strateji
-Kapsamli altyapi ve uygulama izleme stratejisi tasarlar ve uygular.
+### monitoring-strategy
+Designs and implements a comprehensive infrastructure and application monitoring strategy.
 
 ---
 
 ### prometheus-grafana
-Prometheus ile metrik toplama ve Grafana ile gorselllestirme altyapisini kurar.
+Builds metric collection with Prometheus and visualization with Grafana.
 
 ---
 
-### log-toplama
-Merkezi log toplama, isleme ve analiz altyapisi kurar.
+### log-aggregation
+Builds centralized log collection, processing, and analysis infrastructure.
 
 ---
 
 ### elk-stack
-Elasticsearch, Logstash, Kibana (ELK) stack ile log yonetim altyapisi kurar.
+Builds log-management infrastructure with the Elasticsearch, Logstash, Kibana (ELK) stack.
 
 ---
 
-### alarm-tasarimi
-Anlamli ve aksiyona donusturulebilir alarm sistemi tasarlar.
+### alert-design
+Designs a meaningful, actionable alerting system.
 
 ---
 
-### olay-yonetimi
-IT olay yonetim surecini tasarlayarak kesinti surelerini minimize eder.
+### incident-management
+Minimizes downtime by designing the IT incident-management process.
 
 ---
 
-### on-call-rotasyonu
-Nobetci muhendis rotasyon sistemi tasarlayarak 7/24 destek saglar.
+### on-call-rotation
+Provides 24/7 coverage by designing the on-call engineer rotation system.
 
 ---
 
-### runbook-olusturma
-Tekrarlanabilir operasyonel gorevler icin adim adim runbook dokumanlari olusturur.
+### runbook-creation
+Creates step-by-step runbook documents for repeatable operational tasks.
 
 ---
 
-### kaos-muhendisligi
-Chaos Engineering pratikleri ile sistem dayanikliligini test eder ve iyilestirir.
+### chaos-engineering
+Tests and improves system resilience with Chaos Engineering practices.
 
 ---
 
-### felaket-kurtarma
-Felaket kurtarma (disaster recovery) plani olusturarak is surekliligi saglar.
+### disaster-recovery
+Ensures business continuity by building a disaster recovery plan.
 
 ---
 
-### yedekleme-strateji
-Veri yedekleme stratejisi tasarlayarak veri kaybini onler.
+### backup-strategy
+Prevents data loss by designing the data backup strategy.
 
 ---
 
-### guvenlik-sertlestirme
-Sunucu ve altyapi guvenlik sertlestirme (hardening) prosedurlerini uygular.
+### security-hardening
+Applies server and infrastructure security hardening procedures.
 
 ---
 
-### gizli-bilgi-yonetimi
-Sifreler, API anahtarlari ve sertifikalar gibi gizli bilgilerin guvenli yonetimini saglar.
+### secrets-management
+Provides secure management of secrets like passwords, API keys, and certificates.
 
 ---
 
-### sertifika-yonetimi
-SSL/TLS sertifikalarinin yasam dongusu yonetimini otomatiklestirir.
+### certificate-management
+Automates the SSL/TLS certificate lifecycle.
 
 ---
 
-### ag-guvenlik
-Ag mimarisi guvenligini tasarlayarak saldiri yuzeyini minimize eder.
+### network-security
+Minimizes the attack surface by designing network architecture security.
 
 ---
 
-### waf-yapilandirma
-Web Application Firewall yapilandirmasi ile web uygulamalarini saldirilardan korur.
+### waf-configuration
+Protects web applications from attacks through Web Application Firewall configuration.
 
 ---
 
-### ddos-koruma
-DDoS saldirilarina karsi koruma stratejisi ve altyapisi olusturur.
+### ddos-protection
+Builds the protection strategy and infrastructure against DDoS attacks.
 
 ---
 
-### mavi-yesil-dagitim
-Blue-green deployment stratejisi ile sifir kesinti dagitim altyapisi kurar.
+### blue-green-deployment
+Builds zero-downtime deployment infrastructure with the blue-green strategy.
 
 ---
 
-### kanarya-dagitimi
-Canary deployment ile riskleri minimize ederek kademeli dagitim yapar.
+### canary-deployment
+Performs gradual rollouts that minimize risk with canary deployments.
 
 ---
 
-### feature-flag
-Feature flag sistemi kurarak ozellik dagitimini kod dagitimlarindan ayirir.
+### feature-flags
+Decouples feature rollout from code deploys by building a feature-flag system.
 
 ---
 
-### a-b-test-altyapisi
-A/B test altyapisini tasarlayarak veri odakli karar alma kapasitesi olusturur.
+### a-b-test-infrastructure
+Builds A/B testing infrastructure enabling data-driven decision capacity.
 
 ---
 
-### performans-testi
-Uygulama performans testleri tasarlayarak performans darbogazlarini tespit eder.
+### performance-testing
+Detects performance bottlenecks by designing application performance tests.
 
 ---
 
-### yuk-testi
-Yuk testi (load test) ile sistemin kapasite sinirlarini belirler.
+### load-testing
+Determines the system's capacity limits with load tests.
 
 ---
 
-### stres-testi
-Stres testi ile sistemin asiri yuk altindaki davranisini ve kurtarma kapasitesini test eder.
+### stress-testing
+Tests the system's behavior under extreme load and its recovery capacity with stress tests.
 
 ---
 
-### maliyet-optimizasyonu
-Bulut ve altyapi maliyetlerini analiz ederek tasarruf firsatlarini belirler.
+### cost-optimization
+Identifies savings opportunities by analyzing cloud and infrastructure costs.
 
 ---
 
-### kaynak-boyutlandirma
-Bulut kaynaklarini is yuku gereksinimlerine gore dogru boyutlandirir.
+### resource-sizing
+Sizes cloud resources correctly against workload requirements.
 
 ---
 
-### spot-instance
-Spot/preemptible instance kullanarak bulut maliyetlerini dusurur.
+### spot-instances
+Cuts cloud costs by using spot/preemptible instances.
 
 ---
 
-### cdn-yapilandirma
-Content Delivery Network yapilandirmasi ile icerik dagitim performansini arttirir.
+### cdn-configuration
+Raises content-delivery performance through Content Delivery Network configuration.
 
 ---
 
-### dns-yonetimi
-DNS altyapisini guvenli ve yuksek performansli sekilde yonetir.
+### dns-management
+Manages DNS infrastructure securely and with high performance.
 
 ---
 
-### ssl-tls-yonetimi
-SSL/TLS yapilandirmasi ve sertifika yonetimi ile guvenli iletisim saglar.
+### ssl-tls-management
+Delivers secure communication through SSL/TLS configuration and certificate management.
 
 ---
 
-### uyumluluk-otomasyonu
-Yasal ve sektorel uyumluluk gereksinimlerini otomatik denetleme ile saglar.
-
+### compliance-automation
+Meets legal and industry compliance requirements through automated auditing.

--- a/.claude/skills-vault/ecommerce/SKILL.md
+++ b/.claude/skills-vault/ecommerce/SKILL.md
@@ -10,275 +10,274 @@ metadata:
   badi-version: ">=1.14.0"
   category: ecommerce
 ---
-# E-Ticaret Becerileri
-> 54 yapilandirilmis prosedur
-## Beceri Listesi
+# E-Commerce Skills
+> 54 structured procedures
+## Skill List
 
-### urun-katalogu-yonetimi
-E-ticaret urun katalogu olusturma ve yonetme becerisi. Urun bilgileri, kategoriler, varyantlar ve gorseller ile kapsamli katalog yonetimi saglar.
-
----
-
-### fiyatlandirma-yonetimi
-E-ticaret fiyatlandirma stratejisi ve yonetimi becerisi. Dinamik fiyatlandirma, indirim kurallari ve kampanya fiyatlari ile gelir optimizasyonu yapar.
+### product-catalog-management
+The skill of building and managing the e-commerce product catalog. Delivers comprehensive catalog management with product data, categories, variants, and visuals.
 
 ---
 
-### sepet-optimizasyonu
-Alisveris sepeti donusumunu artirma becerisi. Sepet tasarimi, terk azaltma ve cross-sell stratejileri ile sepet degerini ve tamamlama oranini optimize eder.
+### pricing-management
+The e-commerce pricing strategy and management skill. Optimizes revenue with dynamic pricing, discount rules, and campaign prices.
 
 ---
 
-### odeme-sureci-optimizasyonu
-E-ticaret odeme akisini optimize etme becerisi. Misafir odeme, tek sayfa odeme ve guven elemanlari ile odeme tamamlama oranini arttirir.
+### cart-optimization
+The skill of raising shopping-cart conversion. Optimizes cart value and completion rate through cart design, abandonment reduction, and cross-sell strategies.
 
 ---
 
-### siparis-yonetimi
-Siparis yasam dongusu yonetimi becerisi. Siparis alm, isleme, kargolama ve iade surreclerini yonetir.
+### checkout-optimization
+The skill of optimizing the e-commerce checkout flow. Raises completion with guest checkout, single-page checkout, and trust elements.
 
 ---
 
-### stok-yonetimi
-E-ticaret stok ve envanter yonetimi becerisi. Stok takibi, yeniden siparis, cok depolu yonetim ve stok uyarilari ile envanter kontrolu saglar.
+### order-management
+The order-lifecycle management skill. Manages order intake, processing, shipping, and returns.
 
 ---
 
-### kargo-entegrasyonu
-Kargo ve lojistik firmasi entegrasyonu becerisi. Kargo API entegrasyonu, etiket olusturma ve takip numarasi senkronizasyonu ile otomatik kargolama saglar.
+### inventory-management
+The e-commerce stock and inventory management skill. Delivers inventory control with stock tracking, reordering, multi-warehouse management, and stock alerts.
 
 ---
 
-### iade-yonetimi
-Urun iade ve degisim sureci yonetimi becerisi. Iade politikasi, otomasyon ve musteri deneyimi ile etkili iade yonetimi saglar.
+### shipping-integration
+The carrier and logistics integration skill. Automates shipping with carrier API integration, label creation, and tracking-number sync.
 
 ---
 
-### pazar-yeri-entegrasyonu
-Pazar yeri (marketplace) entegrasyonlari becerisi. Trendyol, Hepsiburada, Amazon ve diger pazar yerlerine urun listeleme ve siparis senkronizasyonu saglar.
+### returns-management
+The product return and exchange process skill. Delivers effective returns through return policy, automation, and customer experience.
 
 ---
 
-### e-ticaret-seo
-E-ticaret sitesi SEO optimizasyonu becerisi. Urun sayfasi, kategori ve teknik SEO ile organik arama trafikini arttirir.
+### marketplace-integration
+The marketplace integration skill. Provides product listing and order sync to Trendyol, Hepsiburada, Amazon, and other marketplaces.
 
 ---
 
-### donusum-orani-optimizasyonu
-E-ticaret donusum oranini artirma (CRO) becerisi. Kullanici davranisi analizi, A/B test ve UX iyilestirme ile satis donusum oranini optimize eder.
+### ecommerce-seo
+The e-commerce SEO optimization skill. Lifts organic search traffic with product-page, category, and technical SEO.
 
 ---
 
-### urun-oneri-sistemi
-E-ticaret urun oneri motoru kurma becerisi. Kisisellestirilmis oneriler, cross-sell ve upsell algoritmalari ile sepet degerini ve donusum oranini arttirir.
+### conversion-rate-optimization
+The e-commerce CRO skill. Optimizes the sales conversion rate with behavior analysis, A/B tests, and UX improvements.
 
 ---
 
-### kampanya-yonetimi
-E-ticaret kampanya planlama ve yurutme becerisi. Indirim, kupon, flash satis ve hediye kampanyalari ile satis artisi saglar.
+### product-recommendation-engine
+The skill of building the product recommendation engine. Raises cart value and conversion with personalized recommendations and cross-sell/upsell algorithms.
 
 ---
 
-### musteri-sadakat-programi
-E-ticaret sadakat programi tasarlama becerisi. Puan sistemi, uyelik kademeleri ve ozel teklifler ile musteri bagliligi ve tekrarlayan satisi arttirir.
+### campaign-management
+The e-commerce campaign planning and execution skill. Drives sales with discounts, coupons, flash sales, and gift campaigns.
 
 ---
 
-### e-posta-pazarlama-eticaret
-E-ticaret e-posta pazarlama otomasyonu becerisi. Karsilama, sepet terk, siparis sonrasi ve yeniden etkilesim e-postalari ile gelir artisi saglar.
+### customer-loyalty-program
+The skill of designing the e-commerce loyalty program. Raises loyalty and repeat purchases with point systems, membership tiers, and exclusive offers.
 
 ---
 
-### urun-fotograf-yonetimi
-E-ticaret urun fotograflarini yonetme becerisi. Cekim standartlari, gorsel isleme ve galeri yapilandirmasi ile profesyonel urun gorselleri saglar.
+### ecommerce-email-marketing
+The e-commerce email automation skill. Drives revenue with welcome, cart-abandonment, post-purchase, and re-engagement emails.
 
 ---
 
-### e-ticaret-analitik
-E-ticaret veri analitigi ve raporlama becerisi. Satis, trafik, donusum ve musteri metrikleri ile veri odakli karar alma saglar.
+### product-photo-management
+The skill of managing e-commerce product photos. Delivers professional product imagery via shoot standards, image processing, and gallery structuring.
 
 ---
 
-### mobil-ticaret
-Mobil ticaret (m-commerce) optimizasyonu becerisi. Mobil kullanici deneyimi, hiz ve odeme optimizasyonu ile mobil donusum oranini arttirir.
+### ecommerce-analytics
+The e-commerce data analytics and reporting skill. Enables data-driven decisions with sales, traffic, conversion, and customer metrics.
 
 ---
 
-### coklu-kanal-satis
-Cok kanalli satis stratejisi ve yonetimi becerisi. Online magaza, pazar yeri, sosyal ticaret ve fiziksel magaza kanallari arasinda tutarlilik saglar.
+### mobile-commerce
+The m-commerce optimization skill. Raises mobile conversion through mobile UX, speed, and payment optimization.
 
 ---
 
-### sosyal-ticaret
-Sosyal medya platformlari uzerinden satis becerisi. Instagram Shopping, TikTok Shop ve Facebook Shops ile sosyal medya uzerinden gelir olusturur.
+### omnichannel-sales
+The multi-channel sales strategy and management skill. Keeps consistency across the online store, marketplaces, social commerce, and physical stores.
 
 ---
 
-### abonelik-ticaret
-Abonelik bazli e-ticaret modeli kurma becerisi. Tekrarlayan odeme, abonelik yonetimi ve kayip azaltma ile surdurulebilir abonelik geliri olusturur.
+### social-commerce
+The skill of selling through social platforms. Generates revenue via Instagram Shopping, TikTok Shop, and Facebook Shops.
 
 ---
 
-### b2b-e-ticaret
-B2B e-ticaret platformu kurma becerisi. Kurumsal fiyatlandirma, toplu siparis ve ozel katalog ozellikleri ile isletmeler arasi satis altyapisi olusturur.
+### subscription-commerce
+The skill of building a subscription-based e-commerce model. Builds sustainable subscription revenue with recurring payments, subscription management, and churn reduction.
 
 ---
 
-### urun-arama-optimizasyonu
-Site ici urun arama deneyimini optimize etme becerisi. Arama algoritmasi, filtre ve otomatik tamamlama ile urun bulunabilirligini arttirir.
+### b2b-ecommerce
+The skill of building a B2B e-commerce platform. Builds business-to-business sales infrastructure with corporate pricing, bulk orders, and custom catalogs.
 
 ---
 
-### e-ticaret-personalizasyon
-E-ticaret kisisellesirme stratejisi becerisi. Kullanici davranisi, segment ve baglam bazli kisisellestirilmis deneyimler ile donusum artisi saglar.
+### product-search-optimization
+The skill of optimizing on-site product search. Raises findability with search algorithms, filters, and autocomplete.
 
 ---
 
-### e-ticaret-guvenlik
-E-ticaret platform guvenligi becerisi. Odeme guvenligi, veri koruma ve dolandiricilik onleme ile guvenli alisveris ortami saglar.
+### ecommerce-personalization
+The e-commerce personalization strategy skill. Lifts conversion through behavior-, segment-, and context-based personalized experiences.
 
 ---
 
-### urun-yorum-yonetimi
-Musteri yorum ve degerlendirme sistemi yonetimi becerisi. Yorum toplama, moderasyon ve goruntuleme optimizasyonu ile sosyal kanit gucu arttirir.
+### ecommerce-security
+The e-commerce platform security skill. Delivers a safe shopping environment with payment security, data protection, and fraud prevention.
 
 ---
 
-### dropshipping-yonetimi
-Dropshipping is modeli yonetimi becerisi. Tedarikci entegrasyonu, siparis yonlendirme ve kar marji yonetimi ile stoksuz satis operasyonu yonetir.
+### review-management
+The customer review and rating system skill. Strengthens social proof with review collection, moderation, and display optimization.
 
 ---
 
-### e-fatura-entegrasyonu
-E-fatura ve e-arsiv fatura entegrasyonu becerisi. Yasal uyumluluk, otomatik fatura olusturma ve entegratör baglantisi ile fatura surecini otomatiklestirir.
+### dropshipping-management
+The dropshipping business-model skill. Runs a stockless operation with supplier integration, order routing, and margin management.
 
 ---
 
-### e-ticaret-performans-izleme
-E-ticaret platform performansini izleme becerisi. Sayfa hizi, sunucu yanit suresi ve kullanilabilirlik ile teknik performans optimizasyonu yapar.
+### e-invoice-integration
+The e-invoice and e-archive integration skill. Automates invoicing with legal compliance, automatic creation, and integrator connectivity.
 
 ---
 
-### e-ticaret-a-b-test
-E-ticaret A/B test stratejisi ve uygulama becerisi. Urun sayfasi, sepet ve odeme akisi testleri ile veri odakli donusum iyilestirmesi yapar.
+### ecommerce-performance-monitoring
+The skill of monitoring platform performance. Optimizes technical performance via page speed, server response time, and availability.
 
 ---
 
-### e-ticaret-icerik-stratejisi
-E-ticaret icerik pazarlama stratejisi becerisi. Blog, kilavuz, video ve kullanici uretimi icerik ile organik trafik ve marka bilinirligini arttirir.
+### ecommerce-a-b-testing
+The e-commerce A/B testing strategy and execution skill. Improves conversion with data through product-page, cart, and checkout-flow tests.
 
 ---
 
-### musteri-hizmet-yonetimi
-E-ticaret musteri hizmetleri yonetimi becerisi. Destek kanallari, yanit sablonlari ve eskalasyon sureci ile yuksek musteri memnuniyeti saglar.
+### ecommerce-content-strategy
+The e-commerce content marketing strategy skill. Lifts organic traffic and brand awareness with blogs, guides, video, and user-generated content.
 
 ---
 
-### cross-border-ticaret
-Sinir otesi e-ticaret yonetimi becerisi. Uluslararasi gonderim, vergi hesaplama ve lokalizasyon ile global e-ticaret operasyonu kurar.
+### customer-service-management
+The e-commerce customer service skill. Delivers high satisfaction with support channels, response templates, and an escalation process.
 
 ---
 
-### urun-veri-yonetimi
-Urun bilgi yonetimi (PIM) becerisi. Urun verisi standartlari, zenginlestirme ve dagitim ile tutarli urun bilgisi yonetimi saglar.
+### cross-border-commerce
+The cross-border e-commerce skill. Builds global operations with international shipping, tax calculation, and localization.
 
 ---
 
-### e-ticaret-promosyon-motoru
-Promosyon ve indirim kural motoru tasarlama becerisi. Esnek kural yapisi, kombinasyon kurallari ve otomatik uygulama ile kampanya yonetimi kolaylastirir.
+### product-data-management
+The product information management (PIM) skill. Delivers consistent product data via standards, enrichment, and distribution.
 
 ---
 
-### e-ticaret-test-stratejisi
-E-ticaret platform test stratejisi becerisi. Siparis akisi, odeme, stok ve entegrasyon testleri ile platform guvenirliligi saglar.
+### promotion-engine
+The skill of designing the promotion and discount rule engine. Simplifies campaign management with flexible rules, combination rules, and automatic application.
 
 ---
 
-### e-ticaret-raporlama
-E-ticaret is zekasi ve raporlama becerisi. Satis, musteri, urun ve kanal raporlari ile veri odakli karar alma saglar.
+### ecommerce-test-strategy
+The e-commerce platform test strategy skill. Secures platform reliability with order-flow, payment, stock, and integration tests.
 
 ---
 
-### e-ticaret-migrasyon
-E-ticaret platform gocuu becerisi. Mevcut platformdan yeni platforma urun, musteri, siparis ve icerik gocunu guvenli sekilde gerceklestirir.
+### ecommerce-reporting
+The e-commerce BI and reporting skill. Enables data-driven decisions with sales, customer, product, and channel reports.
 
 ---
 
-### e-ticaret-erp-entegrasyonu
-ERP sistemi entegrasyonu becerisi. Siparis, stok, fatura ve musteri verisi senkronizasyonu ile e-ticaret ve ERP arasinda veri bütünlügü saglar.
+### ecommerce-migration
+The platform migration skill. Migrates products, customers, orders, and content safely from the old platform to the new one.
 
 ---
 
-### urun-lansman
-Yeni urun lansmanini planlama ve yurutme becerisi. On tanitan, lansman gunu ve sonrasi stratejileri ile basarili urun girisi saglar.
+### erp-integration
+The ERP integration skill. Delivers data integrity between e-commerce and ERP through order, stock, invoice, and customer-data sync.
 
 ---
 
-### coklu-dil-magaza
-Cok dilli e-ticaret magaza yonetimi becerisi. Dil bazli icerik, para birimi ve lokalizasyon ile uluslararasi musteri deneyimi saglar.
+### product-launch
+The skill of planning and running new-product launches. Delivers successful market entry with teaser, launch-day, and post-launch strategies.
 
 ---
 
-### e-ticaret-hukuk-uyumluluk
-E-ticaret yasal uyumluluk becerisi. Mesafeli satis, tuketici haklari, KVKK ve cerez politikasi ile yasal uyumluluk saglar.
+### multilingual-store
+The multi-language store management skill. Delivers an international experience with per-language content, currencies, and localization.
 
 ---
 
-### e-ticaret-maliyet-analizi
-E-ticaret operasyon maliyet analizi becerisi. Urun maliyeti, lojistik, komisyon ve pazarlama giderlerini analiz ederek karlilik optimizasyonu yapar.
+### legal-compliance
+The e-commerce legal compliance skill. Covers distance selling, consumer rights, KVKK, and cookie policies.
 
 ---
 
-### e-ticaret-crm
-E-ticaret musteri iliski yonetimi becerisi. Musteri segmentasyonu, yasam degeri ve kisisellestirilmis iletisim ile musteri bagliligi arttirir.
+### cost-analysis
+The e-commerce operations cost-analysis skill. Optimizes profitability by analyzing product cost, logistics, commissions, and marketing spend.
 
 ---
 
-### e-ticaret-chatbot
-E-ticaret chatbot tasarlama becerisi. Urun onerileri, siparis takibi ve destek otomasyonu ile 7/24 musteri hizmeti saglar.
+### ecommerce-crm
+The e-commerce CRM skill. Raises loyalty with customer segmentation, lifetime value, and personalized communication.
 
 ---
 
-### e-ticaret-influencer-pazarlama
-Influencer is birligi yonetimi becerisi. Influencer secimi, kampanya planlama ve performans olcumu ile e-ticaret satislarini arttirir.
+### ecommerce-chatbot
+The e-commerce chatbot design skill. Provides 24/7 service with product recommendations, order tracking, and support automation.
 
 ---
 
-### e-ticaret-email-segmentasyonu
-E-ticaret e-posta segmentasyonu becerisi. Musteri davranisi, satin alma gecmisi ve etkilesim verilerine gore hedefli e-posta listeleri olusturur.
+### influencer-marketing
+The influencer collaboration skill. Drives e-commerce sales with influencer selection, campaign planning, and performance measurement.
 
 ---
 
-### e-ticaret-push-bildirim
-E-ticaret push bildirim stratejisi becerisi. Web ve mobil push bildirimleri ile sepet hatirlatma, kampanya duyurusu ve kisisellestirilmis bildirimler gonderir.
+### email-segmentation
+The e-commerce email segmentation skill. Builds targeted lists from behavior, purchase history, and engagement data.
 
 ---
 
-### e-ticaret-affiliate-programi
-Affiliate (bagali) pazarlama programi kurma becerisi. Ortaklik modeli, komisyon yapisi ve izleme mekanizmasi ile satis kanali olusturur.
+### push-notifications
+The e-commerce push strategy skill. Sends cart reminders, campaign announcements, and personalized notifications via web and mobile push.
 
 ---
 
-### e-ticaret-canli-yayin-satis
-Canli yayin uzerinden satis (live commerce) becerisi. Canli yayin planlama, urun gosterimi ve anlik satis mekanizmasi ile etkilesimli alisveris deneyimi olusturur.
+### affiliate-program
+The affiliate marketing program skill. Builds a sales channel with the partnership model, commission structure, and tracking mechanism.
 
 ---
 
-### e-ticaret-hediye-karti
-Hediye karti ve hediye sertifikasi sistemi kurma becerisi. Dijital ve fiziksel hediye kartlari, bakiye yonetimi ve kullanim izleme ile ek gelir kanali olusturur.
+### live-commerce
+The live-stream selling (live commerce) skill. Builds an interactive shopping experience with stream planning, product showcasing, and instant purchase mechanics.
 
 ---
 
-### e-ticaret-abonelik-kutusu
-Abonelik kutusu (subscription box) modeli kurma becerisi. Kurasyon, gonderim takvimi ve musteri deneyimi ile tekrarlayan gelir modeli olusturur.
+### gift-cards
+The gift card and certificate system skill. Builds an extra revenue channel with digital and physical cards, balance management, and usage tracking.
 
 ---
 
-### e-ticaret-pazar-yeri-kurulumu
-Kendi pazar yeri (marketplace) platformunu kurma becerisi. Satici yonetimi, komisyon yapisi ve siparis akisi ile cok saticiili e-ticaret platformu olusturur.
+### subscription-box
+The subscription-box model skill. Builds recurring revenue with curation, shipping schedules, and customer experience.
 
 ---
 
-### e-ticaret-gorsel-arama
-Gorsel arama (visual search) ozelligi kurma becerisi. Gorsel tabanli urun arama ile fotograftan benzer urun bulma yeteneği saglar.
+### marketplace-setup
+The skill of building your own marketplace platform. Builds multi-vendor e-commerce with seller management, commission structure, and order flow.
 
+---
+
+### visual-search
+The visual-search feature skill. Enables finding similar products from a photo with image-based product search.

--- a/.claude/skills-vault/email/SKILL.md
+++ b/.claude/skills-vault/email/SKILL.md
@@ -10,261 +10,260 @@ metadata:
   badi-version: ">=1.14.0"
   category: email
 ---
-# E-posta Becerileri
-Bu dosya, e-posta pazarlama, otomasyon, segmentasyon, tasarim, uyum ve analiz ile ilgili tum becerileri icerir.
+# Email Skills
+This file contains all the skills around email marketing, automation, segmentation, design, compliance, and analytics.
 
 ---
 
-### e-posta-pazarlama
-E-posta pazarlama stratejisi olusturma ve yonetme becerisi. Hedef kitleye uygun kampanya planlama, kanal entegrasyonu ve performans olcumleme dahil olmak uzere butunsel bir e-posta pazarlama yaklasimi gelistirir.
+### email-marketing
+The skill of building and managing an email marketing strategy. Develops a holistic approach covering audience-fit campaign planning, channel integration, and performance measurement.
 
 ---
 
-### segmentasyon
-Abone listesini anlamli gruplara ayirma becerisi. Demografik, davranissal, psikografik ve islem bazli segmentler olusturarak her gruba ozel icerik ve zamanlama stratejisi gelistirir.
+### segmentation
+The skill of splitting the subscriber list into meaningful groups. Builds demographic, behavioral, psychographic, and transaction-based segments with content and timing strategies tailored to each.
 
 ---
 
-### otomasyon-akislari
-E-posta otomasyon is akislari tasarlama ve uygulama becerisi. Tetikleyici olaylara dayali otomatik e-posta dizileri olusturarak musteri yolculugunun her asamasinda dogru mesaji dogru zamanda iletir.
+### automation-flows
+The skill of designing and implementing email automation workflows. Builds trigger-based automated sequences delivering the right message at the right time across the customer journey.
 
 ---
 
-### karsilama-serisi
-Yeni aboneler icin karsilama e-posta serisi tasarlama becerisi. Ilk izlenimi guclendiren, marka degerlerini aktaran ve abone etkilesimini baslatan cok adimli bir karsilama deneyimi olusturur.
+### welcome-series
+The skill of designing the welcome series for new subscribers. Builds a multi-step welcome experience that strengthens the first impression, conveys brand values, and starts engagement.
 
 ---
 
-### terk-sepet
-Sepetini terk eden musterilere yonelik kurtarma e-posta stratejisi. Satin alma surecini yarim birakan kullanicilari geri kazanmak icin zamanlamasi ve icerigi optimize edilmis e-posta dizileri olusturur.
+### abandoned-cart
+The recovery email strategy for cart abandoners. Builds sequences with optimized timing and content to win back users who left the purchase halfway.
 
 ---
 
-### yeniden-etkilesim
-Etkilesimi dusen veya pasif hale gelen aboneleri yeniden aktive etme becerisi. Uzun suredir etkilesime girmeyen kullanicilara ozel kampanyalar tasarlayarak listeyi canli tutar.
+### re-engagement
+The skill of reactivating subscribers whose engagement dropped or went dormant. Keeps the list alive with campaigns tailored to long-inactive users.
 
 ---
 
-### ab-test
-E-posta kampanyalarinda A/B ve cok degiskenli test tasarlama becerisi. Konu satiri, icerik, tasarim, gonderim zamani ve CTA gibi degiskenleri sistematik olarak test ederek performansi arttirir.
+### ab-testing
+The skill of designing A/B and multivariate tests in email campaigns. Lifts performance by systematically testing variables like subject line, content, design, send time, and CTA.
 
 ---
 
-### konu-satiri
-Etkili e-posta konu satirlari yazma becerisi. Acilma oranini maksimize eden, merak uyandiran ve marka sesine uygun konu satirlari olusturma teknikleri uygular.
+### subject-lines
+The skill of writing effective subject lines. Applies techniques for lines that maximize open rates, spark curiosity, and fit the brand voice.
 
 ---
 
-### onizleme-metni
-E-posta onizleme (preheader) metni yazma becerisi. Konu satirini tamamlayan, ek bilgi veren ve acilma oranini artiran onizleme metinleri olusturur.
+### preheader-text
+The skill of writing email preheader text. Builds preheaders that complement the subject line, add information, and lift open rates.
 
 ---
 
-### kisisellistirme
-E-posta iceriklerini alici bazinda kisisellistirme becerisi. Dinamik icerik bloklari, birlesim alanlari ve davranissal verilere dayali kisisellestirilmis deneyimler olusturur.
+### personalization
+The skill of personalizing email content per recipient. Builds personalized experiences with dynamic content blocks, merge fields, and behavioral data.
 
 ---
 
-### tasarim-sablonu
-E-posta tasarim sablonlari olusturma becerisi. Marka kimligi ile uyumlu, tum cihazlarda duzgun gorunen ve donusum odakli e-posta sablonlari tasarlar.
+### design-templates
+The skill of building email design templates. Designs conversion-focused templates aligned with the brand identity that render correctly on every device.
 
 ---
 
-### mobil-optimizasyon
-E-postalari mobil cihazlar icin optimize etme becerisi. Mobil acilma oranlarinin yuksekligini goz onunde bulundurarak responsive tasarim, dokunmatik uyumlu butonlar ve mobil okunabilirlik saglar.
+### mobile-optimization
+The skill of optimizing emails for mobile devices. Given high mobile open rates, delivers responsive design, touch-friendly buttons, and mobile readability.
 
 ---
 
-### teslim-edilebilirlik
-E-posta teslim edilebilirligini iyilestirme becerisi. Gelen kutusuna ulasma oranini artirmak icin teknik altyapi, gonderici itibari ve icerik kalitesi optimizasyonu yapar.
+### deliverability
+The skill of improving email deliverability. Optimizes technical infrastructure, sender reputation, and content quality to raise inbox placement.
 
 ---
 
-### spam-onleme
-E-postalarin spam filtresine takilmasini onleme becerisi. Icerik, teknik yapilandirma ve gonderim pratiklerini optimize ederek gelen kutusuna ulasma oranini arttirir.
+### spam-prevention
+The skill of keeping emails out of the spam filter. Lifts inbox placement by optimizing content, technical configuration, and sending practices.
 
 ---
 
-### liste-temizligi
-E-posta listesini temizleme ve kalitesini artirma becerisi. Gecersiz, pasif ve riskli adresleri tespit edip cikararak liste sagligini ve teslim edilebilirligini iyilestirir.
+### list-hygiene
+The skill of cleaning and improving the email list. Improves list health and deliverability by detecting and removing invalid, dormant, and risky addresses.
 
 ---
 
-### gdpr-uyum
-E-posta pazarlamada GDPR ve KVKK uyumluluugu saglama becerisi. Veri toplama, islem, saklama ve silme sureclerini yasal gerekliliklere uygun yonetir.
+### gdpr-compliance
+The skill of GDPR and KVKK compliance in email marketing. Manages data collection, processing, retention, and deletion per legal requirements.
 
 ---
 
-### opt-in-stratejisi
-Abone toplama ve opt-in stratejisi gelistirme becerisi. Web sitesi, sosyal medya ve diger kanallardan kaliteli aboneler kazanmak icin etkili opt-in mekanizmalari tasarlar.
+### opt-in-strategy
+The skill of developing the subscriber-acquisition and opt-in strategy. Designs effective opt-in mechanisms to gain quality subscribers from the website, social, and other channels.
 
 ---
 
 ### double-opt-in
-Cift onay (double opt-in) sureci tasarlama becerisi. Abone kalitesini artiran, yasal uyum saglayan ve gercek ilgiyi dogrulayan bir cift onay mekanizmasi kurar.
+The skill of designing the double opt-in process. Builds a confirmation mechanism that raises subscriber quality, ensures legal compliance, and verifies genuine interest.
 
 ---
 
-### unsubscribe-yonetimi
-Abonelikten cikma surecini yonetme becerisi. Yasal gerekliliklere uygun, kullanici dostu ve geri kazanim firsati sunan bir abonelikten cikma deneyimi tasarlar.
+### unsubscribe-management
+The skill of managing the unsubscribe process. Designs a legally compliant, user-friendly unsubscribe experience that offers a win-back opportunity.
 
 ---
 
-### bounce-yonetimi
-E-posta geri donus (bounce) yonetimi becerisi. Hard bounce ve soft bounce durumlarini yoneterek liste kalitesini ve gonderici itibarini korur.
+### bounce-management
+The bounce-management skill. Protects list quality and sender reputation by handling hard and soft bounces.
 
 ---
 
-### raporlama-analiz
-E-posta pazarlama performansini raporlama ve analiz etme becerisi. Kampanya bazli ve genel performans metriklerini izleyerek veri odakli kararlar alinmasini saglar.
+### reporting-analytics
+The skill of reporting and analyzing email marketing performance. Enables data-driven decisions by tracking per-campaign and overall metrics.
 
 ---
 
-### acilma-orani
-E-posta acilma oranini izleme ve iyilestirme becerisi. Acilma oranini etkileyen faktorleri analiz ederek konu satiri, gonderim zamani ve gonderici adi optimizasyonu yapar.
+### open-rate
+The skill of tracking and improving the open rate. Analyzes the drivers and optimizes the subject line, send time, and sender name.
 
 ---
 
-### tiklama-orani
-E-posta tiklama oranini (CTR) izleme ve iyilestirme becerisi. Icerik, tasarim ve CTA optimizasyonu ile tiklama performansini arttirir.
+### click-rate
+The skill of tracking and improving the click-through rate (CTR). Lifts click performance through content, design, and CTA optimization.
 
 ---
 
-### donusum-orani
-E-posta kaynakli donusum oranini izleme ve iyilestirme becerisi. E-postadan web sitesine gecis ve nihai donusume kadar olan sureci optimize eder.
+### conversion-rate
+The skill of tracking and improving the email-driven conversion rate. Optimizes the path from the email to the website to the final conversion.
 
 ---
 
-### gelir-iliskilendirme
-E-posta kampanyalarinin gelire katkisini olcme becerisi. Attribution modelleri kullanarak her kampanya ve otomasyonun gelir uzerindeki etkisini hesaplar.
+### revenue-attribution
+The skill of measuring email campaigns' revenue contribution. Computes each campaign's and automation's revenue impact using attribution models.
 
 ---
 
-### yasam-dongusu
-Musteri yasam dongusu e-posta stratejisi gelistirme becerisi. Musteri yolculugunun her asamasina (edinme, aktivasyon, tutma, gelir, referans) uygun e-posta programlari olusturur.
+### lifecycle
+The skill of developing the customer-lifecycle email strategy. Builds email programs fitting every stage of the journey (acquisition, activation, retention, revenue, referral).
 
 ---
 
-### drip-kampanya
-Zamana dayali damla (drip) e-posta kampanyalari tasarlama becerisi. Belirli araliklarla otomatik gonderilen egitici, beslemeye yonelik veya satisa hazirlayici e-posta dizileri olusturur.
+### drip-campaigns
+The skill of designing time-based drip campaigns. Builds educational, nurturing, or sales-priming sequences sent automatically at set intervals.
 
 ---
 
-### tetiklenmis-e-posta
-Kullanici davranislarina dayali tetiklenmis (trigger-based) e-postalar olusturma becerisi. Web sitesi etkilesimi, urun kullanimi veya belirli olaylara tepki olarak aninda gonderilen e-postalar tasarlar.
+### triggered-email
+The skill of building trigger-based emails on user behavior. Designs instantly sent emails reacting to site interactions, product usage, or specific events.
 
 ---
 
-### transaksiyonel
-Islem (transaksiyonel) e-postalari tasarlama becerisi. Siparis onayi, kargo bildirimi, sifre sifirlama gibi islem odakli e-postalarin icerik ve tasarimini optimize eder.
+### transactional
+The skill of designing transactional emails. Optimizes content and design for order confirmations, shipping notifications, password resets, and the like.
 
 ---
 
-### bildirim-e-postasi
-Bildirim ve uyari e-postalari tasarlama becerisi. Hesap etkinligi, guvenlik uyarilari, stok bildirimleri gibi gercek zamanli bildirim e-postalari olusturur.
+### notification-email
+The skill of designing notification and alert emails. Builds real-time notification emails like account activity, security alerts, and stock notices.
 
 ---
 
-### digest-e-posta
-Ozet (digest) e-postalari tasarlama becerisi. Belirli donemler icerisindeki aktiviteleri, guncellemeleri veya icerikleri derleterek tek bir ozet e-posta haline getirir.
+### digest-email
+The skill of designing digest emails. Compiles a period's activities, updates, or content into one summary email.
 
 ---
 
-### anket-e-posta
-Anket ve geri bildirim toplama e-postalari tasarlama becerisi. Musteri memnuniyeti, NPS, urun geri bildirimi ve pazar arastirmasi anketleri icin etkili e-posta kampanyalari olusturur.
+### survey-email
+The skill of designing survey and feedback-collection emails. Builds effective campaigns for customer satisfaction, NPS, product feedback, and market-research surveys.
 
 ---
 
-### referans-programi
-Referans programi e-postalari tasarlama becerisi. Mevcut musterileri yeni musteriler getirmeye tesvik eden e-posta kampanyalari ve otomasyon akislari olusturur.
+### referral-program
+The skill of designing referral-program emails. Builds campaigns and automation flows that encourage existing customers to bring in new ones.
 
 ---
 
-### sadakat-programi
-Sadakat programi e-postalari tasarlama becerisi. Puan bildirimi, seviye gecisi, ozel teklifler ve sadakat programi iletisimlerini yoneten e-posta stratejisi gelistirir.
+### loyalty-program
+The skill of designing loyalty-program emails. Develops the strategy managing point notifications, tier transitions, special offers, and program communications.
 
 ---
 
 ### upsell-cross-sell
-Upsell ve cross-sell e-postalari tasarlama becerisi. Mevcut musterilere yukseltme ve tamamlayici urun onerileri sunan kisisellestirilmis e-posta kampanyalari olusturur.
+The skill of designing upsell and cross-sell emails. Builds personalized campaigns presenting upgrades and complementary products to existing customers.
 
 ---
 
 ### win-back
-Kaybedilme riski altindaki veya kaybedilmis musterileri geri kazanma becerisi. Churn riski tasiyan musterilere yonelik kurtarma kampanyalari tasarlar.
+The skill of recovering at-risk or lost customers. Designs rescue campaigns for customers carrying churn risk.
 
 ---
 
-### dogum-gunu
-Dogum gunu e-postalari tasarlama becerisi. Musterilerin dogum gunlerinde gonderilen kisisel kutlama ve ozel teklif e-postalari ile musteri bagliligi guclendirir.
+### birthday
+The skill of designing birthday emails. Strengthens loyalty with personal celebration and special-offer emails on customers' birthdays.
 
 ---
 
-### yildonumu
-Yildonumu e-postalari tasarlama becerisi. Musterinin ilk kayit, ilk satin alma gibi onemli tarihlerde gonderilen kutlama ve tesvik e-postalari olusturur.
+### anniversary
+The skill of designing anniversary emails. Builds celebration and incentive emails for milestones like first signup or first purchase.
 
 ---
 
-### mevsimsel-kampanya
-Mevsimsel ve ozel gun e-posta kampanyalari tasarlama becerisi. Bayramlar, ozel gunler ve sezon degisikliklerine uygun kampanya planlama ve uygulama yapar.
+### seasonal-campaigns
+The skill of designing seasonal and special-day campaigns. Plans and runs campaigns fitting holidays, special days, and season changes.
 
 ---
 
-### flash-indirim
-Flash indirim e-posta kampanyalari tasarlama becerisi. Sinirli sureli, aciliyet yaratan kampanyalarla hizli satis artisi saglayan e-posta stratejileri gelistirir.
+### flash-sale
+The skill of designing flash-sale email campaigns. Develops urgency-driven, limited-time strategies that drive fast sales lifts.
 
 ---
 
-### urun-lansman
-Yeni urun lansman e-posta kampanyalari tasarlama becerisi. Heyecan olusturma, lansman gunu ve lansman sonrasi asamalarini iceren kapsamli e-posta stratejisi gelistirir.
+### product-launch
+The skill of designing new-product launch campaigns. Develops a comprehensive strategy covering hype building, launch day, and post-launch stages.
 
 ---
 
-### beta-davet
-Beta programi davet e-postalari tasarlama becerisi. Yeni urun veya ozellik icin beta kullanicilari davet eden, esitleyen ve geri bildirim toplayan e-posta akislari olusturur.
+### beta-invite
+The skill of designing beta-program invitation emails. Builds flows that invite, onboard, and collect feedback from beta users for a new product or feature.
 
 ---
 
-### webinar-davet
-Webinar davet e-postalari tasarlama becerisi. Kayit oranini artiran, hatirlatma gonderimi yapan ve webinar sonrasi takip saglayan e-posta kampanyalari olusturur.
+### webinar-invite
+The skill of designing webinar invitation emails. Builds campaigns that lift registration, send reminders, and follow up after the webinar.
 
 ---
 
-### etkinlik-davet
-Etkinlik davet e-postalari tasarlama becerisi. Fiziksel veya sanal etkinlikler icin davet, hatirlatma ve sonrasi takip e-postalari olusturur.
+### event-invite
+The skill of designing event invitation emails. Builds invitations, reminders, and post-event follow-ups for physical or virtual events.
 
 ---
 
-### tesekkur-e-posta
-Tesekkur e-postalari tasarlama becerisi. Satin alma, kayit, etkinlik katilimi gibi eylemler sonrasinda gonderilen tesekkur e-postalariyla musteri iliskisini guclendirir.
+### thank-you-email
+The skill of designing thank-you emails. Strengthens the relationship with thank-you notes after purchases, signups, and event attendance.
 
 ---
 
-### geri-bildirim-istegi
-Geri bildirim isteme e-postalari tasarlama becerisi. Musteri deneyimi, urun kalitesi ve hizmet memnuniyeti hakkinda yapilandiirlmis geri bildirim toplayan e-postalar olusturur.
+### feedback-request
+The skill of designing feedback-request emails. Builds emails collecting structured feedback on experience, product quality, and service satisfaction.
 
 ---
 
-### review-istegi
-Urun/hizmet degerlendirmesi (review) isteme e-postalari tasarlama becerisi. Musterilerden olumlu yorum ve degerlendirme almak icin optimize edilmis e-posta kampanyalari olusturur.
+### review-request
+The skill of designing review-request emails. Builds optimized campaigns for earning positive reviews and ratings from customers.
 
 ---
 
-### haber-bulteni
-Haber bulteni (newsletter) tasarlama ve yonetme becerisi. Duzenli araliklara gonderilen, bilgilendirici ve etkilesim saglayan haber bultenleri icin strateji ve icerik plani olusturur.
+### newsletter
+The skill of designing and managing newsletters. Builds the strategy and content plan for regular, informative, engagement-driving newsletters.
 
 ---
 
-### kurator-icerik
-Kurate edilmis icerik e-postalari tasarlama becerisi. Sektor haberleri, faydali kaynaklar ve secilmis icerikleri derleyerek deger sunan e-postalar olusturur.
+### curated-content
+The skill of designing curated-content emails. Builds value-delivering emails compiling industry news, useful resources, and selected content.
 
 ---
 
-### sponsorlu-icerik
-Sponsorlu icerik e-postalari tasarlama becerisi. Reklam veren markalar icin dogal ve deger katan sponsorlu icerik entegrasyonlari olusturur.
+### sponsored-content
+The skill of designing sponsored-content emails. Builds natural, value-adding sponsored integrations for advertiser brands.
 
 ---
 
-### partner-e-posta
-Ortaklik ve co-marketing e-postalari tasarlama becerisi. Stratejik partnerlerle ortaklasa gonderilen kampanyalarin planlama, icerik ve teknik koordinasyonunu yonetir.
-
+### partner-email
+The skill of designing partnership and co-marketing emails. Manages the planning, content, and technical coordination of campaigns sent jointly with strategic partners.

--- a/.claude/skills-vault/finance/SKILL.md
+++ b/.claude/skills-vault/finance/SKILL.md
@@ -10,306 +10,305 @@ metadata:
   badi-version: ">=1.14.0"
   category: finance
 ---
-# Finans Becerileri
-Bu dosya, butce, nakit akisi, finansal modelleme, raporlama, vergi, yatirim ve fonlama ile ilgili tum becerileri icerir.
+# Finance Skills
+This file contains all the skills around budgeting, cash flow, financial modeling, reporting, tax, investment, and fundraising.
 
 ---
 
-### butce-planlama
-Isletme butcesi olusturma ve yonetme becerisi. Gelir ve gider kalemlerini detayli sekilde planlayarak finansal hedeflere ulasmak icin yol haritasi cikarir.
+### budget-planning
+The skill of building and managing the business budget. Produces the roadmap to financial goals by planning revenue and expense items in detail.
 
 ---
 
-### nakit-akisi
-Nakit akisi yonetimi ve tahminleme becerisi. Isletmenin nakit giris ve cikislarini izleyerek likidite sorunlarini onceden tespit eder ve yonetir.
+### cash-flow
+The cash-flow management and forecasting skill. Detects and manages liquidity problems early by tracking cash in and out.
 
 ---
 
-### gelir-tahmini
-Gelir tahminleme modeli olusturma becerisi. Gecmis veriler, pazar kosullari ve buyume planlarina dayali gercekci gelir projeksiyonlari yapar.
+### revenue-forecasting
+The skill of building revenue forecasting models. Makes realistic projections grounded in historical data, market conditions, and growth plans.
 
 ---
 
-### gider-analizi
-Isletme giderlerini analiz etme ve optimize etme becerisi. Maliyet kalemlerini detayli inceleyerek tasarruf firsatlarini ve gereksiz harcamalari tespit eder.
+### expense-analysis
+The skill of analyzing and optimizing business expenses. Finds savings opportunities and waste by examining cost items in detail.
 
 ---
 
-### karlilik-analizi
-Isletme, urun veya musteri bazinda karlilik analizi yapma becerisi. Gelir ve maliyet verilerini eslestirerek en karli ve en az karli alanlari belirler.
+### profitability-analysis
+The skill of profitability analysis by business, product, or customer. Maps revenue to costs to find the most and least profitable areas.
 
 ---
 
-### fiyatlandirma-modeli
-Fiyatlandirma stratejisi ve modeli gelistirme becerisi. Maliyet, deger, rekabet ve pazar kosullarini degerlendirerek optimum fiyat noktasini belirler.
+### pricing-model
+The skill of developing the pricing strategy and model. Finds the optimal price point by weighing cost, value, competition, and market conditions.
 
 ---
 
-### birim-ekonomisi
-Birim ekonomisi (unit economics) hesaplama ve analiz becerisi. Her bir musteri, siparis veya islem bazinda karliligi olcerek isletmenin surdurulebilirligini degerlendirir.
+### unit-economics
+The unit-economics calculation and analysis skill. Assesses business sustainability by measuring profitability per customer, order, or transaction.
 
 ---
 
-### ltv-hesaplama
-Musteri yasam boyu degeri (LTV) hesaplama becerisi. Bir musterinin isletmeye katacagi toplam geliri modelleyerek musteri edinme ve tutma yatirimlarina yol gosterir.
+### ltv-calculation
+The customer lifetime value (LTV) calculation skill. Guides acquisition and retention investment by modeling a customer's total revenue contribution.
 
 ---
 
-### cac-hesaplama
-Musteri edinme maliyeti (CAC) hesaplama ve optimize etme becerisi. Pazarlama ve satis harcamalarini edinilen musteri sayisina bolerek kanal bazli CAC belirler.
+### cac-calculation
+The customer acquisition cost (CAC) calculation and optimization skill. Determines per-channel CAC by dividing marketing and sales spend by customers acquired.
 
 ---
 
-### mrr-arr-takibi
-Aylik ve yillik yinelenen gelir (MRR/ARR) takibi becerisi. Abonelik bazli geliri bilesenlere ayirarak buyume, kayip ve genisleme trendlerini izler.
+### mrr-arr-tracking
+The monthly and annual recurring revenue (MRR/ARR) tracking skill. Tracks growth, churn, and expansion trends by decomposing subscription revenue.
 
 ---
 
-### churn-analizi
-Musteri kayip (churn) oranini analiz etme ve azaltma becerisi. Kayip nedenlerini teshis ederek retansiyon stratejileri gelistirir.
+### churn-analysis
+The skill of analyzing and reducing the churn rate. Develops retention strategies by diagnosing the causes of loss.
 
 ---
 
-### finansal-modelleme
-Finansal model olusturma becerisi. Isletmenin gelir, gider ve nakit akisi projeksiyonlarini iceren kapsamli bir finansal model tasarlar.
+### financial-modeling
+The financial-model building skill. Designs a comprehensive model covering revenue, expense, and cash-flow projections.
 
 ---
 
-### senaryo-analizi
-Finansal senaryo analizi yapma becerisi. Farkli pazar kosullari, buyume oranlari ve stratejik kararlar icin en iyi, temel ve en kotu durum senaryolarini modeller.
+### scenario-analysis
+The financial scenario analysis skill. Models best, base, and worst cases for different market conditions, growth rates, and strategic decisions.
 
 ---
 
-### duyarlilik-analizi
-Finansal duyarlilik (sensitivity) analizi yapma becerisi. Temel varsayimlardaki degisikliklerin finansal sonuclara etkisini olcer.
+### sensitivity-analysis
+The financial sensitivity analysis skill. Measures the impact of changes in key assumptions on financial outcomes.
 
 ---
 
-### break-even-analizi
-Basabaas noktasi analizi yapma becerisi. Sabit ve degisken maliyetleri degerlendirerek kara gecisin ne zaman gerceklesecegini hesaplar.
+### break-even-analysis
+The break-even analysis skill. Computes when profitability arrives by weighing fixed and variable costs.
 
 ---
 
-### roi-hesaplama
-Yatirim getirisi (ROI) hesaplama becerisi. Projeler, kampanyalar ve yatirimlarin finansal getirisini olcerek karar almaya destek saglar.
+### roi-calculation
+The return-on-investment (ROI) calculation skill. Supports decisions by measuring the financial return of projects, campaigns, and investments.
 
 ---
 
-### npv-irr-analizi
-Net bugunku deger (NPV) ve ic verim orani (IRR) analizi becerisi. Uzun vadeli yatirimlarin degerlemesini yaparak yatirim kararlarina temel olusturur.
+### npv-irr-analysis
+The net present value (NPV) and internal rate of return (IRR) analysis skill. Grounds investment decisions by valuing long-term investments.
 
 ---
 
-### yatirim-degerlendirmesi
-Yatirim firsatlarini degerlendirme becerisi. Potansiyel yatirimlari finansal, stratejik ve risk acilarindan analiz ederek karar destek cercevesi sunar.
+### investment-evaluation
+The skill of evaluating investment opportunities. Offers a decision framework by analyzing potential investments financially, strategically, and for risk.
 
 ---
 
-### risk-analizi
-Finansal risk analizi ve yonetimi becerisi. Piyasa, kredi, likidite ve operasyonel riskleri tanimlar, olcer ve yonetim stratejileri gelistirir.
+### risk-analysis
+The financial risk analysis and management skill. Defines, measures, and builds strategies for market, credit, liquidity, and operational risks.
 
 ---
 
-### portfoy-yonetimi
-Yatirim portfoyu yonetimi becerisi. Varlik dagilimi, cok cesitlendirme ve risk-getiri optimizasyonu ile portfoy performansini yonetir.
+### portfolio-management
+The investment portfolio management skill. Manages portfolio performance with asset allocation, diversification, and risk-return optimization.
 
 ---
 
-### vergi-planlama
-Vergi planlama ve optimizasyon becerisi. Yasal cercevede vergi yukunu minimize eden stratejiler geliistirerek vergi etkinligini arttirir.
+### tax-planning
+The tax planning and optimization skill. Raises tax efficiency with strategies that legally minimize the tax burden.
 
 ---
 
-### kdv-yonetimi
-KDV hesaplama, beyan ve yonetim becerisi. KDV uyumluluugunu saglayarak zamaninda ve dogru beyanname verme surecini yonetir.
+### vat-management
+The VAT calculation, filing, and management skill. Manages the process of filing on time and correctly while staying VAT-compliant.
 
 ---
 
-### fatura-yonetimi
-Fatura kesme ve yonetme becerisi. Satis faturalari, proforma faturalar ve e-fatura sureclerini sistematik olarak yonetir.
+### invoice-management
+The invoicing skill. Manages sales invoices, proformas, and e-invoice processes systematically.
 
 ---
 
-### odeme-takibi
-Odeme takibi ve yonetimi becerisi. Gelen ve giden odemeleri izleyerek zamaninda tahsilat ve odeme surecleri yonetir.
+### payment-tracking
+The payment tracking and management skill. Manages on-time collection and payment processes by monitoring inbound and outbound payments.
 
 ---
 
-### alacak-yonetimi
-Alacak yonetimi ve tahsilat becerisi. Musterilarden alacaklari etkin sekilde yoneterek nakit akisini optimize eder.
+### receivables-management
+The receivables management and collection skill. Optimizes cash flow by managing customer receivables effectively.
 
 ---
 
-### borc-yonetimi
-Borc yonetimi ve yapilandirma becerisi. Isletmenin borc portfoyunu optimize ederek finansman maliyetini minimize eder.
+### debt-management
+The debt management and restructuring skill. Minimizes financing cost by optimizing the company's debt portfolio.
 
 ---
 
-### kredi-degerlendirmesi
-Kredi degerlendirmesi yapma becerisi. Musteri veya proje bazinda kredi riskini analiz ederek kredi kararlarina destek saglar.
+### credit-assessment
+The credit-assessment skill. Supports credit decisions by analyzing credit risk per customer or project.
 
 ---
 
-### finansal-raporlama
-Finansal raporlama sistemi kurma ve yonetme becerisi. Yasal ve yonetsel finansal raporlari zamaninda ve dogru hazirlar.
+### financial-reporting
+The skill of building and managing the financial reporting system. Prepares statutory and management reports on time and accurately.
 
 ---
 
-### bilanco-analizi
-Bilanco analizi yapma becerisi. Varlik, borc ve ozsermaye yapisini inceleyerek isletmenin finansal sagligini degerlendirir.
+### balance-sheet-analysis
+The balance-sheet analysis skill. Assesses financial health by examining the asset, liability, and equity structure.
 
 ---
 
-### gelir-tablosu
-Gelir tablosu analizi yapma becerisi. Gelir, maliyet ve kar yapisini detayli inceleyerek isletmenin operasyonel performansini degerlendirir.
+### income-statement
+The income-statement analysis skill. Assesses operational performance by examining the revenue, cost, and profit structure in detail.
 
 ---
 
-### nakit-akis-tablosu
-Nakit akis tablosu hazirlama ve analiz etme becerisi. Isletme, yatirim ve finansman faaliyetlerinden kaynaklanan nakit hareketlerini raporlar.
+### cash-flow-statement
+The skill of preparing and analyzing the cash-flow statement. Reports cash movements from operating, investing, and financing activities.
 
 ---
 
-### oran-analizi
-Finansal oran analizi yapma becerisi. Likidite, karlilik, verimlilik ve kaldiraac oranlarini hesaplayarak isletme performansini degerlendirir.
+### ratio-analysis
+The financial-ratio analysis skill. Assesses business performance by computing liquidity, profitability, efficiency, and leverage ratios.
 
 ---
 
-### trend-analizi
-Finansal trend analizi yapma becerisi. Gecmis finansal verilerdeki desenleri ve eggilimleri tespit ederek gelecek performans hakkinda ongoru saglar.
+### trend-analysis
+The financial trend analysis skill. Offers foresight by detecting patterns and tendencies in historical financial data.
 
 ---
 
-### benchmark-karsilastirma
-Finansal benchmark karsilastirmasi yapma becerisi. Isletme performansini sektor ortalamalari ve rakiplerle karsilastirarak konumlandirma yapar.
+### benchmark-comparison
+The financial benchmarking skill. Positions performance against industry averages and competitors.
 
 ---
 
-### yillik-plan
-Yillik finansal plan olusturma becerisi. Gelir hedefleri, gider butcesi, yatirim plani ve nakit akisi projeksiyonlarini iceren kapsamli yillik plan hazirlar.
+### annual-plan
+The skill of building the annual financial plan. Prepares a comprehensive plan covering revenue targets, expense budget, investment plan, and cash-flow projections.
 
 ---
 
-### caylik-inceleme
-Caylik finansal inceleme yapma becerisi. Her cayrek sonunda gerceklesen performansi planla karsilastirarak sapmalari analiz eder ve rotayi gunceller.
+### quarterly-review
+The quarterly financial review skill. Analyzes deviations and updates course by comparing actuals to plan at each quarter's end.
 
 ---
 
-### butce-sapma-analizi
-Butce sapma analizi yapma becerisi. Planlanan ve gerceklesen butce arasindaki farklari inceleyerek sapma nedenlerini ve duzeltici eylemleri belirler.
+### budget-variance-analysis
+The budget variance analysis skill. Determines causes and corrective actions by examining gaps between planned and actual budgets.
 
 ---
 
-### maliyet-muhasebesi
-Maliyet muhasebesi sistemi kurma ve yonetme becerisi. Urun ve hizmet maliyetlerini dogru hesaplayarak fiyatlandirma ve karlilik kararlarini destekler.
+### cost-accounting
+The skill of building and managing the cost-accounting system. Supports pricing and profitability decisions by computing product and service costs accurately.
 
 ---
 
-### abc-maliyetleme
-Faaliyet tabanli maliyetleme (ABC) sistemi kurma becerisi. Genel giderleri faaliyetler bazinda dagitarak daha dogru urun/hizmet maliyetleri hesaplar.
+### abc-costing
+The activity-based costing (ABC) skill. Computes more accurate product/service costs by allocating overheads per activity.
 
 ---
 
-### transfer-fiyatlandirmasi
-Transfer fiyatlandirma politikasi olusturma becerisi. Grup ici islemlerde yasal uyumlu ve vergi etkin fiyatlandirma stratejileri gelistirir.
+### transfer-pricing
+The transfer-pricing policy skill. Develops legally compliant, tax-efficient pricing strategies for intra-group transactions.
 
 ---
 
-### doviz-riski
-Doviz kuru riski yonetimi becerisi. Uluslararasi islemlerden kaynaklanan kur riskini olcer ve hedge stratejileri gelistirir.
+### currency-risk
+The currency-risk management skill. Measures FX risk from international transactions and develops hedging strategies.
 
 ---
 
-### faiz-riski
-Faiz orani riski yonetimi becerisi. Degisken faizli borc ve yatirimlardaki faiz orani degisikliklerinin finansal etkisini yonetir.
+### interest-rate-risk
+The interest-rate risk management skill. Manages the financial impact of rate changes on variable-rate debt and investments.
 
 ---
 
-### sigorta-yonetimi
-Kurumsal sigorta yonetimi becerisi. Isletme risklerini kapsayan uygun sigorta portfoyu olusturma ve yonetme stratejisi gelistirir.
+### insurance-management
+The corporate insurance management skill. Develops the strategy for building and managing the insurance portfolio covering business risks.
 
 ---
 
-### tedarikci-finansman
-Tedarikci finansmani ve odeme optimizasyonu becerisi. Tedarikci iliskilerinde finansal avantaj yaratacak odeme kosullari ve finansman secenekleri gelistirir.
+### supplier-financing
+The supplier financing and payment optimization skill. Develops payment terms and financing options that create financial advantage in supplier relationships.
 
 ---
 
-### musteri-kredisi
-Musteri kredi politikasi yonetimi becerisi. Musterilere acilacak ticari kredi limitlerini ve kosullarini belirleyerek risk ve satis dengesini optimize eder.
+### customer-credit
+The customer credit-policy management skill. Optimizes the risk/sales balance by setting trade credit limits and terms.
 
 ---
 
-### odeme-gecikme
-Odeme gecikmeleri yonetimi becerisi. Geciken odemeleri sistematik sekilde takip ederek tahsilat oranini arttirir ve nakit akisi etkisini minimize eder.
+### late-payments
+The late-payment management skill. Raises collection rates and minimizes cash-flow impact by tracking overdue payments systematically.
 
 ---
 
-### tahsilat-stratejisi
-Tahsilat stratejisi gelistirme becerisi. Alacak tahsilat surecini etkinlestirerek tahsilat oranini arttirir ve DSO'yu dusurur.
+### collection-strategy
+The collection-strategy skill. Raises the collection rate and lowers DSO by making the receivables process effective.
 
 ---
 
-### finansal-otomasyon
-Finansal surec otomasyonu becerisi. Manuel finansal islemleri otomatiklestirerek hata oranini dusurur ve verimliigi arttirir.
+### financial-automation
+The financial process automation skill. Cuts error rates and raises efficiency by automating manual financial operations.
 
 ---
 
-### muhasebe-entegrasyon
-Muhasebe sistemi entegrasyonu becerisi. Farkli is sistemlerini muhasebe yazilimiyla entegre ederek veri akisini otomatiklestirir.
+### accounting-integration
+The accounting-system integration skill. Automates data flow by integrating business systems with the accounting software.
 
 ---
 
-### banka-mutabakat
-Banka mutabakati yapma becerisi. Banka hesap hareketleri ile muhasebe kayitlarini eslestirerek farkliliklari tespit eder ve cozumler.
+### bank-reconciliation
+The bank-reconciliation skill. Detects and resolves differences by matching bank movements to accounting records.
 
 ---
 
-### finansal-dashboard
-Finansal dashboard tasarlama becerisi. Temel finansal metrikleri gercek zamanli goruntuleyen ve karar almaya destek saglayan panolar olusturur.
+### financial-dashboard
+The financial-dashboard design skill. Builds panels showing key financial metrics in real time to support decisions.
 
 ---
 
-### yatirimci-raporlama
-Yatirimci raporlama becerisi. Yatirimcilara sunulacak periyodik raporlari hazirlayarak seffaf ve profesyonel iletisim saglar.
+### investor-reporting
+The investor-reporting skill. Delivers transparent, professional communication by preparing periodic investor reports.
 
 ---
 
-### fonlama-stratejisi
-Fonlama stratejisi gelistirme becerisi. Isletmenin buyume asamasina uygun finansman kaynaklarini belirleyerek fonlama yol haritasi olusturur.
+### funding-strategy
+The funding-strategy skill. Builds the funding roadmap by identifying financing sources fitting the company's growth stage.
 
 ---
 
-### tohum-tur
-Tohum turu (seed round) fonlama hazirligi becerisi. Ilk yatirim turunun basarili gecmesi icin gerekli hazirlik adimlarini ve materyalleri olusturur.
+### seed-round
+The seed-round preparation skill. Builds the preparation steps and materials needed for a successful first investment round.
 
 ---
 
-### seri-a-hazirlik
-Seri A fonlama hazirligi becerisi. Buyume asamasindaki sirketin Seri A turuna hazirlanmasi icin stratejik ve operasyonel hazirlik yapar.
+### series-a-prep
+The Series A preparation skill. Runs the strategic and operational preparation for a growth-stage company's Series A round.
 
 ---
 
-### pitch-deck-finans
-Pitch deck finansal bolumleri hazirlama becerisi. Yatirimci sunumundaki finansal slaytlari (pazar buyuklugu, is modeli, metrikler, projeksiyonlar) profesyonelce olusturur.
+### pitch-deck-finance
+The skill of preparing the pitch deck's financial sections. Builds the financial slides (market size, business model, metrics, projections) professionally.
 
 ---
 
-### term-sheet-analizi
-Term sheet analizi ve muzakere becerisi. Yatirim term sheet'lerini analiz ederek kurucu icin en uygun kosullari muzakere etme stratejisi gelistirir.
+### term-sheet-analysis
+The term-sheet analysis and negotiation skill. Develops the strategy for negotiating founder-favorable terms by analyzing investment term sheets.
 
 ---
 
 ### cap-table
-Cap table (sermaye tablosu) yonetimi becerisi. Sirketin hisse dagilimini, opsiyon havuzunu ve yatirim turlarinin seyreltme etkisini modeller.
+The cap-table management skill. Models the equity distribution, the option pool, and the dilution effect of investment rounds.
 
 ---
 
-### hisse-havuzu
-Calisan hisse opsiyon havuzu (ESOP) yonetimi becerisi. Yetenek cekmek ve elde tutmak icin hisse opsiyon programi tasarlar ve yonetir.
+### esop
+The employee stock option pool (ESOP) management skill. Designs and manages the option program for attracting and retaining talent.
 
 ---
 
-### exit-stratejisi
-Cikis (exit) stratejisi gelistirme becerisi. Sirketin potansiyel cikis senaryolarini (satin alma, halka arz, ikincil satis) analiz ederek deger maksimizasyonu planlaar.
-
+### exit-strategy
+The exit-strategy skill. Plans value maximization by analyzing potential exits (acquisition, IPO, secondary sale).

--- a/.claude/skills-vault/marketing/SKILL.md
+++ b/.claude/skills-vault/marketing/SKILL.md
@@ -10,386 +10,385 @@ metadata:
   badi-version: ">=1.14.0"
   category: marketing
 ---
-# Pazarlama Becerileri
-Bu dosya, dijital pazarlama, marka stratejisi, reklam yonetimi, icerik pazarlama, donusum optimizasyonu ve pazarlama otomasyonu ile ilgili tum becerileri icerir.
+# Marketing Skills
+This file contains all the skills around digital marketing, brand strategy, ad management, content marketing, conversion optimization, and marketing automation.
 
 ---
 
-### pazarlama-stratejisi
-Butunsel pazarlama stratejisi olusturma becerisi. Isletmenin hedeflerine uygun, kanallari entegre eden ve olculebilir sonuclar ureten kapsamli bir pazarlama plani gelistirir.
+### marketing-strategy
+The skill of building a holistic marketing strategy. Develops a comprehensive plan aligned with business goals, integrating channels, and producing measurable results.
 
 ---
 
-### marka-stratejisi
-Marka stratejisi gelistirme becerisi. Marka kimligini, konumlandirmasini ve hikayesini tanimlayarak tutarli ve guclu bir marka algisi olusturur.
+### brand-strategy
+The brand-strategy skill. Builds a consistent, strong brand perception by defining the brand identity, positioning, and story.
 
 ---
 
-### konumlandirma
-Marka ve urun konumlandirma stratejisi becerisi. Hedef kitle zihninde benzersiz ve degerli bir yer edinmek icin farklilastirma stratejisi gelistirir.
+### positioning
+The brand and product positioning strategy skill. Develops the differentiation strategy for earning a unique, valuable place in the audience's mind.
 
 ---
 
-### hedef-kitle
-Hedef kitle analizi ve tanimlama becerisi. Demografik, psikografik ve davranissal verilerle ideal musteri profilini cikartir.
+### target-audience
+The target-audience analysis and definition skill. Profiles the ideal customer with demographic, psychographic, and behavioral data.
 
 ---
 
-### persona-olusturma
-Musteri persona olusturma becerisi. Gercek verilere dayali, detayli ve aksiyona donusuturulebilir musteri profilleri tasarlar.
+### persona-creation
+The customer-persona skill. Designs detailed, actionable customer profiles grounded in real data.
 
 ---
 
-### deger-onerisi
-Deger onerisi (value proposition) gelistirme becerisi. Musteriye sunulan benzersiz degeri net ve ikna edici sekilde ifade eden deger onerisi cercevesi olusturur.
+### value-proposition
+The value-proposition skill. Builds the framework expressing the unique value offered to the customer clearly and persuasively.
 
 ---
 
-### rekabet-analizi
-Rekabet analizi yapma becerisi. Dogrudan ve dolayli rakipleri inceleyerek stratejik avantaj ve firsat alanlari belirler.
+### competitive-analysis
+The competitive-analysis skill. Identifies strategic advantages and opportunity areas by examining direct and indirect competitors.
 
 ---
 
-### pazar-arastirmasi
-Pazar arastirmasi planlama ve yurutme becerisi. Hedef pazarin buyuklugu, trendleri ve dinamiklerini anlamak icin primer ve sekonder arastirma yapar.
+### market-research
+The market-research planning and execution skill. Runs primary and secondary research to understand the target market's size, trends, and dynamics.
 
 ---
 
-### trend-analizi
-Pazarlama trend analizi becerisi. Sektor, tuketici davranisi ve teknoloji trendlerini izleyerek stratejik firsatlari zamaninda yakalar.
+### trend-analysis
+The marketing trend-analysis skill. Catches strategic opportunities on time by tracking industry, consumer-behavior, and technology trends.
 
 ---
 
-### swot-pazarlama
-Pazarlama odakli SWOT analizi becerisi. Pazarlama acisindan guclu yonler, zayif yonler, firsatlar ve tehditleri sistematik olarak degerlendirir.
+### marketing-swot
+The marketing-focused SWOT skill. Systematically assesses strengths, weaknesses, opportunities, and threats from the marketing angle.
 
 ---
 
-### dijital-pazarlama
-Dijital pazarlama stratejisi gelistirme becerisi. Online kanallar uzerinden marka bilinilrligi, trafik ve donusum hedeflerine yonelik butunsel dijital strateji olusturur.
+### digital-marketing
+The digital-marketing strategy skill. Builds the holistic digital strategy toward awareness, traffic, and conversion goals across online channels.
 
 ---
 
-### sosyal-medya-strateji
-Sosyal medya stratejisi gelistirme becerisi. Platform bazli icerik, etkilesim ve buyume stratejileri ile sosyal medya varligini guclendirir.
+### social-media-strategy
+The social-media strategy skill. Strengthens the social presence with platform-based content, engagement, and growth strategies.
 
 ---
 
-### icerik-pazarlama
-Icerik pazarlama stratejisi gelistirme becerisi. Degerli ve ilgi cekici icerikler uretereek hedef kitleyi cekmek, egitmek ve donusturmek icin sistematik bir yaklasim olusturur.
+### content-marketing
+The content-marketing strategy skill. Builds the systematic approach for attracting, educating, and converting the audience with valuable content.
 
 ---
 
-### seo-stratejisi
-SEO stratejisi gelistirme becerisi. Organik arama gorununurligunu artirmak icin teknik, icerik ve otorite odakli SEO plani olusturur.
+### seo-strategy
+The SEO strategy skill. Builds the technical, content, and authority-focused SEO plan for lifting organic search visibility.
 
 ---
 
 ### sem-ppc
-Arama motoru reklamciligi (SEM/PPC) stratejisi becerisi. Google Ads ve diger arama reklamlari platformlarinda maliyet etkin kampanya yonetimi yapar.
+The search-engine advertising (SEM/PPC) strategy skill. Runs cost-efficient campaign management on Google Ads and other search platforms.
 
 ---
 
 ### google-ads
-Google Ads kampanya yonetimi becerisi. Arama, goruntulu reklam, video ve alisveris kampanyalarini olusturma, optimize etme ve olceklendirme islemlerini gerceklestirir.
+The Google Ads campaign-management skill. Creates, optimizes, and scales search, display, video, and shopping campaigns.
 
 ---
 
 ### facebook-ads
-Facebook/Meta reklam kampanyalari yonetimi becerisi. Facebook ve Instagram platformlarinda hedefli reklam kampanyalari olusturur ve optimize eder.
+The Facebook/Meta ad-campaign management skill. Builds and optimizes targeted campaigns on Facebook and Instagram.
 
 ---
 
 ### instagram-ads
-Instagram reklam kampanyalari yonetimi becerisi. Hikaye, feed, reels ve kesif reklam formatlarini kullanarak gorsel odakli kampanyalar yonetir.
+The Instagram ad-campaign management skill. Manages visual-first campaigns across story, feed, reels, and explore formats.
 
 ---
 
 ### linkedin-ads
-LinkedIn reklam kampanyalari yonetimi becerisi. B2B hedefleme, lead generation ve marka bilinilrligi icin LinkedIn reklam platformunu etkin kullanir.
+The LinkedIn ad-campaign management skill. Uses the LinkedIn ads platform effectively for B2B targeting, lead generation, and awareness.
 
 ---
 
 ### twitter-ads
-Twitter/X reklam kampanyalari yonetimi becerisi. Ggercek zamanli pazarlama, trend katilimi ve hedefli kampanyalarla Twitter platformunu etkin kullanir.
+The Twitter/X ad-campaign management skill. Uses the platform effectively with real-time marketing, trend participation, and targeted campaigns.
 
 ---
 
 ### tiktok-ads
-TikTok reklam kampanyalari yonetimi becerisi. Kisa video formatinda genc kitleye yonelik yaratici reklam kampanyalari olusturur.
+The TikTok ad-campaign management skill. Builds creative short-video campaigns aimed at younger audiences.
 
 ---
 
 ### youtube-ads
-YouTube reklam kampanyalari yonetimi becerisi. Video reklam formatlarini kullanarak marka bilinilrligi ve donusum odakli kampanyalar yonetir.
+The YouTube ad-campaign management skill. Manages awareness- and conversion-focused campaigns using video ad formats.
 
 ---
 
-### display-reklam
-Display (goruntulu) reklam kampanyalari yonetimi becerisi. Banner, native ve programatik reklam kampanyalarini olusturur ve optimize eder.
+### display-ads
+The display ad-campaign management skill. Creates and optimizes banner, native, and programmatic campaigns.
 
 ---
 
 ### retargeting
-Yeniden hedefleme (retargeting) kampanyalari yonetimi becerisi. Web sitesi ziyaretcilerini ve mevcut musterileri reklam ile yeniden hedefleyerek donusum oranini arttirir.
+The retargeting campaign skill. Raises conversion by re-targeting site visitors and existing customers with ads.
 
 ---
 
 ### affiliate
-Affiliate (ortaklik) pazarlama programi yonetimi becerisi. Performans bazli ortaklik programi kurarak yeni musteri edinme kanali olusturur.
+The affiliate-program management skill. Builds a new acquisition channel through a performance-based partnership program.
 
 ---
 
 ### influencer
-Influencer pazarlama stratejisi gelistirme becerisi. Marka ile uyumlu influencer'lar ile is birligi yaparak otantik ve etkili pazarlama kampanyalari olusturur.
+The influencer-marketing strategy skill. Builds authentic, effective campaigns by partnering with brand-fit influencers.
 
 ---
 
-### email-pazarlama
-E-posta pazarlama kanal stratejisi becerisi. E-posta kanalini genel pazarlama stratejisi icinde konumlandirarak kanal bazli hedefler ve taktikler belirler.
+### email-marketing
+The email channel strategy skill. Positions email within the overall marketing strategy and sets channel goals and tactics.
 
 ---
 
-### sms-pazarlama
-SMS pazarlama stratejisi gelistirme becerisi. Kisa mesaj kaanalini kullanarak zamaninda, kisisel ve yuksek acilma oranli pazarlama mesajlari gonderir.
+### sms-marketing
+The SMS-marketing strategy skill. Sends timely, personal, high-open-rate marketing messages over the SMS channel.
 
 ---
 
-### push-bildirim
-Push bildirim stratejisi gelistirme becerisi. Web ve mobil push bildirimleri ile kullanicilarla anlik ve kisisellestirilmis iletisim kurar.
+### push-notifications
+The push-notification strategy skill. Builds instant, personalized communication with users via web and mobile push.
 
 ---
 
-### chatbot-pazarlama
-Chatbot ile pazarlama stratejisi becerisi. Sohbet tabanli pazarlama ile lead toplama, musteri destek ve satis sureclerini otomatiklestirir.
+### chatbot-marketing
+The chatbot-marketing strategy skill. Automates lead capture, support, and sales processes with conversation-based marketing.
 
 ---
 
-### webinar-pazarlama
-Webinar pazarlama stratejisi becerisi. Egitici ve ilgi cekici webinarlar ile lead toplama, marka otoritesi ve musteri iliskisi guclendirme yapar.
+### webinar-marketing
+The webinar-marketing strategy skill. Captures leads, builds authority, and strengthens relationships with educational, engaging webinars.
 
 ---
 
-### podcast-pazarlama
-Podcast pazarlama stratejisi becerisi. Podcast yayin veya sponsor olarak marka bilinilrligi ve otorite olusturma stratejisi gelistirir.
+### podcast-marketing
+The podcast-marketing strategy skill. Develops the awareness and authority strategy as a podcast publisher or sponsor.
 
 ---
 
-### video-pazarlama
-Video pazarlama stratejisi becerisi. Video icerikleri ile marka hikayesi, urun tanitimi ve musteri egitimi yapan kapsamli bir video stratejisi olusturur.
+### video-marketing
+The video-marketing strategy skill. Builds a comprehensive video strategy covering brand story, product promotion, and customer education.
 
 ---
 
-### gorsel-pazarlama
-Gorsel pazarlama ve kreatif strateji becerisi. Infografik, gorsel icerik ve tasarim odakli pazarlama ile dikkat cekici kampanyalar olusturur.
+### visual-marketing
+The visual marketing and creative strategy skill. Builds attention-grabbing campaigns with infographics, visual content, and design-led marketing.
 
 ---
 
-### etkinlik-pazarlama
-Etkinlik pazarlama stratejisi becerisi. Fiziksel ve sanal etkinlikler araciligiyla marka deneyimi, lead toplama ve musteri iliskisi guclendirme yapar.
+### event-marketing
+The event-marketing strategy skill. Delivers brand experience, lead capture, and relationship building through physical and virtual events.
 
 ---
 
-### pr-strateji
-Halkla iliskiler (PR) stratejisi gelistirme becerisi. Medya iliskileri, basin bultenleri ve haber degeri olusturma ile marka gorununurlugunu arttirir.
+### pr-strategy
+The public-relations (PR) strategy skill. Raises brand visibility with media relations, press releases, and newsworthiness.
 
 ---
 
-### kriz-yonetimi
-Pazarlama ve iletisim krizi yonetimi becerisi. Marka itibarini tehdit eden kriz durumlarinda hizli ve etkili iletisim stratejisi uygulair.
+### crisis-management
+The marketing and communications crisis-management skill. Applies fast, effective communication strategy when the brand's reputation is threatened.
 
 ---
 
-### marka-bilinirlik
-Marka bilinilrligi olcme ve artirma becerisi. Hedef kitlde marka farkindaligin artirmak icin olcumleme altyapisi ve bilinirlik kampanyalari olusturur.
+### brand-awareness
+The brand-awareness measurement and growth skill. Builds the measurement infrastructure and awareness campaigns raising brand recall in the audience.
 
 ---
 
-### marka-sadakat
-Marka sadakati olusturma ve olcme becerisi. Musteri bagliligi programlari ve deneyim iyilestirmeleri ile tekrar satin alma ve savunuculuk oranini arttirir.
+### brand-loyalty
+The brand-loyalty building and measurement skill. Raises repeat purchase and advocacy through loyalty programs and experience improvements.
 
 ---
 
-### musteri-edinme
-Musteri edinme stratejisi gelistirme becerisi. Yeni musteriler kazanmak icin kanal bazli taktikler ve maliyet optimizasyonu yapar.
+### customer-acquisition
+The customer-acquisition strategy skill. Runs channel-based tactics and cost optimization for winning new customers.
 
 ---
 
-### musteri-tutma
-Musteri tutma (retention) stratejisi gelistirme becerisi. Mevcut musterilerin elde tutulmasini saglayarak yasam boyu deger ve karlilik arttirir.
+### customer-retention
+The retention strategy skill. Raises lifetime value and profitability by keeping existing customers.
 
 ---
 
-### referans-pazarlama
-Referans (tavsiye) pazarlama programi yonetimi becerisi. Mevcut musterilerin yeni musteriler onermesini tesvik eden sistematik bir program olusturur.
+### referral-marketing
+The referral-program management skill. Builds a systematic program encouraging existing customers to recommend new ones.
 
 ---
 
-### viral-pazarlama
-Viral pazarlama stratejisi gelistirme becerisi. Organik paylasim ve agizdan agiza yayilim ile dusuk maliyetle genis kitlelere ulasma stratejisi olusturur.
+### viral-marketing
+The viral-marketing strategy skill. Builds the strategy reaching wide audiences at low cost through organic sharing and word of mouth.
 
 ---
 
-### gerilla-pazarlama
-Gerilla pazarlama stratejisi becerisi. Dusuk butce ile yaratici ve sasirtici pazarlama taktikleri kullanarak yuksek etki yaratan kampanyalar olusturur.
+### guerrilla-marketing
+The guerrilla-marketing strategy skill. Builds high-impact campaigns using creative, surprising tactics on a small budget.
 
 ---
 
 ### community-building
-Topluluk olusturma ve yonetme becerisi. Marka etrafinda bagli ve aktif bir topluluk kurarak organik buyume ve musteri savunuculugu yaratir.
+The community building and management skill. Creates organic growth and advocacy by building an engaged, active community around the brand.
 
 ---
 
-### forum-pazarlama
-Forum pazarlama stratejisi becerisi. Sektor forumlarinda ve soru-cevap platformlarinda marka varliligini olusturarak organik trafik ve otorite kazanir.
+### forum-marketing
+The forum-marketing strategy skill. Earns organic traffic and authority by building brand presence on industry forums and Q&A platforms.
 
 ---
 
-### quora-strateji
-Quora pazarlama stratejisi becerisi. Quora platformunda uzman icerikleri ile marka otoritesi, trafik ve lead olusturma stratejisi gelistirir.
+### quora-strategy
+The Quora marketing strategy skill. Develops brand authority, traffic, and lead generation through expert content on Quora.
 
 ---
 
-### reddit-strateji
-Reddit pazarlama stratejisi becerisi. Reddit toplulugklarinda organik ve otantik katilim ile marka farkindaliigi ve trafik olusturma yapar.
+### reddit-strategy
+The Reddit marketing strategy skill. Builds awareness and traffic through organic, authentic participation in Reddit communities.
 
 ---
 
 ### growth-hacking
-Growth hacking stratejisi gelistirme becerisi. Hizli ve maliyet etkin buyume icin veri odakli, yaratici ve olceklenebilir buyume taktikleri uygular.
+The growth-hacking strategy skill. Applies data-driven, creative, scalable growth tactics for fast, cost-effective growth.
 
 ---
 
-### ab-test-pazarlama
-Pazarlama A/B test stratejisi becerisi. Kampanyalarda sistematik A/B testler yaparak veri odakli optimizasyon kulturu olusturur.
+### marketing-ab-testing
+The marketing A/B test strategy skill. Builds a data-driven optimization culture through systematic A/B tests in campaigns.
 
 ---
 
-### donusum-optimizasyonu
-Donusum orani optimizasyonu (CRO) becerisi. Web sitesi ve pazarlama hunisindeki donusum oranlarini sistematik olarak arttirir.
+### conversion-optimization
+The conversion-rate optimization (CRO) skill. Systematically lifts conversion across the website and the marketing funnel.
 
 ---
 
-### landing-page-opt
-Landing page optimizasyonu becerisi. Kampanya landing page'lerinin donusum oranini artirmak icin tasarim, icerik ve kullanici deneyimi optimizasyonu yapar.
+### landing-page-optimization
+The landing-page optimization skill. Raises campaign landing pages' conversion through design, content, and UX optimization.
 
 ---
 
-### funnel-analizi
-Pazarlama ve satis hunisi analizi becerisi. Huni asamalarindaki performansi olcerek darbogazlari tespit eder ve optimizasyon firsatlarini belirler.
+### funnel-analysis
+The marketing and sales funnel analysis skill. Finds bottlenecks and optimization opportunities by measuring performance per funnel stage.
 
 ---
 
-### attribution-modeli
-Pazarlama attribution modeli olusturma becerisi. Farli kanallarin donusum uzerindeki katkisini olcerek butce dagiliim kararlarina yol gosterir.
+### attribution-modeling
+The attribution-modeling skill. Guides budget-allocation decisions by measuring each channel's contribution to conversion.
 
 ---
 
-### pazarlama-butcesi
-Pazarlama butcesi planlama ve yonetme becerisi. Toplam pazarlama butcesini kanal, kampanya ve donem bazinda planlayarak etkin kullanim saglar.
+### marketing-budget
+The marketing-budget planning and management skill. Ensures effective use by planning the total budget by channel, campaign, and period.
 
 ---
 
-### roas-optimizasyonu
-Reklam harcamasi getirisi (ROAS) optimizasyonu becerisi. Reklam kampanyalarinin getirisini artirmak icin butce, hedefleme ve kreatif optimizasyonu yapar.
+### roas-optimization
+The ROAS optimization skill. Raises campaign returns through budget, targeting, and creative optimization.
 
 ---
 
-### pazarlama-otomasyonu
-Pazarlama otomasyon sistemi kurma ve yonetme becerisi. Tekrarlayan pazarlama gorevlerini otomatiklestirerek verimlilik ve tutarliilik saglar.
+### marketing-automation
+The marketing-automation skill. Delivers efficiency and consistency by automating repetitive marketing tasks.
 
 ---
 
-### crm-entegrasyon
-CRM sistemi entegrasyonu becerisi. Pazarlama ve satis verilerini CRM ile entegre ederek 360 derece musteri gorunumu olusturur.
+### crm-integration
+The CRM-integration skill. Builds a 360-degree customer view by integrating marketing and sales data with the CRM.
 
 ---
 
 ### lead-scoring
-Lead skorlama modeli olusturma becerisi. Potansiyel musterileri davranissal ve demografik verilere gore puanlayarak satis onceliklendirmesi yapar.
+The lead-scoring model skill. Drives sales prioritization by scoring prospects on behavioral and demographic data.
 
 ---
 
 ### lead-nurturing
-Lead beslemme (nurturing) stratejisi becerisi. Henuz satin almaya hazir olmayan potansiyel musterileri egiterek ve besleyerek satisa hazir hale getirir.
+The lead-nurturing strategy skill. Makes not-yet-ready prospects sales-ready by educating and nurturing them.
 
 ---
 
-### pazarlama-raporlama
-Pazarlama performans raporlama becerisi. Tum pazarlama faaliyetlerinin performansini olcen, raporlayan ve icerik ureten sistematik bir raporlama cercevesi kurar.
+### marketing-reporting
+The marketing-performance reporting skill. Builds the systematic framework measuring, reporting, and producing insights for all marketing activity.
 
 ---
 
-### kampanya-planlama
-Pazarlama kampanyasi planlama becerisi. Hedeften uygulamaya kadar kampanya yasam dongusunun her asamasini sistematik olarak planlar.
+### campaign-planning
+The campaign-planning skill. Plans every stage of the campaign lifecycle from goal to execution.
 
 ---
 
-### kampanya-yonetimi
-Kampanya yurutme ve yonetim becerisi. Devam eden kampanyalari izleyerek performans optimizasyonu ve gunluk operasyonel yonetim yapar.
+### campaign-management
+The campaign execution and management skill. Runs performance optimization and daily operations on live campaigns.
 
 ---
 
-### kampanya-analizi
-Kampanya sonrasi analiz ve degerlendirme becerisi. Tamamlanan kampanyanin performansini kapsamli olarak degerlendirerek gelecek kampanyalara dersler cikarir.
+### campaign-analysis
+The post-campaign analysis skill. Extracts lessons for future campaigns by evaluating the finished campaign comprehensively.
 
 ---
 
-### mevsimsel-pazarlama
-Mevsimsel pazarlama planlama becerisi. Sezon, tatil ve ozel gunlere uygun kampanya takvimi ve strateji olusturur.
+### seasonal-marketing
+The seasonal-marketing planning skill. Builds the campaign calendar and strategy fitting seasons, holidays, and special days.
 
 ---
 
-### lansman-pazarlama
-Urun lansmansi pazarlama stratejisi becerisi. Yeni urun veya hizmet lansmanlarini basarili kilmak icin cok kanalli pazarlama plani olusturur.
+### launch-marketing
+The product-launch marketing strategy skill. Builds the multi-channel plan that makes new product or service launches succeed.
 
 ---
 
-### urun-pazarlama
-Urun pazarlama stratejisi becerisi. Urun degerini hedef kitleye etkili sekilde iletmek icin konumlandirma, mesaj ve go-to-market stratejisi gelistirir.
+### product-marketing
+The product-marketing strategy skill. Develops positioning, messaging, and go-to-market strategy for conveying product value to the audience.
 
 ---
 
-### b2b-pazarlama
-B2B pazarlama stratejisi becerisi. Isletmelere yonelik pazarlama taktikleri, account-based marketing ve uzun satis dongusu yonetimi yapar.
+### b2b-marketing
+The B2B marketing strategy skill. Runs business-facing tactics, account-based marketing, and long sales-cycle management.
 
 ---
 
-### b2c-pazarlama
-B2C pazarlama stratejisi becerisi. Bireysel tuketicilere yonelik duygusal, hizli ve olceklenebilir pazarlama kampanyalari olusturur.
+### b2c-marketing
+The B2C marketing strategy skill. Builds emotional, fast, scalable campaigns aimed at individual consumers.
 
 ---
 
-### saas-pazarlama
-SaaS pazarlama stratejisi becerisi. Yazilim hizmeti (SaaS) isletmeleri icin ozel lead generation, trial donusum ve buyume stratejileri gelistirir.
+### saas-marketing
+The SaaS marketing strategy skill. Develops SaaS-specific lead generation, trial conversion, and growth strategies.
 
 ---
 
-### e-ticaret-pazarlama
-E-ticaret pazarlama stratejisi becerisi. Online magaza icin trafik, donusum ve tekrar satin alma odakli cok kanalli pazarlama stratejisi gelistirir.
+### ecommerce-marketing
+The e-commerce marketing strategy skill. Develops the multi-channel strategy focused on traffic, conversion, and repeat purchase for online stores.
 
 ---
 
-### yerel-pazarlama
-Yerel pazarlama stratejisi becerisi. Belirli cografi bolgelerde marka gorununurlugu ve musteri edinme icin lokasyon bazli pazarlama taktikleri uygular.
+### local-marketing
+The local-marketing strategy skill. Applies location-based tactics for visibility and acquisition in specific geographic areas.
 
 ---
 
-### global-pazarlama
-Global pazarlama stratejisi becerisi. Uluslararasi pazarlara giris ve cok ulkeli pazarlama operasyonlarini yonetir.
+### global-marketing
+The global-marketing strategy skill. Manages international market entries and multi-country marketing operations.
 
 ---
 
-### coklu-kanal
-Coklu kanal (multichannel) pazarlama stratejisi becerisi. Birden fazla pazarlama kanalini koordineli sekilde yoneterek tutarli musteri deneyimi saglar.
+### multichannel
+The multichannel marketing strategy skill. Delivers a consistent customer experience by coordinating multiple marketing channels.
 
 ---
 
 ### omnichannel
-Omnichannel pazarlama stratejisi becerisi. Tum kanallarda kesintisiz ve entegre musteri deneyimi olusturarak kanal sinirllarini ortadan kaldirir.
+The omnichannel marketing strategy skill. Removes channel boundaries by building a seamless, integrated experience everywhere.
 
 ---
 
-### pazarlama-teknolojisi
-Pazarlama teknoloji yigini (MarTech stack) yonetimi becerisi. Pazarlama araclari ve platformlarini secme, entegre etme ve optimize etme stratejisi gelistirir.
-
+### marketing-technology
+The MarTech-stack management skill. Develops the strategy for picking, integrating, and optimizing marketing tools and platforms.

--- a/.claude/skills-vault/mobile/SKILL.md
+++ b/.claude/skills-vault/mobile/SKILL.md
@@ -10,261 +10,260 @@ metadata:
   badi-version: ">=1.14.0"
   category: mobile
 ---
-# Mobil Gelistirme Becerileri
-Bu dosya, mobil uygulama tasarimi, gelistirme, test, dagitim ve optimizasyon alanlarindaki tum becerileri icerir.
+# Mobile Development Skills
+This file contains all the skills across mobile app design, development, testing, deployment, and optimization.
 
-## Yerlesik Alt Skill'ler
+## Built-in Sub-skills
 
 ### app-store-screenshots
-App Store ve Google Play icin tanitim screenshot'larini otomatik uretir (Next.js + html-to-image). Tum Apple/Google zorunlu cozunurluklerinde PNG export. Tetikleyiciler: "app store screenshot", "play store screenshot", "marketing asset". Detay: `.claude/skills/mobile/app-store-screenshots/SKILL.md`
+Auto-generates App Store and Google Play promotional screenshots (Next.js + html-to-image). PNG export at all mandatory Apple/Google resolutions. Triggers: "app store screenshot", "play store screenshot", "marketing asset". Detail: `.claude/skills/mobile/app-store-screenshots/SKILL.md`
 
 ---
 
-### mobil-mimari-tasarimi
-Mobil uygulama icin olceklenebilir ve bakilabilir mimari yaklasim secer ve uygular.
+### mobile-architecture-design
+Picks and applies a scalable, maintainable architectural approach for the mobile app.
 
 ---
 
-### cross-platform-strateji
-iOS ve Android icin ortak kod tabani ile gelistirme stratejisi belirler.
+### cross-platform-strategy
+Sets the shared-codebase development strategy for iOS and Android.
 
 ---
 
-### react-native-gelistirme
-React Native ile mobil uygulama gelistirme en iyi uygulamalarini ve mimarisini olusturur.
+### react-native-development
+Builds best practices and architecture for mobile development with React Native.
 
 ---
 
-### flutter-gelistirme
-Flutter framework ile mobil uygulama gelistirme mimarisi ve uygulamalari olusturur.
+### flutter-development
+Builds mobile development architecture and practices with the Flutter framework.
 
 ---
 
-### ios-native-gelistirme
-Swift ve SwiftUI ile iOS native uygulama gelistirme rehberi olusturur.
+### ios-native-development
+Builds the iOS native development guide with Swift and SwiftUI.
 
 ---
 
-### android-native-gelistirme
-Kotlin ve Jetpack Compose ile Android native uygulama gelistirme rehberi olusturur.
+### android-native-development
+Builds the Android native development guide with Kotlin and Jetpack Compose.
 
 ---
 
-### mobil-ui-tasarimi
-Mobil uygulamalar icin kullanici arayuzu tasarim ilkeleri ve komponent sistemi olusturur.
+### mobile-ui-design
+Builds UI design principles and a component system for mobile apps.
 
 ---
 
-### mobil-navigasyon
-Mobil uygulamada kullanici navigasyonunu ve ekran gecislerini tasarlar.
+### mobile-navigation
+Designs user navigation and screen transitions in the mobile app.
 
 ---
 
-### mobil-state-yonetimi
-Mobil uygulama state yonetimi stratejisi tasarlayarak veri akisini optimize eder.
+### mobile-state-management
+Optimizes data flow by designing the mobile state-management strategy.
 
 ---
 
-### mobil-performans-optimizasyonu
-Mobil uygulamanin performansini analiz ederek iyilestirme stratejileri uygular.
+### mobile-performance-optimization
+Applies improvement strategies by analyzing the mobile app's performance.
 
 ---
 
-### mobil-depolama-stratejisi
-Mobil uygulamada yerel veri depolama yaklasimi ve stratejisi belirler.
+### mobile-storage-strategy
+Sets the local data-storage approach and strategy in the mobile app.
 
 ---
 
-### mobil-ag-iletisimi
-Mobil uygulamanin ag iletisim katmanini tasarlar ve optimize eder.
+### mobile-networking
+Designs and optimizes the mobile app's network communication layer.
 
 ---
 
-### mobil-push-bildirimi
-Push bildirim altyapisi kurulumu ve bildirim stratejisi olusturur.
+### mobile-push-notifications
+Builds the push-notification infrastructure and notification strategy.
 
 ---
 
-### mobil-guvenlik-uygulama
-Mobil uygulama guvenligini saglayan teknik kontroller ve en iyi uygulamalar uygular.
+### mobile-security-implementation
+Applies technical controls and best practices securing the mobile app.
 
 ---
 
-### mobil-kimlik-dogrulama
-Mobil uygulamada kullanici kimlik dogrulama akislarini tasarlar.
+### mobile-authentication
+Designs user authentication flows in the mobile app.
 
 ---
 
-### mobil-cevrimdisi-destek
-Cevrimdisi calisan mobil uygulama stratejisi ve senkronizasyon mekanizmasi tasarlar.
+### mobile-offline-support
+Designs the offline-capable app strategy and synchronization mechanism.
 
 ---
 
-### mobil-lokalizasyon
-Mobil uygulamayi cok dilli destekle lokalize etme stratejisi ve uygulamasi yapar.
+### mobile-localization
+Plans and implements multi-language localization for the mobile app.
 
 ---
 
-### mobil-erisilebilirlik
-Mobil uygulamada erisilebilirlik standartlarini uygulayarak herkes icin kullanilabilir yapar.
+### mobile-accessibility
+Makes the app usable for everyone by applying accessibility standards.
 
 ---
 
-### mobil-animasyon
-Mobil uygulamada performansli ve anlamli animasyonlar tasarlar ve uygular.
+### mobile-animation
+Designs and implements performant, meaningful animations in the mobile app.
 
 ---
 
-### mobil-test-otomasyonu
-Mobil uygulamalar icin test otomasyon altyapisi ve stratejisi olusturur.
+### mobile-test-automation
+Builds the test automation infrastructure and strategy for mobile apps.
 
 ---
 
-### app-store-optimizasyonu
-App Store ve Google Play'de uygulama gorunurlugunu artiran ASO stratejisi gelistirir.
+### app-store-optimization
+Develops the ASO strategy lifting app visibility on the App Store and Google Play.
 
 ---
 
-### mobil-dagitim-sureci
-Mobil uygulama build, imzalama ve magaza dagitim surecini otomatiklestirir.
+### mobile-release-process
+Automates the mobile build, signing, and store-distribution process.
 
 ---
 
-### mobil-analitik
-Mobil uygulama kullanici davranislarini izleyen analitik altyapisi kurar.
+### mobile-analytics
+Builds the analytics infrastructure tracking mobile user behavior.
 
 ---
 
-### mobil-hata-izleme
-Mobil uygulamada hata izleme ve crash raporlama altyapisi kurar.
+### mobile-error-tracking
+Builds error tracking and crash-reporting infrastructure in the mobile app.
 
 ---
 
-### mobil-a-b-testi
-Mobil uygulamada A/B test altyapisi kurarak veri odakli karar alma saglar.
+### mobile-a-b-testing
+Enables data-driven decisions by building mobile A/B testing infrastructure.
 
 ---
 
-### mobil-ci-cd
-Mobil uygulama icin CI/CD pipeline tasarlayarak gelistirme dongusu hizlandirir.
+### mobile-ci-cd
+Speeds up the development cycle by designing the mobile CI/CD pipeline.
 
 ---
 
-### mobil-bellek-yonetimi
-Mobil uygulamada bellek kullanimini optimize ederek performans ve kararlilik arttirir.
+### mobile-memory-management
+Raises performance and stability by optimizing memory usage in the mobile app.
 
 ---
 
-### mobil-pil-optimizasyonu
-Mobil uygulamanin pil tuketimini minimize eden stratejiler ve uygulamalar gelistirir.
+### mobile-battery-optimization
+Develops strategies and implementations minimizing the app's battery drain.
 
 ---
 
-### mobil-deep-linking
-Deep link ve evrensel baglanti (universal link) altyapisini kurar.
+### mobile-deep-linking
+Builds the deep link and universal link infrastructure.
 
 ---
 
-### mobil-odeme-entegrasyonu
-Mobil uygulamada uygulama ici satin alma ve odeme sistemlerini entegre eder.
+### mobile-payment-integration
+Integrates in-app purchase and payment systems into the mobile app.
 
 ---
 
-### mobil-harita-entegrasyonu
-Mobil uygulamaya harita ve konum hizmetlerini entegre eder.
+### mobile-map-integration
+Integrates maps and location services into the mobile app.
 
 ---
 
-### mobil-kamera-medya
-Mobil uygulamada kamera ve medya islevselligini gelistirir.
+### mobile-camera-media
+Develops camera and media functionality in the mobile app.
 
 ---
 
-### mobil-form-tasarimi
-Mobil cihazlar icin kullanici dostu form deneyimi tasarlar.
+### mobile-form-design
+Designs a user-friendly form experience for mobile devices.
 
 ---
 
-### mobil-widget-gelistirme
-Ana ekran widget'lari gelistirerek uygulama gorunurlugunu ve etkilesimi arttiirir.
+### mobile-widget-development
+Raises app visibility and engagement by building home-screen widgets.
 
 ---
 
-### mobil-wear-os
-Giyilebilir cihazlar (WearOS, watchOS) icin mobil uygulama uzantisi gelistirir.
+### mobile-wear-os
+Builds the app extension for wearables (WearOS, watchOS).
 
 ---
 
-### mobil-ar-entegrasyonu
-Arttirilmis gerceklik (AR) ozelliklerini mobil uygulamaya entegre eder.
+### mobile-ar-integration
+Integrates augmented reality (AR) features into the mobile app.
 
 ---
 
-### mobil-bildirim-yonetimi
-Yerel ve uzak bildirimleri yoneten kapsamli bildirim sistemi tasarlar.
+### mobile-notification-management
+Designs the comprehensive system managing local and remote notifications.
 
 ---
 
-### mobil-tema-sistemi
-Mobil uygulamada tema yonetimi ve karanlik mod destegi saglayan sistem kurar.
+### mobile-theme-system
+Builds the system providing theme management and dark-mode support.
 
 ---
 
-### mobil-surum-yonetimi
-Mobil uygulama surum stratejisi, versiyonlama ve eski surum yonetimini planlar.
+### mobile-version-management
+Plans the app's release strategy, versioning, and legacy-version management.
 
 ---
 
-### mobil-uygulama-boyutu
-Uygulama boyutunu optimize ederek indirme ve kurulum oranlarini arttirir.
+### mobile-app-size
+Raises download and install rates by optimizing the app size.
 
 ---
 
-### mobil-erisim-izni-yonetimi
-Kullanici izinlerini en iyi uygulamalarla yoneten strateji olusturur.
+### mobile-permission-management
+Builds the strategy managing user permissions per best practices.
 
 ---
 
-### mobil-uygulama-ici-mesajlasma
-Uygulama ici mesaj, banner ve rehber sistemi olusturarak kullanici iletisimini guclendirir.
+### mobile-in-app-messaging
+Strengthens user communication by building in-app messages, banners, and guides.
 
 ---
 
-### mobil-clipboard-paylasim
-Mobil uygulamada paylas islevi ve pano (clipboard) entegrasyonunu tasarlar.
+### mobile-clipboard-sharing
+Designs the share functionality and clipboard integration in the mobile app.
 
 ---
 
-### mobil-biometric-guvenlik
-Biyometrik kimlik dogrulama (parmak izi, yuz tanima) entegrasyonunu uygular.
+### mobile-biometric-security
+Implements biometric authentication (fingerprint, face recognition) integration.
 
 ---
 
-### mobil-arka-plan-isleme
-Mobil uygulamada arka plan gorevlerini verimli yoneten strateji olusturur.
+### mobile-background-processing
+Builds the strategy managing background tasks efficiently in the mobile app.
 
 ---
 
-### mobil-uygulama-icin-seo
-Mobil uygulamanin web aramalarinda gorunur olmasini saglayan App Indexing ve ASO stratejisi gelistirir.
+### mobile-app-seo
+Develops the App Indexing and ASO strategy making the app visible in web searches.
 
 ---
 
-### mobil-canli-etkinlik
-Mobil uygulamada canli etkinlik (Live Activity, Dynamic Island) ozelligini uygular.
+### mobile-live-activities
+Implements live-activity features (Live Activity, Dynamic Island) in the mobile app.
 
 ---
 
-### mobil-veri-senkronizasyonu
-Yerel ve uzak veri kaynaklari arasinda guvenilir senkronizasyon mekanizmasi kurar.
+### mobile-data-sync
+Builds a reliable synchronization mechanism between local and remote data sources.
 
 ---
 
-### mobil-ses-video-akisi
-Mobil uygulamada ses ve video akis (streaming) ozelligini entegre eder.
+### mobile-audio-video-streaming
+Integrates audio and video streaming features into the mobile app.
 
 ---
 
-### mobil-qr-barkod-tarama
-Mobil uygulamada QR kod ve barkod tarama islevselligini entegre eder.
-
+### mobile-qr-barcode-scanning
+Integrates QR code and barcode scanning functionality into the mobile app.

--- a/.claude/skills-vault/product/SKILL.md
+++ b/.claude/skills-vault/product/SKILL.md
@@ -10,321 +10,320 @@ metadata:
   badi-version: ">=1.14.0"
   category: product
 ---
-# Urun Becerileri
-Bu dosya, urun yonetimi, urun stratejisi, kullanici deneyimi, urun gelistirme ve urun analizleri ile ilgili tum becerileri icerir.
+# Product Skills
+This file contains all the skills around product management, product strategy, user experience, product development, and product analytics.
 
 ---
 
-### urun-stratejisi
-Urun stratejisi gelistirme becerisi. Uzun vadeli urun vizyonunu is hedefleriyle uyumlastirarak rekabet avantaji saglayan stratejik yol haritasi olusturur.
+### product-strategy
+The product-strategy skill. Builds the strategic roadmap delivering competitive advantage by aligning the long-term product vision with business goals.
 
 ---
 
-### urun-vizyonu
-Urun vizyonu tanimlama becerisi. Ilham verici ve yol gosterici bir urun vizyon ifadesi olusturarak takim ve paydas uyumunu saglar.
+### product-vision
+The product-vision definition skill. Builds an inspiring, guiding vision statement that aligns the team and stakeholders.
 
 ---
 
-### urun-yol-haritasi
-Urun yol haritasi (roadmap) olusturma becerisi. Urun gelistirme onceliklerini zamana yayarak paydas beklentilerini ve kaynak planlamasini yonetir.
+### product-roadmap
+The product roadmap skill. Manages stakeholder expectations and resource planning by laying development priorities over time.
 
 ---
 
 ### product-market-fit
-Urun-pazar uyumu (PMF) olcme ve iyilestirme becerisi. Urunun hedef pazarin ihtiyaclarini ne kadar karsiladigini degerlendirir ve uyumu guclendirir.
+The PMF measurement and improvement skill. Assesses how well the product meets the target market's needs and strengthens the fit.
 
 ---
 
-### musteri-kesfi
-Musteri kesif (discovery) sureci becerisi. Kullanici ihtiyaclarini, sorunlarini ve davranislarini derinlemesine anlamak icin arastirma yontemleri uygular.
+### customer-discovery
+The customer-discovery skill. Applies research methods for deeply understanding user needs, problems, and behavior.
 
 ---
 
-### kullanici-arastirmasi
-Kullanici arastirmasi planlama ve yurutme becerisi. Nitel ve nicel arastirma yontemleri ile kullanici davranislari ve tercihleri hakkinda veri toplar.
+### user-research
+The user-research planning and execution skill. Collects data on user behavior and preferences with qualitative and quantitative methods.
 
 ---
 
-### persona-urun
-Urun odakli persona olusturma becerisi. Urun kararlarini yonlendirecek detayli kullanici profilleri tasarlar.
+### product-personas
+The product-focused persona skill. Designs detailed user profiles that guide product decisions.
 
 ---
 
-### kullanici-hikayesi
-Kullanici hikayesi (user story) yazma becerisi. Urun gereksinimlerini kullanici perspektifinden net ve test edilebilir hikayeler olarak ifade eder.
+### user-stories
+The user-story writing skill. Expresses requirements as clear, testable stories from the user's perspective.
 
 ---
 
-### ozellik-onceliklendirme
-Ozellik onceliklendirme becerisi. Urun backlog'undaki ozellikleri sistematik cerceveler kullanarak siralar ve kaynak daginlimini optimize eder.
+### feature-prioritization
+The feature-prioritization skill. Ranks backlog features with systematic frameworks and optimizes resource allocation.
 
 ---
 
-### mvp-tanimlama
-MVP (Minimum Viable Product) tanimlama becerisi. Urunun pazara en hizli ve en az kaynakla cikarilabilecek cekirdek deger setini belirler.
+### mvp-definition
+The MVP definition skill. Identifies the core value set that gets the product to market fastest with the least resources.
 
 ---
 
-### prototipleme
-Prototip olusturma stratejisi becerisi. Fikirleri hizla test edilebilir prototiplere donusturerek erken geri bildirim toplamayi saglar.
+### prototyping
+The prototyping strategy skill. Enables early feedback by turning ideas into testable prototypes fast.
 
 ---
 
-### kullanilabilirlik-testi
-Kullanilabilirlik testi planlama ve yurutme becerisi. Urunun kullanici dostu olup olmadigini test ederek kullanici deneyimi sorunlarini tespit eder.
+### usability-testing
+The usability-test planning and execution skill. Detects UX problems by testing whether the product is user-friendly.
 
 ---
 
-### urun-analitik
-Urun analitik stratejisi ve uygulama becerisi. Kullanici davranisi verilerini toplayarak urun kararlarini veri ile destekler.
+### product-analytics
+The product analytics strategy and implementation skill. Backs product decisions with data by collecting user-behavior data.
 
 ---
 
-### metrik-cerceve
-Urun metrik cercevesi olusturma becerisi. North Star metrigi, girdi metrikleri ve saglik metrikleri ile urun performansini butunsel olarak olcer.
+### metric-framework
+The product metric framework skill. Measures product performance holistically with a North Star metric, input metrics, and health metrics.
 
 ---
 
-### ab-test-urun
-Urun A/B testi tasarlama ve analiz becerisi. Urun degisikliklerinin etkisini kanitlayan bilimsel deneyler tasarlar ve analiz eder.
+### product-ab-testing
+The product A/B test design and analysis skill. Designs and analyzes scientific experiments proving the impact of product changes.
 
 ---
 
-### onboarding-tasarimi
-Kullanici onboarding deneyimi tasarlama becerisi. Yeni kullanicilari urune alistiaran, deger kesfini hizlandiran ve aktivasyonu artiran akislar olusturur.
+### onboarding-design
+The user-onboarding experience skill. Builds flows that ramp new users, speed up value discovery, and raise activation.
 
 ---
 
-### retansiyon-stratejisi
-Urun retansiyon stratejisi gelistirme becerisi. Kullanicilarin urunu duzenli kullanmaya devam etmesini saglayan taktikler ve mekanizmalar olusturur.
+### retention-strategy
+The product-retention strategy skill. Builds the tactics and mechanisms that keep users coming back.
 
 ---
 
-### urun-geri-bildirim
-Urun geri bildirim toplama ve yonetme becerisi. Kullanici geri bildirimlerini sistematik olarak toplayarak, analiz ederek urun kararlarini besler.
+### product-feedback
+The product feedback collection and management skill. Feeds product decisions by collecting and analyzing user feedback systematically.
 
 ---
 
-### ozellik-talep-yonetimi
-Ozellik talep yonetimi becerisi. Musteriler, satis ekibi ve paydlaslardan gelen ozellik taleplerini sistematik olarak degerlendirir ve yonetir.
+### feature-request-management
+The feature-request management skill. Evaluates and manages requests from customers, sales, and stakeholders systematically.
 
 ---
 
-### urun-lansmani
-Urun lansman planlamasi becerisi. Yeni urun veya ozelligin basarili bir sekilde pazara sunulmasi icin tum hazirliklari koordine eder.
+### product-launch
+The product-launch planning skill. Coordinates all the preparation for bringing a new product or feature to market successfully.
 
 ---
 
-### urun-yasam-dongusu
-Urun yasam dongusu yonetimi becerisi. Urunun giris, buyume, olgunluk ve dusus asamalarini yoneterek her asamada uygun strateji uygular.
+### product-lifecycle
+The product lifecycle management skill. Applies the right strategy at every stage by managing introduction, growth, maturity, and decline.
 
 ---
 
-### rekabet-istihbarat
-Rekabet istihbarati toplama ve analiz becerisi. Rakip urunleri, stratejileri ve pazardaki hareketleri sistematik olarak izler ve degerlendirir.
+### competitive-intelligence
+The competitive-intelligence skill. Systematically tracks and assesses rival products, strategies, and market moves.
 
 ---
 
 ### product-ops
-Urun operasyonlari (Product Ops) yonetimi becerisi. Urun gelistirme sureclerini, arac ve yontemleri optimize ederek takim verimliligini arttirir.
+The Product Ops skill. Raises team efficiency by optimizing development processes, tools, and methods.
 
 ---
 
-### sprint-planlama
-Sprint planlama ve yonetme becerisi. Agile sprint dongulerini planlayarak takim kapasitesi ve is onceliklerini dengeler.
+### sprint-planning
+The sprint planning and management skill. Balances team capacity and work priorities by planning agile sprint cycles.
 
 ---
 
-### backlog-yonetimi
-Urun backlog yonetimi becerisi. Backlog'u temiz, organize ve onceliklendirilmis sekilde tutarak urun gelistirme akisini saglar.
+### backlog-management
+The product backlog skill. Keeps the backlog clean, organized, and prioritized so development flows.
 
 ---
 
-### urun-dokumantasyonu
-Urun dokumantasyonu olusturma becerisi. PRD, spesifikasyon ve teknik dokumantasyonlari yazarak urun gelistirme surecini destekler.
+### product-documentation
+The product-documentation skill. Supports development by writing PRDs, specifications, and technical documentation.
 
 ---
 
-### prd-yazimi
-Urun Gereksinim Dokumani (PRD) yazma becerisi. Ozellik veya urun icin kapsamli bir PRD hazirlayarak gelistirme ekibine net yonlendirme saglar.
+### prd-writing
+The Product Requirements Document (PRD) skill. Gives the dev team clear direction by preparing a comprehensive PRD per feature or product.
 
 ---
 
-### urun-fiyatlandirma
-Urun fiyatlandirma stratejisi becerisi. Fiyat modeli, paket yapisi ve fiyat noktalarini belirleyerek gelir ve musteri edinme hedeflerini dengeler.
+### product-pricing
+The product-pricing strategy skill. Balances revenue and acquisition goals by setting the price model, packaging, and price points.
 
 ---
 
 ### go-to-market
-Go-to-Market (GTM) stratejisi olusturma becerisi. Yeni urun veya pazara giris icin kapsamli bir pazara cikis plani hazirlar.
+The Go-to-Market (GTM) strategy skill. Prepares a comprehensive launch plan for a new product or market entry.
 
 ---
 
-### urun-buyume
-Urun odakli buyume (product-led growth) stratejisi becerisi. Urunun kendisini birincil buyume motoru olarak konumlandirarak organik ve viralkullanici edinme saglar.
+### product-led-growth
+The product-led growth strategy skill. Drives organic, viral acquisition by positioning the product itself as the primary growth engine.
 
 ---
 
-### platform-stratejisi
-Platform stratejisi gelistirme becerisi. Cok tarafli platform is modelinde ag etkisi, ekosistem ve partner stratejisi olusturur.
+### platform-strategy
+The platform-strategy skill. Builds the network effects, ecosystem, and partner strategy in a multi-sided platform model.
 
 ---
 
-### api-urun-yonetimi
-API urun yonetimi becerisi. API'leri urun olarak yoneterek gelistirici deneyimi, dokumantasyon ve ekosistem buyumesini saglar.
+### api-product-management
+The API product-management skill. Manages APIs as products, delivering developer experience, documentation, and ecosystem growth.
 
 ---
 
-### veri-odakli-karar
-Veri odakli urun karari alma becerisi. Urun kararlarini sezgi yerine veriye dayandirarak daha isabetli ve olculebilir sonuclar elde eder.
+### data-driven-decisions
+The data-driven product-decision skill. Delivers more accurate, measurable outcomes by grounding decisions in data instead of intuition.
 
 ---
 
-### musteri-yolculugu
-Musteri yolculugu (customer journey) haritalama becerisi. Kullanicinin urunle ilk temasindan sadik musteriye donusumune kadar tum yolculugu gorsellestirir.
+### customer-journey
+The customer-journey mapping skill. Visualizes the whole journey from first contact to loyal customer.
 
 ---
 
-### urun-kalite
-Urun kalite yonetimi becerisi. Urun kalite standartlarini belirleyerek hata azaltma, performans ve guvenilirlik saglar.
+### product-quality
+The product-quality management skill. Delivers fewer bugs, better performance, and reliability by setting quality standards.
 
 ---
 
-### teknik-borc-yonetimi
-Teknik borc yonetimi becerisi. Urun gelistirmedeki teknik borcu olcer, onceliklendirir ve azaltma stratejisi olusturur.
+### tech-debt-management
+The technical-debt management skill. Measures, prioritizes, and builds the reduction strategy for technical debt in product development.
 
 ---
 
-### urun-ekibi-yonetimi
-Urun ekibi yonetimi ve liderlik becerisi. Urun ekibini olusturma, gelistirme ve yuksek performansli bir takim haline getirme stratejileri uygular.
+### product-team-management
+The product-team management and leadership skill. Applies strategies for forming, growing, and turning the product team into a high-performing unit.
 
 ---
 
-### paydas-yonetimi
-Urun paydas yonetimi becerisi. Farkli paydlas gruplarinin (yonetim, satis, muhendislik, musteri) beklentilerini yonetir ve uyum saglar.
+### stakeholder-management
+The product stakeholder-management skill. Manages and aligns the expectations of different groups (leadership, sales, engineering, customers).
 
 ---
 
-### urun-etigi
-Urun etigi ve soruumlu tasarim becerisi. Urun kararlarinda etik ilkeleri gozeterek kullanici guveni ve toplumsal sorumluluk saglar.
+### product-ethics
+The product ethics and responsible design skill. Maintains user trust and social responsibility by honoring ethical principles in product decisions.
 
 ---
 
-### olceklendirme-stratejisi
-Urun olceklendirme stratejisi becerisi. Buyuyen kullanici tabanina ve artan talebe hazirlik yaparak olceklenebilir urun mimarisi ve operasyonlari planlar.
+### scaling-strategy
+The product-scaling strategy skill. Plans scalable architecture and operations preparing for a growing user base and rising demand.
 
 ---
 
-### urun-pivotu
-Urun pivot stratejisi becerisi. Mevcut stratejinin ise yaramadigina dair sinyalleri tespit ederek kontrol altinda yeniden yonlenme planlar.
+### product-pivot
+The product-pivot strategy skill. Plans a controlled redirection by detecting signals that the current strategy is failing.
 
 ---
 
-### urun-kaldirma
-Urun kaldiirma (sunsetting) stratejisi becerisi. Yasam dongusu sonuna gelen urun veya ozellikleri duzenli sekilde kaldiirma plani olusturur.
+### product-sunsetting
+The product-sunsetting strategy skill. Builds the orderly retirement plan for products or features at the end of their lifecycle.
 
 ---
 
-### urun-deneyimi
-Urun deneyimi (product experience) tasarlama becerisi. Kullanicinin urunle olan tum etkilesimlerini butunsel olarak tasarlayarak memnuniyet ve bagliligi arttirir.
+### product-experience
+The product-experience design skill. Raises satisfaction and loyalty by designing all user-product interactions holistically.
 
 ---
 
-### urun-kesfedilebilirlik
-Urun icinde kesfedilebilirlik (discoverability) becerisi. Kullanicilarin urun ozelliklerini ve degerini kolayca kesfetmesini saglayan tasarim desenleri uygular.
+### product-discoverability
+The in-product discoverability skill. Applies design patterns helping users easily discover features and value.
 
 ---
 
-### urun-erisilebiirlik
-Urun erisilebiirlik (accessibility) becerisi. Urunu engelli bireylerin de etkili kullanabilmesini saglayan WCAG uyumlu tasarim ve gelistirme pratikleri uygular.
+### product-accessibility
+The product-accessibility skill. Applies WCAG-compliant design and development so people with disabilities can use the product effectively.
 
 ---
 
-### urun-lokalizasyonu
-Urun lokalizasyon stratejisi becerisi. Urunu farkli dil, kultur ve pazarlara uyarlayarak uluslararasi kullanimini sagllar.
+### product-localization
+The product-localization strategy skill. Enables international use by adapting the product to different languages, cultures, and markets.
 
 ---
 
-### urun-guvenligi
-Urun guvenliigi ve gizlilik becerisi. Urun tasariminda guvenlik ve gizlilik ilkelerini (privacy by design) uygulair.
+### product-security
+The product security and privacy skill. Applies security and privacy-by-design principles in product design.
 
 ---
 
-### deney-kulturu
-Urun deney kulturu olusturma becerisi. Hipotez odakli deney yapma aliskanligini takim rutinlerine yerlestirerek veri odakli urun gelistirme saglar.
+### experimentation-culture
+The product experimentation-culture skill. Enables data-driven development by embedding hypothesis-driven experimentation into team routines.
 
 ---
 
-### kullanici-segmentasyonu
-Urun ici kullanici segmentasyonu becerisi. Kullanicilari davranissal ve demografik verilere gore gruplayarak kisisellestirilmis deneyimler sunar.
+### user-segmentation
+The in-product user-segmentation skill. Delivers personalized experiences by grouping users on behavioral and demographic data.
 
 ---
 
-### gamifikasyon
-Urun gamifikasyon stratejisi becerisi. Oyun mekanikleri (puanlar, rozetler, seviyeler, siralamalar) ile kullanici etkilesimini ve bagliliigini arttirir.
+### gamification
+The product-gamification strategy skill. Raises engagement and loyalty with game mechanics (points, badges, levels, leaderboards).
 
 ---
 
-### urun-komunite
-Urun etrafinda topluluk olusturma becerisi. Kullanicilar arasinda bilgi paylasiimi, destek ve etkilesim saglayan topluluk stratejisi gelistirir.
+### product-community
+The skill of building a community around the product. Develops the community strategy enabling knowledge sharing, support, and interaction among users.
 
 ---
 
-### urun-entegrasyonu
-Urun entegrasyon stratejisi becerisi. Ucuncu parti aracllar ve platformlarla entegrasyonlar gelistireek urun ekosistemini genisletir.
+### product-integrations
+The product-integration strategy skill. Expands the ecosystem by building integrations with third-party tools and platforms.
 
 ---
 
-### urun-bildirim
-Urun ici bildirim stratejisi becerisi. Kullanicilara zamaninda, ilgili ve aksiyona yonelik bildirimler gondereek etkilesimi arttirir.
+### product-notifications
+The in-product notification strategy skill. Raises engagement by sending timely, relevant, action-oriented notifications.
 
 ---
 
-### urun-performansi
-Urun performans izleme becerisi. Teknik performans metriklerini (hiz, uptime, hata orani) izleyerek kullanici deneyimi kalitesini korur.
+### product-performance
+The product performance-monitoring skill. Protects experience quality by tracking technical metrics (speed, uptime, error rate).
 
 ---
 
-### urun-farkindaliigi
-Urun ici farkindaliik ve egitim becerisi. Kullanicilari yeni ozellikler, ipuclari ve en iyi pratikler hakkinda urun icerisinde bilgilendirir.
+### product-awareness
+The in-product awareness and education skill. Informs users about new features, tips, and best practices inside the product.
 
 ---
 
-### urun-self-serve
-Self-serve urun deneyimi tasarlama becerisi. Kullanicilarin satis ekibi olmadan kendileri kayit olma, kesfetme ve satin alma yapabilecegi otonom deneyimler olusturur.
+### product-self-serve
+The self-serve product-experience skill. Builds autonomous experiences where users sign up, explore, and purchase without a sales team.
 
 ---
 
-### urun-deneyi-tasarimi
-Urun deneyi tasarimi becerisi. Urun hipotezlerini test etmek icin bilimsel yontemle deneyler tasarlar ve sonuclarini yorumlar.
+### product-experiment-design
+The product experiment-design skill. Designs experiments with scientific methods to test product hypotheses and interprets the results.
 
 ---
 
-### urun-buyume-dongusu
-Urun buyume dongusu (growth loop) tasarlama becerisi. Urun kullaniminin dogal olarak yeni kullanicilar cektiggi kendi kendini besleyen buyume mekanizmalari olusturur.
+### growth-loops
+The growth-loop design skill. Builds self-feeding growth mechanisms where product usage naturally attracts new users.
 
 ---
 
-### urun-veri-stratejisi
-Urun veri stratejisi gelistirme becerisi. Urun verilerinin toplanmasi, islenmesi ve karar alma surecinde kullanimini saglayan veri altyapisi ve yonetisim plani olusturur.
+### product-data-strategy
+The product data-strategy skill. Builds the data infrastructure and governance plan for collecting, processing, and using product data in decisions.
 
 ---
 
-### urun-inovasyon
-Urun inovasyon sureci becerisi. Yeni fikirler kesfetme, dogrulama ve hayata gecirme icin yapilandirilmis bir inovasyon cercevesi olusturur.
+### product-innovation
+The product-innovation process skill. Builds a structured innovation framework for discovering, validating, and shipping new ideas.
 
 ---
 
-### urun-metrik-dashboard
-Urun metrik dashboard'u olusturma becerisi. Temel urun metriklerini gercek zamanli gorsellestiren ve karar almaya destek saglayan panolar tasarlar.
+### product-metric-dashboard
+The product metric-dashboard skill. Designs panels visualizing key product metrics in real time to support decisions.
 
 ---
 
-### urun-strateji-incelemesi
-Urun strateji gozden gecirme becerisi. Periyodik olarak urun stratejisini degerlendirerek pazar degisikliklerine ve performans verilerine gore stratejiyi gunceller.
+### product-strategy-review
+The product-strategy review skill. Updates the strategy against market shifts and performance data through periodic reviews.
 
 ---
 
-### urun-benchmark
-Urun benchmark karsilastirmasi becerisi. Urun performansini ve ozelliklerini rakip urunler ve sektor standartlari ile karsilastirarak konum belirler.
-
+### product-benchmarking
+The product-benchmarking skill. Positions the product by comparing performance and features against rivals and industry standards.

--- a/.claude/skills-vault/productivity/SKILL.md
+++ b/.claude/skills-vault/productivity/SKILL.md
@@ -10,291 +10,290 @@ metadata:
   badi-version: ">=1.14.0"
   category: productivity
 ---
-# Verimlilik Becerileri
-Bu dosya, kisisel verimlilik, zaman yonetimi, proje yonetimi, takim verimliligi, otomasyon ve is sureci iyilestirme ile ilgili tum becerileri icerir.
+# Productivity Skills
+This file contains all the skills around personal productivity, time management, project management, team productivity, automation, and process improvement.
 
 ---
 
-### zaman-yonetimi
-Zaman yonetimi stratejisi gelistirme becerisi. Gunluk, haftalik ve aylik zaman kullanimini optimize ederek odakli ve uretken calisma saglar.
+### time-management
+The skill of developing a time-management strategy. Delivers focused, productive work by optimizing daily, weekly, and monthly time use.
 
 ---
 
-### gorev-yonetimi
-Gorev yonetimi sistemi kurma becerisi. Tum gorevleri sistematik olarak yakalama, organize etme, onceliklendirme ve tamamlama sureci olusturur.
+### task-management
+The skill of building a task-management system. Builds the process of capturing, organizing, prioritizing, and completing all tasks systematically.
 
 ---
 
-### proje-planlama
-Proje planlama ve baslangic becerisi. Projeleri basindan sonuna kadar planlayarak kapsam, zaman ve kaynak yonetimini saglar.
+### project-planning
+The project planning and kickoff skill. Manages scope, time, and resources by planning projects end to end.
 
 ---
 
-### proje-izleme
-Proje ilerleme izleme ve raporlama becerisi. Devam eden projelerin durumunu izleyerek sapmalari erken tespit eder ve duzeltici eylem alir.
+### project-tracking
+The project progress tracking and reporting skill. Detects deviations early and takes corrective action by monitoring ongoing projects.
 
 ---
 
-### agile-yonetim
-Agile proje yonetimi becerisi. Scrum, Kanban veya hibrit agile cerceveler kullanarak esnek ve iteratif urun gelistirme yapar.
+### agile-management
+The agile project-management skill. Runs flexible, iterative product development using Scrum, Kanban, or hybrid agile frameworks.
 
 ---
 
-### kanban-sistemi
-Kanban is akisi yonetimi becerisi. Gorsel is akisi tahtasi ile devam eden isleri yonetir, darbogazlari tespit eder ve akisi optimize eder.
+### kanban-system
+The Kanban workflow management skill. Manages WIP with a visual board, finds bottlenecks, and optimizes flow.
 
 ---
 
-### okr-yonetimi
-OKR (Hedefler ve Anahtar Sonuclar) sistemi kurma ve yonetme becerisi. Organizasyonel hedefleri olculebilir sonuclara donusturerek odak ve uyum saglar.
+### okr-management
+The skill of building and managing an OKR (Objectives and Key Results) system. Drives focus and alignment by turning organizational goals into measurable results.
 
 ---
 
-### kpi-tanimlama
-KPI tanimlama ve izleme becerisi. Is hedeflerini olculebilir performans gostergelerine donusturerek ilerlemelyi somut verilerle takip eder.
+### kpi-definition
+The KPI definition and tracking skill. Tracks progress with concrete data by turning business goals into measurable indicators.
 
 ---
 
-### toplanti-yonetimi
-Etkili toplanti yonetimi becerisi. Toplantilari verimli, odakli ve sonuc odakli hale getireek zaman israfini onler.
+### meeting-management
+The effective meeting-management skill. Prevents wasted time by making meetings efficient, focused, and outcome-driven.
 
 ---
 
-### uzaktan-calisma
-Uzaktan calisma verimliligi becerisi. Uzaktan veya hibrit calisma ortaminda kisisel ve takim verimliligini artiran strateji ve araclar uygulair.
+### remote-work
+The remote-work productivity skill. Applies strategies and tools raising personal and team productivity in remote or hybrid setups.
 
 ---
 
-### odak-derin-calisma
-Odak ve derin calisma pratikleri becerisi. Kesintisiz, yuksek konsantrasyonlu calisma bloklari olusturarak uretkenlik ve is kalitesini arttirir.
+### focus-deep-work
+The focus and deep-work practice skill. Raises productivity and work quality by building uninterrupted, high-concentration work blocks.
 
 ---
 
-### enerji-yonetimi
-Kisisel enerji yonetimi becerisi. Fiziksel, zihinsel ve duygusal enerji seviyelerini yoneterek gun boyunca yuksek performans saglar.
+### energy-management
+The personal energy management skill. Sustains high performance through the day by managing physical, mental, and emotional energy.
 
 ---
 
-### aliskanlik-olusturma
-Aliskanlik olusturma ve degistirme becerisi. Uretkenlik artiran yeni aliskanliklari sistematik olarak kazandiran ve kotu aliskanliklari dontustuuren stratejiler uygular.
+### habit-building
+The habit formation and change skill. Applies strategies that systematically build productivity-raising habits and transform bad ones.
 
 ---
 
-### bilgi-yonetimi
-Kisisel bilgi yonetimi (PKM) sistemi becerisi. Bilgiyi yakalama, organize etme, baglama ve yeniden kullanma sistemini kurar.
+### knowledge-management
+The personal knowledge management (PKM) system skill. Builds the system for capturing, organizing, linking, and reusing knowledge.
 
 ---
 
-### not-alma-sistemi
-Etkili not alma sistemi kurma becerisi. Toplanti, okuma ve dusunce notlarini sistematik olarak yakalama ve organize etme yontemi olusturur.
+### note-taking-system
+The skill of building an effective note-taking system. Builds the method for capturing and organizing meeting, reading, and thinking notes.
 
 ---
 
-### e-posta-verimliligi
-E-posta verimliligi artirma becerisi. E-posta islem surecini hizlandirarak gelen kutusu yonetimini ve iletisim etkinligini optimize eder.
+### email-efficiency
+The email-efficiency skill. Optimizes inbox management and communication effectiveness by speeding up email processing.
 
 ---
 
-### delegasyon
-Etkili delegasyon becerisi. Gorevleri uygun kisillere delege ederek kisisel zaman verimliligi ve takim kapasite gelistirme saglar.
+### delegation
+The effective delegation skill. Delivers personal time efficiency and team capacity growth by delegating tasks to the right people.
 
 ---
 
-### onceliklendirme
-Is ve gorev onceliklendirme becerisi. Sinirli zaman ve kaynaklari en yuksek etkili islere yonlendirerek stratejik odak saglar.
+### prioritization
+The work and task prioritization skill. Delivers strategic focus by directing limited time and resources to the highest-impact work.
 
 ---
 
-### hedef-belirleme
-Etkili hedef belirleme becerisi. Kisisel ve profesyonel hedefleri SMART veya benzeri cercevelerle tanimlar ve basari olasiligini arttirir.
+### goal-setting
+The effective goal-setting skill. Raises the odds of success by defining personal and professional goals with SMART or similar frameworks.
 
 ---
 
-### karar-alma
-Etkili karar alma becerisi. Kisisel ve profesyonel kararlari sistematik, veri destekli ve zaman verimli bir sekilde alma yontemleri uygular.
+### decision-making
+The effective decision-making skill. Applies systematic, data-supported, time-efficient methods to personal and professional decisions.
 
 ---
 
-### is-sureci-iyilestirme
-Is sureci iyilestirme becerisi. Mevcut is sureclerini analiz ederek darbogazlari, israaflari ve verimsizlikleri ortadan kaldirir.
+### process-improvement
+The process-improvement skill. Removes bottlenecks, waste, and inefficiency by analyzing current workflows.
 
 ---
 
-### otomasyon-kisisel
-Kisisel otomasyon becerisi. Tekrarlayan kisisel gorevleri otomatiiklestirerek zaman kazandiran is akislari olusturur.
+### personal-automation
+The personal automation skill. Builds time-saving workflows by automating repetitive personal tasks.
 
 ---
 
-### sablon-sistem
-Sablon ve kontrol listesi sistemi olusturma becerisi. Tekrarlayan isler icin yeniden kullanilabilir sablonlar ve kontrol listeleri olusturarak tutarlilik ve hiz saglar.
+### template-systems
+The skill of building template and checklist systems. Delivers consistency and speed with reusable templates and checklists for recurring work.
 
 ---
 
-### iletisim-verimliligi
-Is iletisimi verimliligi artirma becerisi. Yazili ve sozlu iletisimi daha net, kisa ve etkili hale getireek yanlys anlamalari ve zaman kaybini azaltir.
+### communication-efficiency
+The skill of raising business-communication efficiency. Reduces misunderstanding and lost time by making written and verbal communication clearer, shorter, and more effective.
 
 ---
 
-### takim-verimliligi
-Takim verimliligi artirma becerisi. Takim dinamiklerini, sureclerini ve araclarini optimize ederek kolektif uretkenlik artisi saglar.
+### team-productivity
+The team-productivity skill. Drives collective output by optimizing team dynamics, processes, and tools.
 
 ---
 
-### is-yasam-dengesi
-Is-yasam dengesi yonetimi becerisi. Profesyonel ve kisisel yasamm arasinda saglikli bir denge kurarak uzun vadeli surdurulebilirlik saglar.
+### work-life-balance
+The work-life balance management skill. Delivers long-term sustainability through a healthy balance between professional and personal life.
 
 ---
 
-### stres-yonetimi
-Stres yonetimi becerisi. Is kaynakli stresi azaltan ve stresle basa cikma becerilerini gelistiren stratejiler uygular.
+### stress-management
+The stress-management skill. Applies strategies that reduce work-driven stress and build coping skills.
 
 ---
 
-### surekli-ogrenme
-Surekli ogrenme ve kisisel geliism stratejisi becerisi. Profesyonel gelisim icin sistematik ogrenme aliskanliklari ve kaynak yonetimi olusturur.
+### continuous-learning
+The continuous learning and personal-development strategy skill. Builds systematic learning habits and resource management for professional growth.
 
 ---
 
-### geri-bildirim-kulturu
-Geri bildirim verme ve alma becerisi. Yapici geri bildirim kulturu olusturarak bireysel ve takim performansini arttirir.
+### feedback-culture
+The skill of giving and receiving feedback. Raises individual and team performance by building a constructive feedback culture.
 
 ---
 
-### performans-degerlendirme
-Performans degerlendirme sureci yonetimi becerisi. Bireysel ve takim performansini adil, tutarli ve gelistirici sekilde degerlendirir.
+### performance-review
+The performance-review process skill. Evaluates individual and team performance fairly, consistently, and developmentally.
 
 ---
 
-### mentor-koocluk
-Mentorluk ve kocluk becerisi. Bireylerin potansiyellerini gelistirmelerine yardimci olan yapilandirilmis mentorluk ve kocluk iliskilerini yonetir.
+### mentoring-coaching
+The mentoring and coaching skill. Manages structured relationships that help individuals grow their potential.
 
 ---
 
-### dokumantasyon-kulturu
-Dokumantasyon kulturu olusturma becerisi. Bilgi ve sureclerin sistematik olarak dokumante edildigi bir organizasyon kulturu gelistirir.
+### documentation-culture
+The skill of building a documentation culture. Develops an organizational culture where knowledge and processes are documented systematically.
 
 ---
 
-### is-birligi-araclari
-Is birligi araci secimi ve yapilandirmasi becerisi. Takim icin uygun dijital is birligi araclarini secerek verimli calisma ortami olusturur.
+### collaboration-tools
+The collaboration-tool selection and configuration skill. Builds an efficient working environment by picking the right digital tools for the team.
 
 ---
 
-### calisma-ortami
-Verimli calisma ortami tasarlama becerisi. Fiziksel ve dijital calisma ortamini verimlilik, odak ve saglik icin optimize eder.
+### work-environment
+The skill of designing a productive work environment. Optimizes the physical and digital workspace for productivity, focus, and health.
 
 ---
 
-### haftalik-gozden-gecirme
-Haftalik gozden gecirme (weekly review) becerisi. Haftayi degerlendirerek ogrenimler cikarma ve sonraki haftayi planlama sureci kurar.
+### weekly-review
+The weekly-review skill. Builds the process of evaluating the week, extracting learnings, and planning the next one.
 
 ---
 
-### yillik-planlama
-Yillik kisisel ve profesyonel planlama becerisi. Yil icin hedefler, projeler ve gelisim planlari olusturarak uzun vadeli yonelim saglar.
+### annual-planning
+The annual personal and professional planning skill. Delivers long-term direction with yearly goals, projects, and development plans.
 
 ---
 
-### is-akisi-otomasyonu
-Is akisi otomasyon stratejisi becerisi. Isletme sureclerindeki tekrarlayan is akislarini otomatiklestirerek verimlilik ve hata azaltma saglar.
+### workflow-automation
+The workflow-automation strategy skill. Delivers efficiency and fewer errors by automating repetitive business workflows.
 
 ---
 
-### coklu-gorev-yonetimi
-Coklu gorev (multitasking) ve context-switching yonetimi becerisi. Birden fazla projeyi ve sorumlulugu etkili sekilde yonetir.
+### multitasking-management
+The multitasking and context-switching management skill. Manages multiple projects and responsibilities effectively.
 
 ---
 
 ### batch-processing
-Is gruplama (batch processing) becerisi. Benzer gorevleri gruplandirarak baglam gecis maliyetini azaltir ve verimliligi arttirir.
+The batch-processing skill. Cuts context-switch cost and raises efficiency by grouping similar tasks.
 
 ---
 
-### dijital-minimalizm
-Dijital minimalizm ve dikkat yonetimi becerisi. Dijital araclarin kontrolsuz kullanimini sinirlandirarak odak ve zihinsel netlik saglar.
+### digital-minimalism
+The digital minimalism and attention-management skill. Delivers focus and mental clarity by limiting uncontrolled digital-tool use.
 
 ---
 
-### sorun-cozme
-Sistematik sorun cozme becerisi. Karmasik sorunlari yapilandirilmis yontemlerle analiz ederek kok nedenlere dayali kalici cozumler uretir.
+### problem-solving
+The systematic problem-solving skill. Produces durable, root-cause-based solutions by analyzing complex problems with structured methods.
 
 ---
 
-### degisim-yonetimi
-Degisim yonetimi becerisi. Organizasyonel veya kisisel degisiklikleri planlama, iletisim ve uyum surecleriyle etkili sekilde yonetir.
+### change-management
+The change-management skill. Manages organizational or personal change effectively through planning, communication, and adaptation.
 
 ---
 
-### retrospektif
-Retrospektif (gerive bakis) yonetimi becerisi. Sprint, proje veya donem sonlarinda yapilan geriye bakis toplantilariyla surekli iyilestirme saglar.
+### retrospectives
+The retrospective management skill. Drives continuous improvement through look-back meetings at sprint, project, or period ends.
 
 ---
 
-### kisisel-marka
-Kisisel marka olusturma becerisi. Profesyonel kimliiki, uzmanligi ve gorunurlugu sistematik olarak gelistirerek kariyer firsatlarini arttirir.
+### personal-brand
+The personal-brand building skill. Grows career opportunities by systematically developing professional identity, expertise, and visibility.
 
 ---
 
-### kariyer-planlama
-Kariyer planlama ve gelisim becerisi. Uzun vadeli kariyer hedeflerini tanimlayyarak stratejik kariyer adimlari ve yetkinlik gelisiimi planlar.
+### career-planning
+The career planning and development skill. Plans strategic career moves and competence growth by defining long-term goals.
 
 ---
 
-### network-gelistirme
-Profesyonel ag (network) gelistirme becerisi. Anlamli profesyonel iliskiler kurarak kariyer ve is firsatlarini geniisleten sistematik bir ag olusturur.
+### networking
+The professional networking skill. Builds a systematic network expanding career and business opportunities through meaningful relationships.
 
 ---
 
-### asenkron-iletisim
-Asenkron iletisim stratejisi becerisi. Farkli zaman dilimlerinde ve esnek calisma duzeniinde etkili iletisim pratikleri olusturur.
+### async-communication
+The asynchronous communication strategy skill. Builds effective communication practices across time zones and flexible schedules.
 
 ---
 
-### gunluk-rutin
-Gunluk verimlilik rutini olusturma becerisi. Gune baslangiic ve bitis rutinleri tasarlayarak tutarli uretkenlik ve odak saglar.
+### daily-routine
+The skill of building a daily productivity routine. Delivers consistent output and focus by designing start-of-day and end-of-day routines.
 
 ---
 
-### proje-portfoy-yonetimi
-Proje portfoy yonetimi becerisi. Birden fazla projeyi kaynak kisitlari altinda onceliklendirerek stratejik hizalanma ve kaynak verimliiligi saglar.
+### project-portfolio-management
+The project portfolio management skill. Delivers strategic alignment and resource efficiency by prioritizing multiple projects under constraints.
 
 ---
 
-### liderlik-gelistirme
-Liderlik becerileri gelistirme plani olusturma becerisi. Kisisel liderlik yeteneklerini degerlendirerek ve gelistirerek etkili liderlik saglar.
+### leadership-development
+The skill of building a leadership-development plan. Delivers effective leadership by assessing and growing personal leadership capabilities.
 
 ---
 
-### zihin-haritalama
-Zihin haritasi (mind mapping) teknigi becerisi. Fikirleri, projeleri ve bilgileri gorsel olarak organize ederek yaratici dusunme ve planlama yapar.
+### mind-mapping
+The mind-mapping technique skill. Enables creative thinking and planning by organizing ideas, projects, and information visually.
 
 ---
 
-### motivasyon-yonetimi
-Kisisel motivasyon yonetimi becerisi. Uzun vadeli hedefler icin motivasyonu surdurmede zorluk yasanan donemlerden gecmeye yardimci stratejiler uygular.
+### motivation-management
+The personal motivation management skill. Applies strategies that help push through periods when sustaining motivation for long-term goals is hard.
 
 ---
 
-### kriz-aninda-verimlilik
-Kriz ve yogun donemllerde verimlilik becerisi. Yoigun, stresli ve belirsiz donemllerde odak ve uretkeniligi koruyan stratejiler uygular.
+### crisis-productivity
+The productivity-under-pressure skill. Applies strategies preserving focus and output through busy, stressful, uncertain periods.
 
 ---
 
-### yaratici-dusunme
-Yaratici dusunme teknikleri becerisi. Problem cozme ve fikir uretmede yaraticiligi artiran sistematik dusunme yontemleri uygular.
+### creative-thinking
+The creative-thinking techniques skill. Applies systematic methods that raise creativity in problem solving and ideation.
 
 ---
 
-### sprint-kisisel
-Kisisel sprint ve odak donemi yonetimi becerisi. Belirli bir hedefe yonelik yoigun, zaman sinirli calisma donemlleri planlayarak buyuk projelerde ilerleme saglar.
+### personal-sprints
+The personal sprint and focus-period management skill. Makes progress on big projects by planning intense, time-boxed work periods toward a specific goal.
 
 ---
 
-### etkili-okuma
-Etkili okuma ve bilgi isleme becerisi. Mesleki kaynaklari, raporlari ve kitaplari hizli ve etkili sekilde okuyarak bilgiyi isleme ve uygulamaya donusturme saglar.
+### effective-reading
+The effective reading and information-processing skill. Reads professional sources, reports, and books fast and well, converting knowledge into application.
 
 ---
 
-### iyi-uyku
-Uyku kalitesi ve verimlilik iliskisi yonetimi becerisi. Uyku duzeniini optimize ederek biliseel performans ve gun boyu enerji seviyesini arttirir.
-
+### good-sleep
+The sleep-quality and productivity management skill. Raises cognitive performance and all-day energy by optimizing the sleep routine.

--- a/.claude/skills-vault/sales/SKILL.md
+++ b/.claude/skills-vault/sales/SKILL.md
@@ -10,336 +10,335 @@ metadata:
   badi-version: ">=1.14.0"
   category: sales
 ---
-# Satis Becerileri
-Bu dosya, satis stratejisi, musteri iliskileri, pipeline yonetimi, satis teknikleri, CRM ve satis analizleri ile ilgili tum becerileri icerir.
+# Sales Skills
+This file contains all the skills around sales strategy, customer relationships, pipeline management, sales techniques, CRM, and sales analytics.
 
 ---
 
-### satis-stratejisi
-Satis stratejisi gelistirme becerisi. Is hedeflerine uygun, olceklenebilir ve veri odakli satis yaklasimi olusturarak gelir hedeflerine ulasilmasini saglar.
+### sales-strategy
+The sales-strategy skill. Reaches revenue targets by building a scalable, data-driven sales approach aligned with business goals.
 
 ---
 
-### satis-sureci
-Satis sureci tasarlama ve optimize etme becerisi. Ilk temastan kapanisa kadar sistematik, tekrarlanabilir ve olculebilir bir satis sureci olusturur.
+### sales-process
+The sales-process design and optimization skill. Builds a systematic, repeatable, measurable process from first touch to close.
 
 ---
 
 ### lead-generation
-Lead (potansiyel musteri) uretme becerisi. Inbound ve outbound kanallardan kaliteli lead akisi olusturarak satis pipeline'ini besler.
+The lead-generation skill. Feeds the pipeline by building a quality lead flow from inbound and outbound channels.
 
 ---
 
-### lead-kalifikasyonu
-Lead kalifikasyon sureci becerisi. Potansiyel musterileri satin alma niyeti ve uygunluk acisindan degerlendirerek satis ekibinin zamanini optimize eder.
+### lead-qualification
+The lead-qualification skill. Optimizes the team's time by assessing prospects for buying intent and fit.
 
 ---
 
-### pipeline-yonetimi
-Satis pipeline yonetimi becerisi. Satis firsatlarini asamalar bazinda izleyerek gelir tahmini ve satis performansi yonetimi yapar.
+### pipeline-management
+The sales-pipeline management skill. Runs revenue forecasting and performance management by tracking opportunities per stage.
 
 ---
 
-### satis-tahmini
-Satis tahmini (forecasting) becerisi. Pipeline verilerine ve tarihi performansa dayali gelir tahminleri yaparak is planlama ve kaynak yonetimine destek saglar.
+### sales-forecasting
+The sales-forecasting skill. Supports planning and resourcing with revenue forecasts grounded in pipeline data and historical performance.
 
 ---
 
-### firsat-yonetimi
-Satis firsati yonetimi becerisi. Her bir satis firsatini stratejik olarak yoneterek kapanma olasiligi ve degerini arttirir.
+### opportunity-management
+The opportunity-management skill. Raises close probability and value by managing each opportunity strategically.
 
 ---
 
-### musteri-iliskisi
-Musteri iliski yonetimi (CRM stratejisi) becerisi. Musteri iliskilerini sistematik olarak yoneterek uzun vadeli deger ve sadakat olusturur.
+### customer-relationship
+The customer-relationship (CRM strategy) skill. Builds long-term value and loyalty by managing relationships systematically.
 
 ---
 
-### soguk-arama
-Soguk arama (cold calling) stratejisi ve teknikleri becerisi. Onceden iliski kurulmamis potansiyel musterilere telefon ile etkili bir sekilde ulasilmasini saglar.
+### cold-calling
+The cold-calling strategy and techniques skill. Enables effective phone outreach to prospects with no prior relationship.
 
 ---
 
-### soguk-e-posta
-Soguk e-posta (cold email) stratejisi becerisi. Potansiyel musterilere kisisellestirilmis soguk e-posta kampanyalari ile ulasarak ilk temasi baslatir.
+### cold-email
+The cold-email strategy skill. Starts the first touch with personalized cold-email campaigns to prospects.
 
 ---
 
-### sosyal-satis
-Sosyal satis (social selling) stratejisi becerisi. LinkedIn ve diger sosyal platformlarda iliskisel satis yaklasimi ile firsatlat olusturur ve gelistirir.
+### social-selling
+The social-selling strategy skill. Builds and develops opportunities with a relational approach on LinkedIn and other platforms.
 
 ---
 
-### demo-sunum
-Satis demo ve sunum becerisi. Urun degerini etkili sekilde gosteren, musteri ihtiyacina ozel demo ve sunum hazirlar.
+### demo-presentation
+The sales demo and presentation skill. Prepares demos and decks tailored to customer needs that show product value effectively.
 
 ---
 
-### teklif-hazirlama
-Satis teklifi hazirlama becerisi. Profesyonel, ikna edici ve muteri ihtiyacina ozel satis teklifleri olusturur.
+### proposal-preparation
+The sales-proposal skill. Builds professional, persuasive proposals tailored to the customer's needs.
 
 ---
 
-### fiyat-muzakeresi
-Fiyat muzakeresi becerisi. Satis surecinde fiyat gorusmelerini yoneterek deger odakli muzakere ile karlilik korumasii saglar.
+### price-negotiation
+The price-negotiation skill. Protects profitability through value-focused negotiation during pricing discussions.
 
 ---
 
-### itiraz-karsilama
-Satis itirazlarini karsilama becerisi. Musteri itirazlarini firsata donusturerek satin alma surecini ilerletir.
+### objection-handling
+The objection-handling skill. Advances the purchase by turning customer objections into opportunities.
 
 ---
 
-### kapanish-teknikleri
-Satis kapanish teknikleri becerisi. Satis surecini basarili bir analsmayla sonuclandiran etkili kapanish stratejileri ve teknikleri uygular.
+### closing-techniques
+The closing-techniques skill. Applies effective closing strategies that end the sales process in a successful agreement.
 
 ---
 
-### analsma-yonetimi
-Satis sonrasi analsma ve sozlesme yonetimi becerisi. Anlasma kosullarinin yerine getirilmesini ve musteri iliskisinin surduulumesini saglar.
+### deal-management
+The post-sale agreement and contract management skill. Ensures terms are fulfilled and the relationship continues.
 
 ---
 
 ### account-based-selling
-Hesap bazli satis (ABS) stratejisi becerisi. Yuksek degerli hedef hesaplar icin kisisellestirilmis ve cok temas noktali satis stratejisi uygular.
+The account-based selling (ABS) strategy skill. Applies a personalized, multi-touch strategy for high-value target accounts.
 
 ---
 
-### coklu-paydas-satisi
-Coklu paydas satisi becerisi. Karmasik satis sureclerinde birden fazla karar vericiyi ve etkileyiciyi yoneterek konsensus olusturur.
+### multi-stakeholder-selling
+The multi-stakeholder selling skill. Builds consensus by managing multiple decision-makers and influencers in complex deals.
 
 ---
 
-### upsell-stratejisi
-Upsell (yukseltme) stratejisi becerisi. Mevcut musterilere daha yuksek degerli urun veya hizmet satarak musteri basina geliri arttirir.
+### upsell-strategy
+The upsell strategy skill. Raises revenue per customer by selling higher-value products or services to existing customers.
 
 ---
 
-### cross-sell-stratejisi
-Cross-sell (capraz satis) stratejisi becerisi. Mevcut musterilere tamamlayici urun veya hizmetler sunarak toplam sepet degerini ve musteri degerini arttirir.
+### cross-sell-strategy
+The cross-sell strategy skill. Raises basket and customer value by offering complementary products or services.
 
 ---
 
-### musteri-basari
-Musteri basari (customer success) stratejisi becerisi. Musterilerin urununden maksimum deger almasini saglayarak retansiyon ve genisleme arttirir.
+### customer-success
+The customer-success strategy skill. Drives retention and expansion by ensuring customers get maximum value.
 
 ---
 
-### hesap-yonetimi
-Anahtar hesap (key account) yonetimi becerisi. Stratejik oneme sahip musterilerle derin, uzun vadeli ve karsilikli deger yaratan iliskiler kurar.
+### key-account-management
+The key-account management skill. Builds deep, long-term, mutually valuable relationships with strategic customers.
 
 ---
 
-### satis-ekibi-yonetimi
-Satis ekibi yonetimi ve liderlik becerisi. Satis takimini olusturma, gelistirme, motive etme ve yuksek performans sagllama stratejileri uygular.
+### sales-team-management
+The sales-team management and leadership skill. Applies strategies for building, growing, motivating, and driving high performance.
 
 ---
 
-### satis-koclugu
-Satis koclugu (coaching) becerisi. Satis temsilcilerinin bireysel performansini gelistirmek icin yapilandirilmis kocluk programi uygular.
+### sales-coaching
+The sales-coaching skill. Applies a structured coaching program improving each rep's individual performance.
 
 ---
 
-### satis-egitimi
-Satis egitim programi tasarlama becerisi. Satis ekibinin yetkinliklerini artiran kapsamli egitim programlari olusturur ve uygular.
+### sales-training
+The sales-training design skill. Builds and runs comprehensive programs raising the team's competence.
 
 ---
 
-### satis-otomasyonu
-Satis surec otomasyonu becerisi. Tekrarlayan satis gorevlerini otomatiklestirerek satis temsilcilerinin musteri ile gecirdigi zamani arttirir.
+### sales-automation
+The sales-process automation skill. Increases reps' customer-facing time by automating repetitive tasks.
 
 ---
 
-### crm-yonetimi
-CRM sistemi yonetimi ve optimizasyonu becerisi. CRM platformunu satis surecini destekleyecek sekilde yapilandirir ve veri kalitesini saglar.
+### crm-management
+The CRM management and optimization skill. Configures the platform to support the sales process and keeps data quality high.
 
 ---
 
-### satis-raporlama
-Satis performans raporlama becerisi. Satis ekibi ve pipeline performansini olcen, raporlayan kapsamli raporlama cercevesi kurar.
+### sales-reporting
+The sales-performance reporting skill. Builds the comprehensive framework measuring and reporting team and pipeline performance.
 
 ---
 
-### satis-metrikleri
-Satis metrikleri tanimlama ve izleme becerisi. Dogru metrikleri secerek satis performansini cok boyutlu olarak olcer.
+### sales-metrics
+The sales-metric definition and tracking skill. Measures performance multi-dimensionally by picking the right metrics.
 
 ---
 
-### satis-hunisi
-Satis hunisi analizi ve optimizasyonu becerisi. Satis hunisinin her asamasindaki performansi analiz ederek donusum oranlarini arttirir.
+### sales-funnel
+The sales-funnel analysis and optimization skill. Raises conversion rates by analyzing performance at every funnel stage.
 
 ---
 
-### gelir-operasyonlari
-Gelir operasyonlari (RevOps) becerisi. Satis, pazarlama ve musteri basari fonksiyonlarini uyumlastirarak gelir motorunu optimize eder.
+### revenue-operations
+The revenue operations (RevOps) skill. Optimizes the revenue engine by aligning sales, marketing, and customer success.
 
 ---
 
-### satis-enable
-Satis etkinlestirme (sales enablement) becerisi. Satis ekibinin daha etkili satmasi icin gereken araclar, icerikler ve egitimi saglar.
+### sales-enablement
+The sales-enablement skill. Provides the tools, content, and training the team needs to sell more effectively.
 
 ---
 
-### rekabet-kartlari
-Rekabet satis kartlari (battle cards) olusturma becerisi. Rakip urunlere karsi satis argumanlari ve farklilastirma noktalarini iceren hazir referans kartlari hazirlaar.
+### battle-cards
+The competitive battle-card skill. Prepares ready references with sales arguments and differentiation points against rival products.
 
 ---
 
-### case-study
-Musteri basari hikayesi (case study) olusturma becerisi. Mevcut musteri basarilarini ikna edici hikayelere donustuurerek satis surecini destekler.
+### case-studies
+The customer case-study skill. Supports the sale by turning customer wins into persuasive stories.
 
 ---
 
-### satis-sunumu
-Satis sunum materyali hazirlama becerisi. Ikna edici, gorsel ve musteri odakli satis sunumlari olusturur.
+### sales-presentations
+The sales-deck preparation skill. Builds persuasive, visual, customer-centered sales presentations.
 
 ---
 
-### satis-oyun-kitabi
-Satis oyun kitabi (sales playbook) olusturma becerisi. Satis surecinin her asamasi icin standart prosedurler, mesajlar ve en iyi pratikleri iceren kapsamli rehber hazirlar.
+### sales-playbook
+The sales-playbook skill. Prepares the comprehensive guide with standard procedures, messages, and best practices for every stage.
 
 ---
 
-### territory-planlama
-Satis bolge planlama becerisi. Satis bolgelerini stratejik olarak tanimlayyarak dengeli is yuku ve pazar kapsamini saglar.
+### territory-planning
+The territory-planning skill. Delivers balanced workloads and market coverage by defining sales territories strategically.
 
 ---
 
-### kota-belirleme
-Satis kotasi belirleme becerisi. Adil, motive edici ve ulasilabilir satis kotlari belirleyerek ekip performansini optimize eder.
+### quota-setting
+The quota-setting skill. Optimizes team performance by setting fair, motivating, reachable quotas.
 
 ---
 
-### komisyon-yapisi
-Satis komisyon ve tesvik yapisi tasarlama becerisi. Satis davranislarini hedeflerle uyumlastiran adil ve motive edici bir odeme plani olusturur.
+### commission-structure
+The commission and incentive design skill. Builds a fair, motivating pay plan aligning sales behavior with targets.
 
 ---
 
-### satis-kulturu
-Satis kulturu olusturma becerisi. Yuksek performansli, is birlikci ve gelisim odakli bir satis kulturu gelistirir.
+### sales-culture
+The sales-culture skill. Develops a high-performance, collaborative, growth-minded sales culture.
 
 ---
 
-### satis-teknolojisi
-Satis teknoloji yigini (SalesTech stack) yonetimi becerisi. Satis surecini destekleyen araclari secme, entegre etme ve optimize etme stratejisi gelistirir.
+### sales-technology
+The SalesTech-stack management skill. Develops the strategy for picking, integrating, and optimizing the tools supporting the process.
 
 ---
 
-### musteri-edinme-maliyeti
-Musteri edinme maliyeti (CAC) optimizasyonu becerisi. Satis ve pazarlama kanallarindaki musteri edinme maliyetini olcen ve optimize eden stratejiler gelistirir.
+### customer-acquisition-cost
+The CAC optimization skill. Develops strategies measuring and optimizing acquisition cost across sales and marketing channels.
 
 ---
 
-### satin-alma-sureci
-Musteri satin alma sureci analizi becerisi. Musterinin satin alma yolculugunu anlamak satis surecini buna uyumlu hale getirir.
+### buying-process
+The customer buying-process analysis skill. Aligns the sales process with how the customer actually buys.
 
 ---
 
-### kanal-satis
-Kanal satis (channel sales) stratejisi becerisi. Distributoer, bayii ve partner kanallari uzerinden satis hacmini artiran kanal stratejisi gelistirir.
+### channel-sales
+The channel-sales strategy skill. Grows volume through distributor, dealer, and partner channels.
 
 ---
 
-### partner-yonetimi
-Satis partneri iliski yonetimi becerisi. Stratejik satis ortakliklari ile karsilikli deger yaratan uzun vadeli iliskiler kurar ve yonetir.
+### partner-management
+The sales-partner relationship skill. Builds and manages long-term, mutually valuable strategic partnerships.
 
 ---
 
-### inbound-satis
-Inbound satis stratejisi becerisi. Pazarlama tarafindan uretilen lead'leri etkili sekilde isleyerek satis firsatina donustuurur.
+### inbound-sales
+The inbound-sales strategy skill. Converts marketing-generated leads into opportunities effectively.
 
 ---
 
-### outbound-satis
-Outbound satis stratejisi becerisi. Proaktif musteri erisimi ile yeni firsatlar olusturan sistematik outbound satis programi kurar.
+### outbound-sales
+The outbound-sales strategy skill. Builds a systematic outbound program generating new opportunities through proactive outreach.
 
 ---
 
-### enterprise-satis
-Enterprise (kurumsal) satis stratejisi becerisi. Buyuk sirketlere yonelik karmasik, uzun dongueli ve yuksek degerli satis sureclerini yonetir.
+### enterprise-sales
+The enterprise-sales strategy skill. Manages complex, long-cycle, high-value sales into large companies.
 
 ---
 
-### saas-satis
-SaaS satis stratejisi becerisi. Yazilim hizmeti is modeline ozgu satis dongusu, deneme donusum ve genisleme stratejileri uygular.
+### saas-sales
+The SaaS-sales strategy skill. Applies the sales cycle, trial conversion, and expansion strategies specific to the software-as-a-service model.
 
 ---
 
-### satis-psikolojisi
-Satis psikolojisi ve ikna teknikleri becerisi. Musteri karar alma surecini anlayarak etik ve etkili ikna stratejileri uygular.
+### sales-psychology
+The sales psychology and persuasion skill. Applies ethical, effective persuasion strategies by understanding customer decision-making.
 
 ---
 
-### kayip-analizi
-Satis kayip (loss) analizi becerisi. Kaybedilen firsatlarin nedenlerini sistematik olarak analiz ederek satis surecini iyilestirir.
+### loss-analysis
+The sales loss-analysis skill. Improves the process by systematically analyzing why opportunities were lost.
 
 ---
 
-### satis-etkinlik
-Satis etkinlik yonetimi becerisi. Fuarlar, konferanslar ve diger satis etkinliklerinde lead toplama ve firsat olusturma stratejisi uygular.
+### sales-events
+The sales-event management skill. Applies lead-capture and opportunity-creation strategy at fairs, conferences, and other events.
 
 ---
 
-### satis-mektuplari
-Satis mektupbve e-posta sablonlari olusturma becerisi. Satis surecinin farkli asamalari icin etkili yazili iletisim sablonlari hazirlar.
+### sales-letters
+The sales letter and email template skill. Prepares effective written-communication templates for different sales stages.
 
 ---
 
-### musteri-yenileme
-Musteri yenileme (renewal) stratejisi becerisi. Abonelik ve sozlesme yenilemelerini proaktif olarak yoneterek retansiyon gelirini korur.
+### customer-renewal
+The renewal strategy skill. Protects retention revenue by managing subscription and contract renewals proactively.
 
 ---
 
-### deger-bazli-satis
-Deger bazli satis (value selling) becerisi. Fiyat yerine musteri icin yaratilan degeri on plana cikararak satis yapar.
+### value-selling
+The value-selling skill. Sells by foregrounding the value created for the customer instead of the price.
 
 ---
 
-### satis-pipeline-verimliligi
-Satis pipeline verimlilik optimizasyonu becerisi. Pipeline hizi, donusum oranlari ve asama surelerini optimize ederek gelir artisi saglar.
+### pipeline-velocity
+The pipeline-efficiency optimization skill. Drives revenue by optimizing pipeline speed, conversion rates, and stage durations.
 
 ---
 
-### musteri-savunuculugu
-Musteri savunuculugu (customer advocacy) programi becerisi. Memnun musterileri aktif savunuculara donustuurerek organik buyume ve guven olusturur.
+### customer-advocacy
+The customer-advocacy program skill. Builds organic growth and trust by turning happy customers into active advocates.
 
 ---
 
-### satis-verisi-analizi
-Satis verisi analizi becerisi. Satis verilerinden derinlemesine icgoruler cikararak strateji ve operasyon iyilestirmesi saglar.
+### sales-data-analysis
+The sales data-analysis skill. Delivers strategy and operations improvements by extracting deep insights from sales data.
 
 ---
 
-### musteri-genisleme
-Musteri genisleme (expansion) stratejisi becerisi. Mevcut musterilerdeki geliri artirmak icin upsell, cross-sell ve seat genisleme taktikleri uygular.
+### customer-expansion
+The expansion strategy skill. Applies upsell, cross-sell, and seat-expansion tactics to grow revenue in existing accounts.
 
 ---
 
-### cozum-satisi
-Cozum satisi (solution selling) becerisi. Urun ozellikleri yerine musteri sorunlarina butunsel cozumler sunarak satis yapar.
+### solution-selling
+The solution-selling skill. Sells by offering holistic solutions to customer problems instead of product features.
 
 ---
 
-### satis-motivasyonu
-Satis ekibi motivasyon stratejisi becerisi. Satis temsilcilerinin performansini ve moralini yuksek tutan motivasyon mekanizmalari tasarlar.
+### sales-motivation
+The sales-team motivation strategy skill. Designs mechanisms keeping reps' performance and morale high.
 
 ---
 
-### musteri-segmentasyonu-satis
-Satis odakli musteri segmentasyonu becerisi. Musterileri satis stratejisi acisindan anlamli gruplara ayirarak kaynak dagiliimini optimize eder.
+### sales-customer-segmentation
+The sales-focused segmentation skill. Optimizes resource allocation by grouping customers into sales-meaningful segments.
 
 ---
 
-### dijital-satis
-Dijital satis stratejisi becerisi. Dijital kanalllar uzerinden self-serve ve asiste satis sureclerini yoneterek online gelir artisi saglar.
+### digital-sales
+The digital-sales strategy skill. Grows online revenue by managing self-serve and assisted processes across digital channels.
 
 ---
 
-### satis-sunum-teknikleri
-Satis sunum ve hikaye anlatma teknikleri becerisi. Ikna edici ve akilda kalici satis sunumlari yapma yetkinligini gelistirir.
+### sales-storytelling
+The sales presentation and storytelling techniques skill. Builds the competence for persuasive, memorable sales presentations.
 
 ---
 
-### musteri-deneyimi-satis
-Satis surecinde musteri deneyimi optimizasyonu becerisi. Satin alma surecindeki her temas noktasinda musteri deneyimini iyilestirerek donusum ve memnuniyet arttirir.
-
+### sales-customer-experience
+The customer-experience optimization skill in sales. Raises conversion and satisfaction by improving every touchpoint in the buying process.

--- a/.claude/skills-vault/security/SKILL.md
+++ b/.claude/skills-vault/security/SKILL.md
@@ -10,256 +10,255 @@ metadata:
   badi-version: ">=1.14.0"
   category: security
 ---
-# Guvenlik Becerileri
-Bu dosya, siber guvenlik, uyumluluk, erisim kontrolu, uygulama guvenligi ve tehdit yonetimi alanlarindaki tum becerileri icerir.
+# Security Skills
+This file contains all the skills across cybersecurity, compliance, access control, application security, and threat management.
 
 ---
 
-### guvenlik-acigi-degerlendirmesi
-Sistem ve uygulamalardaki guvenlik aciklarini sistematik olarak tespit eder ve onceliklendirir.
+### vulnerability-assessment
+Systematically detects and prioritizes vulnerabilities in systems and applications.
 
 ---
 
-### penetrasyon-test-plani
-Penetrasyon testi kapsamini, metodolojisini ve yurutme planini olusturur.
+### penetration-test-plan
+Builds the penetration test scope, methodology, and execution plan.
 
 ---
 
-### guvenlik-denetim-kontrol-listesi
-Kapsamli guvenlik denetimi icin kontrol listesi olusturur ve denetim surecini yonetir.
+### security-audit-checklist
+Builds the checklist for a comprehensive security audit and manages the audit process.
 
 ---
 
-### uyumluluk-haritalama
-Yasal ve sektorel uyumluluk gereksinimlerini teknik kontrollere haritalayarak uyum saglar.
+### compliance-mapping
+Achieves compliance by mapping legal and industry requirements to technical controls.
 
 ---
 
-### erisim-kontrol-tasarimi
-En az yetki ilkesine dayali erisim kontrol modeli ve politikalari tasarlar.
+### access-control-design
+Designs the access-control model and policies based on the least-privilege principle.
 
 ---
 
-### sifreleme-stratejisi
-Veri sifreleme stratejisi olusturarak dinlenme ve aktarim halindeki verileri korur.
+### encryption-strategy
+Protects data at rest and in transit by building the data-encryption strategy.
 
 ---
 
-### olay-mudahale-plani
-Siber guvenlik olaylarinda mudahale surecini tanimlayan kapsamli plan olusturur.
+### incident-response-plan
+Builds the comprehensive plan defining the response process for cybersecurity incidents.
 
 ---
 
-### tehdit-modelleme
-Tehdit modelleme metodolojisi uygulayarak potansiyel saldiri vektorlerini belirler.
+### threat-modeling
+Identifies potential attack vectors by applying threat-modeling methodology.
 
 ---
 
-### guvenlik-egitim-plani
-Organizasyon icin guvenlik farkindalik ve yetkinlik egitim programi tasarlar.
+### security-training-plan
+Designs the security awareness and competence training program for the organization.
 
 ---
 
-### api-guvenlik-incelemesi
-API guvenligini kapsamli olarak denetleyerek aciklari ve riskleri tespit eder.
+### api-security-review
+Detects gaps and risks by auditing API security comprehensively.
 
 ---
 
-### sifir-guven-mimarisi
-Zero Trust mimarisi ilkelerini uygulayarak ag guvenligi yaklasimini donusturur.
+### zero-trust-architecture
+Transforms the network-security approach by applying Zero Trust principles.
 
 ---
 
-### veri-siniflandirma
-Organizasyonel verileri hassasiyet seviyelerine gore siniflandirma politikasi olusturur.
+### data-classification
+Builds the policy classifying organizational data by sensitivity level.
 
 ---
 
-### gizlilik-etki-degerlendirmesi
-Kisisel verilerin islenmesine yonelik gizlilik etki degerlendirmesi (DPIA) yapar.
+### privacy-impact-assessment
+Runs privacy impact assessments (DPIA) for personal-data processing.
 
 ---
 
-### guvenlik-politika-yazimi
-Organizasyonel bilgi guvenligi politikalarini yazar ve gunceller.
+### security-policy-writing
+Writes and updates organizational information-security policies.
 
 ---
 
-### waf-yapilandirma-guvenlik
-Web Application Firewall'u guvenlik odakli yapilandirarak web uygulamalarini korur.
+### waf-configuration-security
+Protects web applications by configuring the Web Application Firewall with a security focus.
 
 ---
 
-### ddos-azaltma
-DDoS saldirilarina karsi azaltma stratejisi ve prosedurlerini olusturur.
+### ddos-mitigation
+Builds the mitigation strategy and procedures against DDoS attacks.
 
 ---
 
-### tedarik-zinciri-guvenlik
-Yazilim tedarik zinciri guvenligi stratejisi olusturarak ucuncu parti riskleri yonetir.
+### supply-chain-security
+Manages third-party risk by building the software supply-chain security strategy.
 
 ---
 
-### container-guvenlik
-Container ve container orchestration ortamlarinin guvenligini saglar.
+### container-security
+Secures container and container-orchestration environments.
 
 ---
 
-### bulut-guvenlik-durumu
-Cloud Security Posture Management (CSPM) ile bulut ortaminin guvenlik durusunu denetler.
+### cloud-security-posture
+Audits the cloud environment's security posture with Cloud Security Posture Management (CSPM).
 
 ---
 
-### jwt-uygulamasi
-JSON Web Token (JWT) tabanli kimlik dogrulama ve yetkilendirme uygulamasini guvenli tasarlar.
+### jwt-implementation
+Designs JSON Web Token (JWT) based authentication and authorization securely.
 
 ---
 
-### oauth-tasarimi
-OAuth 2.0 yetkilendirme akislarnini guvenli tasarlar ve uygular.
+### oauth-design
+Designs and implements OAuth 2.0 authorization flows securely.
 
 ---
 
-### saml-entegrasyonu
-SAML tabanli tek oturum acma (SSO) entegrasyonunu yapilandirir ve guvence altina alir.
+### saml-integration
+Configures and secures SAML-based single sign-on (SSO) integration.
 
 ---
 
-### mfa-stratejisi
-Cok faktorlu kimlik dogrulama (MFA) stratejisi tasarlayarak hesap guvenligi arttirir.
+### mfa-strategy
+Raises account security by designing the multi-factor authentication (MFA) strategy.
 
 ---
 
-### parola-politikasi
-Guclu parola politikasi olusturarak kimlik dogrulama guvenligi saglar.
+### password-policy
+Delivers authentication security by building a strong password policy.
 
 ---
 
-### sertifika-yonetimi-guvenlik
-Dijital sertifika yasam dongusu yonetimini guvenlik perspektifinden planlar.
+### certificate-management-security
+Plans the digital-certificate lifecycle from a security perspective.
 
 ---
 
-### log-denetimi
-Guvenlik log'larini denetleyerek anormallikleri ve guvenlik olaylarini tespit eder.
+### log-auditing
+Detects anomalies and security events by auditing security logs.
 
 ---
 
-### siem-yapilandirma
-Security Information and Event Management (SIEM) sistemi yapilandirir ve optimize eder.
+### siem-configuration
+Configures and optimizes the Security Information and Event Management (SIEM) system.
 
 ---
 
-### soar-otomasyon
-Security Orchestration, Automation and Response (SOAR) ile guvenlik operasyonlarini otomatiklestirir.
+### soar-automation
+Automates security operations with Security Orchestration, Automation and Response (SOAR).
 
 ---
 
-### guvenlik-izleme
-7/24 guvenlik izleme stratejisi tasarlayarak tehdit tespit kapasitesi olusturur.
+### security-monitoring
+Builds threat-detection capacity by designing a 24/7 security-monitoring strategy.
 
 ---
 
-### zafiyet-tarama
-Duzenli zafiyet tarama programi olusturarak guvenlik aciklarini proaktif olarak tespit eder.
+### vulnerability-scanning
+Detects security gaps proactively by building a regular vulnerability-scanning program.
 
 ---
 
-### yama-yonetimi
-Yazilim ve sistem yamalarini zamaninda ve guvenli sekilde uygulama sureci olusturur.
+### patch-management
+Builds the process for applying software and system patches on time and safely.
 
 ---
 
-### ag-segmentasyonu
-Ag segmentasyonu ile saldiri yuzeyini kuculterek yanal hareketi sinirlar.
+### network-segmentation
+Limits lateral movement by shrinking the attack surface through network segmentation.
 
 ---
 
-### vpn-yapilandirma
-VPN altyapisini guvenli yapilandirarak uzaktan erisim ve site-to-site baglantiyi saglar.
+### vpn-configuration
+Provides remote access and site-to-site connectivity by configuring VPN infrastructure securely.
 
 ---
 
-### guvenlik-duvar-kurallari
-Firewall kural setini en iyi uygulamalara gore tasarlar ve yonetir.
+### firewall-rules
+Designs and manages the firewall rule set per best practices.
 
 ---
 
-### endpoint-koruma
-Son nokta (endpoint) guvenlik stratejisi olusturarak cihazlari korur.
+### endpoint-protection
+Protects devices by building the endpoint security strategy.
 
 ---
 
-### mobil-guvenlik
-Mobil cihaz ve uygulama guvenligi stratejisi olusturur.
+### mobile-security
+Builds the mobile device and application security strategy.
 
 ---
 
-### web-uygulama-guvenlik
-Web uygulamalarinin guvenligini kapsamli olarak degerlendirir ve iyilestirir.
+### web-application-security
+Assesses and improves web application security comprehensively.
 
 ---
 
-### xss-onleme
-Cross-Site Scripting (XSS) saldirilarina karsi koruma stratejisi ve uygulama kontrolleri gelistirir.
+### xss-prevention
+Develops the protection strategy and application controls against Cross-Site Scripting (XSS).
 
 ---
 
-### sql-enjeksiyon-onleme
-SQL Injection saldirilarina karsi koruma stratejisi uygular.
+### sql-injection-prevention
+Applies the protection strategy against SQL Injection attacks.
 
 ---
 
-### csrf-koruma
-Cross-Site Request Forgery (CSRF) saldirilarina karsi koruma mekanizmalari uygular.
+### csrf-protection
+Applies protection mechanisms against Cross-Site Request Forgery (CSRF).
 
 ---
 
-### dosya-yukleme-guvenlik
-Dosya yukleme islevselliginin guvenligini saglayarak zararli dosya yuklemelerini onler.
+### file-upload-security
+Prevents malicious uploads by securing file-upload functionality.
 
 ---
 
-### session-yonetimi
-Oturum yonetimi guvenligini saglayarak oturum ele gecirme saldirilarina karsi koruma uygular.
+### session-management
+Protects against session-hijacking attacks by securing session management.
 
 ---
 
-### rate-limiting-guvenlik
-Rate limiting uygulamasi ile brute force ve kotu amacli trafigi sinirlar.
+### rate-limiting-security
+Limits brute force and malicious traffic through rate limiting.
 
 ---
 
-### cors-yapilandirma
-Cross-Origin Resource Sharing (CORS) yapilandirmasini guvenli sekilde olusturur.
+### cors-configuration
+Builds the Cross-Origin Resource Sharing (CORS) configuration securely.
 
 ---
 
-### csp-baslik
-Content Security Policy basligini yapilandirarak XSS ve veri enjeksiyon saldirilarina karsi koruma saglar.
+### csp-header
+Protects against XSS and data-injection attacks by configuring the Content Security Policy header.
 
 ---
 
-### hsts-yapilandirma
-HTTP Strict Transport Security basligini yapilandirarak HTTPS zorlamasini saglar.
+### hsts-configuration
+Enforces HTTPS by configuring the HTTP Strict Transport Security header.
 
 ---
 
-### guvenlik-basliklari
-Tum HTTP guvenlik basliklarini kapsamli olarak yapilandirir.
+### security-headers
+Configures all HTTP security headers comprehensively.
 
 ---
 
-### penetrasyon-raporu
-Penetrasyon testi sonuclarini profesyonel rapor formatinda sunar.
+### penetration-report
+Presents penetration-test results in a professional report format.
 
 ---
 
-### guvenlik-farkindalik
-Calisan guvenlik farkindalik programi tasarlayarak insan kaynakli riskleri azaltir.
+### security-awareness
+Reduces human-driven risk by designing the employee security-awareness program.
 
 ---
 
-### kvkk-uyumluluk
-Kisisel Verilerin Korunmasi Kanunu (KVKK) uyumluluk surecini yonetir.
-
+### kvkk-compliance
+Manages the compliance process for KVKK (the Turkish Personal Data Protection Law).

--- a/.claude/skills-vault/seo-crawl-budget/SKILL.md
+++ b/.claude/skills-vault/seo-crawl-budget/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: seo-crawl-budget
-description: Dusuk rekabetli long-tail keyword'ler icin 6-24 saatte indexlenme metodolojisi. 20 makalelik kampanya, dongusel ic-link matrisi, Search Console manuel tetikleme. Triggers on: crawl budget, crawl butcesi, long-tail, long tail, indexleme, search console, internal linking, ic linkleme, sitemap, hizli index, fast indexing, SEO kampanya, kampanya plani.
+description: A 6-24 hour indexing methodology for low-competition long-tail keywords. A 20-article campaign, a cyclic internal-link matrix, manual Search Console triggering. Triggers on: crawl budget, crawl butcesi, long-tail, long tail, indexleme, search console, internal linking, ic linkleme, sitemap, hizli index, fast indexing, SEO kampanya, kampanya plani.
 license: MIT
 compatibility: Works with Claude Code, Cursor, or any compatible AI coding agent.
 allowed-tools: Read Write Edit Grep
@@ -15,94 +15,94 @@ metadata:
 
 # SEO Crawl Budget Manipulation
 
-Dusuk rekabetli long-tail keyword'lerde 6-24 saat icinde indexlenme ve ilk sayfa siralamasi hedefleyen sistematik SEO kampanya metodolojisi.
+A systematic SEO campaign methodology targeting indexing within 6-24 hours and first-page rankings on low-competition long-tail keywords.
 
-> **Atif:** Bu skill, [moneyvadi-prog/crawl-budget-manipulation](https://github.com/moneyvadi-prog/crawl-budget-manipulation) (MIT) reposundaki metodolojiden adapte edilmistir. Orijinal yazari Gulsah Arslan / [seodanismanlikhizmeti.com.tr](https://www.seodanismanlikhizmeti.com.tr/crawl-budget-manipulation-deneyi-gulsah-arslan/).
+> **Attribution:** This skill is adapted from the methodology in the [moneyvadi-prog/crawl-budget-manipulation](https://github.com/moneyvadi-prog/crawl-budget-manipulation) (MIT) repository. Original author: Gulsah Arslan / [seodanismanlikhizmeti.com.tr](https://www.seodanismanlikhizmeti.com.tr/crawl-budget-manipulation-deneyi-gulsah-arslan/).
 
-## Ne Zaman Kullanilir
+## When to Use
 
-**Uygun:**
-- KD (keyword difficulty) < 20 olan long-tail sorgular
-- Soru bazli, bilgi amacli veya yumusak ticari niyet
-- Yeni ya da orta otorite domain'ler
-- Hizli indexlenme test edilmek isteniyor
+**Suitable:**
+- Long-tail queries with KD (keyword difficulty) < 20
+- Question-based, informational, or soft-commercial intent
+- New or mid-authority domains
+- When fast indexing is being tested
 
-**Uygun degil:**
-- Yuksek rekabetli ticari kelimeler
-- Yuksek hacimli marka aramalari
-- Domain otoritesi gerektiren kisa-tail sorgular
+**Not suitable:**
+- Highly competitive commercial keywords
+- High-volume brand searches
+- Short-tail queries requiring domain authority
 
-## Calisma Prensibi
+## Operating Principle
 
-Uc esgudumlu sinyal ile crawl butcesi yonlendirilir:
+Crawl budget is steered with three coordinated signals:
 
-1. **Manuel crawl tetikleme** — Search Console "Indexle iste" + guncel sitemap
-2. **Dongusel ic linkleme** — her makale 3 baska makaleye link verir
-3. **Dusuk rekabetli niyet net keyword'ler** — KD < 20
+1. **Manual crawl triggering** — Search Console "Request indexing" + a fresh sitemap
+2. **Cyclic internal linking** — every article links to 3 other articles
+3. **Low-competition, intent-clear keywords** — KD < 20
 
-Bu kombinasyon Google'a sitenin **aktif ve degerli** oldugu sinyalini verir, crawl frekansini artirir.
+This combination signals to Google that the site is **active and valuable**, raising crawl frequency.
 
-## 6 Fazli Kampanya Yapisi
+## The 6-Phase Campaign Structure
 
-### Faz 1 — Keyword Uretimi (Gun 0)
-- 20 long-tail keyword: 10 esit yayin (Group A) + 10 zaman serpiştirilmis (Group B)
-- Her keyword icin: arama hacmi (tahmini), KD, niyet (informational/commercial), SERP yapisi
-- Ciktilar: `keywords-A.json`, `keywords-B.json`
+### Phase 1 — Keyword Generation (Day 0)
+- 20 long-tail keywords: 10 simultaneous-publish (Group A) + 10 time-staggered (Group B)
+- Per keyword: search volume (estimated), KD, intent (informational/commercial), SERP structure
+- Outputs: `keywords-A.json`, `keywords-B.json`
 
-### Faz 2 — Icerik Brief'leri (Gun 0-1)
-- Tum 20 makale icin standart sablon
-- Hedef: 800-900 kelime, ayni H2 yapisi
-- Brief alanlari: title, slug, primary keyword, secondary keywords (2-3), H2 listesi (4-6), TLDR, FAQ (3-5 soru), iç-link hedefleri (3 makale)
+### Phase 2 — Content Briefs (Days 0-1)
+- A standard template for all 20 articles
+- Target: 800-900 words, identical H2 structure
+- Brief fields: title, slug, primary keyword, secondary keywords (2-3), H2 list (4-6), TLDR, FAQ (3-5 questions), internal-link targets (3 articles)
 
-### Faz 3 — Ic Link Matrisi (Gun 1)
-- 20 makale icin dongusel link grafi (her dugum cikis derecesi = 3, gelis derecesi = 3)
-- Group A icindeki 10 makale kendi arasinda + Group B'ye 1 link
-- CSV/Markdown matris ciktisi: `linking-matrix.md`
+### Phase 3 — Internal Link Matrix (Day 1)
+- A cyclic link graph for the 20 articles (every node: out-degree = 3, in-degree = 3)
+- The 10 Group A articles link among themselves + 1 link into Group B
+- CSV/Markdown matrix output: `linking-matrix.md`
 
-### Faz 4 — Yayin Takvimi (Gun 1-6)
-- **Group A**: tek gun icinde 2-3 saat penceresinde 10 makale yayinlanir
-- **Group B**: 5 gune yayilmis, gunde 2 makale
-- Yayin saati onerisi: hedef pazarin pik saatlerine yakin (TR icin 10:00-12:00, 19:00-21:00)
+### Phase 4 — Publication Schedule (Days 1-6)
+- **Group A**: 10 articles published within a 2-3 hour window on a single day
+- **Group B**: spread over 5 days, 2 articles per day
+- Suggested publish times: near the target market's peak hours (for TR: 10:00-12:00, 19:00-21:00)
 
-### Faz 5 — Search Console Aksiyonlari (Yayin gunu)
-- XML sitemap guncellenir + Search Console'a tekrar gonderilir
-- Her URL icin "URL incele" → "Indexle iste" (gunluk kota: ~10-12)
-- robots.txt + canonical tag dogrulamasi
+### Phase 5 — Search Console Actions (Publish day)
+- Update the XML sitemap + resubmit to Search Console
+- For each URL: "Inspect URL" → "Request indexing" (daily quota: ~10-12)
+- robots.txt + canonical tag verification
 
-### Faz 6 — Takip Metrikleri (14-28 gun)
-- Crawl frekansi (Search Console > Settings > Crawl stats)
-- Indexlenme hizi (yayindan kac saat sonra indexlendi?)
-- Coverage durumu (Indexed / Discovered-not-indexed)
-- Anahtar kelime siralama trendi (manuel veya rank-tracker)
-- Hedef: %70-90 makale 6-24 saatte indexli; %40-60 long-tail keyword ilk sayfada
+### Phase 6 — Tracking Metrics (Days 14-28)
+- Crawl frequency (Search Console > Settings > Crawl stats)
+- Indexing speed (how many hours after publication was it indexed?)
+- Coverage state (Indexed / Discovered-not-indexed)
+- Keyword ranking trend (manual or a rank tracker)
+- Target: 70-90% of articles indexed in 6-24 hours; 40-60% of long-tail keywords on the first page
 
-## Veri Kontaminasyon Riskleri
+## Data Contamination Risks
 
-Deney suresince **degistirme**:
-- Yeni backlink kampanyasi
-- Site mimarisi degisiklikleri
-- Mevcut iceriklerin guncellenmesi
-- Robot/canonical/redirect kurallari
+**Do not change** during the experiment:
+- New backlink campaigns
+- Site architecture changes
+- Updates to existing content
+- Robot/canonical/redirect rules
 
-Bu risk faktorleri kontrol grubu temizligini bozar.
+These risk factors break control-group cleanliness.
 
-## Cikti Sablonu
+## Output Template
 
-Bu skill aktifken ajan asagidaki dosyalari uretir/onerir:
+While this skill is active, the agent produces/suggests these files:
 
 ```
 seo-campaign-<slug>/
-├── keywords-A.json          # 10 esit yayin
-├── keywords-B.json          # 10 zamanlanmis
-├── briefs/                  # 20 makale brief'i
-├── linking-matrix.md        # Dongusel grafik
-├── publication-schedule.csv # Tarih + saat
+├── keywords-A.json          # 10 simultaneous
+├── keywords-B.json          # 10 scheduled
+├── briefs/                  # 20 article briefs
+├── linking-matrix.md        # Cyclic graph
+├── publication-schedule.csv # Date + time
 ├── search-console-checklist.md
-└── tracking-template.md     # 14-28 gun metrik
+└── tracking-template.md     # 14-28 day metrics
 ```
 
-## Sinirlilik
+## Limitations
 
-- **Kara sapka degil** — sadece kalite-iceriksel + teknik tetikleme. Spam, gizleme, link agi yok.
-- **Uzun vadeli degil** — kampanya bitiminde (28 gun) icerik ekosistemi normal SEO kurallarina doner.
-- **Domain hassasiyeti** — yeni domain'lerde sandbox etkisi gorulebilir.
+- **Not black hat** — only quality content + technical triggering. No spam, cloaking, or link networks.
+- **Not long-term** — when the campaign ends (28 days) the content ecosystem returns to normal SEO rules.
+- **Domain sensitivity** — new domains may see a sandbox effect.

--- a/.claude/skills-vault/seo/SKILL.md
+++ b/.claude/skills-vault/seo/SKILL.md
@@ -10,291 +10,290 @@ metadata:
   badi-version: ">=1.14.0"
   category: seo
 ---
-# SEO Becerileri
-Bu dosya, teknik SEO, icerik SEO, link building, yerel SEO, e-ticaret SEO, analiz ve AI SEO ile ilgili tum becerileri icerir.
+# SEO Skills
+This file contains all the skills around technical SEO, content SEO, link building, local SEO, e-commerce SEO, analytics, and AI SEO.
 
 ---
 
-### seo-denetimi
-Kapsamli SEO denetimi (audit) yapma becerisi. Web sitesinin teknik, icerik ve otorite acisindan mevcut durumunu degerlendirerek iyilestirme yol haritasi cikarir.
+### seo-audit
+The skill of running a comprehensive SEO audit. Assesses the site's technical, content, and authority state and produces an improvement roadmap.
 
 ---
 
-### anahtar-kelime-arastirmasi
-Anahtar kelime arastirmasi ve strateji becerisi. Hedef kitle arama davranislarini analiz ederek trafik ve donusum potansiyeli yuksek anahtar kelimeleri belirler.
+### keyword-research
+The keyword research and strategy skill. Identifies keywords with high traffic and conversion potential by analyzing audience search behavior.
 
 ---
 
-### arama-amaci-analizi
-Arama amaci (search intent) analizi becerisi. Kullanicilarin arama sorgulari arkasindaki niyeti anlayarak icerik ve sayfa turunu dogru eslestiriiir.
+### search-intent-analysis
+The search-intent analysis skill. Matches content and page types correctly by understanding the intent behind users' queries.
 
 ---
 
-### teknik-seo
-Teknik SEO iyilestirme becerisi. Web sitesinin arama motorlari tarafindan dogru sekilde taranmasini, indexlenmesini ve anlasilmasini saglayan teknik optimizasyonlar yapar.
+### technical-seo
+The technical SEO improvement skill. Applies technical optimizations ensuring the site is crawled, indexed, and understood correctly by search engines.
 
 ---
 
-### sayfa-hizi
-Sayfa hizi optimizasyonu becerisi. Web sitesi yukleme surelerini iyilestirerek kullanici deneyimi ve arama siralamasini arttirir.
+### page-speed
+The page-speed optimization skill. Raises user experience and rankings by improving load times.
 
 ---
 
 ### core-web-vitals
-Core Web Vitals optimizasyonu becerisi. Google'in kullanici deneyimi metrikleriini (LCP, INP, CLS) iyilestirerek arama performansini arttirir.
+The Core Web Vitals optimization skill. Improves Google's UX metrics (LCP, INP, CLS) to lift search performance.
 
 ---
 
-### mobil-seo
-Mobil SEO optimizasyonu becerisi. Mobil oncelikli indexleme caginda web sitesinin mobil arama performansini maksimize eder.
+### mobile-seo
+The mobile SEO optimization skill. Maximizes mobile search performance in the mobile-first indexing era.
 
 ---
 
-### uluslararasi-seo
-Uluslararasi SEO stratejisi becerisi. Cok dilli ve cok ulkeli web siteleri icin arama gorununurlugunu optimize eder.
+### international-seo
+The international SEO strategy skill. Optimizes search visibility for multi-language, multi-country websites.
 
 ---
 
-### icerik-seo
-Icerik SEO optimizasyonu becerisi. Web sitesi iceriklerini arama motorlari ve kullanicilar icin optimize ederek organik trafik artisi saglar.
+### content-seo
+The content SEO optimization skill. Drives organic traffic by optimizing site content for search engines and users.
 
 ---
 
-### meta-etiket-optimizasyonu
-Meta etiket optimizasyonu becerisi. Title, description ve diger meta etiketleri optimize ederek tiklama oranini ve arama gorunurluugunu arttirir.
+### meta-tag-optimization
+The meta-tag optimization skill. Raises CTR and search visibility by optimizing titles, descriptions, and other meta tags.
 
 ---
 
-### baslik-yapisi
-HTML baslik (heading) yapisi optimizasyonu becerisi. H1-H6 baslik hiyerarsisini dogru ve SEO uyumlu sekilde yapilandirarak icerik anlasilirligini arttirir.
+### heading-structure
+The HTML heading structure optimization skill. Improves content clarity by structuring the H1-H6 hierarchy correctly and SEO-soundly.
 
 ---
 
-### yapilandirilmis-veri
-Yapilandirilmis veri (schema markup) uygulama becerisi. Schema.org isaretlemesi ekleyerek arama motorlarinin icerigi daha iyi anlamasini ve zengin sonuclar gostermesini saglar.
+### structured-data
+The structured-data (schema markup) skill. Adds Schema.org markup so engines understand content better and show rich results.
 
 ---
 
-### ic-linkleme
-Ic linkleme stratejisi becerisi. Web sitesi icerisindeki baglanti yapisini optimize ederek sayfa otoritesi dagiliimini ve kullanici navigasyonunu iyilestirir.
+### internal-linking
+The internal-linking strategy skill. Improves authority distribution and user navigation by optimizing the site's link structure.
 
 ---
 
-### url-optimizasyonu
-URL yapisi optimizasyonu becerisi. Temiz, anlasilir ve SEO uyumlu URL yapisi olusturarak arama motoru ve kullanici deneyimini iyilestiir.
+### url-optimization
+The URL structure optimization skill. Improves engine and user experience by building clean, clear, SEO-friendly URLs.
 
 ---
 
-### site-mimarisi
-Web sitesi mimarisi optimizasyonu becerisi. Site yapisini arama motorlari ve kullanicilar icin optimize ederek taranabilirlik ve kullanici deneyimini arttirir.
+### site-architecture
+The site-architecture optimization skill. Raises crawlability and UX by optimizing the structure for engines and users.
 
 ---
 
-### indexleme-yonetimi
-Arama motoru indexleme yonetimi becerisi. Hangi sayfalarin indexlenmesi gerektigini kontrol ederek crawl butcesini ve index kalitesini optimize eder.
+### indexing-management
+The search-engine indexing management skill. Optimizes crawl budget and index quality by controlling which pages get indexed.
 
 ---
 
 ### link-building
-Link building (baglanti kazaanma) stratejisi becerisi. Yuksek kaliteli dis baglantlar kazanarak web sitesinin alan adi otoritesini arttirir.
+The link-building strategy skill. Raises domain authority by earning high-quality external links.
 
 ---
 
-### backlink-analizi
-Backlink profili analizi becerisi. Gelen baglantilarin kalitesini, kaynaklarini ve risk durumunu degerlendirerek link profilini yonetir.
+### backlink-analysis
+The backlink-profile analysis skill. Manages the link profile by assessing inbound links' quality, sources, and risk.
 
 ---
 
-### dijital-pr
-Dijital PR ile link kazanma becerisi. Haber degeri tasiyan icerik ve kampanyalarla medya kaynakiiraandn dogal link kazanir.
+### digital-pr
+The link earning via digital PR skill. Earns natural links from media sources with newsworthy content and campaigns.
 
 ---
 
 ### broken-link-building
-Kirik link building stratejisi becerisi. Baska sitelerdeki kirik linkleri tespit ederek kendi icerigini alternatif olarak onerir ve link kazanir.
+The broken-link building strategy skill. Earns links by finding broken links on other sites and proposing your content as the alternative.
 
 ---
 
 ### guest-posting
-Konuk yazilarla link building becerisi. Hedef sitelerde konuk yazi yayiinlayarak hem otorite hem de referral trafik kazanir.
+The guest-post link-building skill. Earns both authority and referral traffic by publishing guest articles on target sites.
 
 ---
 
-### yerel-seo
-Yerel SEO optimizasyonu becerisi. Fiziksel lokasyonu olan isletmelerin yerel arama sonuclarinda gorunurluugunu arttirir.
+### local-seo
+The local SEO optimization skill. Raises local-search visibility for businesses with physical locations.
 
 ---
 
 ### google-business-profile
-Google Business Profile yonetimi becerisi. GBP profilini optimize ederek yerel arama gorununurlugu, harita gorunumu ve musteri etkilesimini arttirir.
+The Google Business Profile management skill. Lifts local visibility, map presence, and customer engagement by optimizing the GBP profile.
 
 ---
 
-### yorum-yonetimi
-Online yorum yonetimi ve SEO etkisi becerisi. Musteri yorumlarini proaktif olarak yoneterek hem itibar hem de yerel SEO performansi arttirir.
+### review-management
+The online review management and SEO impact skill. Raises both reputation and local SEO by managing customer reviews proactively.
 
 ---
 
-### e-ticaret-seo
-E-ticaret SEO stratejisi becerisi. Online magaza sayfallarini arama motorlari icin optimize ederek organik trafik ve satis artisi saglar.
+### ecommerce-seo
+The e-commerce SEO strategy skill. Drives organic traffic and sales by optimizing store pages for search engines.
 
 ---
 
-### urun-sayfasi-seo
-Urun sayfasi SEO optimizasyonu becerisi. E-ticaret urun sayfalarinin arama gorunurluugunu ve donusum oranini arttirir.
+### product-page-seo
+The product-page SEO optimization skill. Raises e-commerce product pages' search visibility and conversion rate.
 
 ---
 
-### kategori-sayfasi-seo
-Kategori sayfa SEO optimizasyonu becerisi. E-ticaret kategori sayfalarini arama gorununurlugu icin optimize ederek trafik ve icerik siniflandirmasi iyilestirir.
+### category-page-seo
+The category-page SEO optimization skill. Improves traffic and content classification by optimizing category pages for visibility.
 
 ---
 
-### icerik-stratejisi-seo
-SEO odakli icerik stratejisi becerisi. Anahtar kelime ve arama amaci verilerine dayali icerik plani olusturarak organik trafik buyumesi saglar.
+### seo-content-strategy
+The SEO-focused content strategy skill. Drives organic growth with a content plan grounded in keyword and intent data.
 
 ---
 
 ### blog-seo
-Blog SEO optimizasyonu becerisi. Blog iceriklerini arama motorlari icin optimize ederek surekli organik trafik akisi saglar.
+The blog SEO optimization skill. Delivers a continuous organic traffic stream by optimizing blog content for engines.
 
 ---
 
-### icerik-guncelleme
-Mevcut icerikleri guncelleme ve yenileme becerisi. Organik performansi dusen veya eskiyen icerikleri guncelleyerek arama siralamasini yeniden kazanir.
+### content-refresh
+The skill of updating and refreshing existing content. Recovers rankings by updating decayed or aging content.
 
 ---
 
-### featured-snippet
-Featured snippet (one cikan snipet) optimizasyonu becerisi. Google'in sifirinci sirasindaki featured snippet konumlarina icerikleri optimize eder.
+### featured-snippets
+The featured-snippet optimization skill. Optimizes content for Google's position-zero featured snippet placements.
 
 ---
 
-### serp-analizi
-SERP (arama sonuclari sayfasi) analizi becerisi. Hedef anahtar kelimeler icin SERP yapisini analiz ederek strateji ve firsat belirler.
+### serp-analysis
+The SERP analysis skill. Sets strategy and finds opportunity by analyzing the SERP structure for target keywords.
 
 ---
 
-### sirailama-izleme
-Anahtar kelime siralama izleme becerisi. Hedef anahtar kelimelerdeki siralama pozisyonlarini duzenliolarak izler ve trend analizleri yapar.
+### rank-tracking
+The keyword rank-tracking skill. Tracks target keyword positions regularly and runs trend analyses.
 
 ---
 
-### seo-raporlama
-SEO performans raporlama becerisi. Organik trafik, siralama, donusum ve teknik metriklerini iceren kapsamli SEO raporlari hazirlar.
+### seo-reporting
+The SEO performance reporting skill. Prepares comprehensive reports covering organic traffic, rankings, conversions, and technical metrics.
 
 ---
 
 ### google-search-console
-Google Search Console yonetimi becerisi. GSC verilerini analiz ederek teknik sorunlari cozumler ve organik performansi optimize eder.
+The Google Search Console management skill. Fixes technical issues and optimizes organic performance by analyzing GSC data.
 
 ---
 
 ### google-analytics-seo
-Google Analytics ile SEO analizi becerisi. GA verilerini kullanarak organik trafik performansini, kullanici davranisini ve donusum etkisini analiz eder.
+The SEO analysis with Google Analytics skill. Analyzes organic traffic performance, user behavior, and conversion impact with GA data.
 
 ---
 
-### log-analizi
-Arama motoru log dosyasi analizi becerisi. Server log'larini analiz ederek arama motoru botlarinin tarama davranisini anlar ve crawl butcesini optimize eder.
+### log-analysis
+The search-engine log-file analysis skill. Optimizes the crawl budget by analyzing server logs to understand bot crawling behavior.
 
 ---
 
-### rakip-seo-analizi
-Rakip SEO analizi becerisi. Rakiplerin organik arama stratejilerini analiz ederek firsat ve tehdit alanlari belirler.
+### competitor-seo-analysis
+The competitor SEO analysis skill. Identifies opportunity and threat areas by analyzing rivals' organic strategies.
 
 ---
 
-### icerik-boslugu-analizi
-Icerik boslugu (content gap) analizi becerisi. Rakiplerin kapsadigi ama sizin kapsamadiginiz anahtar kelimeleri ve konulari tespit ederek icerik firsatlari belirler.
+### content-gap-analysis
+The content-gap analysis skill. Finds content opportunities by detecting keywords and topics competitors cover but you do not.
 
 ---
 
-### site-goc-seo
-Web sitesi gocu (migration) SEO yonetimi becerisi. Domain, platform veya yapi degisikliginde organik trafik kaybini minimize eden goc planlamasiiyapar.
+### site-migration-seo
+The website migration SEO skill. Plans migrations minimizing organic-traffic loss across domain, platform, or structure changes.
 
 ---
 
 ### ai-seo
-AI arama motorlari icin optimizasyon (AIO/GEO) becerisi. ChatGPT, Perplexity ve diger AI arama motorlarinda gorunnur olmak icin icerik ve teknik optimizasyon yapar.
+The optimization skill for AI search engines (AIO/GEO). Optimizes content and technicals to be visible in ChatGPT, Perplexity, and other AI engines.
 
 ---
 
-### seo-otomasyon
-SEO surec otomasyonu becerisi. Tekrarlayan SEO gorevlerini otomatiklestirerek verimlilik ve tutarlilik saglar.
+### seo-automation
+The SEO process automation skill. Delivers efficiency and consistency by automating repetitive SEO tasks.
 
 ---
 
 ### video-seo
-Video SEO optimizasyonu becerisi. YouTube ve web sitesindeki video icerikllerin arama motorlarindaki gorunurluugunu arttirir.
+The video SEO optimization skill. Raises the search visibility of video content on YouTube and the website.
 
 ---
 
-### gorsel-seo
-Gorsel SEO optimizasyonu becerisi. Web sitesindeki gorsellerin arama motorlari ve gorsel aramada gorunurluugunu arttirir.
+### image-seo
+The image SEO optimization skill. Raises images' visibility in engines and image search.
 
 ---
 
-### seo-ab-test
-SEO A/B testi tasarlama ve yurutme becerisi. Title, description ve icerik degisikliklerinin organik performansa etkisini bilimsel olarak olcer.
+### seo-ab-testing
+The SEO A/B test design and execution skill. Measures the organic impact of title, description, and content changes scientifically.
 
 ---
 
-### programatik-seo
-Programatik SEO stratejisi becerisi. Buyuk olcekli, sablon bazli ve veri odakli sayfalar olusturarak genis anahtar kelime kapsamini yakalaar.
+### programmatic-seo
+The programmatic SEO strategy skill. Captures wide keyword coverage by building large-scale, template-based, data-driven pages.
 
 ---
 
 ### topical-authority
-Konu otoritesi (topical authority) olusturma becerisi. Belirli bir konuda kapsamli ve derinlemesine icerik ureterek arama motorlarinda konu otoritesi kazanir.
+The topical-authority building skill. Earns topic authority in engines by producing comprehensive, in-depth content on a subject.
 
 ---
 
-### crawl-butcesi
-Crawl butce optimizasyonu becerisi. Arama motoru botlarinin site tarama verimliiligini artirarak onemli sayfalarin hizla kesfedilmesini ve indexlenmesini saglar.
+### crawl-budget
+The crawl-budget optimization skill. Ensures key pages are discovered and indexed fast by raising bot crawling efficiency.
 
 ---
 
-### ceza-kurtarma
-Google cezasi teshis ve kurtarma becerisi. Manuel veya algoritmik cezalardan etkilenen sitelerin organik performansini kurtarma stratejisi uygular.
+### penalty-recovery
+The Google penalty diagnosis and recovery skill. Applies the strategy recovering organic performance for sites hit by manual or algorithmic penalties.
 
 ---
 
 ### entity-seo
-Entity (varlik) bazli SEO stratejisi becerisi. Arama motorlarinin varlik anlamla modeline uygun sekilde marka ve icerik otoritesi olusturur.
+The entity-based SEO strategy skill. Builds brand and content authority fitting search engines' entity understanding model.
 
 ---
 
-### seo-stratejisi-genel
-Butunsel SEO stratejisi olusturma becerisi. Teknik, icerik ve otorite bilesenlerini entegre eden kapsamli bir SEO yol haritasi hazirlar.
+### seo-strategy-overall
+The skill of building a holistic SEO strategy. Prepares a comprehensive roadmap integrating technical, content, and authority components.
 
 ---
 
 ### javascript-seo
-JavaScript SEO optimizasyonu becerisi. JavaScript ile olusturulan icerik ve sayfalarin arama motorlari tarafindan dogru taranip indexlenmesini saglar.
+The JavaScript SEO optimization skill. Ensures JS-rendered content and pages are crawled and indexed correctly.
 
 ---
 
-### sayfa-deneyimi
-Sayfa deneyimi (page experience) optimizasyonu becerisi. Google'in sayfa deneyimi sinyallerini (CWV, mobil uyum, HTTPS, guvenlik) iyilestirerek siralama etkisi arttirir.
+### page-experience
+The page-experience optimization skill. Lifts ranking impact by improving Google's page-experience signals (CWV, mobile-friendliness, HTTPS, safety).
 
 ---
 
-### ses-arama-seo
-Ses arama (voice search) optimizasyonu becerisi. Sesli asistanlar ve ses aramasi icin icerik ve teknik optimizasyon yaparak gorsel olmayan aramalarda gorunurluk saglar.
+### voice-search-seo
+The voice-search optimization skill. Delivers visibility in non-visual searches via content and technical optimization for voice assistants.
 
 ---
 
 ### e-e-a-t
-E-E-A-T (Deneyim, Uzmanlik, Otorite, Guvenilirlik) optimizasyonu becerisi. Google'in kalite degerlendirme kriterlerini karsilayarak site ve icerik guvenilirligini arttirir.
+The E-E-A-T (Experience, Expertise, Authoritativeness, Trustworthiness) optimization skill. Raises site and content credibility by meeting Google's quality criteria.
 
 ---
 
 ### link-reclamation
-Link geri kazanim (reclamation) becerisi. Kaybedilen veya kirik olan mevcut backlinkleri yeniden kazanarak link profilini guclendirir.
+The link-reclamation skill. Strengthens the link profile by regaining lost or broken existing backlinks.
 
 ---
 
-### seo-proje-yonetimi
-SEO proje yonetimi becerisi. SEO iyilestirme projelerini planlama, onceliklendirme ve uygulama surecini yoneterek zamaninda ve etkili teslimat saglar.
-
+### seo-project-management
+The SEO project management skill. Delivers on time and effectively by managing the planning, prioritization, and execution of SEO improvement projects.

--- a/.claude/skills-vault/social-media/SKILL.md
+++ b/.claude/skills-vault/social-media/SKILL.md
@@ -10,351 +10,350 @@ metadata:
   badi-version: ">=1.14.0"
   category: social-media
 ---
-# Sosyal Medya Becerileri
-Bu dosya, sosyal medya yonetimi, icerik uretimi, topluluk yonetimi, reklam ve analitik alanlarindaki tum becerileri icerir.
+# Social Media Skills
+This file contains all the skills across social media management, content production, community management, advertising, and analytics.
 
 ---
 
-### platform-stratejisi
-Her sosyal medya platformu icin ozellesmis strateji gelistirir. Hedef kitle, icerik formati, paylasim sikligti ve platform algoritmasina uygun buyume plani olusturur.
+### platform-strategy
+Develops a specialized strategy per social platform. Builds the growth plan fitting the audience, content format, posting frequency, and platform algorithm.
 
 ---
 
-### icerik-takvimi
-Sosyal medya hesaplari icin aylik/haftalik icerik takvimi olusturur. Tema gunleri, kampanya donemleri ve ozel gunleri entegre eder.
+### content-calendar
+Builds the monthly/weekly content calendar for social accounts. Integrates theme days, campaign periods, and special days.
 
 ---
 
-### topluluk-yonetimi
-Sosyal medya topluluklarini aktif ve saglikli tutmak icin moderasyon, etkilesim ve buyume stratejileri uygular.
+### community-management
+Applies moderation, engagement, and growth strategies keeping social communities active and healthy.
 
 ---
 
-### etkilesim-stratejisi
-Takipcilerle organik etkilesimi artirmak icin yorum, begeni, paylasim ve kaydetme aksiyonlarini tetikleyen stratejiler gelistirir.
+### engagement-strategy
+Develops strategies triggering comments, likes, shares, and saves to lift organic engagement with followers.
 
 ---
 
-### hashtag-stratejisi
-Platform bazli hashtag arastirmasi yaparak erisim ve kesif oranlarini maksimize eden hashtag setleri olusturur.
+### hashtag-strategy
+Builds hashtag sets maximizing reach and discovery through platform-specific hashtag research.
 
 ---
 
-### hikaye-stratejisi
-Instagram, Facebook ve diger platformlardaki hikaye formatini etkili kullanan icerik plani ve etkilesim taktikleri gelisitrir.
+### story-strategy
+Develops the content plan and engagement tactics using the story format effectively on Instagram, Facebook, and other platforms.
 
 ---
 
-### reel-stratejisi
-Kisa video formatlari (Reels, Shorts, TikTok) icin icerik stratejisi, uretim sureci ve optimizasyon plani olusturur.
+### reels-strategy
+Builds the content strategy, production process, and optimization plan for short-video formats (Reels, Shorts, TikTok).
 
 ---
 
-### canli-yayin
-Sosyal medya canli yayinlari icin planlama, teknik hazirlik, icerik akisi ve etkilesim stratejisi olusturur.
+### live-streaming
+Builds the planning, technical preparation, content flow, and engagement strategy for social live streams.
 
 ---
 
-### influencer-isbirligi
-Marka hedeflerine uygun influencer secimi, isbirligi modeli tasarimi ve kampanya yonetimi yapar.
+### influencer-collaboration
+Runs influencer selection, collaboration-model design, and campaign management fitting brand goals.
 
 ---
 
-### ugc-stratejisi
-Kullanici tarafindan uretilen icerik (UGC) toplama, kurasyon ve yeniden kullanma stratejisi gelistirir.
+### ugc-strategy
+Develops the strategy for collecting, curating, and reusing user-generated content (UGC).
 
 ---
 
-### sosyal-dinleme
-Marka, sektor ve rakipler hakkindaki sosyal medya konusmalarini izleyerek icgoru cikarir.
+### social-listening
+Extracts insight by monitoring social conversations about the brand, the industry, and competitors.
 
 ---
 
-### duygu-analizi
-Sosyal medya yorumlari ve bahsetmelerdeki duygu durumunu analiz ederek marka algisini olcer.
+### sentiment-analysis
+Measures brand perception by analyzing the sentiment in social comments and mentions.
 
 ---
 
-### kriz-yonetimi
-Sosyal medya krizlerini erken tespit, hizli mudahale ve itibar koruma stratejileriyle yonetir.
+### crisis-management
+Manages social media crises with early detection, fast response, and reputation-protection strategies.
 
 ---
 
-### marka-sesi
-Sosyal medyada tutarli bir marka sesi ve tonu olusturarak tum iletisimlerde uygular.
+### brand-voice
+Builds a consistent brand voice and tone on social media and applies it across all communication.
 
 ---
 
-### gorsel-kimlik
-Sosyal medya hesaplari icin tutarli gorsel kimlik standartlari olusturur ve uygular.
+### visual-identity
+Builds and applies consistent visual-identity standards for social accounts.
 
 ---
 
-### video-uretimi
-Sosyal medya icin video icerik uretim sureci, ekipman secimi ve post-production rehberi sunar.
+### video-production
+Provides the video production process, equipment selection, and post-production guide for social media.
 
 ---
 
-### grafik-tasarim
-Sosyal medya paylasmlari icin gorsel tasarim ilkeleri, arac secimi ve sablon olusturma rehberi sunar.
+### graphic-design
+Provides visual-design principles, tool selection, and template creation guidance for social posts.
 
 ---
 
-### meme-pazarlama
-Marka kimligine uygun meme icerikler ureterek organik erisim ve viral etkilesim saglar.
+### meme-marketing
+Drives organic reach and viral engagement by producing meme content fitting the brand identity.
 
 ---
 
-### trend-takibi
-Sosyal medya trendlerini erken tespit ederek markaya uygun trend katilim stratejileri gelistirir.
+### trend-tracking
+Develops brand-fit trend participation strategies by detecting social trends early.
 
 ---
 
-### viral-icerik
-Viral yayilim potansiyeli yuksek icerikler uretmek icin formul, format ve dagitim stratejileri gelistirir.
+### viral-content
+Develops the formulas, formats, and distribution strategies for producing content with high viral potential.
 
 ---
 
-### platform-optimizasyonu
-Her sosyal medya platformunun algoritma ve ozelliklerine gore profil ve icerik optimizasyonu yapar.
+### platform-optimization
+Optimizes profiles and content per each platform's algorithm and features.
 
 ---
 
-### instagram-buyume
-Instagram hesabi icin organik buyume stratejisi, icerik optimizasyonu ve topluluk gelistirme plani olusturur.
+### instagram-growth
+Builds the organic growth strategy, content optimization, and community plan for an Instagram account.
 
 ---
 
-### tiktok-buyume
-TikTok platformunda organik buyume, trend katilimi ve icerik stratejisi gelistirir.
+### tiktok-growth
+Develops organic growth, trend participation, and content strategy on TikTok.
 
 ---
 
-### youtube-buyume
-YouTube kanali icin uzun ve kisa video stratejisi, SEO optimizasyonu ve abone buyume plani gelistirir.
+### youtube-growth
+Develops the long- and short-video strategy, SEO optimization, and subscriber-growth plan for a YouTube channel.
 
 ---
 
-### linkedin-buyume
-LinkedIn platformunda kisisel veya kurumsal marka buyutme stratejisi gelistirir.
+### linkedin-growth
+Develops the personal or corporate brand-growth strategy on LinkedIn.
 
 ---
 
-### twitter-buyume
-Twitter/X platformunda takipci buyutme, etkilesim artirma ve goruntuluk kazanma stratejisi gelistirir.
+### twitter-growth
+Develops the follower-growth, engagement, and visibility strategy on Twitter/X.
 
 ---
 
-### facebook-buyume
-Facebook sayfasi ve grubu icin organik erisim, topluluk buyutme ve etkilesim stratejisi gelistirir.
+### facebook-growth
+Develops the organic reach, community-growth, and engagement strategy for Facebook pages and groups.
 
 ---
 
-### pinterest-strateji
-Pinterest platformunda gorsel arama optimizasyonu, pin stratejisi ve trafik yonlendirme plani olusturur.
+### pinterest-strategy
+Builds the visual-search optimization, pin strategy, and traffic-routing plan on Pinterest.
 
 ---
 
-### reddit-strateji
-Reddit platformunda topluluk katilimi, icerik paylasimi ve marka bilinirlik stratejisi gelistirir.
+### reddit-strategy
+Develops the community-participation, content-sharing, and brand-awareness strategy on Reddit.
 
 ---
 
-### discord-yonetimi
-Discord sunucusu kurulumu, kanal yapisi, bot entegrasyonu ve topluluk yonetimi yapar.
+### discord-management
+Runs Discord server setup, channel structure, bot integration, and community management.
 
 ---
 
 ### whatsapp-business
-WhatsApp Business hesabi icin musteri iletisimi, otomasyon ve satis stratejisi gelistirir.
+Develops the customer-communication, automation, and sales strategy for a WhatsApp Business account.
 
 ---
 
-### telegram-kanal
-Telegram kanali ve grubu icin icerik stratejisi, uye buyutme ve etkilesim plani olusturur.
+### telegram-channels
+Builds the content strategy, member-growth, and engagement plan for Telegram channels and groups.
 
 ---
 
-### sosyal-ticaret
-Sosyal medya platformlari uzerinden dogrudan satis yapma stratejisi ve altyapi kurulumu yapar.
+### social-commerce
+Builds the strategy and infrastructure for selling directly through social platforms.
 
 ---
 
-### shoppable-post
-Dogrudan alisveris yapilabilen sosyal medya paylasmlari olusturma ve optimize etme stratejisi gelistirir.
+### shoppable-posts
+Develops the strategy for creating and optimizing directly shoppable social posts.
 
 ---
 
-### hikaye-alisveris
-Hikaye formatinda alisveris deneyimi olusturma ve donusum optimizasyonu yapar.
+### story-shopping
+Builds the story-format shopping experience and optimizes its conversion.
 
 ---
 
-### canli-satis
-Sosyal medya canli yayinlari uzerinden urun tanitimi ve satis stratejisi gelistirir.
+### live-selling
+Develops the product showcase and sales strategy over social live streams.
 
 ---
 
-### sosyal-reklam
-Sosyal medya reklam kampanyalari icin strateji, hedefleme ve butce plani olusturur.
+### social-ads
+Builds the strategy, targeting, and budget plan for social ad campaigns.
 
 ---
 
-### reklam-yaratici
-Sosyal medya reklamlari icin dikkat cekici gorsel ve metin yaratici bileenleri gelistirir.
+### ad-creative
+Develops attention-grabbing visual and copy creative components for social ads.
 
 ---
 
-### hedefleme
-Sosyal medya reklamlarinda dogru kitleye ulasmak icin demografik, ilgi alani ve davranis tabanli hedefleme stratejisi gelistirir.
+### targeting
+Develops demographic, interest, and behavior-based targeting strategies for reaching the right audience.
 
 ---
 
-### lookalike-kitle
-Mevcut musterilere benzer yeni kitleler olusturarak reklam erisimini genisletir.
+### lookalike-audiences
+Expands ad reach by building new audiences similar to existing customers.
 
 ---
 
-### retargeting-sosyal
-Web sitesi ziyaretcilerini ve mevcut kitleleri sosyal medya reklamlariyla yeniden hedefler.
+### social-retargeting
+Retargets website visitors and existing audiences with social ads.
 
 ---
 
-### reklam-butcesi
-Sosyal medya reklam butcesini kampanya hedeflerine gore optimal dagitin ve yonetir.
+### ad-budget
+Distributes and manages the social ad budget optimally against campaign goals.
 
 ---
 
-### roas-takibi
-Reklam harcamasi getirisi (ROAS) izleme, analiz ve optimizasyon sistemi kurar.
+### roas-tracking
+Builds the return-on-ad-spend (ROAS) tracking, analysis, and optimization system.
 
 ---
 
-### sosyal-crm
-Sosyal medya etkilesimlerini musteri iliskileri yonetim surecine entegre eder.
+### social-crm
+Integrates social interactions into the customer-relationship management process.
 
 ---
 
-### dm-stratejisi
-Sosyal medya dogrudan mesaj (DM) kanalini satis ve musteri hizmetleri icin stratejik kullanir.
+### dm-strategy
+Uses the direct-message (DM) channel strategically for sales and customer service.
 
 ---
 
-### yorum-yonetimi
-Sosyal medya yorumlarini stratejik yoneterek marka algisini ve etkilesimi guclendirir.
+### comment-management
+Strengthens brand perception and engagement by managing social comments strategically.
 
 ---
 
-### inceleme-yonetimi
-Cevrimici inceleme ve degerlendirmeleri izleyerek marka imajini iyilestirmek icin strateji gelistirir.
+### review-management
+Develops the strategy for monitoring online reviews and ratings to improve the brand image.
 
 ---
 
-### reputation-yonetimi
-Online itibar yonetimi stratejisi gelistirerek marka algisini korur ve guclendirir.
+### reputation-management
+Protects and strengthens brand perception by developing the online reputation strategy.
 
 ---
 
 ### employee-advocacy
-Calisanlarin sosyal medyada marka elcisi olmasini saglayan program tasarimi ve yonetimi yapar.
+Designs and manages the program turning employees into brand ambassadors on social media.
 
 ---
 
-### ceo-marka
-Ust duzey yoneticilerin kisisel markasini sosyal medyada olusturma ve yonetme stratejisi gelisitirir.
+### ceo-branding
+Develops the strategy for building and managing executives' personal brands on social media.
 
 ---
 
-### kisisel-marka
-Bireysel profesyoneller icin sosyal medyada kisisel marka olusturma ve buyutme stratejisi gelistirir.
+### personal-branding
+Develops the personal-brand building and growth strategy for individual professionals.
 
 ---
 
-### b2b-sosyal
-Isletmeler arasi (B2B) pazarlama icin sosyal medya stratejisi gelistirir.
+### b2b-social
+Develops the social media strategy for business-to-business (B2B) marketing.
 
 ---
 
-### b2c-sosyal
-Tuketiciye yonelik (B2C) pazarlama icin sosyal medya stratejisi gelistirir.
+### b2c-social
+Develops the social media strategy for consumer-facing (B2C) marketing.
 
 ---
 
-### sosyal-analitik
-Sosyal medya performansini kapsamli analiz ederek veri odakli kararlar icin icgoru uretir.
+### social-analytics
+Produces insight for data-driven decisions through comprehensive social performance analysis.
 
 ---
 
-### engagement-raporu
-Sosyal medya etkilesim metriklerini detayli raporlayan sistem ve sablonlar olusturur.
+### engagement-reporting
+Builds the system and templates reporting social engagement metrics in detail.
 
 ---
 
-### buyume-raporu
-Sosyal medya hesaplarinin buyume performansini izleyen raporlama sistemi kurar.
+### growth-reporting
+Builds the reporting system tracking accounts' growth performance.
 
 ---
 
-### icerik-performansi
-Her icerik parcasinin performansini analiz ederek icerik stratejisini optimize eder.
+### content-performance
+Optimizes the content strategy by analyzing each piece's performance.
 
 ---
 
-### rekabet-takibi
-Rakiplerin sosyal medya stratejilerini ve performansini sistematik olarak izler ve analiz eder.
+### competitor-tracking
+Systematically monitors and analyzes competitors' social strategies and performance.
 
 ---
 
-### benchmark-sosyal
-Sektor ve rakip karsilastirmali sosyal medya performans referans degerleri olusturur.
+### social-benchmarking
+Builds industry- and competitor-comparative social performance reference values.
 
 ---
 
-### sosyal-roi
-Sosyal medya yatiriminin geri donusunu olcer ve raporlar.
+### social-roi
+Measures and reports the return on social media investment.
 
 ---
 
-### sosyal-otomasyon
-Sosyal medya sureclerini otomatiklestirerek verimlilik artiran arac ve is akislari kurar.
+### social-automation
+Builds tools and workflows raising efficiency by automating social processes.
 
 ---
 
-### zamanlama-optimizasyonu
-Sosyal medya paylasimlarinin zamanlamasini platform ve kitle verilerine gore optimize eder.
+### timing-optimization
+Optimizes posting times against platform and audience data.
 
 ---
 
 ### cross-posting
-Birden fazla platformda icerik paylasimini verimli ve platforma uygun sekilde yonetir.
+Manages multi-platform content sharing efficiently and platform-appropriately.
 
 ---
 
-### repurpose-icerik
-Mevcut icerikleri farkli formatlara ve platformlara donusturerek icerik verimliligi artirmak icin strateji gelistirir.
+### content-repurposing
+Develops the strategy converting existing content into other formats and platforms for content efficiency.
 
 ---
 
-### a-b-test-sosyal
-Sosyal medya icerik ve reklamlarinda A/B testleri tasarlayarak performansi optimize eder.
+### social-a-b-testing
+Optimizes performance by designing A/B tests on social content and ads.
 
 ---
 
-### caption-yazimi
-Sosyal medya paylasmlari icin etkili, etkilesim odakli aciklama metinleri yazar.
+### caption-writing
+Writes effective, engagement-focused captions for social posts.
 
 ---
 
-### bio-optimizasyonu
-Sosyal medya profil biyografilerini platform algoritmalari ve kullanici deneyimi icin optimize eder.
+### bio-optimization
+Optimizes profile bios for platform algorithms and user experience.
 
 ---
 
 ### link-in-bio
-Sosyal medya profillerindeki tek baglanti alanini maksimum verimle kullanan yapilar olusturur.
+Builds structures using the single profile-link slot at maximum efficiency.
 
 ---
 
-### sosyal-seo
-Sosyal medya profillerini ve iceriklerini arama motoru ve platform ici arama icin optimize eder.
-
+### social-seo
+Optimizes social profiles and content for search engines and in-platform search.

--- a/.claude/skills-vault/startup/SKILL.md
+++ b/.claude/skills-vault/startup/SKILL.md
@@ -10,306 +10,305 @@ metadata:
   badi-version: ">=1.14.0"
   category: startup
 ---
-# Startup Becerileri
-Bu dosya, girisimcilik surecinin her asamasini kapsayan fikir dogrulama, urun gelistirme, takim kurma, yatirim hazirligi ve buyume stratejisi becerilerini icerir.
+# Startup Skills
+This file contains idea validation, product development, team building, fundraising preparation, and growth strategy skills covering every stage of the entrepreneurial journey.
 
 ---
 
-### fikir-dogrulama
-Is fikrini sistematik yontemlerle test ederek pazar uygunlugunu ve yasayabilirligini degerlendirir.
+### idea-validation
+Assesses market fit and viability by testing the business idea with systematic methods.
 
 ---
 
-### problem-tanimi
-Girisimin cozmek istedigi problemi derinlemesine analiz ederek net ve olculebilir bir sekilde tanimlar.
+### problem-definition
+Defines the problem the startup aims to solve clearly and measurably through deep analysis.
 
 ---
 
-### cozum-tasarimi
-Tanimlanan probleme yonelik yenilikci ve uygulanabilir cozum alternatiflerini tasarlar.
+### solution-design
+Designs innovative, feasible solution alternatives for the defined problem.
 
 ---
 
-### mvp-planlama
-Minimum uygulanabilir urun (MVP) kapsamini, ozelliklerini ve gelistirme planini olusturur.
+### mvp-planning
+Builds the minimum viable product (MVP) scope, features, and development plan.
 
 ---
 
-### pazar-boyutu
-Hedef pazarin boyutunu ve buyume potansiyelini sistematik yontemlerle hesaplar.
+### market-sizing
+Computes the target market's size and growth potential with systematic methods.
 
 ---
 
 ### tam-sam-som
-Toplam adreslenebilir pazar (TAM), hizmet verilebilir pazar (SAM) ve elde edilebilir pazar (SOM) analizini yapar.
+Runs the total addressable market (TAM), serviceable addressable market (SAM), and serviceable obtainable market (SOM) analysis.
 
 ---
 
-### is-modeli-kanvas
-Business Model Canvas kullanarak is modelinin tum bilesrnlerini sistematik olarak tasarlar.
+### business-model-canvas
+Designs every component of the business model systematically using the Business Model Canvas.
 
 ---
 
-### yalin-kanvas
-Lean Canvas kullanarak startup is modelini hizlica gorsellestirir ve hipotezleri belirler.
+### lean-canvas
+Visualizes the startup business model fast and identifies hypotheses using the Lean Canvas.
 
 ---
 
-### deger-onerisi-kanvas
-Value Proposition Canvas kullanarak musteri ihtiyaclari ile urun ozellikleri arasinda uyum saglar.
+### value-proposition-canvas
+Aligns customer needs with product features using the Value Proposition Canvas.
 
 ---
 
-### musteri-kesifleri
-Customer Discovery sureci ile hedef musterileri derinlemesine anlama ve dogrulama calismalari yapar.
+### customer-discovery
+Runs deep understanding and validation work on target customers through the Customer Discovery process.
 
 ---
 
-### kullanici-gorusmesi
-Kullanici arastirmasi icin gorusme rehberi hazirlar ve etkin gorusme teknikleri uygular.
+### user-interviews
+Prepares interview guides for user research and applies effective interviewing techniques.
 
 ---
 
-### anket-tasarimi
-Hedef kitleden nicel veri toplamak icin etkili anketler tasarlar ve uygular.
+### survey-design
+Designs and runs effective surveys to collect quantitative data from the target audience.
 
 ---
 
-### prototipleme
-Urun fikirlerini hizlica somutlastirmak icin prototip turunu secer ve uretim surecini yonetir.
+### prototyping
+Picks the prototype type and manages production to make product ideas concrete fast.
 
 ---
 
-### kullanilabilirlik-testi
-Urun veya prototipin kullanici deneyimini test ederek iyilestirme firsatlarini tespit eder.
+### usability-testing
+Finds improvement opportunities by testing the product or prototype's user experience.
 
 ---
 
 ### product-market-fit
-Urun-pazar uyumunu olcen ve dogrulamak icin sistematik yaklasim ve metrikler uygular.
+Applies the systematic approach and metrics for measuring and validating product-market fit.
 
 ---
 
-### pivot-stratejisi
-Mevcut stratejinin ise yaramadigi durumlarda yeni yon belirlemek icin pivot analizi ve plani olusturur.
+### pivot-strategy
+Builds the pivot analysis and plan for setting a new direction when the current strategy is not working.
 
 ---
 
-### buyume-stratejisi
-Startup icin surdurulebilir buyume motorunu ve taktiklerini tanimlar.
+### growth-strategy
+Defines the startup's sustainable growth engine and tactics.
 
 ---
 
-### olceklendirme
-Startup'in buyume asamasinda sureclerini, teknolojisini ve takimini olceklendirme plani olusturur.
+### scaling
+Builds the plan for scaling the startup's processes, technology, and team in the growth stage.
 
 ---
 
-### takim-kurma
-Startup icin dogru takim yapisini tasarlayarak ise alim ve takim olusturma stratejisi gelistirir.
+### team-building
+Develops the hiring and team-formation strategy by designing the right team structure.
 
 ---
 
-### co-founder-arama
-Uygun kurucu ortak bulmak icin arama stratejisi, degerlendirme kriterleri ve ortaklik yapisi olusturur.
+### co-founder-search
+Builds the search strategy, evaluation criteria, and partnership structure for finding the right co-founder.
 
 ---
 
-### kultur-tasarimi
-Startup kultur degerlerini, normlarini ve uygulamalarini bilincliteolarak tasarlar.
+### culture-design
+Deliberately designs the startup's culture values, norms, and practices.
 
 ---
 
-### uzaktan-calisma
-Uzaktan calisma modelini etkili yonetmek icin politikalar, araclar ve iletisim stratejileri olusturur.
+### remote-work
+Builds policies, tools, and communication strategies for managing the remote-work model effectively.
 
 ---
 
-### isyeri-kurulumu
-Startup icin fiziksel veya hibrit calisma ortamini olusturma rehberi sunar.
+### workspace-setup
+Provides the guide for building the startup's physical or hybrid working environment.
 
 ---
 
-### hukuki-yapilandirma
-Startup icin uygun sirket turunun secimi ve hukuki altyapinin olusturulmasini yonlendirir.
+### legal-structuring
+Guides the choice of company type and the legal infrastructure setup.
 
 ---
 
-### sirket-kurulus
-Sirket kurulus surecini adim adim yonlendirerek gerekli islemleri ve belgeleri listeler.
+### company-formation
+Guides the incorporation process step by step, listing the required filings and documents.
 
 ---
 
-### fikri-mulkiyet
-Startup'in fikri mulkiyet varliklarini koruma stratejisi gelistirir.
+### intellectual-property
+Develops the strategy protecting the startup's intellectual-property assets.
 
 ---
 
-### patent-strateji
-Startup icin patent basvuru stratejisi ve patent portfoyu yonetimi plani olusturur.
+### patent-strategy
+Builds the patent application strategy and portfolio-management plan.
 
 ---
 
-### marka-tescil
-Marka tescil surecini yoneterek marka korumasi saglar.
+### trademark-registration
+Secures brand protection by managing the trademark registration process.
 
 ---
 
-### gizlilik-anlasmasi
-Farkli senaryolar icin gizlilik anlasmasi (NDA) sablonlari ve strateji gelistirir.
+### nda
+Develops NDA templates and strategy for different scenarios.
 
 ---
 
-### yatirim-hazirligi
-Startup'i yatirim turuna hazirlamak icin finansal, stratejik ve operasyonel hazirlk plani olusturur.
+### fundraising-readiness
+Builds the financial, strategic, and operational preparation plan for an investment round.
 
 ---
 
 ### pitch-deck
-Yatirimcilara sunum icin etkili pitch deck hazirlar.
+Prepares an effective pitch deck for investor presentations.
 
 ---
 
-### yatirimci-arastirmasi
-Startup'a uygun yatirimci profillerini arastirir ve hedef yatirimci listesi olusturur.
+### investor-research
+Researches investor profiles fitting the startup and builds the target investor list.
 
 ---
 
-### demo-gunu
-Akselerator veya etkinlik demo gunlerine hazirlik ve sunum stratejisi gelistirir.
+### demo-day
+Develops the preparation and presentation strategy for accelerator or event demo days.
 
 ---
 
-### melek-yatirim
-Melek yatirimci (angel investor) arama, iletisim ve yatirim surecini yonetir.
+### angel-investment
+Manages the angel-investor search, outreach, and investment process.
 
 ---
 
-### risk-sermayesi
-Venture capital (VC) fonlarindan yatirim alma surecini stratejik olarak yonetir.
+### venture-capital
+Manages the process of raising from venture capital (VC) funds strategically.
 
 ---
 
 ### crowdfunding
-Kitle fonlama kampanyasi planlama ve yonetim stratejisi gelisitirir.
+Develops the crowdfunding campaign planning and management strategy.
 
 ---
 
 ### bootstrapping
-Dis yatirim almadan kendi kaynaklariyla buyume stratejisi gelistirir.
+Develops the strategy for growing on your own resources without external investment.
 
 ---
 
-### hibeler
-Devlet ve kurumsal hibe firsatlarini arastirarak basvuru stratejisi gelistirir.
+### grants
+Develops the application strategy by researching government and institutional grants.
 
 ---
 
-### akselerator-basvuru
-Startup akselerator programlarina basvuru hazirlikk ve strateji gelistirir.
+### accelerator-application
+Develops the preparation and strategy for startup-accelerator applications.
 
 ---
 
-### inkubator-programi
-Inkubator programlarindan maksimum fayda saglayacak katilim stratejisi gelistirir.
+### incubator-program
+Develops the participation strategy for maximum benefit from incubator programs.
 
 ---
 
-### mentor-agi
-Startup icin degerli mentor iliskileri kurma ve yonetme stratejisi gelistirir.
+### mentor-network
+Develops the strategy for building and managing valuable mentor relationships.
 
 ---
 
-### danisma-kurulu
-Startup icin danisma kurulu olusturma ve etkili calistirma stratejisi gelistirir.
+### advisory-board
+Develops the strategy for building and running an effective advisory board.
 
 ---
 
-### metrik-takibi
-Startup icin kritik metrikleri belirleyerek sistematik izleme ve raporlama altyapisi kurar.
+### metric-tracking
+Builds systematic tracking and reporting by identifying the startup's critical metrics.
 
 ---
 
 ### north-star-metric
-Startup'in tek buyume gostergesi olan North Star Metric'i belirler ve takip eder.
+Identifies and tracks the North Star Metric — the startup's single growth indicator.
 
 ---
 
-### okr-hedefleme
-Objectives and Key Results (OKR) cercevesini startup'a uygular ve takip sistemi kurar.
+### okr-goal-setting
+Applies the Objectives and Key Results (OKR) framework to the startup and builds the tracking system.
 
 ---
 
-### sprint-planlama
-Agile sprint planlama surecini startup'a uyarlayarak verimli gelistirme dongusu kurar.
+### sprint-planning
+Builds an efficient development cycle by adapting agile sprint planning to the startup.
 
 ---
 
-### retrospektif
-Sprint veya proje sonrasi retrospektif toplanti formati ve surekli iyilestirme sureci tasarlar.
+### retrospectives
+Designs the post-sprint/post-project retrospective format and the continuous-improvement process.
 
 ---
 
-### kullanici-alistirma
-Yeni kullanicilarinn urunle ilk deneyimini optimize eden onboarding sureci tasarlar.
+### user-onboarding
+Designs the onboarding process optimizing new users' first product experience.
 
 ---
 
-### aktivasyon-optimizasyonu
-Kullanicilarin urunden ilk degeri hizla elde etmesini saglayarak aktivasyon oranini artirit.
+### activation-optimization
+Raises the activation rate by ensuring users reach first value fast.
 
 ---
 
-### tutma-stratejisi
-Kullanici tutma (retention) oranini artirmak icin stratejiler ve taktikler gelistirir.
+### retention-strategy
+Develops strategies and tactics for raising user retention.
 
 ---
 
-### referans-programi
-Mevcut kullanicilarin yeni kullanicilar getirmesini saglayan referans/tavsiye programi tasarlar.
+### referral-program
+Designs the referral program that gets existing users to bring new ones.
 
 ---
 
-### viral-katsayi
-Urunun viral yayilim katsayisini hesaplayan ve artiran strateji gelistirir.
+### viral-coefficient
+Develops the strategy computing and raising the product's viral coefficient.
 
 ---
 
-### freemium-strateji
-Ucretsiz ve ucretli katmanlar arasinda optimal dengeyi kuran freemium model tasarlar.
+### freemium-strategy
+Designs the freemium model striking the optimal balance between free and paid tiers.
 
 ---
 
-### deneme-suresi
-Urun deneme suresi (trial) yapisini ve donusum stratejisini optimize eder.
+### trial-period
+Optimizes the product trial structure and the conversion strategy.
 
 ---
 
-### fiyat-testi
-Farkli fiyatlandirma yaklasimlarini test ederek optimal fiyat noktasini belirler.
+### price-testing
+Determines the optimal price point by testing different pricing approaches.
 
 ---
 
-### gelir-modeli
-Startup icin surdurulebilir gelir modeli tasarlayarak gelir akislarini planlar.
+### revenue-model
+Plans the revenue streams by designing a sustainable revenue model for the startup.
 
 ---
 
-### birim-ekonomisi
-Unit economics hesaplamalari yaparak is modelinin surdurulebilirligini dogrular.
+### unit-economics
+Validates the business model's sustainability with unit-economics calculations.
 
 ---
 
-### tahsilat-sureci
-Startup icin fatura ve tahsilat surecini otomatiklestirerek nakit akisi iyilestirir.
+### billing-process
+Improves cash flow by automating the startup's invoicing and collection process.
 
 ---
 
-### raporlama
-Yatirimcilara, yonetim kuruluna ve ekibe duzenli raporlama sistemi olusturur.
+### reporting
+Builds the regular reporting system for investors, the board, and the team.
 
 ---
 
-### exit-planlama
-Startup icin cikis stratejisi (satin alma, halka arz, birlsesme) planlama ve hazirlik yapar.
-
+### exit-planning
+Plans and prepares the startup's exit strategy (acquisition, IPO, merger).

--- a/.claude/skills-vault/testing/SKILL.md
+++ b/.claude/skills-vault/testing/SKILL.md
@@ -10,256 +10,255 @@ metadata:
   badi-version: ">=1.14.0"
   category: testing
 ---
-# Test Becerileri
-Bu dosya, yazilim testi stratejisi, test otomasyonu, performans testi, guvenlik testi ve kalite guvence alanlarindaki tum becerileri icerir.
+# Testing Skills
+This file contains all the skills across software test strategy, test automation, performance testing, security testing, and quality assurance.
 
 ---
 
-### test-strateji-tasarimi
-Proje icin kapsamli test stratejisi olusturarak kalite hedeflerini ve test yaklasimini belirler.
+### test-strategy-design
+Sets quality goals and the test approach by building the project's comprehensive test strategy.
 
 ---
 
-### birim-test-yazimi
-Unit test'leri etkili yazma teknikleri ve en iyi uygulamalar ile kod kalitesini arttirir.
+### unit-test-writing
+Raises code quality with effective unit-test writing techniques and best practices.
 
 ---
 
-### entegrasyon-testi
-Bilesenleer arasi entegrasyon noktalarini test ederek uyumlulugunus dogrular.
+### integration-testing
+Verifies compatibility by testing the integration points between components.
 
 ---
 
-### uctan-uca-test
-Uygulamayi kullanici perspektifinden uctan uca test ederek is akislarini dogrular.
+### end-to-end-testing
+Validates business flows by testing the application end to end from the user's perspective.
 
 ---
 
-### test-otomasyon-cercevesi
-Test otomasyon altyapisini tasarlayarak tekrarlanabilir ve surebilir test sureci kurar.
+### test-automation-framework
+Builds a repeatable, sustainable test process by designing the test automation infrastructure.
 
 ---
 
-### tdd-uygulamasi
-Test Driven Development metodolojisini projeye uygulayarak kod kalitesini arttirir.
+### tdd-practice
+Raises code quality by applying the Test Driven Development methodology to the project.
 
 ---
 
-### bdd-senaryolari
-Behavior Driven Development ile is gereksinimllerini test senaryolarina donusturur.
+### bdd-scenarios
+Converts business requirements into test scenarios with Behavior Driven Development.
 
 ---
 
-### api-testi
-API endpoint'lerini fonksiyonel, performans ve guvenlik acisindan test eder.
+### api-testing
+Tests API endpoints for functionality, performance, and security.
 
 ---
 
-### performans-test-plani
-Uygulama performansini olcen kapsamli test plani olusturur ve uygular.
+### performance-test-plan
+Builds and runs the comprehensive plan measuring application performance.
 
 ---
 
-### yuk-testi-tasarimi
-Yuk testi senaryolari tasarlayarak sistem kapasite sinirlarini belirler.
+### load-test-design
+Determines system capacity limits by designing load-test scenarios.
 
 ---
 
-### stres-testi-planlama
-Stres testi ile sistemin sinir kosullarindaki davranisini ve kurtarma kapasitesini test eder.
+### stress-test-planning
+Tests the system's behavior at boundary conditions and its recovery capacity with stress tests.
 
 ---
 
-### guvenlik-testi
-Uygulama guvenlik testleri planlayarak zafiyetleri tespit eder.
+### security-testing
+Detects vulnerabilities by planning application security tests.
 
 ---
 
-### mobil-test-stratejisi
-Mobil uygulamalar icin kapsamli test stratejisi ve otomasyon plani olusturur.
+### mobile-test-strategy
+Builds the comprehensive test strategy and automation plan for mobile applications.
 
 ---
 
-### regresyon-test-seti
-Regresyon test seti olusturarak yazilim degisikliklerinin mevcut islevleri bozmadignii dogrular.
+### regression-test-suite
+Verifies changes do not break existing functionality by building a regression suite.
 
 ---
 
-### test-verisi-yonetimi
-Test verisi olusturma, maskeleme ve yonetim stratejisi gelistirir.
+### test-data-management
+Develops the strategy for creating, masking, and managing test data.
 
 ---
 
-### test-ortami-yonetimi
-Test ortamlarini verimli yonetme, provizyon ve bakim stratejisi gelisitirir.
+### test-environment-management
+Develops the strategy for efficiently managing, provisioning, and maintaining test environments.
 
 ---
 
-### kesifsel-test
-Exploratory testing teknikleri ile yapisal testlerin kaciracagi hatalari kesfeder.
+### exploratory-testing
+Discovers bugs that structured tests would miss, using exploratory testing techniques.
 
 ---
 
-### erisilebilirlik-testi
-Uygulamanin erisilebilirlik standartlarina (WCAG) uyumunu test eder.
+### accessibility-testing
+Tests the application's compliance with accessibility standards (WCAG).
 
 ---
 
-### gorsel-regresyon-testi
-UI degisikliklerinin gorsel tutarliligi bozmadignii otomatik olarak dogrular.
+### visual-regression-testing
+Automatically verifies UI changes do not break visual consistency.
 
 ---
 
-### test-kapsam-analizi
-Kod kapsam analizini yaparak test yeterlilgini degerlendirir ve eksikleri belirler.
+### test-coverage-analysis
+Evaluates test sufficiency and finds the gaps through code-coverage analysis.
 
 ---
 
-### hata-raporlama
-Etkili hata raporlama standartlari ve sureci olusturarak hata cozumunu hizlandirir.
+### bug-reporting
+Speeds up resolution by building effective bug-reporting standards and process.
 
 ---
 
-### test-yonetim-araci
-Test yonetim aracini yapilandirarak test surec verimliligini arttirir.
+### test-management-tool
+Raises test-process efficiency by configuring the test management tool.
 
 ---
 
-### mutation-testi
-Mutation testing ile test suitinin hata yakalama kapasitesini degerlendirir.
+### mutation-testing
+Evaluates the test suite's fault-catching capacity with mutation testing.
 
 ---
 
-### sozlesme-testi
-Servisler arasi API sozlesmelerini test ederek entegrasyon uyumsuzluklarini onler.
+### contract-testing
+Prevents integration mismatches by testing inter-service API contracts.
 
 ---
 
-### kaos-testi
-Kaos testi ile uygulamanin beklenmedik kosullardaki davranisini test eder.
+### chaos-testing
+Tests the application's behavior under unexpected conditions with chaos testing.
 
 ---
 
-### kullanilabilirlik-testi-plani
-Kullanici deneyimini test etmek icin kullanilabilirlik testi plani olusturur.
+### usability-test-plan
+Builds the usability test plan for evaluating the user experience.
 
 ---
 
-### cross-browser-testi
-Uygulamanin farkli tarayicilarda tutarli calistigini dogrulayan test stratejisi olusturur.
+### cross-browser-testing
+Builds the test strategy verifying consistent behavior across browsers.
 
 ---
 
-### veritabani-testi
-Veritabani islemlerinin dogrulugunu, butunlugunu ve performansini test eder.
+### database-testing
+Tests the correctness, integrity, and performance of database operations.
 
 ---
 
-### test-pipeline-entegrasyonu
-Test otomasyonunu CI/CD pipeline'a entegre ederek surekli test altyapisi kurar.
+### test-pipeline-integration
+Builds continuous-testing infrastructure by integrating automation into the CI/CD pipeline.
 
 ---
 
-### test-metrik-raporlama
-Test sureci metriklerini izleyen ve raporlayan sistem kurar.
+### test-metric-reporting
+Builds the system that tracks and reports test-process metrics.
 
 ---
 
-### test-tasarimi-teknikleri
-Sistematik test tasarimi teknikleri ile etkili test senaryolari olusturur.
+### test-design-techniques
+Builds effective test scenarios with systematic test-design techniques.
 
 ---
 
-### smoke-test-seti
-Temel islevlerin calistigini hizlica dogrulayan smoke test seti olusturur.
+### smoke-test-suite
+Builds the smoke-test suite that quickly verifies core functionality.
 
 ---
 
-### kabul-testi
-Is gereksinimlerinin karsilandignii dogrulayan kullanici kabul testi sureci tasarlar.
+### acceptance-testing
+Designs the user acceptance testing process verifying business requirements are met.
 
 ---
 
-### test-otomasyon-stratejisi
-Test otomasyon piramidi ve otomasyon kapsamini stratejik olarak planlar.
+### test-automation-strategy
+Plans the test automation pyramid and automation scope strategically.
 
 ---
 
 ### continuous-testing
-Surekli test pratiklerini gelistirme surecine entegre ederek kalite geri bildirimini hizlandirir.
+Speeds up quality feedback by integrating continuous-testing practices into development.
 
 ---
 
-### test-kalite-metrikleri
-Test suitinin kendisinin kalitesini degerlendin metrikler ve analizler uygular.
+### test-quality-metrics
+Applies metrics and analyses that evaluate the quality of the test suite itself.
 
 ---
 
 ### shift-left-testing
-Test aktivitelerini gelistirme surecinin basina tasiyarak hatalarin erken tespitini saglar.
+Enables early defect detection by moving test activities to the start of development.
 
 ---
 
-### test-veri-fabrikasi
-Test verisi olusturma fabrikasi kurarak test senaryolari icin tutarli ve zengin veri saglar.
+### test-data-factory
+Provides consistent, rich data for scenarios by building a test-data factory.
 
 ---
 
-### test-dokumantasyonu
-Test sureclerini, senaryolari ve sonuclari etkili dokumante eden yapilar olusturur.
+### test-documentation
+Builds structures that document test processes, scenarios, and results effectively.
 
 ---
 
-### test-konteynerizasyonu
-Test ortamlarini container'lar ile standartlastirarak tekrarlanabilir test altyapisi kurar.
+### test-containerization
+Builds repeatable test infrastructure by standardizing environments with containers.
 
 ---
 
 ### property-based-testing
-Property-based testing ile geleneksel test senaryolarinin kaciracagi edge case'leri kesfeder.
+Discovers edge cases traditional scenarios would miss, via property-based testing.
 
 ---
 
-### test-raporlama
-Test sonuclarini etkili gorselestiren ve paydeslara sunan raporlama sistemi kurar.
+### test-reporting
+Builds the reporting system that visualizes results effectively for stakeholders.
 
 ---
 
-### risk-tabanli-test
-Risk analizi temelinde test onceliklendirmesi yaparak en kritik alanlari once test eder.
+### risk-based-testing
+Tests the most critical areas first through risk-based test prioritization.
 
 ---
 
-### test-taki-yonetimi
-Test takiminin organizasyonu, yetkinlik gelistirmesi ve verimlilik stratejisi olusturur.
+### test-team-management
+Builds the test team's organization, competence development, and efficiency strategy.
 
 ---
 
-### test-surec-iyilestirme
-Mevcut test sureclerini analiz ederek verimlilik ve etkinlik iyilestirmeleri uygular.
+### test-process-improvement
+Applies efficiency and effectiveness improvements by analyzing current test processes.
 
 ---
 
-### test-araci-degerlendirme
-Test araclari ve frameworklerini degerlendigirerek proje icin en uygun secimi yapar.
+### test-tool-evaluation
+Picks the best fit for the project by evaluating test tools and frameworks.
 
 ---
 
-### test-cevre-izolasyonu
-Test ortamlarini birbirinden izole ederek guvenilir test sonuclari saglar.
+### test-environment-isolation
+Delivers reliable results by isolating test environments from each other.
 
 ---
 
-### snapshot-testi
-Cikti snapshot'larini kaydederek beklenmedik degisiklikleri otomatik tespit eder.
+### snapshot-testing
+Automatically detects unexpected changes by recording output snapshots.
 
 ---
 
-### load-test-senaryolari
-Farkli yuk kaliplari icin detayli test senaryolari tasarlar ve uygular.
+### load-test-scenarios
+Designs and runs detailed test scenarios for different load patterns.
 
 ---
 
-### test-otomasyonu-bakimi
-Mevcut test otomasyon kodlarinin bakilabilirligini ve kararlligini saglayan strateji uygular.
-
+### test-automation-maintenance
+Applies the strategy keeping existing automation code maintainable and stable.


### PR DESCRIPTION
## Summary

**Increment 6** — the largest single batch so far: all **22 Turkish general-family SKILL.md bodies** (~6,200 lines) translated to English. (`frontend-taste`, `design-tokens`, `security-check` were born English.)

### Routing policy (the critical design decision)
`lib/skills-router.js` indexes **only** the frontmatter description + `Triggers on:` tokens — bodies are injected wholesale but never matched. So:
- **Description prose** → English
- **`Triggers on:` lists** → kept **verbatim**, including Turkish keywords (`indexleme`, `ic linkleme`, `crawl butcesi`…) — they are bilingual routing data; the user prompts in Turkish
- **Sub-skill heading slugs** (`### musteri-oryantasyonu` → `### customer-onboarding`) → English kebab-case (display/injection text, not machine-matched)

### Router smoke (verified)
```
"long-tail indexleme kampanya plani yapalim" → seo-crawl-budget (score 12, TR triggers hit)
"design a premium landing page UI"           → frontend-taste
```

## Test plan
- [x] `npm test` — **1161 pass / 0 fail** · biome clean · doctor healthy
- [x] Broad Turkish scan across the family: **zero residual**
- [x] Router smoke: TR and EN prompts both route correctly

## Remaining (final two batches)
3g: pentest-* family (25 SKILL.md) → 3h: expo-* family (12 SKILL.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)