### PR TITLE
fix(hooks): anchor hook commands to $CLAUDE_PROJECT_DIR (v1.34.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
 			],
 			"category": "productivity",
 			"strict": true,
-			"lastUpdated": "2026-06-13T16:13:49+03:00"
+			"lastUpdated": "2026-06-14T14:20:18+03:00"
 		}
 	]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
 	"name": "badi",
-	"version": "1.34.1",
+	"version": "1.34.2",
 	"description": "Workflow management for Claude Code, Cursor, Gemini, Windsurf, AGENTS.md — 30 AI agents, 84 commands, 14 hooks, 62 opt-in skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
 	"author": {
 		"name": "Fatih Kan",
@@ -93,5 +93,5 @@
 			}
 		]
 	},
-	"lastUpdated": "2026-06-13T16:13:49+03:00"
+	"lastUpdated": "2026-06-14T14:20:18+03:00"
 }

--- a/.claude/knowledge-base.md
+++ b/.claude/knowledge-base.md
@@ -75,6 +75,19 @@ edildiginde no-op. v1.31.0 K1 hotfix bu pattern'i secret-scan'e uyguladi
 (badi security baseline'in calismasi icin gerekti).
 [Kaynak: 2026-05-22 v1.31.0 K1 hotfix]
 
+### Hook komutlari $CLAUDE_PROJECT_DIR'e SABITLENMELI — goreli yol alt-dizinde kirilir
+`settings.json`'da hook komutu goreli yazilirsa (`node .claude/hooks/X.mjs`),
+Claude Code bunu hook calistigi andaki **cwd**'ye gore cozer, proje koksune
+gore DEGIL. Claude bir badi projesinin **alt dizininden** baslatilinca (monorepo
+alt-paketi gibi) her hook `Cannot find module '.../<altdizin>/.claude/hooks/X.mjs'`
+ile patlar — dosya proje kokunde, goreli yol oraya ulasamaz. Cozum: tum hook
+komutlarini `node "$CLAUDE_PROJECT_DIR/.claude/hooks/X.mjs"` ile yaz (plugin-variant:
+`$CLAUDE_PLUGIN_ROOT`). statusline.js + marketplace-manifest.js zaten boyleydi;
+ana settings template'i + skills.js skill-router geride kalmisti. Doctor'a
+"project-root anchored" kontrolu eklendi (findRelativeHookCommands, pure+export).
+Mevcut kurulumlar `badi update` ile fix'i alir.
+[Kaynak: 2026-06-16 v1.34.2, e-meta/metaflow alt-dizin MODULE_NOT_FOUND raporu]
+
 ## Surec Kaliplari
 <!-- Calistigi denenmis ve dogrulanmis surecler -->
 

--- a/.claude/knowledge-base.md
+++ b/.claude/knowledge-base.md
@@ -86,7 +86,7 @@ komutlarini `node "$CLAUDE_PROJECT_DIR/.claude/hooks/X.mjs"` ile yaz (plugin-var
 ana settings template'i + skills.js skill-router geride kalmisti. Doctor'a
 "project-root anchored" kontrolu eklendi (findRelativeHookCommands, pure+export).
 Mevcut kurulumlar `badi update` ile fix'i alir.
-[Kaynak: 2026-06-16 v1.34.2, e-meta/metaflow alt-dizin MODULE_NOT_FOUND raporu]
+[Kaynak: 2026-06-20 v1.34.2, e-meta/metaflow alt-dizin MODULE_NOT_FOUND raporu]
 
 ## Surec Kaliplari
 <!-- Calistigi denenmis ve dogrulanmis surecler -->

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,12 +6,12 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node .claude/hooks/guard-bash.mjs",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-bash.mjs\"",
 						"timeout": 5000
 					},
 					{
 						"type": "command",
-						"command": "node .claude/hooks/branch-guard.mjs",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/branch-guard.mjs\"",
 						"timeout": 3000
 					}
 				]
@@ -21,12 +21,12 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node .claude/hooks/backup-before-write.mjs",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/backup-before-write.mjs\"",
 						"timeout": 3000
 					},
 					{
 						"type": "command",
-						"command": "node .claude/hooks/completeness-gate.mjs",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/completeness-gate.mjs\"",
 						"timeout": 5000
 					}
 				]
@@ -38,7 +38,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node .claude/hooks/log-changes.mjs",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/log-changes.mjs\"",
 						"timeout": 3000
 					}
 				]
