### PR TITLE
feat(agents): market-researcher, seo-strategist, data-analyst (atoms.dev gap-fill)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
 		{
 			"name": "badi",
 			"source": "./",
-			"description": "Workflow management for Claude Code — 27 AI agents, 84 commands, 62 skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
+			"description": "Workflow management for Claude Code — 30 AI agents, 84 commands, 62 skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
 			"author": {
 				"name": "Fatih Kan",
 				"url": "https://github.com/fatihkan"
@@ -35,7 +35,7 @@
 			],
 			"category": "productivity",
 			"strict": true,
-			"lastUpdated": "2026-06-04T02:06:19+03:00"
+			"lastUpdated": "2026-06-04T17:57:14+03:00"
 		}
 	]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
 	"name": "badi",
 	"version": "1.32.0",
-	"description": "Workflow management for Claude Code, Cursor, Gemini, Windsurf, AGENTS.md — 27 AI agents, 84 commands, 14 hooks, 62 opt-in skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
+	"description": "Workflow management for Claude Code, Cursor, Gemini, Windsurf, AGENTS.md — 30 AI agents, 84 commands, 14 hooks, 62 opt-in skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
 	"author": {
 		"name": "Fatih Kan",
 		"url": "https://github.com/fatihkan"
@@ -37,9 +37,11 @@
 		"./.claude/agents/coach.md",
 		"./.claude/agents/code-generator.md",
 		"./.claude/agents/content-creator.md",
+		"./.claude/agents/data-analyst.md",
 		"./.claude/agents/debt-collector.md",
 		"./.claude/agents/engineering-manager.md",
 		"./.claude/agents/error-whisperer.md",
+		"./.claude/agents/market-researcher.md",
 		"./.claude/agents/migration-pilot.md",
 		"./.claude/agents/onboarding-sherpa.md",
 		"./.claude/agents/performance-profiler.md",
@@ -51,6 +53,7 @@
 		"./.claude/agents/release-manager.md",
 		"./.claude/agents/rubber-duck.md",
 		"./.claude/agents/security-scanner.md",
+		"./.claude/agents/seo-strategist.md",
 		"./.claude/agents/tasarim-kurator.md",
 		"./.claude/agents/test-strategist.md",
 		"./.claude/agents/unsticker.md",
@@ -90,5 +93,5 @@
 			}
 		]
 	},
-	"lastUpdated": "2026-06-04T02:06:19+03:00"
+	"lastUpdated": "2026-06-04T17:57:14+03:00"
 }

--- a/.claude/agents/data-analyst.md
+++ b/.claude/agents/data-analyst.md
@@ -1,0 +1,52 @@
+---
+name: data-analyst
+description: Data analyst - dataset analysis, metric frameworks, growth insights from the numbers
+tools: [Read, Grep, Glob, Bash]
+model: sonnet
+memory: project
+maxTurns: 15
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
+---
+
+# Data Analyst
+
+## Role
+The numbers voice. Turns raw data (CSVs, JSON, logs, usage/event streams, query output) into decisions: what is happening, why, and what to do about it. Wraps the project's `data-analytics` skill into a focused subagent that owns analysis → insight → recommendation. Advisory only: analyzes and recommends — it does not change the product or the data.
+
+## Responsibilities
+1. **Exploratory Analysis** — Shape, distribution, anomalies, and data-quality issues in a dataset
+2. **Metric Framework** — Define the right metrics (North Star, inputs, health) and how to compute them
+3. **Funnel & Cohort Analysis** — Where users drop off, how retention curves bend, which segments differ
+4. **Growth Insights** — Find the lever: which change moves the metric most, backed by the data
+5. **Hypothesis & Experiment Design** — Frame testable hypotheses; size and read A/B results correctly
+6. **Reporting** — Translate findings into a decision-ready narrative for non-analysts
+
+## How It Works
+- Reads the data files in the project (Read/Glob/Grep) and runs analysis via Bash (node/python/sql/jq, whatever the project has)
+- Grounds every insight in a concrete number and states the confidence/caveats
+- Leans on the `data-analytics` skill's procedures (cohort, funnel, RFM, attribution, forecasting, anomaly detection)
+
+## Output Format
+```
+## Data Summary
+What was analyzed (rows, range, source) + the headline finding.
+
+## Key Findings
+| # | Finding | Evidence (the number) | Confidence |
+
+## Drivers
+What is moving the metric, and why.
+
+## Recommendations
+1. [action] — expected effect, how to measure it
+2. ...
+
+## Caveats
+Data-quality limits, assumptions, what would change the conclusion.
+```
+
+## Boundaries
+- Advisory only — never mutates data or the product
+- Every insight tied to a concrete number; estimates flagged as estimates
+- Read-only tools + Bash for analysis (no writes); does not exfiltrate data externally

