### PR TITLE
fix(init): clean English seed templates for new installs (no maintainer data leak)

### DIFF
--- a/lib/harnesses/claude.js
+++ b/lib/harnesses/claude.js
@@ -28,6 +28,38 @@ function isUserFile(relativePath) {
 	);
 }
 
+// Seed files are written from clean English templates (lib/seed/) on a fresh
+// install, NOT copied from the package's .claude/ (which holds badi's own
+// development memory). They are never overwritten once they exist — the
+// user's working data is preserved across updates.
+const SEED_FILES = [
+	"memory.md",
+	"knowledge-base.md",
+	"knowledge-nominations.md",
+	"workspace/TaskBoard.md",
+];
+
+function isSeedFile(relativePath) {
+	return SEED_FILES.includes(relativePath);
+}
+
+function seedUserFiles(destClaude, dryRun) {
+	const seedDir = resolve(PKG_ROOT, "lib", "seed");
+	let seeded = 0;
+	for (const rel of SEED_FILES) {
+		const dest = join(destClaude, rel);
+		if (existsSync(dest)) continue; // preserve user data, never overwrite
+		const srcSeed = join(seedDir, rel);
+		if (!existsSync(srcSeed)) continue;
+		if (!dryRun) {
+			mkdirSync(join(dest, ".."), { recursive: true });
+			cpSync(srcSeed, dest);
+		}
+		seeded++;
+	}
+	return seeded;
+}
+
 function chmodHooks(destClaude) {
 	const hooksDir = join(destClaude, "hooks");
 	if (!existsSync(hooksDir)) return;
@@ -82,7 +114,12 @@ export default {
 		if (!dryRun && !existsSync(destClaude)) {
 			mkdirSync(destClaude, { recursive: true });
 		}
-		const result = copyRecursive(src, destClaude, { force, dryRun });
+		const result = copyRecursive(src, destClaude, {
+			force,
+			dryRun,
+			exclude: isSeedFile,
+		});
+		result.copied += seedUserFiles(destClaude, dryRun);
 		result.files = [];
 		installClaudeMd(target, force, dryRun, result);
 		if (!dryRun) chmodHooks(destClaude);
@@ -97,7 +134,9 @@ export default {
 			updateMode: !force,
 			force,
 			userCustomizable: isUserFile,
+			exclude: isSeedFile,
 		});
+		result.copied += seedUserFiles(destClaude, dryRun);
 		result.files = [];
 		installClaudeMd(target, force, dryRun, result);
 		if (!dryRun) chmodHooks(destClaude);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,10 +3,10 @@ import { cpSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { extname, join, relative } from "node:path";
 import { chalk } from "./cli.js";
 
-// ─── URL Guvenlik (SSRF) ───
+// ─── URL Security (SSRF) ───
 
 /**
- * URL'i validate et: protokol + localhost + private IP range engeli.
+ * Validate a URL: protocol + localhost + private IP range block.
  * All external fetch wrappers on the CLI side must go through this.
  * @param {string} url
  * @returns {URL} parsed URL
@@ -17,10 +17,10 @@ export function validateUrl(url) {
 	try {
 		parsed = new URL(url);
 	} catch {
-		throw new Error(`Gecersiz URL: ${url}`);
+		throw new Error(`Invalid URL: ${url}`);
 	}
 	if (!["http:", "https:"].includes(parsed.protocol)) {
-		throw new Error(`Sadece http/https desteklenir: ${parsed.protocol}`);
+		throw new Error(`Only http/https is supported: ${parsed.protocol}`);
 	}
 	const host = parsed.hostname.toLowerCase();
 	if (
@@ -29,15 +29,15 @@ export function validateUrl(url) {
 		host === "0.0.0.0" ||
 		host === "::1"
 	) {
-		throw new Error("Lokal adresler desteklenmiyor");
+		throw new Error("Local addresses are not supported");
 	}
 	if (/^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|169\.254\.)/.test(host)) {
-		throw new Error("Private IP adresleri desteklenmiyor");
+		throw new Error("Private IP addresses are not supported");
 	}
 	return parsed;
 }
 
-// ─── Subprocess Yardimcilari ───
+// ─── Subprocess Helpers ───
 
 /**
  * Check whether a command exists on the PATH.
@@ -64,7 +64,7 @@ export function shCapture(cmd, args, opts = {}) {
 	return (res.stdout || "").trim();
 }
 
-// ─── HTTP Fetch Sarmalayicilari (timeout + SSRF guard) ───
+// ─── HTTP Fetch Wrappers (timeout + SSRF guard) ───
 
 const DEFAULT_UA = "Badi/1.11 (+https://github.com/fatihkan/badi)";
 
@@ -106,7 +106,7 @@ export async function fetchJsonWithTimeout(url, opts = {}) {
 	try {
 		return JSON.parse(text);
 	} catch {
-		throw new Error("JSON parse hatasi");
+		throw new Error("JSON parse error");
 	}
 }
 
@@ -116,6 +116,7 @@ export function copyRecursive(src, dest, options = {}, baseDest = null) {
 		dryRun = false,
 		updateMode = false,
 		userCustomizable,
+		exclude,
 	} = options;
 	const rootDest = baseDest || dest;
 	let copied = 0;
@@ -131,7 +132,11 @@ export function copyRecursive(src, dest, options = {}, baseDest = null) {
 		const destPath = join(dest, entry.name);
 		const relFromRoot = relative(rootDest, destPath);
 
-		// User-customizable dosyalari koru (--force'ta bile)
+		// Never copy excluded paths from src (e.g. seed files written from
+		// a clean template instead — see harness seedUserFiles()).
+		if (exclude?.(relFromRoot)) continue;
+
+		// Preserve user-customizable files (even with --force)
 		const isUser = userCustomizable?.(relFromRoot);
 
 		if (entry.isDirectory()) {
@@ -177,7 +182,7 @@ export function copyRecursive(src, dest, options = {}, baseDest = null) {
 					}
 					if (dryRun) {
 						console.log(
-							`  ${chalk.yellow("!")} ${relative(process.cwd(), destPath)} (ustune yazildi)`,
+							`  ${chalk.yellow("!")} ${relative(process.cwd(), destPath)} (overwritten)`,
 						);
 					}
 					copied++;

--- a/lib/seed/knowledge-base.md
+++ b/lib/seed/knowledge-base.md
@@ -1,0 +1,9 @@
+# Knowledge Base
+
+> Every agent reads this file at the start of a session.
+> Written only after Auditor approval.
+> No entry without a source citation.
+> Placeholder markers are not allowed here. Keep it under 200 lines.
+
+## Entries
+- (none yet)

--- a/lib/seed/knowledge-nominations.md
+++ b/lib/seed/knowledge-nominations.md
@@ -1,0 +1,7 @@
+# Knowledge Nominations
+
+> Candidate entries awaiting Auditor review before promotion to the knowledge base.
+> Each nomination needs a source citation.
+
+## Pending
+- (none yet)

--- a/lib/seed/memory.md
+++ b/lib/seed/memory.md
@@ -1,0 +1,12 @@
+# Project Memory
+
+> Session memory. Keep it under 100 lines; run `/clear` when it grows.
+
+## Current State
+- (empty — describe what you're working on)
+
+## Decisions
+- (none yet)
+
+## Open Questions
+- (none yet)

--- a/lib/seed/workspace/TaskBoard.md
+++ b/lib/seed/workspace/TaskBoard.md
@@ -1,0 +1,13 @@
+# Task Board
+
+## Today
+- [ ] (no tasks yet)
+
+## This Week
+- [ ] (no tasks yet)
+
+## Backlog
+- [ ] (no tasks yet)
+
+## Done
+- (none yet)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fatihkan/badi",
   "version": "1.32.0",
-  "description": "Workflow management CLI for Claude Code, Cursor, and Gemini CLI — 26 AI agents (incl. a virtual eng team), 82 commands, OWASP security scans. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
+  "description": "Workflow management CLI for Claude Code, Cursor, and Gemini CLI — 27 AI agents (incl. a virtual eng team + ads strategist), 84 commands, OWASP security scans. Built for Anthropic Claude Opus and Sonnet.",
   "type": "module",
   "main": "bin/badi.js",
   "bin": {
@@ -20,7 +20,7 @@
     "docs:dev": "npx vitepress dev docs",
     "docs:build": "npx vitepress build docs",
     "docs:preview": "npx vitepress preview docs",
-    "prepare": "echo 'Hazir'"
+    "prepare": "echo 'Ready'"
   },
   "keywords": [
     "claude",
@@ -60,11 +60,7 @@
     ".claude/references/",
     ".claude/skills/",
     ".claude/skills-vault/",
-    ".claude/workspace/TaskBoard.md",
     ".claude/settings.json",
-    ".claude/memory.md",
-    ".claude/knowledge-base.md",
-    ".claude/knowledge-nominations.md",
     ".claude/command-index.md",
     "CLAUDE.md",
     "README.md",

--- a/tests/seed-templates.test.js
+++ b/tests/seed-templates.test.js
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const PKG_ROOT = resolve(__dirname, "..");
+const TEMPLATE_DIR = join(PKG_ROOT, ".claude");
+
+const claude = (await import("../lib/harnesses/claude.js")).default;
+
+const SEED_FILES = [
+	"memory.md",
+	"knowledge-base.md",
+	"knowledge-nominations.md",
+	"workspace/TaskBoard.md",
+];
+const TURKISH = /[çğışöüÇĞİŞÖÜ]/;
+
+function freshInstall() {
+	const target = mkdtempSync(join(tmpdir(), "badi-seed-"));
+	claude.install({ target, src: TEMPLATE_DIR });
+	return target;
+}
+
+describe("seed templates (fresh install)", () => {
+	it("writes all seed files from the clean English template, not badi's own data", () => {
+		const target = freshInstall();
+		try {
+			for (const rel of SEED_FILES) {
+				const p = join(target, ".claude", rel);
+				assert.ok(existsSync(p), `${rel} should exist after install`);
+				const content = readFileSync(p, "utf-8");
+				assert.ok(
+					!TURKISH.test(content),
+					`${rel} must be English (no Turkish chars)`,
+				);
+			}
+		} finally {
+			rmSync(target, { recursive: true, force: true });
+		}
+	});
+
+	it("seeds an empty board/memory, not the maintainer's tasks or notes", () => {
+		const target = freshInstall();
+		try {
+			const memory = readFileSync(join(target, ".claude/memory.md"), "utf-8");
+			const board = readFileSync(
+				join(target, ".claude/workspace/TaskBoard.md"),
+				"utf-8",
+			);
+			// must not leak badi's own dev data
+			assert.ok(!/Proje Bellegi|Badi -|v1\.32/.test(memory));
+			assert.ok(!/#33|#52|Awesome Claude Code/.test(board));
+			// must be the clean template
+			assert.match(memory, /# Project Memory/);
+			assert.match(board, /## Today/);
+		} finally {
+			rmSync(target, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("seed templates (update preserves user data)", () => {
+	it("never overwrites existing seed files, even with --force", () => {
+		const target = freshInstall();
+		try {
+			const memPath = join(target, ".claude/memory.md");
+			const boardPath = join(target, ".claude/workspace/TaskBoard.md");
+			writeFileSync(memPath, "# Project Memory\n\n- MY OWN NOTES\n");
+			writeFileSync(
+				boardPath,
+				"# Task Board\n\n## Today\n- [ ] MY REAL TASK\n",
+			);
+
+			claude.update({ target, src: TEMPLATE_DIR, force: true });
+
+			assert.match(readFileSync(memPath, "utf-8"), /MY OWN NOTES/);
+			assert.match(readFileSync(boardPath, "utf-8"), /MY REAL TASK/);
+		} finally {
+			rmSync(target, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("seed templates (npm packaging)", () => {
+	it("package.json files does not ship badi's own seed data", () => {
+		const pkg = JSON.parse(
+			readFileSync(join(PKG_ROOT, "package.json"), "utf-8"),
+		);
+		const leaked = [
+			".claude/memory.md",
+			".claude/knowledge-base.md",
+			".claude/knowledge-nominations.md",
+			".claude/workspace/TaskBoard.md",
+		].filter((f) => pkg.files.includes(f));
+		assert.deepEqual(leaked, [], "seed data must not be in package.json files");
+	});
+
+	it("ships the clean seed templates under lib/seed/", () => {
+		for (const rel of SEED_FILES) {
+			assert.ok(
+				existsSync(join(PKG_ROOT, "lib", "seed", rel)),
+				`lib/seed/${rel} must exist`,
+			);
+		}
+	});
+});


### PR DESCRIPTION
## The bug (found by the `/team` audit, answering "what does a new user see?")

A fresh `badi init` copied **badi's own development data** to every new user. `claude.js` install ran `copyRecursive` over the package's `.claude/`, so the maintainer's:
- `memory.md` — Turkish (`# Proje Bellegi`) + project notes + stale counts
- `knowledge-base.md` — Turkish (`# Bilgi Tabani`)
- `workspace/TaskBoard.md` — the maintainer's real GitHub issues (#33, #52…)

…all shipped to new users. Both a **language** and a **data-leak** problem.

## Fix — separate template from working data
- **`lib/seed/`** — clean, empty, English seed templates (memory, knowledge-base, knowledge-nominations, workspace/TaskBoard)
- **`helpers.js copyRecursive`** — new `exclude` option (skip paths from src)
- **`claude.js` install + update** — exclude seed files from the recursive copy, then `seedUserFiles()` writes them from `lib/seed/` **only if absent** → fresh install gets clean templates; updates never clobber user data
- **`package.json files`** — drop the four `.claude/` seed files (no longer shipped; `lib/seed/` carries the templates)

The repo's own `.claude/` working memory is preserved — it just no longer doubles as the npm seed.

### Also caught
- `helpers.js`: untranslated user-facing error messages (`validateUrl`, JSON parse) + section comments
- `package.json`: `"prepare": echo 'Hazir'` → `'Ready'`; description `26 agents/82 commands` → `27/84`

## Test plan
- [x] **Real `npm pack` tarball install**: new user gets empty English memory/kb/TaskBoard, **zero Turkish**, none of the maintainer's data
- [x] **Update preserves** user-written seed files even with `--force`
- [x] `npm pack --dry-run`: `.claude/memory.md`/kb/TaskBoard absent, `lib/seed/` present
- [x] `npm test` — **1166 pass / 0 fail** (5 new seed tests) · biome clean · doctor healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)