@@ -48,7 +48,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node .claude/hooks/track-usage.mjs",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/track-usage.mjs\"",
 						"timeout": 3000
 					}
 				]
@@ -60,7 +60,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node .claude/hooks/log-failures.mjs",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/log-failures.mjs\"",
 						"timeout": 3000
 					}
 				]
@@ -72,7 +72,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node .claude/hooks/pre-compact-handoff.mjs",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-compact-handoff.mjs\"",
 						"timeout": 5000
 					}
 				]
@@ -84,12 +84,12 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node .claude/hooks/session-reset.mjs",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-reset.mjs\"",
 						"timeout": 3000
 					},
 					{
 						"type": "command",
-						"command": "node .claude/hooks/dependency-audit.mjs",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/dependency-audit.mjs\"",
 						"timeout": 30000
 					}
 				]
@@ -99,7 +99,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node .claude/hooks/post-compact-resume.mjs",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-compact-resume.mjs\"",
 						"timeout": 10000
 					}
 				]
@@ -111,7 +111,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node .claude/hooks/log-stop-verdict.mjs",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/log-stop-verdict.mjs\"",
 						"timeout": 5000
 					}
 				]
@@ -123,7 +123,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "node .claude/hooks/inject-active-plan.mjs",
+						"command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-active-plan.mjs\"",
 						"timeout": 2000
 					}
 				]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-## [1.34.2] - 2026-06-16
+## [1.34.2] - 2026-06-20
 
 ### Fixed — hooks break when Claude is launched from a subdirectory
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [1.34.2] - 2026-06-16
+
+### Fixed — hooks break when Claude is launched from a subdirectory
+
+The generated `.claude/settings.json` registered all 14 hooks with **relative**
+commands (`node .claude/hooks/X.mjs`). A relative path resolves against the
+current working directory at hook-execution time, not the project root. So
+launching Claude Code from any **subdirectory** of a badi-managed project (for
+example a sub-package inside a monorepo) made every hook fail with
+`Error: Cannot find module '.../<subdir>/.claude/hooks/X.mjs'` — the hook file
+lives at the project root, which the relative path can't reach.
+
+- **Anchor every hook to `$CLAUDE_PROJECT_DIR`** in the `settings.json` template
+  (`node "$CLAUDE_PROJECT_DIR/.claude/hooks/X.mjs"`) so hooks resolve regardless
+  of the launch directory. This matches what `statusline.js` and the
+  plugin-variant manifest (`$CLAUDE_PLUGIN_ROOT`) already do.
+- **`badi skills auto on`** now writes the skill-router hook with the same
+  `$CLAUDE_PROJECT_DIR` anchoring.
+- **New doctor check** — "hook commands are project-root anchored" warns when a
+  `settings.json` still carries relative hook paths (catches installs created by
+  an older badi before they break in a subdirectory).
+- **Migration:** existing installs pick up the fix by running `badi update`.
+
+Tests: 1269 → 1274 (+5: `findRelativeHookCommands` producer + the shipped
+template is fully anchored). Doctor: 52 → 53 checks.
+
 ## [1.34.1] - 2026-06-14
 
 ### Fixed — self-review of the hygiene round (multi-agent code review of #275-#277)

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,7 +6,7 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
-## [1.34.2] - 2026-06-16
+## [1.34.2] - 2026-06-20
 
 ### Duzeltildi — Claude bir alt-dizinden baslatilinca hook'lar kiriliyordu
 

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,33 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+## [1.34.2] - 2026-06-16
+
+### Duzeltildi — Claude bir alt-dizinden baslatilinca hook'lar kiriliyordu
+
+Uretilen `.claude/settings.json`, 14 hook'un tamamini **goreli** komutla
+yaziyordu (`node .claude/hooks/X.mjs`). Goreli yol, hook calistigi andaki
+calisma dizinine (cwd) gore cozulur — proje koksune gore degil. Bu yuzden
+Claude Code'u badi-yonetimli bir projenin herhangi bir **alt dizininden**
+(orn. bir monorepo icindeki alt-paket) baslatinca her hook
+`Error: Cannot find module '.../<altdizin>/.claude/hooks/X.mjs'` ile
+basarisiz oluyordu — hook dosyasi proje kokunde duruyor, goreli yol oraya
+ulasamiyor.
+
+- **Her hook `$CLAUDE_PROJECT_DIR`'e sabitlendi** (`settings.json` template'inde
+  `node "$CLAUDE_PROJECT_DIR/.claude/hooks/X.mjs"`) — cwd ne olursa olsun hook'lar
+  cozulur. `statusline.js` ve plugin-variant manifest (`$CLAUDE_PLUGIN_ROOT`)
+  zaten bunu yapiyordu.
+- **`badi skills auto on`** skill-router hook'unu artik ayni `$CLAUDE_PROJECT_DIR`
+  sabitlemesiyle yaziyor.
+- **Yeni doctor kontrolu** — "hook commands are project-root anchored": bir
+  `settings.json` hala goreli hook yolu tasiyorsa uyarir (eski badi ile yapilan
+  kurulumlari, alt-dizinde kirilmadan once yakalar).
+- **Migrasyon:** mevcut kurulumlar `badi update` ile bu fix'i alir.
+
+Test: 1269 → 1274 (+5: `findRelativeHookCommands` ureticisi + shipped template'in
+tam sabitli oldugu). Doctor: 52 → 53 kontrol.
+
 ## [1.34.1] - 2026-06-14
 
 ### Duzeltildi — hijyen turunun oz-incelemesi (#275-#277 cok-ajanli code review)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img src="https://img.shields.io/npm/dm/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm downloads per month" />
   <img src="https://img.shields.io/npm/dt/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm total downloads" />
   <img src="https://img.shields.io/npm/l/@fatihkan/badi?color=00d4ff&style=flat-square" alt="license" />
