### PR TITLE
fix(i18n): last residue from audit #3 — code-block labels + CHANGELOG

### DIFF
--- a/.claude/skills-vault/pentest-cicd/SKILL.md
+++ b/.claude/skills-vault/pentest-cicd/SKILL.md
@@ -72,7 +72,7 @@ jobs:
 
 Detect:
 - `pull_request_target` + checkout `head.sha` = HIGH risk
-- `pull_request_target` + secret kullanim = HIGH risk
+- `pull_request_target` + secret usage = HIGH risk
 
 ### Self-Hosted Runner Takeover
 

--- a/.claude/skills-vault/pentest-malware/SKILL.md
+++ b/.claude/skills-vault/pentest-malware/SKILL.md
@@ -90,7 +90,7 @@ objdump -d sample.elf | head
 ```bash
 # Cuckoo (self-hosted)
 cuckoo submit --machine win10-clean sample.exe
-# Sonuc: behavior log, network capture, dropped files, registry changes
+# Result: behavior log, network capture, dropped files, registry changes
 
 # REMnux (Linux analysis distro)
 inetsim                          # fake internet (DNS, HTTP, SMTP)

--- a/.claude/skills-vault/pentest-privesc/SKILL.md
+++ b/.claude/skills-vault/pentest-privesc/SKILL.md
@@ -82,8 +82,8 @@ WinPEAS colored output -> prioritize red/yellow. The skill gives a BROAD explana
 
 ```
 Is SeImpersonatePrivilege present?
-  -> EVET: JuicyPotato (Win 10 < 1809), RoguePotato, PrintSpoofer (modern)
-  -> Local SYSTEM kazanci
+  -> YES: JuicyPotato (Win 10 < 1809), RoguePotato, PrintSpoofer (modern)
+  -> Local SYSTEM gain
 
 SeAssignPrimaryToken:
   -> spawn SYSTEM via CreateProcessAsUser

--- a/.claude/skills-vault/security-check/SKILL.md
+++ b/.claude/skills-vault/security-check/SKILL.md
@@ -18,10 +18,10 @@ metadata:
 > Your AI Becomes a Security Team. Every Language. Every Layer. Zero Tools.
 
 > **Entry points (v1.31.0+)**:
-> - `/security-review` — Anthropic native komut (Claude Code 2.1.140+, AI semantic)
+> - `/security-review` — Anthropic native command (Claude Code 2.1.140+, AI semantic)
 > - `badi security baseline` — deterministic baseline (secret-scan + audit)
-> - `badi security triage` — /security-review rapor severity filtreleme
-> - Bu skill: `sc-orchestrator` 4-fazli pipeline (Recon → Hunt → Verify → Report)
+> - `badi security triage` — /security-review report severity filtering
+> - This skill: `sc-orchestrator` 4-phase pipeline (Recon → Hunt → Verify → Report)
 
 ## What This Skill Does
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 > **Language / Dil:** **English** · [Turkce](CHANGELOG.tr.md)
 
-This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantik Versioning](https://semver.org/).
+This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format and [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
@@ -510,7 +510,7 @@ missing from `commands --help`) at PR time instead of after release.
 ### Fixed — drift exposed by the new detector
 
 - `lib/commands/market.js` — `--days`, `--query`, `--json` flags added to
-  the `Secenekler:` block (were parsed but never documented).
+  the `Options:` block (were parsed but never documented).
 - `lib/commands/stats.js` — `--week` flag added to help (default behaviour
   but the explicit form was undocumented).
 - `lib/commands/publish.js` — `--source` flag added to the skill-bundle
@@ -1729,8 +1729,8 @@ Documentation polish. No code or test changes.
 
 ### Added — `badi market`
 
-App Store pazar arastirmasi komutu. MVP scope: rakip kesfi + coklu
-bolge yorum aggregation + 11-kod sikayet kategorize + zorluk skoru
+App Store market-research command. MVP scope: competitor discovery + multi-
+region review aggregation + 11-code complaint categorization + difficulty score
 (BLUE_OCEAN / COMPETITIVE / HARD / SATURATED).
 
 Subcommands:


### PR DESCRIPTION
## Audit #3: 55 → 6 (trend: 171 → 55 → 6)

Third exhaustive audit dropped real residue to **6** — small leftovers inside code blocks / decision trees, one born-English skill whose body wasn't, and CHANGELOG prose:

- `pentest-cicd`: `secret kullanim` → `secret usage`
- `pentest-malware`: `# Sonuc:` → `# Result:`
- `pentest-privesc`: `EVET:` → `YES:`, `kazanci` → `gain`
- `security-check`: 3 blockquote lines (assumed born-English, wasn't)
- `CHANGELOG.md`: `Semantik` → `Semantic`, `` `Secenekler:` `` → `` `Options:` ``, Turkish `badi market` entry → English

## Test plan
- [x] `npm test` 1184/0 · biome clean · 5 files verified clean

After merge: audit #4 to confirm `VERIFIED CLEAN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)