### PR TITLE
feat(cli): badi security pipeline — harness-interop chain status subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ the artifact names of Anthropic's [defending-code-reference-harness](https://git
   skill text and the sc-* verification methodology are independently authored (MIT).
   Deliberately deferred: an advisory `patch` stage (conflicts with the security
   family's no-write contract) and the upstream autonomous pipeline (gVisor + ASAN).
+- New CLI subcommand **`badi security pipeline [--json]`** — read-only status of the
+  artifact chain: per-stage exists/missing/stale (mtime-based: upstream newer than
+  downstream = stale), suggested next step, and a triage-naming disambiguation note
+  (`badi security triage` = deterministic severity filter; `sc-verifier` = agentic
+  verify writing `TRIAGE.json`). Always exits 0 — informational, not a CI gate.
+  Tests: 1185 → 1191.
 
 ## [1.33.2] - 2026-06-05
 

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -34,6 +34,12 @@ projesiyle (Apache-2.0) uyumlu: `THREAT_MODEL.md → VULN-FINDINGS.json/.md → 
   metni ve sc-* dogrulama metodolojisi badi icin bagimsiz yazildi (MIT). Bilincli
   ertelenen: advisory `patch` asamasi (guvenlik ailesinin yazma-yok kontratiyla
   celisiyor) ve upstream otonom pipeline'i (gVisor + ASAN).
+- Yeni CLI alt komutu **`badi security pipeline [--json]`** — artifact zincirinin
+  salt-okunur durumu: asama basina var/eksik/bayat (mtime tabanli: upstream alt
+  akistan yeniyse = bayat), onerilen sonraki adim ve triage ad-ayrimi notu
+  (`badi security triage` = deterministik severity filtresi; `sc-verifier` =
+  `TRIAGE.json` yazan agentic dogrulama). Her zaman exit 0 — bilgilendirme amacli,
+  CI kapisi degil. Test: 1185 → 1191.
 
 ## [1.33.2] - 2026-06-05
 

--- a/bin/badi.js
+++ b/bin/badi.js
@@ -85,7 +85,7 @@ function showHelp() {
 		`  ${chalk.cyan("events")}    Badi self-telemetry (command counters, durations) — v1.30+`,
 	);
 	console.log(
-		`  ${chalk.cyan("security")}  Security orchestration (baseline/triage/init --ci) — v1.31+`,
+		`  ${chalk.cyan("security")}  Security orchestration (baseline/triage/pipeline/init --ci) — v1.31+`,
 	);
 	console.log("");
 	console.log(chalk.bold("Domain & Infrastructure:"));
@@ -280,6 +280,9 @@ function showHelp() {
 	);
 	console.log(
 		"  badi security triage [report]   Filter the /security-review report by severity",
+	);
+	console.log(
+		"  badi security pipeline          Harness-interop artifact chain status (v1.34+)",
 	);
 	console.log(
 		"  badi security init --ci         GitHub Action scaffold (official Anthropic action)",

--- a/lib/commands/security.js
+++ b/lib/commands/security.js
@@ -1,5 +1,11 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chalk } from "../cli.js";
@@ -9,11 +15,12 @@ import { chalk } from "../cli.js";
 // v1.31.0+ — As of Anthropic 2.1.140, /security-review is embedded in Claude
 // Code as a native slash command. This module makes no AI calls; it provides a
 // bridge/orchestration via baseline (deterministic) + triage (report reading) +
-// init (CI scaffold).
+// init (CI scaffold) + pipeline (artifact-chain status, v1.34+).
 //
 // Subcommands:
 //   badi security baseline           — secret-scan + npm audit deterministic baseline
 //   badi security triage [report]    — filter the latest /security-review report by severity
+//   badi security pipeline [--json]  — harness-interop artifact chain status (read-only)
 //   badi security init [--ci]        — GitHub Action scaffold (wraps anthropics/claude-code-security-review)
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -41,6 +48,8 @@ export function runSecurity(args) {
 			return runBaseline(args.slice(1));
 		case "triage":
 			return runTriage(args.slice(1));
+		case "pipeline":
+			return runPipeline(args.slice(1));
 		case "init":
 			return runInit(args.slice(1));
 		default:
@@ -57,6 +66,7 @@ ${chalk.bold("badi security")} — Security orchestration (Anthropic /security-r
 ${chalk.bold("Subcommands:")}
   ${chalk.cyan("baseline [--json]")}     Deterministic baseline scan (secret-scan + npm audit)
   ${chalk.cyan("triage [report]")}       Filter/summarize the latest /security-review report
+  ${chalk.cyan("pipeline [--json]")}     Harness-interop artifact chain status (read-only, v1.34+)
   ${chalk.cyan("init --ci [--force]")}   GitHub Action scaffold (wraps Anthropic's official action)
 
 ${chalk.bold("Recommended flow:")}
@@ -64,6 +74,10 @@ ${chalk.bold("Recommended flow:")}
   2. ${chalk.cyan("/security-review")} inside Claude Code (native, semantic AI)
   3. ${chalk.cyan("badi security triage")}      # filter by severity if a report exists
   4. CI: ${chalk.cyan("badi security init --ci")} (automatic review on PRs)
+
+${chalk.bold("Note:")} ${chalk.cyan("badi security triage")} is a deterministic severity filter over
+  security-report/SECURITY-REPORT.md. The agentic verify stage (sc-verifier skill)
+  is separate — it writes TRIAGE.json; track it with ${chalk.cyan("badi security pipeline")}.
 
 ${chalk.bold("Cross-ref:")}
   /security-review  → Anthropic native (Claude Code 2.1.140+)
@@ -265,6 +279,122 @@ function runTriage(args) {
 			chalk.yellow("\n  ➜ High findings should be reviewed before merge."),
 		);
 	}
+	process.exit(0);
+}
+
+// ─── pipeline ───
+//
+// v1.34+ — read-only status of the harness-interop artifact chain
+// (THREAT_MODEL.md → VULN-FINDINGS.json → TRIAGE.json) emitted by the
+// security-check skill family. Filenames follow Anthropic's
+// defending-code-reference-harness for outbound, name-level interop.
+// Always exits 0: this is an informational status, not a CI gate.
+
+const PIPELINE_STAGES = [
+	{
+		file: "THREAT_MODEL.md",
+		label: "Threat model",
+		optional: true,
+		producer: 'pentest-threat-model skill — "create a threat model"',
+	},
+	{
+		file: "VULN-FINDINGS.json",
+		label: "Raw findings",
+		optional: false,
+		producer: 'sc-orchestrator Phase 2 — "run security check"',
+	},
+	{
+		file: "TRIAGE.json",
+		label: "Triage verdicts",
+		optional: false,
+		producer: "sc-verifier Phase 3 (runs within the same scan)",
+	},
+];
+
+function stageStatus(root) {
+	const stages = PIPELINE_STAGES.map((s) => {
+		const path = join(root, s.file);
+		const exists = existsSync(path);
+		return {
+			...s,
+			path,
+			exists,
+			mtimeMs: exists ? statSync(path).mtimeMs : null,
+			stale: false,
+		};
+	});
+	// Downstream is stale when any existing upstream artifact is newer than it.
+	for (let i = 1; i < stages.length; i++) {
+		const down = stages[i];
+		if (!down.exists) continue;
+		for (let j = 0; j < i; j++) {
+			const up = stages[j];
+			if (up.exists && up.mtimeMs > down.mtimeMs) down.stale = true;
+		}
+	}
+	return stages;
+}
+
+function pipelineNextStep(stages) {
+	const [threat, findings, triage] = stages;
+	if (!findings.exists)
+		return threat.exists
+			? `Run the scan: ${findings.producer}`
+			: `Optional head first (${threat.producer}), then: ${findings.producer}`;
+	if (!triage.exists) return `Run the verify stage: ${triage.producer}`;
+	const stale = stages.filter((s) => s.stale);
+	if (stale.length > 0)
+		return `Re-run the scan to refresh: ${stale.map((s) => s.file).join(", ")} (upstream changed)`;
+	return "Chain complete and fresh — review TRIAGE.md / security-report/SECURITY-REPORT.md";
+}
+
+function runPipeline(args) {
+	const jsonOut = args.includes("--format=json") || args.includes("--json");
+	const root = projectRoot(); // Y3: not cwd-relative
+	const stages = stageStatus(root);
+
+	if (jsonOut) {
+		console.log(
+			JSON.stringify(
+				{
+					pipeline: stages.map((s) => ({
+						file: s.file,
+						exists: s.exists,
+						stale: s.stale,
+						optional: s.optional,
+					})),
+					next: pipelineNextStep(stages),
+				},
+				null,
+				2,
+			),
+		);
+		process.exit(0);
+	}
+
+	console.log(chalk.bold("\n🔗 Security artifact chain (harness-interop)\n"));
+	console.log(
+		chalk.dim("  THREAT_MODEL.md → VULN-FINDINGS.json → TRIAGE.json\n"),
+	);
+	for (const s of stages) {
+		const mark = s.exists
+			? s.stale
+				? chalk.yellow("⚠ stale ")
+				: chalk.green("✓ ok    ")
+			: s.optional
+				? chalk.gray("○ none  ")
+				: chalk.red("✗ missing");
+		const opt = s.optional ? chalk.dim(" (optional)") : "";
+		console.log(`  ${mark} ${chalk.cyan(s.file.padEnd(19))} ${s.label}${opt}`);
+		if (!s.exists || s.stale)
+			console.log(chalk.dim(`           ↳ ${s.producer}`));
+	}
+	console.log(`\n  ${chalk.bold("Next:")} ${pipelineNextStep(stages)}`);
+	console.log(
+		chalk.dim(
+			"\n  Note: `badi security triage` is a deterministic severity filter over\n  security-report/SECURITY-REPORT.md — distinct from the agentic verify\n  stage (sc-verifier) that writes TRIAGE.json.",
+		),
+	);
 	process.exit(0);
 }
 

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -1,6 +1,6 @@
 // `badi security` command tests (v1.31.0+).
 //
-// 3 subcommands: baseline / triage / init --ci
+// 4 subcommands: baseline / triage / pipeline / init --ci
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
@@ -8,8 +8,10 @@ import {
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
+	readdirSync,
 	readFileSync,
 	rmSync,
+	utimesSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -29,11 +31,12 @@ function runBadi(args, opts = {}) {
 }
 
 describe("badi security command", () => {
-	it("badi security --help works, lists 3 subcommands", () => {
+	it("badi security --help works, lists 4 subcommands", () => {
 		const r = runBadi(["security", "--help"]);
 		assert.equal(r.status, 0);
 		assert.match(r.stdout, /baseline/);
 		assert.match(r.stdout, /triage/);
+		assert.match(r.stdout, /pipeline/);
 		assert.match(r.stdout, /init/);
 		assert.match(r.stdout, /security-review/);
 	});
@@ -131,6 +134,119 @@ describe("badi security command", () => {
 			const r = runBadi(["security", "triage"], { cwd: tmp });
 			// Heading-based count: should be exactly 1 DUSUK, never 4+
 			assert.match(r.stdout, /Low.*1\b/, `K2 regression. stdout: ${r.stdout}`);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	// ─── pipeline (v1.34+) ───
+
+	it("badi security pipeline: empty chain reports missing stages, exits 0", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-sec-pipe1-"));
+		try {
+			spawnSync("git", ["init"], { cwd: tmp, encoding: "utf-8" });
+			const r = runBadi(["security", "pipeline"], { cwd: tmp });
+			assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+			assert.match(r.stdout, /VULN-FINDINGS\.json/);
+			assert.match(r.stdout, /missing/);
+			// THREAT_MODEL.md is the optional head — marked none, not missing
+			assert.match(r.stdout, /THREAT_MODEL\.md.*\(optional\)/);
+			assert.match(r.stdout, /Next:/);
+			assert.match(r.stdout, /run security check/);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("badi security pipeline: findings present, triage missing → suggests verify stage", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-sec-pipe2-"));
+		try {
+			spawnSync("git", ["init"], { cwd: tmp, encoding: "utf-8" });
+			writeFileSync(join(tmp, "VULN-FINDINGS.json"), '{"findings":[]}');
+			const r = runBadi(["security", "pipeline"], { cwd: tmp });
+			assert.equal(r.status, 0);
+			assert.match(r.stdout, /TRIAGE\.json.*missing|missing.*TRIAGE/s);
+			assert.match(r.stdout, /verify stage/);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("badi security pipeline: downstream older than upstream is flagged stale", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-sec-pipe3-"));
+		try {
+			spawnSync("git", ["init"], { cwd: tmp, encoding: "utf-8" });
+			writeFileSync(join(tmp, "VULN-FINDINGS.json"), '{"findings":[]}');
+			writeFileSync(join(tmp, "TRIAGE.json"), '{"findings":[]}');
+			// Make TRIAGE.json 60s older than VULN-FINDINGS.json (deterministic mtimes)
+			const now = Date.now() / 1000;
+			utimesSync(join(tmp, "TRIAGE.json"), now - 60, now - 60);
+			utimesSync(join(tmp, "VULN-FINDINGS.json"), now, now);
+			const r = runBadi(["security", "pipeline"], { cwd: tmp });
+			assert.equal(r.status, 0);
+			assert.match(r.stdout, /stale/i);
+			assert.match(r.stdout, /Re-run/);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("badi security pipeline: full fresh chain reports complete, no stale", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-sec-pipe4-"));
+		try {
+			spawnSync("git", ["init"], { cwd: tmp, encoding: "utf-8" });
+			const now = Date.now() / 1000;
+			writeFileSync(join(tmp, "THREAT_MODEL.md"), "# Threat Model\n");
+			writeFileSync(join(tmp, "VULN-FINDINGS.json"), '{"findings":[]}');
+			writeFileSync(join(tmp, "TRIAGE.json"), '{"findings":[]}');
+			// Explicit mtime order: head oldest → triage newest
+			utimesSync(join(tmp, "THREAT_MODEL.md"), now - 120, now - 120);
+			utimesSync(join(tmp, "VULN-FINDINGS.json"), now - 60, now - 60);
+			utimesSync(join(tmp, "TRIAGE.json"), now, now);
+			const r = runBadi(["security", "pipeline"], { cwd: tmp });
+			assert.equal(r.status, 0);
+			assert.doesNotMatch(r.stdout, /stale/i);
+			assert.doesNotMatch(r.stdout, /missing/);
+			assert.match(r.stdout, /Chain complete/);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("badi security pipeline --json emits machine-readable status", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-sec-pipe5-"));
+		try {
+			spawnSync("git", ["init"], { cwd: tmp, encoding: "utf-8" });
+			writeFileSync(join(tmp, "VULN-FINDINGS.json"), '{"findings":[]}');
+			const r = runBadi(["security", "pipeline", "--json"], { cwd: tmp });
+			assert.equal(r.status, 0);
+			const parsed = JSON.parse(r.stdout);
+			assert.equal(parsed.pipeline.length, 3);
+			const findings = parsed.pipeline.find(
+				(s) => s.file === "VULN-FINDINGS.json",
+			);
+			assert.equal(findings.exists, true);
+			assert.equal(findings.stale, false);
+			assert.match(parsed.next, /verify stage/);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("badi security pipeline is read-only — writes no files", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-sec-pipe6-"));
+		try {
+			spawnSync("git", ["init"], { cwd: tmp, encoding: "utf-8" });
+			writeFileSync(join(tmp, "VULN-FINDINGS.json"), '{"findings":[]}');
+			const before = readdirSync(tmp).sort();
+			const r = runBadi(["security", "pipeline"], { cwd: tmp });
+			assert.equal(r.status, 0);
+			const after = readdirSync(tmp).sort();
+			assert.deepEqual(
+				after,
+				before,
+				"pipeline must not create or remove files",
+			);
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary

PR2 of the harness-interop work (PR1: #271). Adds the user-requested CLI helper: `badi security pipeline [--json]` — a **read-only** status view of the artifact chain shipped in #271.

```
🔗 Security artifact chain (harness-interop)

  THREAT_MODEL.md → VULN-FINDINGS.json → TRIAGE.json

  ○ none   THREAT_MODEL.md     Threat model (optional)
  ✗ missing VULN-FINDINGS.json  Raw findings
  ✗ missing TRIAGE.json         Triage verdicts

  Next: Optional head first (pentest-threat-model skill), then: "run security check"
```

## Behavior

- **Per-stage status**: exists / missing / stale — staleness is mtime-based (any newer upstream artifact marks the downstream stale); the optional `THREAT_MODEL.md` head renders `○ none (optional)`, never "missing"
- **Next-step suggestion** per chain state: scan → verify → complete/refresh
- **`--json`**: `{pipeline: [{file, exists, stale, optional}], next}`
- **Triage disambiguation** in help + output: `badi security triage` (deterministic severity filter over `security-report/SECURITY-REPORT.md`) vs the agentic `sc-verifier` stage (writes `TRIAGE.json`)
- **Always exits 0** — informational, not a CI gate (reviewer-recommended contract)
- Artifacts resolved via `projectRoot()` (git toplevel, cwd fallback) — consistent with baseline/triage (Y3 pattern)

## Tests

**1185 → 1191** (6 new, spawn-based like the existing suite): empty chain · verify-stage suggestion · staleness via `utimesSync` (deterministic mtimes) · full fresh chain · `--json` shape · read-only guarantee (readdir before/after). `--help` test extended to 4 subcommands. biome clean.

## Scope notes

- No slash-command/manifest changes (CLI subcommand only — command count derives from `.claude/commands/*.md`)
- Implements the increments specified by the pre-build verification workflow (insertion point, statSync import, exit-code contract, help locations, test sketch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)