-  <img src="https://img.shields.io/badge/tests-1269%20passing-00d4ff?style=flat-square" alt="tests" />
+  <img src="https://img.shields.io/badge/tests-1274%20passing-00d4ff?style=flat-square" alt="tests" />
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
@@ -87,7 +87,7 @@ Claude is the canonical source. Cursor/Gemini/Windsurf/AGENTS.md adapters compil
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+, expanded v1.30+)** | Claude Code, Cursor, Gemini CLI, Windsurf, AGENTS.md — same `.claude/` source, 5 targets |
 | **Observability (v1.29+) + self-telemetry (v1.30+)** | Read Claude Code transcripts (`badi stats --session/--models/--cost`, `badi search`, `badi session`) + emit own command events (`badi events list/stats`, BADI_TELEMETRY=off to disable) |
-| **1269 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, design, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter, vault frontmatter |
+| **1274 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, design, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter, vault frontmatter, hook-path anchoring |
 | **Content engine (English)** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
 | **Modular architecture** | 36 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
@@ -655,7 +655,7 @@ No telemetry, no analytics. See `lib/update-check.js` and `lib/commands/*` for t
 
 ```bash
 npm install
-npm test           # 1269 tests across 221 suites
+npm test           # 1274 tests across 222 suites
 npm run lint       # Biome code-quality checks
 npm run format     # Biome formatting
 ```

