### PR TITLE
docs(i18n): English watcher definitions (audit #6)

### DIFF
--- a/.claude/watchers/deploy-watchdog.md
+++ b/.claude/watchers/deploy-watchdog.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-watchdog
-description: Yayindaki servisin saglik + log takipcisi
+description: Health + log watcher for the live service
 active: false
 every: 5m
 watch:
@@ -13,25 +13,25 @@ watch:
 report_to: .claude/workspace/watcher-reports/deploy-watchdog.md
 ---
 
-## Notlar
+## Notes
 
-Yayindaki servisi 5 dakikada bir sorgular:
+Polls the live service every 5 minutes:
 
-- **http** — Health endpoint'i 200 donmeli, 2 saniyeden uzun suren cevaplar uyari verir.
-  Kompozit `alert_on` notasyonu: `status-nonok|latency>2s`.
-- **log** — Lokal deploy error dosyasinda ERROR/FATAL/Exception ararken
-  gordugu her yeni satirla dertlenir.
+- **http** — The health endpoint must return 200; responses taking longer than 2 seconds raise a warning.
+  Composite `alert_on` notation: `status-nonok|latency>2s`.
+- **log** — While scanning the local deploy error file for ERROR/FATAL/Exception,
+  it flags every new line it sees.
 
-Bu watcher **varsayilanda `active: false`** — ozel URL ve log yolu ile doldurup
-true yaptiktan sonra:
+This watcher is **`active: false` by default** — fill in your own URL and log path, set it to
+true, then:
 
 \`\`\`bash
 badi agent install deploy-watchdog
 \`\`\`
 
-### Slack/Discord webhook eklemek (opsiyonel)
+### Adding a Slack/Discord webhook (optional)
 
-Frontmatter'a:
+In the frontmatter:
 
 \`\`\`yaml
 notify:
@@ -39,4 +39,4 @@ notify:
   - desktop: true
 \`\`\`
 
-Bu MVP'de basit rapor yazimi var; notify provider'lari v1.14 faz 2'de.
+This MVP has simple report writing; notify providers come in v1.14 phase 2.

--- a/.claude/watchers/project-health.md
+++ b/.claude/watchers/project-health.md
@@ -1,6 +1,6 @@
 ---
 name: project-health
-description: Ana proje saglik takipcisi (git + test + deps + failure log)
+description: Main project health watcher (git + test + deps + failure log)
 active: true
 every: 15m
 watch:
@@ -20,21 +20,21 @@ watch:
 report_to: .claude/workspace/watcher-reports/project-health.md
 ---
 
-## Notlar
+## Notes
 
-Bu watcher, her 15 dakikada bir asagidakileri kontrol eder:
+This watcher checks the following every 15 minutes:
 
-- **git** — Son 10 commit'te "merge conflict", "fatal", "WIP", "DEBUG" pattern'larini arar.
-  Yaygin kotu-commit kokulari.
-- **shell: npm test** — Test suite'i kirildiysa uyarir. Test yoksa exit 0 varsay ki bu kontrol sessiz kalsin.
-- **file: package.json** — Yeni bir bagimlilik eklendiginde bildirir.
-  Ekip dismindan gelen ani bagimlilik surprizi tutar.
-- **log: failures.log** — Badi'nin kendi hook'larindan gelen hata kayitlarini izler.
+- **git** — Scans the last 10 commits for "merge conflict", "fatal", "WIP", "DEBUG" patterns.
+  Common bad-commit smells.
+- **shell: npm test** — Warns if the test suite is broken. If there are no tests it assumes exit 0 so this check stays quiet.
+- **file: package.json** — Notifies when a new dependency is added.
+  Catches surprise dependencies coming from outside the team.
+- **log: failures.log** — Monitors the error records coming from Badi's own hooks.
 
-Arka planda calistirmak icin:
+To run it in the background:
 
 \`\`\`bash
 badi agent install project-health
 \`\`\`
 
-Sabah \`/start\` dedigin zaman bu watcher'in son 24 saatlik uyarilari briefing'e eklenir.
+When you say \`/start\` in the morning, this watcher's alerts from the last 24 hours are added to the briefing.


### PR DESCRIPTION
## Audit #6: new surface — `.claude/watchers/*.md`

The 6th audit surfaced a dev component the prior 5 never swept: watcher definition files, fully Turkish (frontmatter `description` + `## Notlar` body). Git-tracked + developer-facing (`lib/watchers/` reads them); not npm-shipped, but translated for full English consistency.

- `project-health.md`, `deploy-watchdog.md` — description + Notes body → English (watch config / patterns / YAML examples preserved)

## Kept as historical (allowlist #11)
CHANGELOG.md version-history entries that record then-Turkish names — translating would falsify what those versions shipped:
- v1.x TaskBoard entry mapping priorities to the then-current `## Bugun`/`## Bu Hafta`/`## Bekleyen Isler` (renamed to Today/This Week/Backlog in v1.32)
- v1.0.0 feature list `post, karousel, video, gorsel, takvim, marka`

## Test plan
- [x] `npm test` 1184/0 · biome clean · both watcher files clean

After merge: audit #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)