### PR TITLE
docs(tr): archived-snapshot banner on README.tr — closes the last #207 thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ code healthy but the marketing surfaces drifting one release behind, every relea
   new vault-walking test prevents a third silent recurrence. `badi doctor` now also
   verifies the 14th hook (`inject-active-plan.mjs` was missing from its checklist).
 - memory.md consolidated (98 → under budget; older entries moved to memory-archive.md).
+- README.tr.md: archived-snapshot banner added (TR + EN) pointing to the canonical
+  English README; the stale static test badge removed (dynamic npm badges stay).
+  Closes the last open thread of the English-only migration tracking issue (#207) —
+  full TR re-sync only if demand materializes. CHANGELOG.tr.md remains actively
+  maintained as the intentional Turkish variant.
 
 ## [1.34.0] - 2026-06-06
 

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -32,6 +32,11 @@ saglikli ama pazarlama yuzeylerini her release'de bir surum geride buldu.
   otomatik dolduruyordu); yeni vault-gezen test ucuncu sessiz tekrari engeller.
   `badi doctor` artik 14. hook'u da dogrular (`inject-active-plan.mjs` listede yoktu).
 - memory.md konsolide edildi (98 → butce alti; eski girdiler memory-archive.md'ye).
+- README.tr.md: arsiv-goruntusu banner'i eklendi (TR + EN) — kanonik Ingilizce
+  README'ye yonlendirir; bayat statik test rozeti kaldirildi (dinamik npm
+  rozetleri kalir). English-only goc takip issue'sunun (#207) son acik ucunu
+  kapatir — tam TR senkronu ancak talep olusursa. CHANGELOG.tr.md kasitli
+  Turkce varyant olarak aktif bakimda kalir.
 
 ## [1.34.0] - 2026-06-06
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -2,12 +2,22 @@
 
 > **Dil / Language:** [English](README.md) · **Turkce**
 
+> ⚠️ **Bu ceviri arsiv niteligindedir ve guncel degildir.** Kanonik ve eksiksiz
+> dokumantasyon **[README.md (English)](README.md)** dosyasidir — surum gecmisi,
+> kurulum secenekleri ve ozellik tablolari yalnizca orada gunceldir. Bu dosyadaki
+> bolum ve sayilar eski surumlerden kalmis olabilir. Turkce dokumantasyona talep
+> olursa tam senkronizasyon yeniden degerlendirilecektir
+> ([tartisma acin](https://github.com/fatihkan/badi/discussions)).
+>
+> ⚠️ **This translation is an archived snapshot and out of date.** The canonical,
+> complete documentation is **[README.md (English)](README.md)**. Full TR re-sync
+> will be reconsidered if demand materializes.
+
 <p align="center">
   <img src="https://img.shields.io/npm/v/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm version" />
   <img src="https://img.shields.io/npm/dm/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm downloads per month" />
   <img src="https://img.shields.io/npm/dt/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm total downloads" />
   <img src="https://img.shields.io/npm/l/@fatihkan/badi?color=00d4ff&style=flat-square" alt="license" />
-  <img src="https://img.shields.io/badge/tests-915%20passing-00d4ff?style=flat-square" alt="tests" />
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 


### PR DESCRIPTION
## Summary

Final piece of today's hygiene round (#275, #276) and the **last open thread of #207** (English-only migration tracker).

The 3-lens review found README.tr.md ~60-80 lines materially divergent, 4 EN sections missing, and a version history frozen at v1.27. Per the review decision (CEO + ENG consensus): demote to archived snapshot instead of line-by-line patching that never converges.

## Changes
- **TR + EN banner** at the top: this translation is an archived snapshot; canonical docs = README.md; full re-sync reconsidered only if TR demand materializes
- Stale static test badge removed (claimed **915**; actual 1260 — dynamic npm badges stay)
- CHANGELOG entries (EN + TR) appended to the existing [Unreleased] hygiene section
- CHANGELOG.tr.md unaffected — remains the actively maintained intentional TR variant

## #207 status after this PR
| Phase | Closed by |
|---|---|
| 2 (CLI output strings) | v1.32 #222-#226 + v1.33 #248-#257 |
| Interface rename capstone | v1.32 #227 + #228 |
| 3-5 (comments, .md descriptions, .claude/) | v1.33 7-round adversarial audit → VERIFIED CLEAN |
| 6 (README.tr/CHANGELOG.tr) | **this PR** (banner) + CHANGELOG.tr stays maintained |

Will close #207 with the mapping above once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)