--- a/dist/scoop/badi.json
+++ b/dist/scoop/badi.json
@@ -1,7 +1,7 @@
 {
 	"_comment_": "Scoop bucket manifest. fatihkan/scoop-bucket repo'sunda bucket/badi.json olarak yer alir.",
 	"_install_": "scoop bucket add badi https://github.com/fatihkan/scoop-bucket && scoop install badi",
-	"version": "1.34.1",
+	"version": "1.34.2",
 	"description": "Workflow management for Claude Code (30 AI agents, 84 commands, 62 opt-in skill categories). Supports Cursor, Gemini, Windsurf, AGENTS.md.",
 	"homepage": "https://github.com/fatihkan/badi",
 	"license": "MIT",

--- a/lib/commands/skills.js
+++ b/lib/commands/skills.js
@@ -640,7 +640,8 @@ export async function runSkills(args) {
 				hooks: [
 					{
 						type: "command",
-						command: "node .claude/hooks/skill-router.mjs",
+						command:
+							'node "$CLAUDE_PROJECT_DIR/.claude/hooks/skill-router.mjs"',
 						timeout: 5000,
 					},
 				],

--- a/lib/harnesses/claude.js
+++ b/lib/harnesses/claude.js
@@ -28,6 +28,44 @@ function isUserFile(relativePath) {
 	);
 }
 
+/**
+ * Find hook commands that reference `.claude/hooks/` with a relative path.
+ *
+ * Relative commands (`node .claude/hooks/X.mjs`) resolve against the launch
+ * cwd, so launching Claude from a SUBDIRECTORY of a badi project breaks every
+ * hook with MODULE_NOT_FOUND. Commands anchored to `$CLAUDE_PROJECT_DIR` (local
+ * install) or `$CLAUDE_PLUGIN_ROOT` (plugin variant) resolve regardless of cwd.
+ *
+ * Pure + exported for testing.
+ *
+ * @param {object} settings  parsed settings.json
+ * @returns {string[]}  the offending command strings (empty = all anchored)
+ */
+export function findRelativeHookCommands(settings) {
+	const hookGroups = settings?.hooks;
+	if (!hookGroups || typeof hookGroups !== "object") return [];
+	const offenders = [];
+	for (const entries of Object.values(hookGroups)) {
+		if (!Array.isArray(entries)) continue;
+		for (const entry of entries) {
+			for (const h of entry?.hooks ?? []) {
+				const cmd = h?.command;
+				if (typeof cmd !== "string") continue;
+				if (
+					cmd.includes(".claude/hooks/") &&
+					!cmd.includes("$CLAUDE_PROJECT_DIR") &&
+					!cmd.includes("${CLAUDE_PROJECT_DIR") &&
+					!cmd.includes("$CLAUDE_PLUGIN_ROOT") &&
+					!cmd.includes("${CLAUDE_PLUGIN_ROOT")
+				) {
+					offenders.push(cmd);
+				}
+			}
+		}
+	}
+	return offenders;
+}
+
 // Seed files are written from clean English templates (lib/seed/) on a fresh
 // install, NOT copied from the package's .claude/ (which holds badi's own
 // development memory). They are never overwritten once they exist — the
@@ -171,6 +209,23 @@ export default {
 			if (!existsSync(p)) return false;
 			JSON.parse(readFileSync(p, "utf-8"));
 			return true;
+		});
+		run("hook commands are project-root anchored", () => {
+			// Relative `node .claude/hooks/X.mjs` commands resolve against the
+			// launch cwd, not the project root — so launching Claude from a
+			// SUBDIRECTORY of a badi project makes every hook MODULE_NOT_FOUND.
+			// Anchor with $CLAUDE_PROJECT_DIR (or $CLAUDE_PLUGIN_ROOT for the
+			// plugin variant) so they resolve regardless of cwd.
+			const p = join(claudeDir, "settings.json");
+			if (!existsSync(p)) return "warn";
+			let settings;
+			try {
+				settings = JSON.parse(readFileSync(p, "utf-8"));
+			} catch {
+				return "warn"; // invalid-JSON already failed above
+			}
+			const stale = findRelativeHookCommands(settings);
+			return stale.length === 0 ? true : "warn";
 		});
 
 		const hooks = [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fatihkan/badi",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "description": "Workflow management CLI for Claude Code, Cursor, and Gemini CLI — 30 AI agents (incl. a virtual eng team, ads strategist, market/SEO/data analysts), 84 commands, OWASP security scans. Built for Anthropic Claude Opus and Sonnet.",
   "type": "module",
   "main": "bin/badi.js",

--- a/tests/cli.skills-router.test.js
+++ b/tests/cli.skills-router.test.js
@@ -281,8 +281,12 @@ describe("skills-router: CLI integration", () => {
 		const cmds = JSON.stringify(settings.hooks.UserPromptSubmit);
 		// Must invoke the real Node ESM hook — the hooks were migrated .sh -> .mjs
 		// in v1.22; a `bash ...skill-router.sh` entry would be a dead hook.
-		assert.match(cmds, /node \.claude\/hooks\/skill-router\.mjs/);
+		assert.match(cmds, /node .*\.claude\/hooks\/skill-router\.mjs/);
 		assert.doesNotMatch(cmds, /skill-router\.sh|bash /);
+		// v1.34.2+: anchored to $CLAUDE_PROJECT_DIR so the hook resolves when
+		// Claude is launched from a subdirectory of the project (relative
+		// `node .claude/hooks/...` resolved against cwd → MODULE_NOT_FOUND).
+		assert.match(cmds, /\$CLAUDE_PROJECT_DIR/);
 	});
 
 	it("badi skills auto off removes the hook", () => {

--- a/tests/harness.test.js
+++ b/tests/harness.test.js
@@ -14,7 +14,9 @@ import { join, resolve } from "node:path";
 import { after, before, describe, it } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { parseMenuAnswer } from "../lib/commands/init.js";
-import claudeAdapter from "../lib/harnesses/claude.js";
+import claudeAdapter, {
+	findRelativeHookCommands,
+} from "../lib/harnesses/claude.js";
 import cursorAdapter, { transformCommand } from "../lib/harnesses/cursor.js";
 import geminiAdapter from "../lib/harnesses/gemini.js";
 import {
@@ -581,5 +583,77 @@ describe("preferences env var isolation", () => {
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
 		}
+	});
+});
+
+describe("findRelativeHookCommands — hook path anchoring", () => {
+	it("flags a relative `node .claude/hooks/X.mjs` command", () => {
+		const settings = {
+			hooks: {
+				Stop: [
+					{
+						matcher: "",
+						hooks: [{ type: "command", command: "node .claude/hooks/x.mjs" }],
+					},
+				],
+			},
+		};
+		const offenders = findRelativeHookCommands(settings);
+		assert.equal(offenders.length, 1);
+		assert.equal(offenders[0], "node .claude/hooks/x.mjs");
+	});
+
+	it("accepts a $CLAUDE_PROJECT_DIR-anchored command", () => {
+		const settings = {
+			hooks: {
+				Stop: [
+					{
+						hooks: [
+							{
+								type: "command",
+								command: 'node "$CLAUDE_PROJECT_DIR/.claude/hooks/x.mjs"',
+							},
+						],
+					},
+				],
+			},
+		};
+		assert.deepEqual(findRelativeHookCommands(settings), []);
+	});
+
+	it("accepts the $CLAUDE_PLUGIN_ROOT plugin variant", () => {
+		const settings = {
+			hooks: {
+				Stop: [
+					{
+						hooks: [
+							{
+								// biome-ignore lint/suspicious/noTemplateCurlyInString: literal ${CLAUDE_PLUGIN_ROOT} is the shipped plugin-variant form, not JS interpolation
+								command: "node ${CLAUDE_PLUGIN_ROOT}/.claude/hooks/x.mjs",
+							},
+						],
+					},
+				],
+			},
+		};
+		assert.deepEqual(findRelativeHookCommands(settings), []);
+	});
+
+	it("tolerates missing/empty/odd shapes", () => {
+		assert.deepEqual(findRelativeHookCommands(undefined), []);
+		assert.deepEqual(findRelativeHookCommands({}), []);
+		assert.deepEqual(findRelativeHookCommands({ hooks: null }), []);
+		assert.deepEqual(findRelativeHookCommands({ hooks: { Stop: "x" } }), []);
+	});
+
+	it("the shipped template settings.json is fully anchored", () => {
+		const settings = JSON.parse(
+			readFileSync(join(SRC, "settings.json"), "utf-8"),
+		);
+		assert.deepEqual(
+			findRelativeHookCommands(settings),
+			[],
+			"badi's own .claude/settings.json must anchor every hook to $CLAUDE_PROJECT_DIR",
+		);
 	});
 });


### PR DESCRIPTION
## Problem

Launching Claude Code from a **subdirectory** of a badi-managed project made every hook crash:

```
Error: Cannot find module '/.../e-meta/metaflow/.claude/hooks/log-stop-verdict.mjs'
code: 'MODULE_NOT_FOUND'
```

**Root cause:** the generated `.claude/settings.json` registered all 14 hooks with **relative** commands (`node .claude/hooks/X.mjs`). A relative path resolves against the **launch cwd**, not the project root. When Claude is started from a sub-directory (e.g. `e-meta/metaflow`, a subfolder of the `e-meta` git repo), `.claude/hooks/` resolves against the sub-dir — where no hooks exist. The real hook file lives at the project root, unreachable via the relative path.

## Fix

- **`.claude/settings.json` template** — all 14 hooks anchored: `node "$CLAUDE_PROJECT_DIR/.claude/hooks/X.mjs"`. Resolves regardless of cwd. (Matches `statusline.js` and the `$CLAUDE_PLUGIN_ROOT` plugin variant, which already did this.)
- **`lib/commands/skills.js`** — `badi skills auto on` writes the skill-router hook with the same anchoring.
- **New doctor check** — *"hook commands are project-root anchored"* warns when a `settings.json` still carries relative hook paths. Backed by `findRelativeHookCommands` (pure, exported). Doctor: 52 → 53 checks.
- **Migration** — existing installs pick up the fix by running `badi update`.

## Verification

- `node bin/badi.js doctor` → 53/0/0, new check `OK`
- `node bin/badi.js release check` → Test 1274 passed · Lint clean · Docs in sync · target v1.34.2
- Tests: 1269 → **1274** (+5: producer test for `findRelativeHookCommands` + "shipped template is fully anchored")

## Scope

Bug fix only — no new features (consistent with the feature freeze). README / scoop / plugin manifest / CHANGELOG (EN+TR) synced to **v1.34.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)