### PR TITLE
fix(i18n): English runtime surfaces — CLI output, generated files, hook messages (audit wave 1)

### DIFF
--- a/.claude/hooks/_util.mjs
+++ b/.claude/hooks/_util.mjs
@@ -39,7 +39,7 @@ export async function readStdinJson() {
 }
 
 /**
- * Tarih damgasi. Format: '2026-05-10 14:30:45'
+ * Date stamp. Format: '2026-05-10 14:30:45'
  */
 export function timestamp() {
 	const d = new Date();
@@ -63,8 +63,8 @@ export function isoTimestamp() {
 let _projectRootCache = null;
 
 /**
- * Proje kokunu tespit et. git rev-parse --show-toplevel; basarisizsa cwd.
- * Memoize edilir.
+ * Detect the project root. git rev-parse --show-toplevel; falls back to cwd.
+ * Memoized.
  */
 export function projectRoot() {
 	if (_projectRootCache !== null) return _projectRootCache;
@@ -80,7 +80,7 @@ export function projectRoot() {
 }
 
 /**
- * Mevcut git branch (HEAD). Yoksa bos string.
+ * Current git branch (HEAD). Empty string if none.
  */
 export function currentBranch() {
 	try {
@@ -123,7 +123,7 @@ export function incidentLine(prefix, severity, message) {
 }
 
 /**
- * Decision JSON cevabi yaz (stdout) — Claude Code'a gonderilir.
+ * Write a decision JSON response (stdout) — sent to Claude Code.
  *
  * { decision: "block" | "allow", reason: string }
  */
@@ -132,7 +132,7 @@ export function writeDecision(decision, reason) {
 }
 
 /**
- * UserPromptSubmit hook output: additionalContext yaz.
+ * UserPromptSubmit hook output: write additionalContext.
  */
 export function writeContextInjection(text) {
 	process.stdout.write(
@@ -165,8 +165,8 @@ export function lineCount(file) {
 }
 
 /**
- * Bir log dosyasini son N satirla kirp. Atomik: tmp dosyaya yaz, rename.
- * Crash sirasinda kismi yazma olmaz (bulgu #4).
+ * Truncate a log file to the last N lines. Atomic: write to a tmp file, then rename.
+ * No partial write during a crash (finding #4).
  */
 export function truncateLog(file, maxLines, keepLines) {
 	if (!existsSync(file)) return false;
@@ -206,8 +206,8 @@ export function olderThan(filePath, days) {
 }
 
 /**
- * Komut PATH'te mi? Pure PATH probe — shell built-in 'command -v' yerine
- * (Linux'ta executable degil, bulgu #2).
+ * Is the command on PATH? Pure PATH probe — instead of the shell built-in
+ * 'command -v' (not executable on Linux, finding #2).
  *
  * Windows: PATHEXT (.exe/.cmd/.bat) + PATH; Unix: PATH.
  * Identical to lib/platform.js commandExists.

--- a/.claude/hooks/branch-guard.mjs
+++ b/.claude/hooks/branch-guard.mjs
@@ -11,9 +11,9 @@ const _badiFailSafe = (e) => {
 process.on("uncaughtException", _badiFailSafe);
 process.on("unhandledRejection", _badiFailSafe);
 
-// Badi - Dal Korumasi (PreToolUse - Bash)
-// Korunmus dallara dogrudan commit islemlerini engeller.
-// Push islemi merge sonrasi yayim olarak kabul edilir, engellenmez.
+// Badi - Branch Guard (PreToolUse - Bash)
+// Blocks direct commit operations on protected branches.
+// A push is treated as a post-merge publish and is not blocked.
 
 import {
 	appendLog,
@@ -30,8 +30,8 @@ if (!command) process.exit(0);
 
 const branch = currentBranch();
 
-// Force push: main/master/release/* dallarinda engelle
-// --force | --force-with-lease | -f flag (bulgu #8).
+// Force push: block on main/master/release/* branches
+// --force | --force-with-lease | -f flag (finding #8).
 if (/git\s+push.*(--force\b|\s-f\b)/.test(command)) {
 	if (branch === "main" || branch === "master" || /^release\//.test(branch)) {
 		appendLog(
@@ -39,7 +39,7 @@ if (/git\s+push.*(--force\b|\s-f\b)/.test(command)) {
 			incidentLine(
 				"BRANCH-GUARD",
 				"BLOCK",
-				`'${branch}' dalinda force push engellendi`,
+				`force push to '${branch}' blocked`,
 			),
 		);
 		writeDecision(
@@ -50,10 +50,10 @@ if (/git\s+push.*(--force\b|\s-f\b)/.test(command)) {
 	}
 }
 
-// Sadece git commit komutunu korunmus dallarda engelle
+// Only block the git commit command on protected branches
 if (!/git\s+commit\b/.test(command)) process.exit(0);
 
-// Merge commit'leri engelleme — git merge zaten otomatik commit olusturur
+// Do not block merge commits — git merge already creates a commit automatically
 if (/git\s+merge\b/.test(command)) process.exit(0);
 
 if (!branch) process.exit(0);
@@ -65,7 +65,7 @@ if (protectedBranches.includes(branch)) {
 		incidentLine(
 			"BRANCH-GUARD",
 			"BLOCK",
-			`'${branch}' dalinda dogrudan commit engellendi: ${command}`,
+			`direct commit to '${branch}' blocked: ${command}`,
 		),
 	);
 	writeDecision(

--- a/.claude/hooks/completeness-gate.mjs
+++ b/.claude/hooks/completeness-gate.mjs
@@ -11,7 +11,7 @@ const _badiFailSafe = (e) => {
 process.on("uncaughtException", _badiFailSafe);
 process.on("unhandledRejection", _badiFailSafe);
 
-// Badi - Tamamlanmislik Kapisi (PreToolUse)
+// Badi - Completeness Gate (PreToolUse)
 // Validates content before writes to critical files.
 
 import { basename } from "node:path";
@@ -31,8 +31,8 @@ if (filePath.includes(".test-tmp-") || filePath.startsWith("/tmp/")) {
 
 const fileName = basename(filePath);
 
-// ─── Gizli Bilgi Tespiti (.env haricinde) ───
-// Modern token formatlari dahil (bulgu #9).
+// ─── Secret Detection (except .env) ───
+// Includes modern token formats (finding #9).
 if (!fileName.startsWith(".env")) {
 	const secretPatterns = [
 		// Stripe
@@ -70,12 +70,12 @@ if (!fileName.startsWith(".env")) {
 	}
 }
 
-// ─── Bilgi Tabani Dogrulamasi ───
+// ─── Knowledge Base Validation ───
 if (filePath.endsWith("knowledge-base.md")) {
 	if (/(TBD|TODO|FIXME|PLACEHOLDER|XXX)/.test(content)) {
 		writeDecision(
 			"block",
-			"knowledge-base.md dosyasinda TBD/TODO/FIXME isaretleri olamaz. Tamamlanmis icerik girin.",
+			"knowledge-base.md must not contain placeholder markers. Enter completed content.",
 		);
 		process.exit(0);
 	}
@@ -91,7 +91,7 @@ if (filePath.endsWith("knowledge-base.md")) {
 	}
 }
 
-// ─── Bellek Dosyasi Dogrulamasi ───
+// ─── Memory File Validation ───
 if (filePath.endsWith("memory.md") && toolName === "Write") {
 	const lines = content.split("\n").length;
 	if (lines > 100) {
@@ -103,20 +103,20 @@ if (filePath.endsWith("memory.md") && toolName === "Write") {
 	}
 }
 
-// ─── Settings JSON Dogrulamasi ───
+// ─── Settings JSON Validation ───
 if (fileName === "settings.json") {
 	try {
 		JSON.parse(content);
 	} catch {
 		writeDecision(
 			"block",
-			"settings.json gecersiz JSON iceriyor. Lutfen JSON soz dizimini duzeltip tekrar deneyin.",
+			"settings.json contains invalid JSON. Please fix the JSON syntax and try again.",
 		);
 		process.exit(0);
 	}
 }
 
-// ─── Agent Tanimlari Dogrulamasi ───
+// ─── Agent Definition Validation ───
 if (
 	(filePath.includes("agents/") || filePath.includes("agents\\")) &&
 	filePath.endsWith(".md")
@@ -124,7 +124,7 @@ if (
 	if (/(\[TAMAMLANACAK\]|\[TODO\]|\[TBD\]|\[PLACEHOLDER\])/.test(content)) {
 		writeDecision(
 			"block",
-			"Agent taniminda tamamlanmamis isaretler var. Icerik tamamlanmadan kayit yapilamaz.",
+			"The agent definition has incomplete markers. It cannot be saved until the content is complete.",
 		);
 		process.exit(0);
 	}

--- a/.claude/hooks/dependency-audit.mjs
+++ b/.claude/hooks/dependency-audit.mjs
@@ -11,7 +11,7 @@ const _badiFailSafe = (e) => {
 process.on("uncaughtException", _badiFailSafe);
 process.on("unhandledRejection", _badiFailSafe);
 
-// Badi - Bagimlilik Denetimi (SessionStart - New)
+// Badi - Dependency Audit (SessionStart - New)
 // Security scan at session start with a 24-hour cache.
 
 import { execSync } from "node:child_process";
@@ -35,7 +35,7 @@ const cacheDirPath = configDir("badi");
 const cacheFile = join(cacheDirPath, "dep-audit-cache.json");
 mkdirSync(cacheDirPath, { recursive: true });
 
-// Paket yoneticisi tespit
+// Detect the package manager
 let manager = "";
 let lockFile = "";
 if (existsSync(join(root, "package-lock.json"))) {
@@ -62,7 +62,7 @@ try {
 }
 
 // Cache check (24 hours + lock file hash)
-// v1.31.0+ D1 hotfix: cache'e lastInjectedAt eklendi — audit cache'i taze ama
+// v1.31.0+ D1 hotfix: added lastInjectedAt to the cache — the audit cache is fresh, but
 // Do not re-inject if the message is younger than 1 hour (reduce Claude context noise).
 let cachedInjectAt = 0;
 if (existsSync(cacheFile)) {
@@ -75,7 +75,7 @@ if (existsSync(cacheFile)) {
 			if (diff < 86400 * 1000) process.exit(0);
 		}
 	} catch {
-		/* cache bozuk, devam */
+		/* cache corrupt, continue */
 	}
 }
 
@@ -114,14 +114,14 @@ try {
 		high = parsed.metadata?.vulnerabilities?.high || 0;
 	}
 } catch {
-	/* audit basarisiz, sayilari 0 birak */
+	/* audit failed, leave the counts at 0 */
 }
 
 // D1 hotfix: skip if the inject message is younger than 1 hour to avoid context noise
 const shouldInject = Date.now() - cachedInjectAt > 3600 * 1000;
 const nowMs = Date.now();
 
-// Cache kaydet (lastInjectedAt yalniz inject ettigimizde guncellenir)
+// Save the cache (lastInjectedAt is only updated when we inject)
 writeFileSync(
 	cacheFile,
 	`${JSON.stringify({
@@ -139,7 +139,7 @@ writeFileSync(
 const ts = timestamp();
 appendLog(
 	logPath("dependency-audit.md"),
-	`- \`${ts}\` | ${manager} | Kritik: ${critical} | Yuksek: ${high}`,
+	`- \`${ts}\` | ${manager} | Critical: ${critical} | High: ${high}`,
 );
 
 // Inject additionalContext into Claude with the finding counts
@@ -152,7 +152,7 @@ if (critical > 0) {
 		incidentLine(
 			"DEPENDENCY-AUDIT",
 			"CRITICAL",
-			`${critical} kritik guvenlik acigi`,
+			`${critical} critical vulnerabilities`,
 		),
 	);
 	if (shouldInject) {
@@ -162,7 +162,7 @@ if (critical > 0) {
 	}
 } else if (high > 0 && shouldInject) {
 	writeContextInjection(
-		`[badi:dependency-audit] Bilgi: ${high} yuksek oncelikli guvenlik acigi. Detay: \`${manager} audit\``,
+		`[badi:dependency-audit] Info: ${high} high-priority vulnerabilities. Details: \`${manager} audit\``,
 	);
 }
 

--- a/.claude/hooks/guard-bash.mjs
+++ b/.claude/hooks/guard-bash.mjs
@@ -11,8 +11,8 @@ const _badiFailSafe = (e) => {
 process.on("uncaughtException", _badiFailSafe);
 process.on("unhandledRejection", _badiFailSafe);
 
-// Badi - Bash Guvenlik Korumasi (PreToolUse)
-// Tehlikeli komutlari uc katmanli izin sistemiyle denetler.
+// Badi - Bash Security Guard (PreToolUse)
+// Inspects dangerous commands with a three-tier permission system.
 
 import {
 	appendLog,
@@ -33,7 +33,7 @@ function log(severity, message) {
 	appendLog(incidentLog, incidentLine("GUARD-BASH", severity, message));
 }
 
-// ─── SERT ENGELLER (kesinlikle izin verilmez) ───
+// ─── HARD BLOCKS (never allowed) ───
 const HARD_BLOCKS = [
 	/rm\s+-rf\s+\//i,
 	/rm\s+-rf\s+\*/i,
@@ -51,10 +51,10 @@ const HARD_BLOCKS = [
 
 for (const re of HARD_BLOCKS) {
 	if (re.test(command)) {
-		log("CRITICAL", `ENGELLENDI: ${command}`);
+		log("CRITICAL", `BLOCKED: ${command}`);
 		writeDecision(
 			"block",
-			"Tehlikeli komut engellendi. Bu islem sisteme zarar verebilir.",
+			"Dangerous command blocked. This operation could harm the system.",
 		);
 		process.exit(0);
 	}
@@ -78,7 +78,7 @@ const SOFT_BLOCKS = [
 
 for (const re of SOFT_BLOCKS) {
 	if (re.test(command)) {
-		log("WARN", `YUMUSAK ENGEL: ${command}`);
+		log("WARN", `SOFT BLOCK: ${command}`);
 		writeDecision(
 			"block",
 			"This command is potentially dangerous. Use a safer alternative.",
@@ -87,7 +87,7 @@ for (const re of SOFT_BLOCKS) {
 	}
 }
 
-// ─── KAYIT UYARILARI (engellenmez ama kaydedilir) ───
+// ─── LOG WARNINGS (not blocked, but recorded) ───
 const LOG_WARNINGS = [
 	/^rm\s+/i,
 	/^mv\s+/i,
@@ -100,15 +100,15 @@ const LOG_WARNINGS = [
 
 for (const re of LOG_WARNINGS) {
 	if (re.test(command)) {
-		log("INFO", `KAYIT: ${command}`);
+		log("INFO", `LOGGED: ${command}`);
 		break;
 	}
 }
 
-// Proje disi yazma tespiti
+// Detect writes outside the project
 const root = projectRoot();
 if (/>\s*\//.test(command) && !command.includes(`> ${root}`)) {
-	log("WARN", `PROJE DISI YAZMA: ${command}`);
+	log("WARN", `WRITE OUTSIDE PROJECT: ${command}`);
 }
 
 process.exit(0);

--- a/.claude/hooks/log-stop-verdict.mjs
+++ b/.claude/hooks/log-stop-verdict.mjs
@@ -11,7 +11,7 @@ const _badiFailSafe = (e) => {
 process.on("uncaughtException", _badiFailSafe);
 process.on("unhandledRejection", _badiFailSafe);
 
-// Badi - Durak Karari Kaydi (Stop Hook - Async)
+// Badi - Stop Verdict Log (Stop Hook - Async)
 // Records end-of-session decisions and learnings.
 
 import {
@@ -71,7 +71,7 @@ if (blockCount >= 2) {
 	writeFileSync(qualityGateFile, "", "utf-8");
 	appendLog(
 		logPath("incident-log.md"),
-		`- \`${ts}\` | QUALITY-GATE | WARN | Kalite kapisi etkinlestirildi (${blockCount} engel)`,
+		`- \`${ts}\` | QUALITY-GATE | WARN | Quality gate activated (${blockCount} blocks)`,
 	);
 }
 

--- a/.claude/hooks/pre-compact-handoff.mjs
+++ b/.claude/hooks/pre-compact-handoff.mjs
@@ -11,7 +11,7 @@ const _badiFailSafe = (e) => {
 process.on("uncaughtException", _badiFailSafe);
 process.on("unhandledRejection", _badiFailSafe);
 
-// Badi - Sikistirma Oncesi Durum Kaydi (PreCompact)
+// Badi - Pre-Compaction State Save (PreCompact)
 // Saves state before automatic compaction.
 
 import { mkdirSync, writeFileSync } from "node:fs";
@@ -36,7 +36,7 @@ appendLog(
 	incidentLine(
 		"COMPACTION",
 		"INFO",
-		"Otomatik sikistirma tetiklendi — durum kaydedildi",
+		"Automatic compaction triggered — state saved",
 	),
 );
 process.exit(0);

--- a/lib/commands/completion.js
+++ b/lib/commands/completion.js
@@ -60,7 +60,7 @@ export function generateBashCompletion() {
 	const cmds = getCommandMap();
 	const mainCmds = Object.keys(cmds).join(" ");
 	let script = `# badi bash completion
-# Kullanim: badi completion bash >> ~/.bashrc && source ~/.bashrc
+# Usage: badi completion bash >> ~/.bashrc && source ~/.bashrc
 
 _badi_completion() {
     local cur prev words cword
@@ -91,24 +91,24 @@ export function generateZshCompletion() {
 	const cmds = getCommandMap();
 	let script = `#compdef badi
 # badi zsh completion
-# Kullanim: badi completion zsh > "\${fpath[1]}/_badi" && compinit
+# Usage: badi completion zsh > "\${fpath[1]}/_badi" && compinit
 
 _badi() {
     local -a commands
     commands=(
 `;
 	for (const cmd of Object.keys(cmds)) {
-		script += `        '${cmd}:${cmd} komutu'\n`;
+		script += `        '${cmd}:${cmd} command'\n`;
 	}
 	script += `    )
 
     _arguments -C \\
-        '1:komut:->command' \\
+        '1:command:->command' \\
         '*::arg:->args'
 
     case $state in
         command)
-            _describe 'badi komutu' commands
+            _describe 'badi command' commands
             ;;
         args)
             case $words[1] in
@@ -116,10 +116,10 @@ _badi() {
 	for (const [cmd, info] of Object.entries(cmds)) {
 		if (info.subs) {
 			const subsStr = info.subs.map((s) => `'${s}:${s}'`).join(" ");
-			script += `                ${cmd})\n                    local -a subcmds=(${subsStr})\n                    _describe '${cmd} alt komutu' subcmds\n                    ;;\n`;
+			script += `                ${cmd})\n                    local -a subcmds=(${subsStr})\n                    _describe '${cmd} subcommand' subcmds\n                    ;;\n`;
 		} else if (info.flags) {
 			const flagStr = info.flags.join(" ");
-			script += `                ${cmd})\n                    _arguments '*:bayrak:(${flagStr})'\n                    ;;\n`;
+			script += `                ${cmd})\n                    _arguments '*:flag:(${flagStr})'\n                    ;;\n`;
 		}
 	}
 	script += `            esac
@@ -135,16 +135,16 @@ _badi "$@"
 export function generateFishCompletion() {
 	const cmds = getCommandMap();
 	let script = `# badi fish completion
-# Kullanim: badi completion fish > ~/.config/fish/completions/badi.fish
+# Usage: badi completion fish > ~/.config/fish/completions/badi.fish
 
-# Ana komutlar
+# Main commands
 set -l commands ${Object.keys(cmds).join(" ")}
 
-# Sadece ust duzey komutlarda tamamla
+# Complete only on top-level commands
 complete -c badi -f
-complete -c badi -n "not __fish_seen_subcommand_from $commands" -a "$commands" -d "Badi komutu"
-complete -c badi -n "not __fish_seen_subcommand_from $commands" -l help -d "Yardim goster"
-complete -c badi -n "not __fish_seen_subcommand_from $commands" -l version -d "Surum goster"
+complete -c badi -n "not __fish_seen_subcommand_from $commands" -a "$commands" -d "Badi command"
+complete -c badi -n "not __fish_seen_subcommand_from $commands" -l help -d "Show help"
+complete -c badi -n "not __fish_seen_subcommand_from $commands" -l version -d "Show version"
 
 `;
 	for (const [cmd, info] of Object.entries(cmds)) {
@@ -167,18 +167,18 @@ export function runCompletion(args) {
 	const shell = args[0];
 
 	if (!shell || shell === "--help" || shell === "-h") {
-		console.log(chalk.bold("Kabuk Tamamlama Scriptleri:"));
+		console.log(chalk.bold("Shell Completion Scripts:"));
 		console.log(
-			`  badi completion ${chalk.cyan("bash")}    Bash tamamlama scripti`,
+			`  badi completion ${chalk.cyan("bash")}    Bash completion script`,
 		);
 		console.log(
-			`  badi completion ${chalk.cyan("zsh")}     Zsh tamamlama scripti`,
+			`  badi completion ${chalk.cyan("zsh")}     Zsh completion script`,
 		);
 		console.log(
-			`  badi completion ${chalk.cyan("fish")}    Fish tamamlama scripti`,
+			`  badi completion ${chalk.cyan("fish")}    Fish completion script`,
 		);
 		console.log("");
-		console.log(chalk.bold("Kurulum:"));
+		console.log(chalk.bold("Installation:"));
 		console.log("  badi completion bash >> ~/.bashrc");
 		// biome-ignore lint/suspicious/noTemplateCurlyInString: shell syntax, not JS template
 		console.log('  badi completion zsh > "${fpath[1]}/_badi"');
@@ -199,8 +199,8 @@ export function runCompletion(args) {
 			process.stdout.write(generateFishCompletion());
 			break;
 		default:
-			console.error(chalk.red(`Bilinmeyen kabuk: ${shell}`));
-			console.log("Desteklenen kabuklar: bash, zsh, fish");
+			console.error(chalk.red(`Unknown shell: ${shell}`));
+			console.log("Supported shells: bash, zsh, fish");
 			process.exit(1);
 	}
 }

--- a/lib/commands/plan.js
+++ b/lib/commands/plan.js
@@ -256,7 +256,7 @@ function cmdReset(slug, cwd) {
 		unlinkSync(dn);
 		removed++;
 	}
-	console.log(chalk.dim(`Reset: ${slug} (${removed} marker silindi)`));
+	console.log(chalk.dim(`Reset: ${slug} (${removed} markers removed)`));
 }
 
 export function runPlan(args) {
@@ -284,7 +284,7 @@ export function runPlan(args) {
 		case "approve":
 			return cmdApprove(args[1], cwd);
 		case "deny": {
-			// reason: 2. argumandan sonrasi (boslukla join)
+			// reason: everything after the 2nd argument (joined with spaces)
 			const reason = args
 				.slice(2)
 				.filter((a) => !a.startsWith("--"))
@@ -294,7 +294,7 @@ export function runPlan(args) {
 		case "reset":
 			return cmdReset(args[1], cwd);
 		default:
-			console.error(chalk.red(`Bilinmeyen plan komutu: ${sub}`));
+			console.error(chalk.red(`Unknown plan command: ${sub}`));
 			printHelp();
 			process.exit(1);
 	}

--- a/lib/commands/schedule.js
+++ b/lib/commands/schedule.js
@@ -123,10 +123,10 @@ export function runSchedule(args) {
 		console.log("");
 		console.log(chalk.bold("Examples:"));
 		console.log(
-			'  badi schedule add "icerik basla" --at "09:00" --days "mon-fri"',
+			'  badi schedule add "content start" --at "09:00" --days "mon-fri"',
 		);
 		console.log('  badi schedule add "wrap-up" --at "18:00"');
-		console.log('  badi schedule add "icerik plan" --at "sun 20:00"');
+		console.log('  badi schedule add "content plan" --at "sun 20:00"');
 		console.log("");
 		console.log(chalk.bold("Shell Integration:"));
 		console.log(chalk.dim("  Add to ~/.bashrc or ~/.zshrc:"));

--- a/lib/commands/search.js
+++ b/lib/commands/search.js
@@ -96,19 +96,19 @@ export function runSearch(args) {
 	}
 
 	if (showHelp || !query) {
-		console.log(chalk.bold("Session-level Transcript Arama:"));
+		console.log(chalk.bold("Session-level Transcript Search:"));
 		console.log("");
 		console.log(
-			`  badi search "<query>"           ${chalk.dim('Multi-token AND search (ornek: "secret-scan refactor")')}`,
+			`  badi search "<query>"           ${chalk.dim('Multi-token AND search (example: "secret-scan refactor")')}`,
 		);
 		console.log(
-			`  badi search "<q>" --since DATE  ${chalk.dim("Tarih filtre basi")}`,
+			`  badi search "<q>" --since DATE  ${chalk.dim("Date filter start")}`,
 		);
 		console.log(
-			`  badi search "<q>" --until DATE  ${chalk.dim("Tarih filtre sonu")}`,
+			`  badi search "<q>" --until DATE  ${chalk.dim("Date filter end")}`,
 		);
 		console.log(
-			`  badi search "<q>" --branch X    ${chalk.dim("Git branch filtre")}`,
+			`  badi search "<q>" --branch X    ${chalk.dim("Git branch filter")}`,
 		);
 		console.log(
 			`  badi search "<q>" --limit N     ${chalk.dim("Result count (default 20)")}`,
@@ -140,8 +140,8 @@ export function runSearch(args) {
 	);
 
 	showBanner();
-	console.log(chalk.bold(`Arama: "${query}"`));
-	console.log(chalk.dim(`${matches.length} session eslesti`));
+	console.log(chalk.bold(`Search: "${query}"`));
+	console.log(chalk.dim(`${matches.length} sessions matched`));
 	console.log("");
 
 	for (const m of matches.slice(0, limit)) {

--- a/lib/data/transcript-reader.js
+++ b/lib/data/transcript-reader.js
@@ -2,13 +2,13 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 
-// Claude Code transcript JSONL'lerinin kanonik konumu.
+// Canonical location of Claude Code transcript JSONLs.
 // can be overridden (for tests).
 export function transcriptsRoot(override) {
 	return override || join(homedir(), ".claude", "projects");
 }
 
-// Per-1M-token approximate pricing (USD). Public Anthropic listesi.
+// Per-1M-token approximate pricing (USD). Public Anthropic list.
 // Note: this table is not fixed; if the model name changes, a fallback applies.
 export const MODEL_PRICING = {
 	"claude-opus-4-7": {
@@ -122,8 +122,8 @@ export function listTranscriptFiles(root) {
 	return out;
 }
 
-// Tek JSONL'i okuyup minimal session ozetine cevirir.
-// Bu hot-path; gerekli olan minimum alanlari toplar.
+// Reads a single JSONL and converts it to a minimal session summary.
+// This is a hot path; collects only the minimum required fields.
 export function parseSession(filePath) {
 	let raw;
 	try {
@@ -156,7 +156,7 @@ export function parseSession(filePath) {
 		costUsd: 0,
 		lastPromptText: "",
 		firstPromptText: "",
-		events: [], // sadece istenirse doldurulur (parseSession(path, {events:true}))
+		events: [], // only filled when requested (parseSession(path, {events:true}))
 	};
 
 	for (const line of lines) {
@@ -333,7 +333,7 @@ export function findSession(idOrPrefix, opts = {}) {
 	if (prefix.length === 1) return prefix[0];
 	if (prefix.length > 1) {
 		const err = new Error(
-			`Birden fazla session eslesiyor: ${prefix.map((p) => shortSessionId(p.sessionId)).join(", ")}`,
+			`Multiple sessions match: ${prefix.map((p) => shortSessionId(p.sessionId)).join(", ")}`,
 		);
 		err.code = "AMBIGUOUS";
 		err.matches = prefix;

--- a/lib/harnesses/_single-file.js
+++ b/lib/harnesses/_single-file.js
@@ -9,18 +9,18 @@ import {
 import { dirname, join, resolve } from "node:path";
 import { PKG_ROOT } from "../cli.js";
 
-// _single-file.js — paylasilan harness factory'si (v1.30 review C1 fix).
+// _single-file.js — shared harness factory (v1.30 review C1 fix).
 //
 // the gemini / windsurf / agents adapters shared more than 80% of the same code
 // (553 lines, count*, build*, runInstall, doctor). This module abstracts the
 // shared signature; each adapter only declares its own configuration.
 //
-// Konfigurasyon:
+// Configuration:
 //   id: "windsurf"
 //   name: "Windsurf"
-//   filename: ".windsurfrules"             // hedef dosya (single-file rules)
+//   filename: ".windsurfrules"             // target file (single-file rules)
 //   skippedReasons: {                       // a reason per component
-//     hooks: "Windsurf'ta hook esdegeri yok",
+//     hooks: "Windsurf has no hook equivalent",
 //     skills: "...",
 //     subagents: "...",
 //     commands: "...",
@@ -30,8 +30,8 @@ import { PKG_ROOT } from "../cli.js";
 //   ensureDir (optional):                   // the .gemini/ directory for gemini
 //     (target) => string | null
 //
-// Adapter sonucta { id, name, supports, detect, install, update, doctor }
-// ihrac eder — eskisi gibi.
+// The adapter ultimately exports { id, name, supports, detect, install, update, doctor }
+// — as before.
 
 export function countSourceCommands(src) {
 	const dir = join(src, "commands");
@@ -62,7 +62,7 @@ export function countSourceAgents(src) {
 }
 
 /**
- * Canonical CLAUDE.md + memory + knowledge-base'i tek string'e merge eder.
+ * Merges canonical CLAUDE.md + memory + knowledge-base into a single string.
  * All single-file harnesses read the same source.
  */
 export function buildMergedDoc(src) {
@@ -74,13 +74,13 @@ export function buildMergedDoc(src) {
 	const memoryMd = join(src, "memory.md");
 	if (existsSync(memoryMd)) {
 		sections.push(
-			`\n---\n\n# Proje Bellegi\n\n${readFileSync(memoryMd, "utf-8").trim()}`,
+			`\n---\n\n# Project Memory\n\n${readFileSync(memoryMd, "utf-8").trim()}`,
 		);
 	}
 	const kbMd = join(src, "knowledge-base.md");
 	if (existsSync(kbMd)) {
 		sections.push(
-			`\n---\n\n# Bilgi Tabani\n\n${readFileSync(kbMd, "utf-8").trim()}`,
+			`\n---\n\n# Knowledge Base\n\n${readFileSync(kbMd, "utf-8").trim()}`,
 		);
 	}
 	return sections.length ? `${sections.join("\n\n")}\n` : null;
@@ -133,8 +133,8 @@ function buildSkippedReport(src, reasons) {
 }
 
 /**
- * Factory — single-file harness adapter olustur.
- * Eski 3 adapter (gemini/windsurf/agents) bunu sariyor.
+ * Factory — create a single-file harness adapter.
+ * The former 3 adapters (gemini/windsurf/agents) wrap this.
  */
 export function buildSingleFileHarness({
 	id,
@@ -208,8 +208,8 @@ export function buildSingleFileHarness({
 				}
 			};
 
-			// Default: hedef dosya mevcudiyeti
-			run(`${filename} mevcut`, () => existsSync(join(target, filename)));
+			// Default: target file existence
+			run(`${filename} present`, () => existsSync(join(target, filename)));
 			// Adapter-specific extra checks (.gemini/settings.json for gemini)
 			if (Array.isArray(doctorChecks)) {
 				for (const c of doctorChecks) run(c.label, () => c.fn(target));

--- a/lib/harnesses/gemini.js
+++ b/lib/harnesses/gemini.js
@@ -3,13 +3,13 @@ import { join, resolve } from "node:path";
 import { PKG_ROOT } from "../cli.js";
 import { buildSingleFileHarness } from "./_single-file.js";
 
-// Gemini CLI adapter — GEMINI.md + opsiyonel .gemini/settings.json (MCP).
-// CLAUDE.md + memory + knowledge-base'i tek dosyaya merge eder.
+// Gemini CLI adapter — GEMINI.md + optional .gemini/settings.json (MCP).
+// Merges CLAUDE.md + memory + knowledge-base into a single file.
 //
-// Adapter mantigi lib/harnesses/_single-file.js factory'sine cikarildi
-// (v1.30 review C1 fix). MCP settings.json yazimi extraWriter olarak
-// ozellestirildi cunku gemini, diger tek-dosya harness'lerden farkli
-// olarak MCP yapilandirmasini destekler.
+// Adapter logic was extracted to the lib/harnesses/_single-file.js factory
+// (v1.30 review C1 fix). Writing the MCP settings.json was customized via
+// extraWriter because gemini, unlike the other single-file harnesses,
+// supports MCP configuration.
 
 function writeGeminiSettings({ target, force, dryRun, result }) {
 	const srcMcp = resolve(PKG_ROOT, ".mcp.json");
@@ -41,9 +41,9 @@ export default buildSingleFileHarness({
 		skills: false,
 	},
 	skippedReasons: {
-		hooks: "Gemini CLI'de hook yok",
-		skills: "Gemini CLI'de skill yok",
-		subagents: "Gemini CLI'de subagent yok",
+		hooks: "Gemini CLI has no hooks",
+		skills: "Gemini CLI has no skills",
+		subagents: "Gemini CLI has no subagents",
 		commands:
 			"Gemini CLI has no slash commands (routed to embedding in GEMINI.md)",
 	},

--- a/lib/harnesses/index.js
+++ b/lib/harnesses/index.js
@@ -46,7 +46,7 @@ export function resolveHarnesses(value) {
 	const out = [];
 	for (const id of ids) {
 		const h = getHarness(id);
-		if (!h) throw new Error(`Bilinmeyen harness: ${id}`);
+		if (!h) throw new Error(`Unknown harness: ${id}`);
 		out.push(h);
 	}
 	return out;

--- a/lib/harnesses/windsurf.js
+++ b/lib/harnesses/windsurf.js
@@ -1,8 +1,8 @@
 import { buildSingleFileHarness } from "./_single-file.js";
 
-// Windsurf adapter — `.windsurfrules` tek dosya. CLAUDE.md + memory +
-// knowledge-base'i merge eder. Adapter mantigi lib/harnesses/_single-file.js
-// factory'sine cikarildi (v1.30 review C1 fix).
+// Windsurf adapter — `.windsurfrules` single file. CLAUDE.md + memory +
+// merges the knowledge-base. Adapter logic was extracted to lib/harnesses/_single-file.js
+// factory (v1.30 review C1 fix).
 
 export default buildSingleFileHarness({
 	id: "windsurf",
@@ -17,9 +17,9 @@ export default buildSingleFileHarness({
 		skills: false,
 	},
 	skippedReasons: {
-		hooks: "Windsurf'ta hook esdegeri yok",
-		skills: "Windsurf'ta skill esdegeri yok",
-		subagents: "Windsurf'ta subagent yok",
+		hooks: "Windsurf has no hook equivalent",
+		skills: "Windsurf has no skill equivalent",
+		subagents: "Windsurf has no subagents",
 		commands:
 			"Windsurf has no slash commands (inline guidance sent to .windsurfrules)",
 	},

--- a/lib/preferences.js
+++ b/lib/preferences.js
@@ -39,7 +39,7 @@ export function getPreference(key, fallback = undefined) {
 export function setPreference(key, value) {
 	const validator = VALIDATORS[key];
 	if (validator && !validator(value)) {
-		throw new Error(`Gecersiz tercih degeri: ${key}=${value}`);
+		throw new Error(`Invalid preference value: ${key}=${value}`);
 	}
 	const prefs = loadPreferences();
 	prefs[key] = value;

--- a/lib/schedulers/index.js
+++ b/lib/schedulers/index.js
@@ -21,7 +21,7 @@ export const SCHEDULERS = [launchd, systemd, taskscheduler, cron];
 export function pickScheduler(preferred = null) {
 	if (preferred) {
 		const s = SCHEDULERS.find((x) => x.id === preferred);
-		if (!s) throw new Error(`Bilinmeyen scheduler: ${preferred}`);
+		if (!s) throw new Error(`Unknown scheduler: ${preferred}`);
 		if (!s.isAvailable())
 			throw new Error(`${preferred} is not available on this system`);
 		return s;

--- a/lib/update-check.js
+++ b/lib/update-check.js
@@ -28,7 +28,7 @@ export async function checkForUpdate() {
 			}
 		}
 	} catch {
-		// Cache okuma hatasi
+		// Cache read error
 	}
 
 	try {
@@ -54,7 +54,7 @@ export async function checkForUpdate() {
 				}),
 			);
 		} catch {
-			// Cache yazma hatasi
+			// Cache write error
 		}
 
 		return { current: VERSION, latest };
@@ -71,12 +71,12 @@ export function showUpdateBanner(info) {
 	);
 	console.log(
 		chalk.yellow(
-			`│  Yeni surum mevcut: ${chalk.bold(info.current)} → ${chalk.bold.green(info.latest)}${" ".repeat(Math.max(0, 23 - info.current.length - info.latest.length))}│`,
+			`│  New version available: ${chalk.bold(info.current)} → ${chalk.bold.green(info.latest)}${" ".repeat(Math.max(0, 21 - info.current.length - info.latest.length))}│`,
 		),
 	);
 	console.log(
 		chalk.yellow(
-			`│  Guncelle: ${chalk.cyan("npm install -g @fatihkan/badi")}        │`,
+			`│  Update: ${chalk.cyan("npm install -g @fatihkan/badi")}          │`,
 		),
 	);
 	console.log(

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,8 +1,8 @@
 // Cross-platform test runner.
 //
-// Sebep: shell glob (bash) Windows cmd'de yok; Node 22 'node --test tests/'
-// directory argini modul olarak yorumluyor. Bu script tests/*.test.js
-// dosyalarini Node.js readdirSync ile bulup --test flagiyle calistirir.
+// Reason: shell glob (bash) does not exist in Windows cmd; Node 22 interprets
+// the 'node --test tests/' directory arg as a module. This script finds the
+// tests/*.test.js files via Node.js readdirSync and runs them with the --test flag.
 
 import { spawn } from "node:child_process";
 import { readdirSync } from "node:fs";
@@ -16,7 +16,7 @@ const files = readdirSync(dir)
 	.map((f) => join(dir, f));
 
 if (files.length === 0) {
-	console.error(`No .test.js dosyasi bulunamadi: ${dir}`);
+	console.error(`No .test.js files found: ${dir}`);
 	process.exit(1);
 }
 

--- a/tests/cli.completion.test.js
+++ b/tests/cli.completion.test.js
@@ -17,7 +17,7 @@ function run(args = []) {
 describe("badi completion", () => {
 	it("shows help (without arguments)", () => {
 		const output = run(["completion"]);
-		assert.ok(output.includes("Kabuk Tamamlama"));
+		assert.ok(output.includes("Shell Completion"));
 		assert.ok(output.includes("bash"));
 		assert.ok(output.includes("zsh"));
 		assert.ok(output.includes("fish"));
@@ -25,7 +25,7 @@ describe("badi completion", () => {
 
 	it("--help shows help", () => {
 		const output = run(["completion", "--help"]);
-		assert.ok(output.includes("Kabuk Tamamlama"));
+		assert.ok(output.includes("Shell Completion"));
 	});
 
 	it("produces a bash script", () => {

--- a/tests/harness.test.js
+++ b/tests/harness.test.js
@@ -85,7 +85,7 @@ describe("harness registry", () => {
 	});
 
 	it("resolveHarnesses throws on an unknown id", () => {
-		assert.throws(() => resolveHarnesses("bogus"), /Bilinmeyen harness/);
+		assert.throws(() => resolveHarnesses("bogus"), /Unknown harness/);
 	});
 
 	it("resolveHarnesses works case-insensitively", () => {


### PR DESCRIPTION
## Context

The exhaustive `/team` completeness audit (193 agents, 4-modal sweep + adversarial verify + critic) found **171 real residue findings** my prior "100% done" claims missed — across 4 separate "done" declarations. Verdict: `residue-found` (high confidence). This is **wave 1 of 3**: the product-surface runtime Turkish users actually see.

## Fixed

**CLI output / errors**
- `completion.js` — shell-completion help **+ the generated bash/zsh/fish scripts** users install (Turkish help, comments, descriptors)
- `update-check.js` — the **update banner**; box-border padding recomputed for English width (**verified 51-col aligned**)
- `search.js`, `plan.js`, `preferences.js`, `harnesses/index.js`, `schedulers/index.js`, `transcript-reader.js`, `run-tests.mjs`

**Generated harness output**
- `_single-file.js` — was injecting `# Proje Bellegi`/`# Bilgi Tabani` into every generated `.windsurfrules`/`GEMINI.md`/`AGENTS.md`
- `windsurf.js`/`gemini.js` skip reasons; `schedule.js` examples → renamed commands

**Hook runtime messages** (block/inject/incident — #234 only caught some)
- guard-bash, completeness-gate, dependency-audit, branch-guard, pre-compact-handoff, log-stop-verdict, _util.mjs

## Test plan
- [x] `npm test` — **1166 pass / 0 fail** (lockstep: completion + harness asserts retargeted)
- [x] All 7 hooks exit 0 on `{}` stdin · biome clean
- [x] Update banner rendered & verified column-aligned
- [x] Wave-1 file Turkish scan: clean

## Next
Wave 2: shipped skills indexes (`.claude/skills/INDEX.md`, `SOLOPRENEUR-REHBER.md` ×2) + docs/meta (SECURITY/CONTRIBUTING/.github/docs/README/Makefile/Dockerfile + stale counts). Wave 3: ~15 lib files' comments (incl. critic-caught `stack-map.js`, `icerik/_shared.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)