### PR TITLE
chore(release): v1.34.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
 			],
 			"category": "productivity",
 			"strict": true,
-			"lastUpdated": "2026-06-05T13:19:57+03:00"
+			"lastUpdated": "2026-06-13T16:13:49+03:00"
 		}
 	]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
 	"name": "badi",
-	"version": "1.34.0",
+	"version": "1.34.1",
 	"description": "Workflow management for Claude Code, Cursor, Gemini, Windsurf, AGENTS.md — 30 AI agents, 84 commands, 14 hooks, 62 opt-in skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
 	"author": {
 		"name": "Fatih Kan",
@@ -93,5 +93,5 @@
 			}
 		]
 	},
-	"lastUpdated": "2026-06-05T13:19:57+03:00"
+	"lastUpdated": "2026-06-13T16:13:49+03:00"
 }

--- a/.claude/memory-archive.md
+++ b/.claude/memory-archive.md
@@ -101,3 +101,10 @@
 - 2026-05-22..29: v1.31.0 (Anthropic 2.1.126-147 uyum, badi security, /review
   parity, hook isolation audit) + bakim turu (#199-#201; lint 19->0, manifest
   re-sync, T3 denetim). Test 1074 -> 1130.
+- 2026-06-05 (ogleden sonra): v1.33.2 (#261-#267) — evaluate-repository on-kosul 7.5/10,
+  ilk 3 bulgu #264 (dep-audit network disclosure + BADI_NO_DEP_AUDIT + regresyon → 1185);
+  npm keywords +6 + GitHub topics swap; #267 .mcp.json context7 pin + track-usage null-honest.
+  awesome-claude-code #1955 + awesome-ai-devtools #615→#616 basvurulari acildi. LinkedIn+X paylasildi.
+- 2026-06-05: v1.33.0+v1.33.1 (#248-#260) — English-only VERIFIED CLEAN 7 tur (171→0); kok ders:
+  grep-hedefli ceviri satir kacirir, TAM DOSYA + repo-wide ASCII-TR grep + bagimsiz audit sart.
+  3 advisory ajan (market/seo/data, 27→30). v1.33.1 `skills auto on` olu hook fix (bash→node .mjs).

--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -7,7 +7,7 @@
 - **Sanal eng ekibi (v1.32+)**: product-strategist/engineering-manager/release-manager/qa-lead ajanlari + /ceo-review /eng-review /qa /ship + /team orkestratoru (kapi zinciri: strateji->plan->build->QA->ship)
 - **Advisory uclu (v1.33, atoms.dev bosluk-doldurma)**: market-researcher / seo-strategist / data-analyst (read-only, ads-strategist kalibi)
 - Ajan: 30 · Komut: 84 · Skill: 62 · Harness: 5 · Hook: 14 (13 varsayilan + skill-router opt-in)
-- Tests: 1191 yesil · biome 2.4.16 clean · doctor healthy
+- Tests: 1269 yesil (main @ 217df48) · biome 2.4.16 clean · doctor 52/0/0 healthy
 - Dagitim: npm (✅ 1.34.0) + marketplace (✅ senkron) + Homebrew + Scoop (⏳) + GH Actions templates
 - Yan repo: badi-skills v1.0.0 · Engines: Node >=20.11.0
 - Self-telemetry: badi.command.* lokal JSONL, BADI_TELEMETRY=off
@@ -18,7 +18,11 @@
 - **Token-only rename pattern (v1.32)**: kullanici-yuzeyi token'lari degisir, ic fonksiyon/dosya/dizin adlari kalir (runBasla, basla.js, takvim/). template.js'de token->dir map (visual->gorseller). ~300 referansli rename'i guvenli kildi
 - `lib/commands/icerik/` 13 modul (v1.13.1) — mobile.js 1226 / seo.js 1071 / aso.js 820 ayni pattern adayi
 - `lib/commands/plugin/` 8 dosya split (v1.30+) · `lib/harnesses/_single-file.js` factory (v1.30+)
-- `lib/commands/release.js` CHECKS array — 9 pure check; `runSyncManifest` subcommand
+- `lib/commands/release.js` CHECKS array — 10 pure check (+docs-sync, test'ten SONRA sirali
+  ki ctx.actualTests dolsun); `runSyncManifest` subcommand. **GOTCHA**: test runner SPEC
+  reporter basar (`ℹ pass N`), TAP DEGIL (`# pass N`) — test ciktisi parse eden her sey
+  iki formati da okumali (`parseTestSummary` export). docs-sync README sayisini GERCEK
+  suite'e karsi dogrular (sadece ic-tutarlilik degil) — her test eklemede README guncelle.
 - `lib/data/marketplace-manifest.js` — pure generator; komutlar dir+count ile referansli (isimle DEGIL) -> komut rename manifest'i etkilemez
 - `lib/observability/event-emitter.js` — badi.* closed list + plugin namespace
 - `lib/skills/schema.js` — badi-skills CI curl ediyor; canonical `lib/frontmatter.js`
@@ -42,9 +46,13 @@
 - **Kullanici-aksiyonu**: #33 awesome-claude-code basvuru · #126 Windows VM smoke
 - **Scope-acik MVP**: #11 badi gh (P3) · #12 badi kb (P3)
 - **P3/P4**: #9 serve · #10 marketplace · #52 mobile crash · #13/#14/#15
-- **11.06 tam-proje degerlendirmesi (3 mercek)**: CEO "feature freeze — dagitim+guvenilirlik
-  dongusu, hedef ILK ORGANIK DIS SINYAL"; ENG "kod saglam, drift'in koku release kapisinda
-  docs-sync eksigi"; QA "CLEAN WITH RISKS, 1.34.0 yayinda kalabilir". Hijyen turu basladi.
+- **11-13.06 degerlendirme + hijyen turu KAPANDI (5 PR #275-#278, hepsi merged)**:
+  3-mercek review → CEO "feature freeze, hedef ILK ORGANIK DIS SINYAL". Hijyen: docs
+  credibility + YENI docs-sync release kapisi (checkDocsSync) + vault backfill 37 +
+  vault-gezen test + README.tr arsiv banner (#207 KAPANDI). 2 tur /code-review kendi
+  isimizi denetledi, 2 gercek regresyon yakaladi: (1) docs-sync kapisi gerceklige karsi
+  dogrulamiyordu → checkNpmTest ctx.actualTests besliyor; (2) stray expo skill npm'e
+  siziyordu → files[] daraltildi + .gitignore. DEVAM: yeni feature/release YOK.
 
 ## Son Kararlar (son ~2 hafta — eskiler `memory-archive.md`)
 - 2026-06-06: **v1.34.0 yayinlandi** (#271-#273) — Anthropic defending-code-reference-harness
@@ -59,28 +67,10 @@
   `skills add` aktif skill'in ustune yazmaz (retrofit = remove+add). Yeni borclar backlog'da:
   vault frontmatter 37/62 fail (CI gezmez), README.tr tablo drift'i, dist/scoop bayat (1.30.1),
   INDEX.md 25-vs-21.
-- 2026-06-05 (ogleden sonra): **v1.33.2 yayinlandi** (#261-#267) + **awesome-claude-code
-  BASVURUSU CANLI** (hesreallyhim/awesome-claude-code#1955, validation ✅, maintainer
-  kuyrugu — #1955'e AI yorumu YASAK, cooldown riski; tum etkilesim kullanicidan).
-  (1) Maintainer'in evaluate-repository prompt'u bagimsiz ajanla on-kosuldu: 7.5/10
-  "Recommend with caveats"; ilk 3 bulgu #264'te kapatildi (dep-audit network disclosure +
-  BADI_NO_DEP_AUDIT opt-out + regresyon testi → 1185 test; SECURITY.md 1.33.x/14/62;
-  "251 tests"→1184). (2) Bulunurluk: npm keywords +6 (chatgpt/codex/openai/copilot/
-  ai-cli/coding-assistant, #263) + GitHub topics swap (aninda canli). (3) Hafif kalan
-  bulgular kapandi (#267): .mcp.json context7@3.1.0 pin, track-usage exit_code null-honest,
-  **awesome-ai-devtools PR'i da ACILDI** (jamesmurdza/awesome-ai-devtools#615 — orada
-  insan-eli sarti yok). LinkedIn + X (tek tweet) PAYLASILDI; NotebookLM infografik prompt'u
-  teslim (kaydedilmedi). awesome-nodejs uygun degil (≥100 yildiz). Yan bulgu: branch-guard
-  hook cwd-farkindaligi yok — /tmp clone'a commit'i ve heredoc icindeki komut metnini
-  blokladi (TaskBoard P4).
-- 2026-06-05: **v1.33.0 + v1.33.1 yayinlandi** (PR #248-#260). (1) English-only bagimsiz
-  adversarial audit ile VERIFIED CLEAN — 7 tur gerekti (171→0); kok ders: grep-hedefli ceviri
-  satir kacirir, TAM DOSYA okuma + repo-wide ASCII-TR grep + bagimsiz audit sart.
-  (2) atoms.dev kiyasindan 3 advisory ajan: market-researcher/seo-strategist/data-analyst (27→30).
-  (3) v1.33.1: `badi skills auto on` olu hook fix (bash .sh → node .mjs, v1.22'den beri bozuktu;
-  testi bug'i pinliyordu — test de sertlestirildi). (4) Hijyen PR: --help events/security
-  ayni-satir bug + eksik bolumler (commands/schedule/agent/transcript/gh-kb/ai-dev) +
-  command-index 4 profil + doctor ajan listesi 30 + README history eksik satirlar.
+- 2026-06-05: v1.33.0/.1/.2 (#248-#267) — English-only VERIFIED CLEAN + 3 advisory ajan
+  (27→30) + evaluate-repository 7.5/10 onarimlari. **AKTIF KISIT**: awesome-claude-code
+  #1955'e AI yorumu YASAK (maintainer kuyrugu, cooldown riski; tum etkilesim kullanicidan).
+  Detay: memory-archive.md. Yan bulgu (acik P4): branch-guard hook cwd-farkindaligi yok.
 - 2026-06-03/04: v1.32.0 (#221-#230) — sanal eng ekibi + CLI grammar/content- oneki
   (BREAKING ama MINOR, kullanici karari). Detay: memory-archive.md. Test 1130->1155.
 - 2026-05-22..29: v1.31.0 + bakim turu. Detay: memory-archive.md. Test 1074->1130.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [1.34.1] - 2026-06-14
+
 ### Fixed — self-review of the hygiene round (multi-agent code review of #275-#277)
 
 A recall-mode multi-agent review of the same-day merge caught two regressions the

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,8 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+## [1.34.1] - 2026-06-14
+
 ### Duzeltildi — hijyen turunun oz-incelemesi (#275-#277 cok-ajanli code review)
 
 Ayni-gun merge'unun recall-modlu cok-ajanli incelemesi, hijyen PR'larinin kendi

--- a/dist/scoop/badi.json
+++ b/dist/scoop/badi.json
@@ -1,12 +1,12 @@
 {
 	"_comment_": "Scoop bucket manifest. fatihkan/scoop-bucket repo'sunda bucket/badi.json olarak yer alir.",
 	"_install_": "scoop bucket add badi https://github.com/fatihkan/scoop-bucket && scoop install badi",
-	"version": "1.34.0",
+	"version": "1.34.1",
 	"description": "Workflow management for Claude Code (30 AI agents, 84 commands, 62 opt-in skill categories). Supports Cursor, Gemini, Windsurf, AGENTS.md.",
 	"homepage": "https://github.com/fatihkan/badi",
 	"license": "MIT",
 	"depends": "nodejs-lts",
-	"url": "https://registry.npmjs.org/@fatihkan/badi/-/badi-1.34.0.tgz",
+	"url": "https://registry.npmjs.org/@fatihkan/badi/-/badi-1.34.1.tgz",
 	"hash": "REPLACE_AT_RELEASE_TIME",
 	"extract_dir": "package",
 	"installer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fatihkan/badi",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "description": "Workflow management CLI for Claude Code, Cursor, and Gemini CLI — 30 AI agents (incl. a virtual eng team, ads strategist, market/SEO/data analysts), 84 commands, OWASP security scans. Built for Anthropic Claude Opus and Sonnet.",
   "type": "module",
   "main": "bin/badi.js",


### PR DESCRIPTION
## v1.34.1 — hygiene + self-review patch

PATCH (no new user-facing features; component counts unchanged 30/84/62/14). Bundles the work merged since v1.34.0 (#275-#278) and cuts the release.

### What's in it
- **docs credibility**: README/SECURITY/scoop/INDEX corrected; test count → **1269**
- **NEW docs-sync release gate** (`checkDocsSync`): verifies README counts against the **real** suite (not just internal agreement) via `parseTestSummary` reading both reporter formats — proven live in this release's own pre-flight (`Test (npm test) (1269 tests passed)` + `Docs in sync OK`)
- **vault validation**: 37 `metadata.homepage` backfills + vault-walking test + `doctor` 14th hook
- **README.tr** archived-snapshot banner (closes #207)
- **npm packaging hardened**: `files[]` narrowed to the `.claude/skills/` scaffold so a locally-activated skill can't ride a local publish

### Pre-flight (`badi release check --version 1.34.1`)
8 OK / 2 WARN / 1 FAIL — the FAIL (git clean) + WARNs (branch, npm-pack quirk) are expected on a release branch and clear on merge to main. All substantive gates green: changelog ×2, manifest, lint, **test 1269**, **docs-sync**.

npm publish is done manually by the maintainer after merge+tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)