### PR TITLE
fix(transparency): disclose dep-audit network call + BADI_NO_DEP_AUDIT opt-out

### DIFF
--- a/.claude/hooks/dependency-audit.mjs
+++ b/.claude/hooks/dependency-audit.mjs
@@ -13,6 +13,8 @@ process.on("unhandledRejection", _badiFailSafe);
 
 // Badi - Dependency Audit (SessionStart - New)
 // Security scan at session start with a 24-hour cache.
+// NOTE: `npm/yarn/pnpm audit` contacts the package registry — this is the
+// only automatic network call Badi makes. Opt out with BADI_NO_DEP_AUDIT=1.
 
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -28,6 +30,9 @@ import {
 	timestamp,
 	writeContextInjection,
 } from "./_util.mjs";
+
+// Opt-out: skip the audit (and its registry call) entirely.
+if (process.env.BADI_NO_DEP_AUDIT) process.exit(0);
 
 const root = projectRoot();
 // XDG_CONFIG_HOME-aware (finding #10).

--- a/README.md
+++ b/README.md
@@ -600,11 +600,12 @@ mv .claude/settings.json .claude/settings.json.bak
 
 ## Network Usage (Transparency)
 
-Badi makes network requests only when you invoke features that require them. Nothing is sent in the background.
+Badi makes network requests only for the features below. The single automatic one is the session-start dependency audit (24h-cached; disable with `BADI_NO_DEP_AUDIT=1`) — everything else fires only when you invoke it. No payload of yours is ever uploaded anywhere.
 
 | Feature | Endpoint | Purpose |
 |---------|----------|---------|
-| Update check | `registry.npmjs.org` | Notify when a newer version is published |
+| Update check | `registry.npmjs.org` | Notify when a newer version is published (opt-out: `BADI_NO_UPDATE_NOTIFIER=1`) |
+| Dependency audit hook (SessionStart) | package registry via `npm/yarn/pnpm audit` | Vulnerability counts at session start, 24h cache (opt-out: `BADI_NO_DEP_AUDIT=1`) |
 | `badi aso *` | `itunes.apple.com` | App Store listing data |
 | `badi seo *` | URL you provide | SEO audits |
 | `badi lighthouse`, `badi a11y` | `googleapis.com/pagespeedonline` | PageSpeed Insights |
@@ -618,7 +619,7 @@ No telemetry, no analytics. See `lib/update-check.js` and `lib/commands/*` for t
 
 ```bash
 npm install
-npm test           # 251 tests (207 CLI + 44 harness adapter)
+npm test           # 1184 tests across 219 suites
 npm run lint       # Biome code-quality checks
 npm run format     # Biome formatting
 ```

--- a/README.tr.md
+++ b/README.tr.md
@@ -549,7 +549,7 @@ mv .claude/settings.json .claude/settings.json.bak
 
 ```bash
 npm install
-npm test           # 251 test (207 CLI + 44 harness adapter)
+npm test           # 1184 test, 219 suite
 npm run lint       # Biome ile kod kalitesi
 npm run format     # Biome ile formatlama
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,17 +4,17 @@
 
 | Version | Support |
 |---------|---------|
-| 1.3.x | Active |
-| < 1.3 | Unsupported |
+| 1.33.x | Active |
+| < 1.33 | Unsupported |
 
 ## Security Features
 
 Badi includes the following security layers:
 
-- **12 Hooks** — guard-bash (dangerous command blocking), branch-guard (branch protection), backup-before-write, completeness-gate (secret detection)
-- **48 Security Skills** — OWASP Top 10, 7 language-specific scanners, dependency audit, secret scanning
+- **14 Hooks** — guard-bash (dangerous command blocking), branch-guard (branch protection), backup-before-write, completeness-gate (secret detection)
+- **62 opt-in skill categories** (incl. 25 advisory `pentest-*`) — OWASP Top 10, language-specific scanners, dependency audit, secret scanning
 - **Log Rotation** — Prevents unbounded growth
-- **Dependency Audit** — npm audit on every session (24h cache)
+- **Dependency Audit** — `npm audit` at session start (24h cache; the only automatic network call — opt-out: `BADI_NO_DEP_AUDIT=1`)
 
 ## Reporting a Vulnerability
 

--- a/tests/hooks-isolation.test.js
+++ b/tests/hooks-isolation.test.js
@@ -11,7 +11,15 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readdirSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -161,6 +169,40 @@ describe("hooks isolation regression — Category 2 fix verification", () => {
 					"post-compact-resume non-JSON output: regression!",
 				);
 			}
+		}
+	});
+});
+
+describe("dependency-audit opt-out (BADI_NO_DEP_AUDIT)", () => {
+	it("BADI_NO_DEP_AUDIT=1 exits 0 before any cache write or registry call", () => {
+		// A lock file is present, so without the opt-out the hook would proceed
+		// to mkdir the cache dir and run `npm audit`. With the env set it must
+		// exit silently first — observable as: no cache dir under XDG_CONFIG_HOME.
+		const tmp = mkdtempSync(join(tmpdir(), "badi-depaudit-"));
+		try {
+			const proj = join(tmp, "proj");
+			mkdirSync(proj);
+			writeFileSync(join(proj, "package-lock.json"), "{}\n");
+			const xdg = join(tmp, "xdg");
+			const r = spawnSync(
+				process.execPath,
+				[join(HOOKS_DIR, "dependency-audit.mjs")],
+				{
+					input: "{}",
+					encoding: "utf-8",
+					timeout: 5000,
+					cwd: proj,
+					env: { ...process.env, BADI_NO_DEP_AUDIT: "1", XDG_CONFIG_HOME: xdg },
+				},
+			);
+			assert.equal(r.status, 0);
+			assert.equal((r.stdout || "").trim(), "");
+			assert.ok(
+				!existsSync(join(xdg, "badi")),
+				"opt-out must exit before the cache dir is created",
+			);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
 		}
 	});
 });


### PR DESCRIPTION
## Summary

Pre-submission fixes from the awesome-claude-code `evaluate-repository` self-review (run by an independent agent against the maintainer's verbatim prompt — overall 7.5/10, "Recommend with caveats"). These close the three documentation/transparency findings before the listing submission.

### 1. Undisclosed automatic network call (the review's top finding)
`dependency-audit.mjs` runs `npm/yarn/pnpm audit` on every SessionStart — the **only** automatic network call Badi makes — but the README "Network Usage" table omitted it and claimed "Nothing is sent in the background."
- Table row added + lead sentence corrected
- New **`BADI_NO_DEP_AUDIT=1`** opt-out exits the hook before any cache write or registry call
- Regression test: opt-out must exit before the cache dir is created (1184 → **1185 tests**)

### 2. SECURITY.md staleness
- Supported versions `1.3.x` → `1.33.x`
- `12 Hooks` → `14 Hooks`; `48 Security Skills` → `62 opt-in skill categories (incl. 25 advisory pentest-*)`
- Dep-audit line now notes the network call + opt-out

### 3. Stale test count
README dev section claimed `251 tests` (v1.12-era) → `1184 tests across 219 suites`; same fix in README.tr.md. The v1.12.0 version-history row keeps its then-accurate 251 (history allowlist).

## Verification
- `node --test tests/hooks-isolation.test.js` — 46/46
- `npm test` — **1185/1185**
- biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)