### PR TITLE
feat(tooling): v1.35.0 PR-A — doctor/release-gate robustness foundation

### DIFF
--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -7,7 +7,7 @@
 - **Sanal eng ekibi (v1.32+)**: product-strategist/engineering-manager/release-manager/qa-lead ajanlari + /ceo-review /eng-review /qa /ship + /team orkestratoru (kapi zinciri: strateji->plan->build->QA->ship)
 - **Advisory uclu (v1.33, atoms.dev bosluk-doldurma)**: market-researcher / seo-strategist / data-analyst (read-only, ads-strategist kalibi)
 - Ajan: 30 · Komut: 84 · Skill: 62 · Harness: 5 · Hook: 14 (13 varsayilan + skill-router opt-in)
-- Tests: 1274 yesil (main @ b107832) · biome 2.5.0 clean · doctor 53/0/0 healthy
+- Tests: 1285 yesil · biome 2.5.0 clean · doctor 53/0/0 healthy (hook checks settings.json'dan turetilir, hardcoded liste degil)
 - Dagitim: npm (✅ 1.34.1 · ⏳ 1.34.2 publish bekliyor — tag+GH release hazir) + marketplace (✅ senkron) + Homebrew + Scoop (⏳, repo'lar henuz yok — README "Planned"; scoop manifest version+url senkron, checkScoopManifest gate) + GH Actions templates
 - Yan repo: badi-skills v1.0.0 · Engines: Node >=20.11.0
 - Self-telemetry: badi.command.* lokal JSONL, BADI_TELEMETRY=off

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Changed — doctor & release-gate robustness (v1.35.0 hardening, PR-A)
+
+- **`doctor` derives the expected hooks from `settings.json`** instead of a
+  hardcoded list — adding/removing a hook no longer needs a hand-edit here (the
+  52→53 hand-bump pain). New exported pure helper `hookFilesFromSettings`.
+- **`release check` now verifies the README suite count too** (the "N tests
+  across M suites" line), not just the test count — `parseTestSummary` parses
+  `suites`, fed forward as `ctx.actualSuites`.
+- **`release check --skip-test` now WARNs** that the docs-sync reality check was
+  skipped (README counts verified for internal consistency only, not against the
+  live suite) instead of reporting a clean reality-verified pass.
+- **New vault guard test:** `INDEX.md`'s advertised category counts must match
+  the categories on disk (catches the 25-vs-21 drift class).
+
 ### Fixed — release tooling
 
 - `dist/scoop/badi.json` carried a stale download `url` (`badi-1.34.1.tgz`) after the

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,20 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+### Degisti — doctor & release-gate saglamlastirma (v1.35.0 hardening, PR-A)
+
+- **`doctor` beklenen hook'lari `settings.json`'dan turetir** (hardcoded liste yerine)
+  — hook ekleme/cikarma artik burada elle duzenleme istemiyor (52→53 elle-bump derdi).
+  Yeni export pure helper: `hookFilesFromSettings`.
+- **`release check` artik README suite sayisini da dogruluyor** ("N tests across M suites"
+  satiri), sadece test sayisini degil — `parseTestSummary` `suites` parse ediyor,
+  `ctx.actualSuites` olarak iletiliyor.
+- **`release check --skip-test` artik UYARIYOR** — docs-sync reality kontrolu atlandi
+  (README sayilari sadece ic-tutarlilik icin dogrulandi, canli suite'e karsi degil);
+  temiz reality-dogrulanmis pass raporlamak yerine.
+- **Yeni vault guard testi:** `INDEX.md`'nin ilan ettigi kategori sayilari diskteki
+  kategorilerle esmeli (25-vs-21 drift sinifini yakalar).
+
 ### Duzeltildi — release araclari
 
 - `dist/scoop/badi.json` v1.34.2 version bump'indan sonra bayat indirme `url`'i tasiyordu

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img src="https://img.shields.io/npm/dm/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm downloads per month" />
   <img src="https://img.shields.io/npm/dt/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm total downloads" />
   <img src="https://img.shields.io/npm/l/@fatihkan/badi?color=00d4ff&style=flat-square" alt="license" />
-  <img src="https://img.shields.io/badge/tests-1279%20passing-00d4ff?style=flat-square" alt="tests" />
+  <img src="https://img.shields.io/badge/tests-1285%20passing-00d4ff?style=flat-square" alt="tests" />
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
@@ -87,7 +87,7 @@ Claude is the canonical source. Cursor/Gemini/Windsurf/AGENTS.md adapters compil
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+, expanded v1.30+)** | Claude Code, Cursor, Gemini CLI, Windsurf, AGENTS.md — same `.claude/` source, 5 targets |
 | **Observability (v1.29+) + self-telemetry (v1.30+)** | Read Claude Code transcripts (`badi stats --session/--models/--cost`, `badi search`, `badi session`) + emit own command events (`badi events list/stats`, BADI_TELEMETRY=off to disable) |
-| **1279 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, design, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter, vault frontmatter, hook-path anchoring, scoop manifest sync |
+| **1285 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, design, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter, vault frontmatter, hook-path anchoring, scoop manifest sync, settings-derived doctor hooks |
 | **Content engine (English)** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
 | **Modular architecture** | 36 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
@@ -655,7 +655,7 @@ No telemetry, no analytics. See `lib/update-check.js` and `lib/commands/*` for t
 
 ```bash
 npm install
-npm test           # 1279 tests across 222 suites
+npm test           # 1285 tests across 223 suites
 npm run lint       # Biome code-quality checks
 npm run format     # Biome formatting
 ```

--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -74,9 +74,11 @@ export function parseTestSummary(out) {
 	// "ℹ tests N" and per-test "✔ … pass …" descriptions.
 	const passMatch = text.match(/^[^A-Za-z\n]*pass\s+(\d+)\s*$/im);
 	const failMatch = text.match(/^[^A-Za-z\n]*fail\s+(\d+)\s*$/im);
+	const suitesMatch = text.match(/^[^A-Za-z\n]*suites\s+(\d+)\s*$/im);
 	return {
 		passed: passMatch ? Number(passMatch[1]) : null,
 		failed: failMatch ? Number(failMatch[1]) : null,
+		suites: suitesMatch ? Number(suitesMatch[1]) : null,
 	};
 }
 
@@ -86,11 +88,12 @@ function runNpmTest() {
 		timeout: 120_000,
 	});
 	const out = `${r.stdout || ""}${r.stderr || ""}`;
-	const { passed, failed } = parseTestSummary(out);
+	const { passed, failed, suites } = parseTestSummary(out);
 	return {
 		exitCode: r.status,
 		out,
 		passed,
+		suites,
 		// A null fail count means the summary was unparseable; fall back to the
 		// exit code (don't silently treat "couldn't tell" as zero failures).
 		failed: failed == null ? (r.status === 0 ? 0 : null) : failed,
@@ -228,6 +231,7 @@ function checkNpmTest(ctx) {
 	// Feed the real pass count forward so a later checkDocsSync can compare the
 	// README's advertised count against reality (not just internal agreement).
 	if (ok && typeof t.passed === "number") ctx.actualTests = t.passed;
+	if (ok && typeof t.suites === "number") ctx.actualSuites = t.suites;
 	return {
 		name: "test",
 		label: "Test (npm test)",
@@ -445,6 +449,18 @@ export function checkDocsSync(ctx = {}) {
 		}
 	}
 
+	// 1b) dev-section suite count vs reality — the "N tests across M suites" line
+	//     advertises M too; verify it against the real suite count so a split or
+	//     merge that changes suite totals can't leave the README stale.
+	if (typeof ctx.actualSuites === "number") {
+		const sm = readme.match(/#\s*\d+ tests across (\d+) suites/);
+		if (sm && Number(sm[1]) !== ctx.actualSuites) {
+			problems.push(
+				`README suite count stale vs suite (${ctx.actualSuites}): dev section=${sm[1]}`,
+			);
+		}
+	}
+
 	// 2) harness-table subagent count vs disk
 	try {
 		const agents = readdirSync(paths.agentsDir).filter((f) =>
@@ -494,6 +510,19 @@ export function checkDocsSync(ctx = {}) {
 			pass: false,
 			level: "fail",
 			hint: problems.join(" · "),
+		};
+	}
+	// Internal consistency held, but with --skip-test the suite never ran, so
+	// ctx.actualTests/actualSuites were never populated — the README counts were
+	// checked only against EACH OTHER, not reality. Surface that the gate
+	// degraded rather than reporting a clean reality-verified pass.
+	if (ctx.skipTest) {
+		return {
+			name: "docs-sync",
+			label: "Docs in sync (README/SECURITY counts)",
+			pass: true,
+			level: "warn",
+			hint: "reality check skipped (--skip-test): README counts verified for internal consistency only, not against the live suite",
 		};
 	}
 	return {

--- a/lib/harnesses/claude.js
+++ b/lib/harnesses/claude.js
@@ -66,6 +66,34 @@ export function findRelativeHookCommands(settings) {
 	return offenders;
 }
 
+/**
+ * Extract the hook script filenames wired in a settings.json (e.g.
+ * "guard-bash.mjs"). Lets `doctor` derive which hooks to verify from the
+ * actually-wired set instead of a hardcoded list that has to be hand-bumped
+ * every time a hook is added or removed.
+ *
+ * Pure + exported for testing.
+ *
+ * @param {object} settings  parsed settings.json
+ * @returns {string[]}  unique hook filenames referenced by hook commands
+ */
+export function hookFilesFromSettings(settings) {
+	const hookGroups = settings?.hooks;
+	if (!hookGroups || typeof hookGroups !== "object") return [];
+	const files = new Set();
+	for (const entries of Object.values(hookGroups)) {
+		if (!Array.isArray(entries)) continue;
+		for (const entry of entries) {
+			for (const h of entry?.hooks ?? []) {
+				if (typeof h?.command !== "string") continue;
+				const m = h.command.match(/\.claude\/hooks\/([\w.-]+\.mjs)/);
+				if (m) files.add(m[1]);
+			}
+		}
+	}
+	return [...files];
+}
+
 // Seed files are written from clean English templates (lib/seed/) on a fresh
 // install, NOT copied from the package's .claude/ (which holds badi's own
 // development memory). They are never overwritten once they exist — the
@@ -228,24 +256,21 @@ export default {
 			return stale.length === 0 ? true : "warn";
 		});
 
-		const hooks = [
-			"guard-bash.mjs",
-			"backup-before-write.mjs",
-			"completeness-gate.mjs",
-			"log-changes.mjs",
-			"log-failures.mjs",
-			"log-stop-verdict.mjs",
-			"post-compact-resume.mjs",
-			"pre-compact-handoff.mjs",
-			"session-reset.mjs",
-			"dependency-audit.mjs",
-			"branch-guard.mjs",
-			"track-usage.mjs",
-			"skill-router.mjs",
-			// v1.34.1+: was missing from the checklist — doctor reported healthy
-			// even if the UserPromptSubmit plan-injection hook file disappeared.
-			"inject-active-plan.mjs",
-		];
+		// Expected hooks are DERIVED from the wired settings.json (so adding or
+		// removing a hook there no longer requires hand-editing a list here — the
+		// 52->53 hand-bump pain), plus skill-router.mjs which ships but is only
+		// wired on demand by `badi skills auto on`. Falls back to a known set if
+		// settings.json is missing/invalid so doctor still checks something.
+		let hooks;
+		try {
+			const sp = join(claudeDir, "settings.json");
+			const wired = existsSync(sp)
+				? hookFilesFromSettings(JSON.parse(readFileSync(sp, "utf-8")))
+				: [];
+			hooks = [...new Set([...wired, "skill-router.mjs"])].sort();
+		} catch {
+			hooks = ["skill-router.mjs"]; // invalid-JSON already failed above
+		}
 		for (const h of hooks) {
 			run(`Hook: ${h}`, () => {
 				const p = join(claudeDir, "hooks", h);

--- a/tests/harness.test.js
+++ b/tests/harness.test.js
@@ -16,6 +16,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { parseMenuAnswer } from "../lib/commands/init.js";
 import claudeAdapter, {
 	findRelativeHookCommands,
+	hookFilesFromSettings,
 } from "../lib/harnesses/claude.js";
 import cursorAdapter, { transformCommand } from "../lib/harnesses/cursor.js";
 import geminiAdapter from "../lib/harnesses/gemini.js";
@@ -655,5 +656,65 @@ describe("findRelativeHookCommands — hook path anchoring", () => {
 			[],
 			"badi's own .claude/settings.json must anchor every hook to $CLAUDE_PROJECT_DIR",
 		);
+	});
+});
+
+describe("hookFilesFromSettings — doctor derives hooks from settings", () => {
+	it("extracts hook filenames from wired commands (anchored or relative)", () => {
+		const settings = {
+			hooks: {
+				PreToolUse: [
+					{
+						hooks: [
+							{
+								command:
+									'node "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-bash.mjs"',
+							},
+							{ command: "node .claude/hooks/branch-guard.mjs" },
+						],
+					},
+				],
+				Stop: [
+					{
+						hooks: [
+							{
+								// biome-ignore lint/suspicious/noTemplateCurlyInString: literal ${CLAUDE_PLUGIN_ROOT} is the plugin-variant form, not JS interpolation
+								command: "node ${CLAUDE_PLUGIN_ROOT}/.claude/hooks/x.mjs",
+							},
+						],
+					},
+				],
+			},
+		};
+		assert.deepEqual(hookFilesFromSettings(settings).sort(), [
+			"branch-guard.mjs",
+			"guard-bash.mjs",
+			"x.mjs",
+		]);
+	});
+
+	it("dedupes and tolerates odd/empty shapes", () => {
+		assert.deepEqual(hookFilesFromSettings(undefined), []);
+		assert.deepEqual(hookFilesFromSettings({}), []);
+		assert.deepEqual(hookFilesFromSettings({ hooks: { Stop: "x" } }), []);
+		const dup = {
+			hooks: {
+				A: [{ hooks: [{ command: "node .claude/hooks/h.mjs" }] }],
+				B: [{ hooks: [{ command: "node .claude/hooks/h.mjs" }] }],
+			},
+		};
+		assert.deepEqual(hookFilesFromSettings(dup), ["h.mjs"]);
+	});
+
+	it("derives the real wired set from the shipped settings.json", () => {
+		const settings = JSON.parse(
+			readFileSync(join(SRC, "settings.json"), "utf-8"),
+		);
+		const wired = hookFilesFromSettings(settings);
+		// 13 default-active hooks ship wired; skill-router is opt-in (not here).
+		assert.ok(wired.length >= 13, `only ${wired.length} hooks wired`);
+		assert.ok(wired.includes("guard-bash.mjs"));
+		assert.ok(wired.includes("inject-active-plan.mjs"));
+		assert.ok(!wired.includes("skill-router.mjs"), "skill-router is opt-in");
 	});
 });

--- a/tests/release-checks.test.js
+++ b/tests/release-checks.test.js
@@ -91,28 +91,45 @@ describe("release checks (post C2 refactor)", () => {
 	// emits the spec reporter ("ℹ pass N"), so the count was always null and the
 	// docs-sync reality check was silently inert in production (review #278).
 
-	it("parseTestSummary reads the spec reporter (ℹ pass/fail N)", () => {
+	it("parseTestSummary reads the spec reporter (ℹ pass/fail/suites N)", () => {
 		const out = "ℹ tests 1264\nℹ suites 221\nℹ pass 1264\nℹ fail 0\nℹ todo 0\n";
-		assert.deepEqual(parseTestSummary(out), { passed: 1264, failed: 0 });
+		assert.deepEqual(parseTestSummary(out), {
+			passed: 1264,
+			failed: 0,
+			suites: 221,
+		});
 	});
 
 	it("parseTestSummary reads the TAP reporter (# pass/fail N)", () => {
-		const out = "1..1264\n# tests 1264\n# pass 1264\n# fail 0\n";
-		assert.deepEqual(parseTestSummary(out), { passed: 1264, failed: 0 });
+		const out = "1..1264\n# tests 1264\n# suites 220\n# pass 1264\n# fail 0\n";
+		assert.deepEqual(parseTestSummary(out), {
+			passed: 1264,
+			failed: 0,
+			suites: 220,
+		});
 	});
 
 	it("parseTestSummary does not mistake 'ℹ tests N' or per-test lines for the pass count", () => {
 		const out =
 			"  ✔ something pass-through (1ms)\nℹ tests 9\nℹ pass 7\nℹ fail 2\n";
-		assert.deepEqual(parseTestSummary(out), { passed: 7, failed: 2 });
+		assert.deepEqual(parseTestSummary(out), {
+			passed: 7,
+			failed: 2,
+			suites: null,
+		});
 	});
 
 	it("parseTestSummary returns nulls when the summary is absent", () => {
 		assert.deepEqual(parseTestSummary("no summary here\n"), {
 			passed: null,
 			failed: null,
+			suites: null,
 		});
-		assert.deepEqual(parseTestSummary(""), { passed: null, failed: null });
+		assert.deepEqual(parseTestSummary(""), {
+			passed: null,
+			failed: null,
+			suites: null,
+		});
 	});
 
 	// ─── docs-sync gate (v1.34.1+) ───
@@ -239,6 +256,53 @@ describe("release checks (post C2 refactor)", () => {
 			});
 			assert.equal(r.level, "fail");
 			assert.match(r.hint, /stale vs suite \(1260\)/);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("checkDocsSync fails when the dev-section SUITE count is stale vs reality", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-docs-suites-"));
+		try {
+			// test count is correct (1260) but the suite count (220) lags reality (222)
+			writeFileSync(
+				join(tmp, "README.md"),
+				'<img src="https://img.shields.io/badge/tests-1260%20passing-x" />\n' +
+					"| **1260 passing tests** | stuff |\n" +
+					"npm test # 1260 tests across 220 suites\n",
+			);
+			const r = checkDocsSync({
+				actualTests: 1260,
+				actualSuites: 222,
+				paths: { readme: join(tmp, "README.md") },
+			});
+			assert.equal(r.level, "fail");
+			assert.match(
+				r.hint,
+				/suite count stale vs suite \(222\): dev section=220/,
+			);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("checkDocsSync WARNs that reality was skipped under --skip-test", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-docs-skip-"));
+		try {
+			// counts agree internally; with skipTest the suite never ran, so the
+			// gate must warn it verified consistency only, not reality.
+			writeFileSync(
+				join(tmp, "README.md"),
+				'<img src="https://img.shields.io/badge/tests-1260%20passing-x" />\n' +
+					"| **1260 passing tests** | stuff |\n",
+			);
+			const r = checkDocsSync({
+				skipTest: true,
+				paths: { readme: join(tmp, "README.md") },
+			});
+			assert.equal(r.pass, true);
+			assert.equal(r.level, "warn");
+			assert.match(r.hint, /reality check skipped/);
 		} finally {
 			rmSync(tmp, { recursive: true, force: true });
 		}

--- a/tests/skills-vault.test.js
+++ b/tests/skills-vault.test.js
@@ -67,4 +67,31 @@ describe("skills-vault frontmatter (walks every category)", () => {
 			"categories missing an explicit metadata.homepage",
 		);
 	});
+
+	// INDEX.md is hand-curated; this guard asserts its advertised counts match
+	// the categories actually on disk, so adding/removing a category without
+	// updating INDEX.md fails CI instead of drifting silently (the noted
+	// 25-vs-21 drift class). Exact-match by design — it's the forcing function.
+	it("INDEX.md tagline counts match the categories on disk", () => {
+		const index = readFileSync(join(VAULT, "INDEX.md"), "utf-8");
+		const pentest = categories.filter((d) => d.startsWith("pentest-")).length;
+		const expo = categories.filter((d) => d.startsWith("expo-")).length;
+		const general = categories.length - pentest - expo;
+		const num = (re) => {
+			const m = index.match(re);
+			return m ? Number(m[1]) : null;
+		};
+		assert.equal(
+			num(/(\d+) opt-in categories/),
+			categories.length,
+			"INDEX.md total category count is stale vs disk",
+		);
+		assert.equal(num(/(\d+) general/), general, "INDEX.md general count stale");
+		assert.equal(
+			num(/(\d+) pentest-\*/),
+			pentest,
+			"INDEX.md pentest-* count stale",
+		);
+		assert.equal(num(/(\d+) expo-\*/), expo, "INDEX.md expo-* count stale");
+	});
 });


### PR DESCRIPTION
**First increment of the v1.35.0 hardening release** (freeze-compatible: no new features, counts unchanged). Self-updating tooling that removes hand-maintenance and closes silent-drift gaps — and lays the groundwork the later command-file splits need.

## Changes
- **`doctor` derives expected hooks from `settings.json`** (new exported pure helper `hookFilesFromSettings`) instead of a hardcoded 14-entry list — adding/removing a hook no longer needs a hand-edit (the 52→53 bump pain). Falls back to a known set if settings.json is missing/invalid. `doctor` stays **53/0/0**.
- **`release check` verifies the README suite count too** ("N tests across M suites"), not just the test count. `parseTestSummary` now parses `suites`; `checkNpmTest` feeds `ctx.actualSuites`; `checkDocsSync` flags a stale dev-section suite count.
- **`release check --skip-test` now WARNs** that the docs-sync reality check was skipped (README counts verified for internal consistency only, not against the live suite) — instead of a clean reality-verified pass.
- **New vault guard test:** `INDEX.md`'s advertised category counts must match disk (the 25-vs-21 drift class). No drift today (62 = 25+25+12); the test locks it.

## Verification
- `npx biome check` clean · `doctor` 53/0/0 · `release check`: docs in sync (1285/223) ✓, scoop ✓, lint ✓, test 1285 ✓
- Tests **1279 → 1285** (+6: hookFilesFromSettings ×3, docs suite-count + --skip-test warn, INDEX guard)

## Scope note
help-doctor **directory-awareness was re-scoped OUT of PR-A into the mobile split (PR-E)** — it's only testable against real split code, so writing it blind here would be unvalidated. The scoping sweep flagged that `doctor.js` help-doctor reads `lib/commands` non-recursively by filename; PR-E carries that fix alongside the first directory-module.

Part of the sequenced v1.35.0 plan: **PR-A (this)** → B parseVersion · C branch-guard · D stats-flake → E mobile-split · F seo-split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)