--- a/.claude/agents/market-researcher.md
+++ b/.claude/agents/market-researcher.md
@@ -1,0 +1,60 @@
+---
+name: market-researcher
+description: Market & demand researcher - niche discovery, competitor/demand signals, opportunity sizing before you build
+tools: [Read, Grep, Glob, Bash, WebSearch, WebFetch]
+model: sonnet
+memory: project
+maxTurns: 20
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
+---
+
+# Market Researcher
+
+## Role
+The outside-in research voice. Before a line of code is written, finds whether real demand exists, who already serves it, and where the gap is. Turns scattered signals (search trends, competitor reviews, community chatter, app-store data) into a focused, sized opportunity. Advisory only: produces research and recommendations — it does not build, design, or decide direction (that is `product-strategist`'s call). Complements `ads-strategist` (which is paid-acquisition-focused) with broad pre-build demand discovery.
+
+## Responsibilities
+1. **Demand Discovery** — Is there a real, recurring problem? Quantify search volume, frequency, and willingness to pay
+2. **Niche Definition** — Narrow a broad space to a specific, reachable, underserved segment
+3. **Competitor Landscape** — Direct + indirect + DIY alternatives; strengths, weaknesses, pricing, positioning
+4. **Gap & Opportunity Sizing** — Where competitors fail, which segments are underserved, TAM/SAM/SOM estimate
+5. **Signal Synthesis** — Cross competitor complaints, wishlist demand, and trends into ranked opportunities
+6. **Go/No-Go Input** — A defensible recommendation: pursue, reshape, or drop — with the evidence behind it
+
+## Research Sources
+- **Search & trends** — query volume, seasonality, related questions (via WebSearch/WebFetch)
+- **Competitor reviews** — recurring complaints = unmet needs (App Store via the project's market tooling)
+- **Communities** — Reddit/forums demand signals for a category/keyword
+- **Pricing pages** — what the market already pays, where the price gaps are
+- **The project itself** — Read code/memory to ground research in what is actually being built
+
+## Output Format
+```
+## Opportunity Summary
+What the demand is, who has it, why now. One paragraph.
+
+## Demand Evidence
+| Signal | Source | Strength (Low/Med/High) | Note |
+
+## Competitor Landscape
+| Competitor | Type | Strength | Weakness | Pricing |
+
+## Market Gap
+- Underserved segment(s)
+- Unmet need(s) the leaders miss
+- Estimated size (TAM / SAM / SOM)
+
+## Ranked Opportunities
+1. [opportunity] — evidence, effort, differentiation
+2. ...
+
+## Recommendation
+PURSUE / RESHAPE / DROP — with the single strongest reason and the biggest risk.
+```
+
+## Boundaries
+- Advisory only — produces research, never builds or commits to a direction
+- Every claim carries a source; flags estimates as estimates
+- Hands direction decisions to `product-strategist` and paid-acquisition strategy to `ads-strategist`
+- Read-only tools + Bash/Web for research only

--- a/.claude/agents/seo-strategist.md
+++ b/.claude/agents/seo-strategist.md
@@ -1,0 +1,57 @@
+---
+name: seo-strategist
+description: SEO strategy owner - audits, keyword/architecture strategy, organic-traffic growth plan
+tools: [Read, Grep, Glob, Bash, WebSearch, WebFetch]
+model: sonnet
+memory: project
+maxTurns: 15
+permissionMode: default
+disallowedTools: [Write, Edit, NotebookEdit]
+---
+
+# SEO Strategist
+
+## Role
+The organic-growth voice. Owns SEO end to end as a dedicated subagent: technical audit, content/keyword strategy, site architecture, and a prioritized growth plan. Wraps the project's SEO capability (the `/seo` command, the `seo` and `seo-crawl-budget` skills, `badi lighthouse`/`badi seo`) into one focused advisory context. Advisory only: audits, strategies, and recommendations — it does not publish pages or edit the site.
+
+## Responsibilities
+1. **Technical SEO Audit** — Crawlability, indexing, canonicals, sitemap/robots, Core Web Vitals, structured data
+2. **Keyword Strategy** — Research, search-intent mapping, difficulty vs. opportunity, content-gap analysis
+3. **Content & Architecture** — Topical authority plan, internal-linking map, URL/heading structure
+4. **Growth Plan** — A prioritized, sequenced roadmap (quick wins → strategic bets) with expected impact
+5. **AI/Answer-Engine Optimization** — Visibility in ChatGPT/Perplexity (GEO/AEO), schema, llms.txt
+6. **Measurement** — KPIs, rank tracking, Search Console signals, what to watch and when
+
+## Tooling It Leans On
+- `badi seo audit/meta/sitemap/speed [url]` — on-page + technical signals
+- `badi lighthouse [url]` — Core Web Vitals
+- the `seo-crawl-budget` skill — fast-indexing campaign methodology
+- WebSearch/WebFetch — SERP structure, competitor positioning, keyword signals
+
+## Output Format
+```
+## SEO Snapshot
+Overall state + the single biggest lever. One paragraph.
+
+## Audit Findings
+| # | Area | Severity (Crit/High/Med/Low) | Finding | Fix |
+
+## Keyword & Content Plan
+- Target clusters (intent + difficulty + opportunity)
+- Content gaps vs. competitors
+
+## Growth Roadmap
+### Quick Wins (this week)
+1. [action] — expected impact
+### Strategic (this quarter)
+1. [action] — expected impact
+
+## Metrics to Track
+KPIs + cadence.
+```
+
+## Boundaries
+- Advisory only — never publishes/edits pages or ships changes
+- Concrete, prioritized recommendations (not generic SEO advice)
+- Read-only tools + Bash (badi seo/lighthouse) + Web for research only
+- Hands implementation to the developer / `/seo` command

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Badi - Workflow Management System
 
-> Structured operations management for Claude Code. 27 agents, 84 commands, 14 hooks, 62 opt-in skill categories. v1.20+ prompt-aware skill router; v1.25+ pentest-* family (25 categories, advisory/defensive); v1.26+ profile-based command management (core/dev/content/pentest) + command routing; v1.27+ expo-* family (12 categories, Expo + React Native mobile dev lifecycle); v1.32+ virtual eng team (product-strategist, engineering-manager, release-manager, qa-lead + /ceo-review, /eng-review, /qa, /ship) + the /team orchestrator; v1.33+ ads review (ads-strategist agent + /meta-review + /ads-review, advisory-only).
+> Structured operations management for Claude Code. 30 agents, 84 commands, 14 hooks, 62 opt-in skill categories. v1.20+ prompt-aware skill router; v1.25+ pentest-* family (25 categories, advisory/defensive); v1.26+ profile-based command management (core/dev/content/pentest) + command routing; v1.27+ expo-* family (12 categories, Expo + React Native mobile dev lifecycle); v1.32+ virtual eng team (product-strategist, engineering-manager, release-manager, qa-lead + /ceo-review, /eng-review, /qa, /ship) + the /team orchestrator; v1.33+ ads review (ads-strategist agent + /meta-review + /ads-review, advisory-only). v1.34+ research/SEO/data advisory agents (market-researcher, seo-strategist, data-analyst).
 
 ## Memory Rules
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **27 AI subagents** (incl. a virtual eng team + ads strategist), **84 slash commands** (profile-based core/dev/content/pentest management since v1.26), **14 automation hooks**, and **62 opt-in skill categories** (25 general + 25 pentest-* advisory/defensive since v1.25 + 12 expo-* mobile dev lifecycle since v1.27) with **prompt-aware auto-routing** for both skills and commands (v1.20+ / v1.26+). OWASP Top 10 scans, code review, content production, mobile/web SEO, App Store market research with `wishlist` + `gaps` analysis. Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
+**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **30 AI subagents** (incl. a virtual eng team, ads strategist, and market/SEO/data analysts), **84 slash commands** (profile-based core/dev/content/pentest management since v1.26), **14 automation hooks**, and **62 opt-in skill categories** (25 general + 25 pentest-* advisory/defensive since v1.25 + 12 expo-* mobile dev lifecycle since v1.27) with **prompt-aware auto-routing** for both skills and commands (v1.20+ / v1.26+). OWASP Top 10 scans, code review, content production, mobile/web SEO, App Store market research with `wishlist` + `gaps` analysis. Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
 
 ## Demo
 
@@ -43,7 +43,7 @@ Source of truth: npm. Other channels mirror the same `@fatihkan/badi-<version>.t
 /plugin install badi@badi-marketplace
 ```
 
-**As an npm CLI (full feature set: 27 agents · 84 commands with profile management (v1.26+) · 14 hooks · 62 opt-in skill categories with auto-router)**:
+**As an npm CLI (full feature set: 30 agents · 84 commands with profile management (v1.26+) · 14 hooks · 62 opt-in skill categories with auto-router)**:
 
 ```bash
 npx @fatihkan/badi init                    # interactive harness picker
@@ -82,7 +82,7 @@ Claude is the canonical source. Cursor/Gemini/Windsurf/AGENTS.md adapters compil
 
 | Feature | Details |
 |---------|---------|
-| **27 expert agents + 84 commands** | Full toolkit from security scanner to performance profiler, plus a virtual eng team (CEO / eng manager / release manager / QA lead) wired together by `/team`, and an ads strategist (`/meta-review`, `/ads-review`) — profile-based filtering (core/dev/content/pentest) since v1.26 |
+| **30 expert agents + 84 commands** | Full toolkit from security scanner to performance profiler, plus a virtual eng team (CEO / eng manager / release manager / QA lead) wired together by `/team`, and an ads strategist (`/meta-review`, `/ads-review`) — profile-based filtering (core/dev/content/pentest) since v1.26 |
 | **14 automation hooks + 62 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants. Skills load zero tokens by default since v1.17; auto-router (v1.20+) injects matching skills per prompt; pentest-* family (v1.25+ advisory/defensive); expo-* family (v1.27+ mobile dev lifecycle); command routing (v1.26+); plan-injection hook (v1.30+) |
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+, expanded v1.30+)** | Claude Code, Cursor, Gemini CLI, Windsurf, AGENTS.md — same `.claude/` source, 5 targets |
@@ -105,7 +105,7 @@ npx @fatihkan/badi init
 badi doctor
 
 # Daily workflow
-badi list --agents     # List 27 agents
+badi list --agents     # List 30 agents
 badi stats             # Usage analytics
 badi schedule list     # Reminders
 ```
@@ -493,13 +493,14 @@ badi ai [token|prompt-test|memory-diff|review|translate]          # v1.8+
 badi dev [deps|bundle|docker-lint|env-check|api-test]             # v1.8+
 ```
 
-## Agents (27)
+## Agents (30)
 
 | Category | Agents |
 |----------|--------|
 | **Software** | auditor, security-scanner, performance-profiler, test-strategist, api-designer, migration-pilot, code-generator, refactoring-advisor, architecture-advisor, project-architect |
 | **Diagnostics** | archaeologist, error-whisperer, unsticker, yak-shave-detector, debt-collector |
-| **Content** | content-creator, visual-director |
+| **Content & Design** | content-creator, visual-director, tasarim-kurator |
+| **Strategy & Ops** | product-strategist, engineering-manager, release-manager, qa-lead, ads-strategist, market-researcher, seo-strategist, data-analyst |
 | **Support** | coach, onboarding-sherpa, pr-ghostwriter, rubber-duck |
 
 ## Directory Structure
@@ -514,7 +515,7 @@ lib/                   17 ESM modules
   templates/           TR/EN template generators
   icerik-helpers.js    Search, similarity, frontmatter
 .claude/
-  agents/              27 expert agents
+  agents/              30 expert agents
   commands/            84 workflow commands
   hooks/               12 automation hooks
   skills/              62 skill categories (25 general + 25 pentest + 12 expo)

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -42,7 +42,7 @@ export default defineConfig({
 				{
 					text: "Reference",
 					items: [
-						{ text: "Agents (27)", link: "/agents/" },
+						{ text: "Agents (30)", link: "/agents/" },
 						{ text: "Commands (84)", link: "/commands/" },
 						{ text: "Skills (62 opt-in)", link: "/skills/" },
 						{ text: "Hooks (14)", link: "/hooks/" },

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1,6 +1,6 @@
 # Agents
 
-Badi ships 27 specialized agents under `.claude/agents/`. Each agent declares its tools, permissionMode, and (for read-only agents) disallowedTools so Claude Code 2.1.119+ honors the policy in headless/`--print` execution.
+Badi ships 30 specialized agents under `.claude/agents/`. Each agent declares its tools, permissionMode, and (for read-only agents) disallowedTools so Claude Code 2.1.119+ honors the policy in headless/`--print` execution.
 
 ## Read-only / advisor agents (19)
 
@@ -12,9 +12,11 @@ Cannot Write, Edit, or NotebookEdit:
 | [archaeologist](https://github.com/fatihkan/badi/blob/main/.claude/agents/archaeologist.md) | Code history researcher — answers "why was this written this way?" |
 | [api-designer](https://github.com/fatihkan/badi/blob/main/.claude/agents/api-designer.md) | API design expert — REST/GraphQL consistency, documentation, versioning |
 | [architecture-advisor](https://github.com/fatihkan/badi/blob/main/.claude/agents/architecture-advisor.md) | Architecture design advisor — patterns, system design, ADRs |
+| [data-analyst](https://github.com/fatihkan/badi/blob/main/.claude/agents/data-analyst.md) | Data analyst — dataset analysis, metric frameworks, growth insights |
 | [debt-collector](https://github.com/fatihkan/badi/blob/main/.claude/agents/debt-collector.md) | Technical debt scanner and prioritization |
 | [engineering-manager](https://github.com/fatihkan/badi/blob/main/.claude/agents/engineering-manager.md) | Locks architecture, sequences work into shippable increments, coordinates specialists |
 | [error-whisperer](https://github.com/fatihkan/badi/blob/main/.claude/agents/error-whisperer.md) | Error diagnosis — translates errors into readable language |
+| [market-researcher](https://github.com/fatihkan/badi/blob/main/.claude/agents/market-researcher.md) | Market & demand researcher — niche discovery, opportunity sizing |
 | [migration-pilot](https://github.com/fatihkan/badi/blob/main/.claude/agents/migration-pilot.md) | Migration planner — risk analysis + step-by-step plans |
 | [onboarding-sherpa](https://github.com/fatihkan/badi/blob/main/.claude/agents/onboarding-sherpa.md) | Codebase guide — makes new projects digestible in minutes |
 | [performance-profiler](https://github.com/fatihkan/badi/blob/main/.claude/agents/performance-profiler.md) | Performance analyzer — bottlenecks, N+1, memory leaks |
@@ -23,6 +25,7 @@ Cannot Write, Edit, or NotebookEdit:
 | [qa-lead](https://github.com/fatihkan/badi/blob/main/.claude/agents/qa-lead.md) | Verification and sign-off — acceptance criteria, test execution, edge cases, ship verdict |
 | [refactoring-advisor](https://github.com/fatihkan/badi/blob/main/.claude/agents/refactoring-advisor.md) | Code quality + refactoring — pattern detection, modernization |
 | [rubber-duck](https://github.com/fatihkan/badi/blob/main/.claude/agents/rubber-duck.md) | Socratic questioning partner — thought partner for complex decisions |
+| [seo-strategist](https://github.com/fatihkan/badi/blob/main/.claude/agents/seo-strategist.md) | SEO strategy owner — audits, keyword strategy, organic-traffic plan |
 | [security-scanner](https://github.com/fatihkan/badi/blob/main/.claude/agents/security-scanner.md) | Security vulnerability scanner — OWASP Top 10, secrets, deps |
 | [test-strategist](https://github.com/fatihkan/badi/blob/main/.claude/agents/test-strategist.md) | Test strategy expert — coverage analysis, test planning |
 | [unsticker](https://github.com/fatihkan/badi/blob/main/.claude/agents/unsticker.md) | Root-cause analyst — diagnoses project blockers |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,7 +37,7 @@ The plugin path ships agents, slash commands, and the two universal safety hooks
 ## First steps
 
 ```bash
-# List the 27 agents
+# List the 30 agents
 badi list --agents
 
 # Browse the 84 commands

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: "Badi"
   text: "Workflow management CLI"
-  tagline: "27 AI agents · 84 commands · 14 hooks · 62 opt-in skills — for Claude Code, Cursor, and Gemini CLI"
+  tagline: "30 AI agents · 84 commands · 14 hooks · 62 opt-in skills — for Claude Code, Cursor, and Gemini CLI"
   actions:
     - theme: brand
       text: Get Started
@@ -15,7 +15,7 @@ hero:
 
 features:
   - icon: 🤖
-    title: 27 specialized agents
+    title: 30 specialized agents
     details: From auditor to security-scanner to performance-profiler. Each agent declares an explicit permissionMode and disallowedTools whitelist.
   - icon: ⚡
     title: 84 slash commands

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fatihkan/badi",
   "version": "1.32.0",
-  "description": "Workflow management CLI for Claude Code, Cursor, and Gemini CLI — 27 AI agents (incl. a virtual eng team + ads strategist), 84 commands, OWASP security scans. Built for Anthropic Claude Opus and Sonnet.",
+  "description": "Workflow management CLI for Claude Code, Cursor, and Gemini CLI — 30 AI agents (incl. a virtual eng team, ads strategist, market/SEO/data analysts), 84 commands, OWASP security scans. Built for Anthropic Claude Opus and Sonnet.",
   "type": "module",
   "main": "bin/badi.js",
   "bin": {

--- a/tests/agent-frontmatter.test.js
+++ b/tests/agent-frontmatter.test.js
@@ -32,6 +32,10 @@ const READ_ONLY_AGENTS = new Set([
 	"engineering-manager",
 	"qa-lead",
 	"ads-strategist",
+	// atoms.dev-inspired advisory roles
+	"market-researcher",
+	"seo-strategist",
+	"data-analyst",
 ]);
 
 const PRODUCER_AGENTS = new Set([
@@ -76,7 +80,7 @@ describe("agent frontmatter audit (#90)", () => {
 	const agents = listAgents();
 
 	it("27 ajan mevcut", () => {
-		assert.equal(agents.length, 27);
+		assert.equal(agents.length, 30);
 	});
 
 	it("her ajan READ_ONLY veya PRODUCER kategorisinde", () => {


### PR DESCRIPTION
## Context
Compared badi's 27 agents to **atoms.dev**'s 8 named agents (per the user's request to fill role gaps). Most were already covered:

| atoms.dev | badi |
|-----------|------|
| Bob (Architect) | architecture-advisor + project-architect ✓ |
| Emma (PM) | product-strategist + project-architect ✓ |
| Mike (Lead) | engineering-manager + /team ✓ |
| Adrian (Ads) | ads-strategist ✓ |
| Alex (Engineer) | Claude Code itself (badi is the workflow layer) ➖ |
| **Iris (Researcher)** | gap → **market-researcher** |
| **Sarah (SEO)** | gap → **seo-strategist** |
| **David (Data)** | gap → **data-analyst** |

## Added (3 advisory/read-only agents, ads-strategist pattern)
- **market-researcher** — demand/niche discovery, competitor signals, opportunity sizing *before* building (fills the gap between `product-strategist` and `ads-strategist`)
- **seo-strategist** — SEO audit + keyword/architecture strategy + growth plan; wraps `/seo` + `seo`/`seo-crawl-budget` skills as one subagent
- **data-analyst** — dataset analysis → growth insight; wraps the `data-analytics` skill (62 procedures)

All READ_ONLY (`disallowedTools: [Write, Edit, NotebookEdit]`), English-only.

## Wiring
- `agent-frontmatter.test.js`: 27→30 + READ_ONLY_AGENTS
- `badi release sync-manifest`: manifests declare 30 agents
- Counts updated across CLAUDE.md / README / docs / package.json — **and completed the README agent table** (it listed only 21 of the existing 27; now all 30)
- Ships to new users (npm pack verified)

## Test plan
- [x] `npm test` 1184/0 · biome clean · doctor healthy · `badi list --agents` = 30
- [x] 3 new agents English-only · ship in `npm pack`

🤖 Generated with [Claude Code](https://claude.com/claude-code)