### PR TITLE
chore(workspace): wrap-up 14.06 — v1.34.1 state sync

### DIFF
--- a/.claude/knowledge-base.md
+++ b/.claude/knowledge-base.md
@@ -159,3 +159,15 @@ lockstep test kirigini, marka-sesi path bozulmasini ve test-kaynakli profil
 mutasyonunu (aktif 38'e dusmus -> profile all --yes ile 82'ye restore) yakaladi.
 Komut grammar gibi genis-yuzeyli isler icin varsayilan calisma bicimi olmali.
 [Kaynak: 2026-06-04 PR #224-#230 /team kosulari]
+
+### Enjekte-edilen test degeri, bozuk uretici fonksiyonu GIZLER
+docs-sync kapisi README sayisini ctx.actualTests'e karsi dogruluyordu; 4 unit
+test actualTests'i ELLE enjekte ettigi icin yesildi — ama gercek uretici
+(runNpmTest) hicbir zaman calismiyordu: TAP `# pass N` ariyordu, runner ise
+SPEC `ℹ pass N` basiyor (node --test default reporter). t.passed hep null ->
+kapi production'da OLU kod. Ders: bir tuketici-fonksiyonu test ederken degeri
+enjekte ediyorsan, URETICIYI de ayri test et (parse/IO sinirini), yoksa yesil
+suite kirigi gizler. Ek: test ciktisi parse eden kod iki reporter formatini
+da okumali (parseTestSummary, glyph-agnostik anchor). Iki tur /code-review'in
+ikincisi yakaladi — kendi fix'ini de denetle.
+[Kaynak: 2026-06-14 PR #278 self-review, v1.34.1]

--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -2,13 +2,13 @@
 
 ## Mevcut Durum
 - Proje: Badi - Claude Code Is Akisi Yonetim Sistemi
-- npm: @fatihkan/badi **v1.34.0** (yayinda, 06.06.2026) — harness-uyumlu guvenlik artifact zinciri (THREAT_MODEL.md → VULN-FINDINGS.json → TRIAGE.json; security-check ailesine fold-in) + `badi security pipeline` CLI
+- npm: @fatihkan/badi **v1.34.1** (yayinda, 14.06.2026 — hijyen+self-review patch: docs-sync reality kapisi, vault validation, npm packaging, #207 kapandi). v1.34.0 (06.06): harness-uyumlu guvenlik artifact zinciri (THREAT_MODEL.md → VULN-FINDINGS.json → TRIAGE.json; security-check fold-in) + `badi security pipeline` CLI
 - **English-only goc DOGRULANDI (05.06)**: bagimsiz adversarial audit 7 turda `VERIFIED CLEAN` (171→0, PR #248-257). Kasitli TR kalanlar: stopword Set'leri, icerik-helpers normalize tablosu, workspace veri yollari (takvim/, gorseller/, marka-sesi.md), CHANGELOG version-history girdileri
 - **Sanal eng ekibi (v1.32+)**: product-strategist/engineering-manager/release-manager/qa-lead ajanlari + /ceo-review /eng-review /qa /ship + /team orkestratoru (kapi zinciri: strateji->plan->build->QA->ship)
 - **Advisory uclu (v1.33, atoms.dev bosluk-doldurma)**: market-researcher / seo-strategist / data-analyst (read-only, ads-strategist kalibi)
 - Ajan: 30 · Komut: 84 · Skill: 62 · Harness: 5 · Hook: 14 (13 varsayilan + skill-router opt-in)
 - Tests: 1269 yesil (main @ 217df48) · biome 2.4.16 clean · doctor 52/0/0 healthy
-- Dagitim: npm (✅ 1.34.0) + marketplace (✅ senkron) + Homebrew + Scoop (⏳) + GH Actions templates
+- Dagitim: npm (✅ 1.34.1) + marketplace (✅ senkron) + Homebrew + Scoop (⏳, repo'lar henuz yok — README "Planned") + GH Actions templates
 - Yan repo: badi-skills v1.0.0 · Engines: Node >=20.11.0
 - Self-telemetry: badi.command.* lokal JSONL, BADI_TELEMETRY=off
 - Auto-router: prompt -> skill+command injection (dinamik, slash adlarini hardcode etmez — rename'de kirilmadi)


### PR DESCRIPTION
End-of-day sync after the v1.34.1 release.

- `memory.md`: npm state → **v1.34.1** (published 2026-06-14)
- `knowledge-base.md`: durable learning from the #278 self-review — *an injected test value hides a broken producer* (docs-sync reality feed was green in 4 unit tests but `runNpmTest` parsed TAP while the runner emits the spec reporter, so it never ran in production).

Docs/memory only; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)