### PR TITLE
fix(skills): badi skills auto on wired a dead .sh hook — register node .mjs

### DIFF
--- a/lib/commands/skills.js
+++ b/lib/commands/skills.js
@@ -636,17 +636,18 @@ export async function runSkills(args) {
 			settings.hooks.UserPromptSubmit = settings.hooks.UserPromptSubmit || [];
 
 			const HOOK_ENTRY = {
-				matcher: "*",
+				matcher: "",
 				hooks: [
 					{
 						type: "command",
-						command: "bash .claude/hooks/skill-router.sh",
+						command: "node .claude/hooks/skill-router.mjs",
+						timeout: 5000,
 					},
 				],
 			};
 
 			const hasEntry = settings.hooks.UserPromptSubmit.some((entry) =>
-				JSON.stringify(entry).includes("skill-router.sh"),
+				JSON.stringify(entry).includes("skill-router.mjs"),
 			);
 
 			if (onOff === "on") {
@@ -670,7 +671,7 @@ export async function runSkills(args) {
 				}
 				settings.hooks.UserPromptSubmit =
 					settings.hooks.UserPromptSubmit.filter(
-						(entry) => !JSON.stringify(entry).includes("skill-router.sh"),
+						(entry) => !JSON.stringify(entry).includes("skill-router.mjs"),
 					);
 				if (settings.hooks.UserPromptSubmit.length === 0) {
 					delete settings.hooks.UserPromptSubmit;

--- a/tests/cli.skills-router.test.js
+++ b/tests/cli.skills-router.test.js
@@ -278,11 +278,11 @@ describe("skills-router: CLI integration", () => {
 		assert.ok(existsSync(settingsPath));
 		const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
 		assert.ok(settings.hooks.UserPromptSubmit);
-		assert.ok(
-			settings.hooks.UserPromptSubmit.some((entry) =>
-				JSON.stringify(entry).includes("skill-router.sh"),
-			),
-		);
+		const cmds = JSON.stringify(settings.hooks.UserPromptSubmit);
+		// Must invoke the real Node ESM hook — the hooks were migrated .sh -> .mjs
+		// in v1.22; a `bash ...skill-router.sh` entry would be a dead hook.
+		assert.match(cmds, /node \.claude\/hooks\/skill-router\.mjs/);
+		assert.doesNotMatch(cmds, /skill-router\.sh|bash /);
 	});
 
 	it("badi skills auto off removes the hook", () => {
@@ -300,7 +300,7 @@ describe("skills-router: CLI integration", () => {
 		const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
 		const has =
 			settings.hooks?.UserPromptSubmit?.some((entry) =>
-				JSON.stringify(entry).includes("skill-router.sh"),
+				JSON.stringify(entry).includes("skill-router.mjs"),
 			) ?? false;
 		assert.equal(has, false);
 	});


### PR DESCRIPTION
## The 13-vs-14 hook discrepancy — investigated

**Resolution of the count:** 14 hook files ship (excluding `_util.mjs`, a shared library). **13** are wired into the default `settings.json` (always-on). The 14th — `skill-router.mjs` — is **opt-in**, activated by `badi skills auto on`. So "14 hooks" is correct, not a miscount.

| Event | Hooks |
|-------|-------|
| PreToolUse | guard-bash, branch-guard, backup-before-write, completeness-gate |
| PostToolUse | log-changes, track-usage |
| PostToolUseFailure | log-failures |
| PreCompact | pre-compact-handoff |
| SessionStart | session-reset, dependency-audit, post-compact-resume |
| Stop | log-stop-verdict |
| UserPromptSubmit | inject-active-plan |
| **opt-in** (`badi skills auto on`) | **skill-router** |

## But the opt-in activation was broken (real bug)

`badi skills auto on` wrote `{ command: "bash .claude/hooks/skill-router.sh" }`:
- `skill-router.sh` **doesn't exist** — hooks migrated `.sh → .mjs` in v1.22 (#129); this registration in `skills.js` was missed.
- it used `bash` to run a **Node ESM** file.

→ Any user who enabled the prompt-aware auto-router (a headline v1.20+/v1.26+ feature) got a **dead hook that silently never ran.**

**Why it persisted:** the existing test asserted the buggy string (`includes("skill-router.sh")`) — it enshrined the wrong behavior.

## Fix
- `lib/commands/skills.js`: register `node .claude/hooks/skill-router.mjs` (matcher `""` + `timeout: 5000`, matching `inject-active-plan`); on/off detection `.sh → .mjs`.
- `tests/cli.skills-router.test.js`: auto-on now asserts `node ...skill-router.mjs` **and** `doesNotMatch(/skill-router\.sh|bash /)` — the regression guard that would have caught this.

## Test plan
- [x] `npm test` 1184/0 · biome clean
- [x] Functional: `badi skills auto on` in a clean dir writes `"command": "node .claude/hooks/skill-router.mjs"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)