### PR TITLE
refactor(semver): v1.35.0 PR-B — consolidate version helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Changed — internal refactor (v1.35.0 hardening, PR-B)
+
+- **Consolidated semver helpers into `lib/helpers.js`.** `parseVersion` (was in
+  `lib/data/plugin-manifest.js`), the byte-identical `bumpVersion` duplicated in
+  `release.js` + `mobile.js`, and the ad-hoc `semverGt` split in `update-check.js`
+  now share one strict 3-part implementation (re-exported from the old locations
+  so importers are unaffected). `bumpVersion` now throws on an unparseable
+  version instead of silently producing `1.2.NaN`; `semverGt` tolerates
+  prerelease tails and is conservative on bad input.
+
 ### Changed — doctor & release-gate robustness (v1.35.0 hardening, PR-A)
 
 - **`doctor` derives the expected hooks from `settings.json`** instead of a

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,16 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+### Degisti — ic refactor (v1.35.0 hardening, PR-B)
+
+- **Semver helper'lari `lib/helpers.js`'te birlestirildi.** `parseVersion`
+  (eskiden `lib/data/plugin-manifest.js`), `release.js` + `mobile.js`'te birebir
+  kopya `bumpVersion` ve `update-check.js`'teki ad-hoc `semverGt` split'i artik
+  tek strict 3-part implementasyonu paylasiyor (eski konumlardan re-export
+  ediliyor, importer'lar etkilenmiyor). `bumpVersion` artik parse edilemeyen
+  version'da sessizce `1.2.NaN` uretmek yerine HATA atiyor; `semverGt`
+  prerelease takilarini tolere ediyor ve bozuk girdide muhafazakar.
+
 ### Degisti — doctor & release-gate saglamlastirma (v1.35.0 hardening, PR-A)
 
 - **`doctor` beklenen hook'lari `settings.json`'dan turetir** (hardcoded liste yerine)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img src="https://img.shields.io/npm/dm/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm downloads per month" />
   <img src="https://img.shields.io/npm/dt/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm total downloads" />
   <img src="https://img.shields.io/npm/l/@fatihkan/badi?color=00d4ff&style=flat-square" alt="license" />
-  <img src="https://img.shields.io/badge/tests-1285%20passing-00d4ff?style=flat-square" alt="tests" />
+  <img src="https://img.shields.io/badge/tests-1293%20passing-00d4ff?style=flat-square" alt="tests" />
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
@@ -87,7 +87,7 @@ Claude is the canonical source. Cursor/Gemini/Windsurf/AGENTS.md adapters compil
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+, expanded v1.30+)** | Claude Code, Cursor, Gemini CLI, Windsurf, AGENTS.md — same `.claude/` source, 5 targets |
 | **Observability (v1.29+) + self-telemetry (v1.30+)** | Read Claude Code transcripts (`badi stats --session/--models/--cost`, `badi search`, `badi session`) + emit own command events (`badi events list/stats`, BADI_TELEMETRY=off to disable) |
-| **1285 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, design, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter, vault frontmatter, hook-path anchoring, scoop manifest sync, settings-derived doctor hooks |
+| **1293 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, design, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter, vault frontmatter, hook-path anchoring, scoop manifest sync, settings-derived doctor hooks, consolidated semver |
 | **Content engine (English)** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
 | **Modular architecture** | 36 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
@@ -655,7 +655,7 @@ No telemetry, no analytics. See `lib/update-check.js` and `lib/commands/*` for t
 
 ```bash
 npm install
-npm test           # 1285 tests across 223 suites
+npm test           # 1293 tests across 226 suites
 npm run lint       # Biome code-quality checks
 npm run format     # Biome formatting
 ```

--- a/lib/commands/mobile.js
+++ b/lib/commands/mobile.js
@@ -2,7 +2,11 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { chalk, showBanner } from "../cli.js";
-import { fetchJsonWithTimeout, hasCommand } from "../helpers.js";
+import {
+	bumpVersion,
+	fetchJsonWithTimeout,
+	hasCommand,
+} from "../helpers.js";
 
 // ─── Helpers ───
 
@@ -138,13 +142,6 @@ function findIosPlist() {
 		}
 	}
 	return null;
-}
-
-function bumpVersion(version, type = "patch") {
-	const [major, minor, patch] = version.split(".").map(Number);
-	if (type === "major") return `${major + 1}.0.0`;
-	if (type === "minor") return `${major}.${minor + 1}.0`;
-	return `${major}.${minor}.${patch + 1}`;
 }
 
 function mobileVersion(args) {

--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -7,7 +7,7 @@ import {
 	isManifestStale,
 	writeManifests,
 } from "../data/marketplace-manifest.js";
-import { hasCommand, shCapture as sh } from "../helpers.js";
+import { bumpVersion, hasCommand, shCapture as sh } from "../helpers.js";
 
 // Release pre-flight verifier.
 //
@@ -34,13 +34,6 @@ function currentBranch() {
 	} catch {
 		return null;
 	}
-}
-
-function bumpVersion(version, type) {
-	const [major, minor, patch] = version.split(".").map(Number);
-	if (type === "major") return `${major + 1}.0.0`;
-	if (type === "minor") return `${major}.${minor + 1}.0`;
-	return `${major}.${minor}.${patch + 1}`;
 }
 
 function readPackageJson() {

--- a/lib/data/plugin-manifest.js
+++ b/lib/data/plugin-manifest.js
@@ -19,6 +19,8 @@
 // If apiVersion is missing: BADI_DEFAULT_API_VERSION applies (1.x). This
 // provides backward compatibility for old plugins.
 
+import { parseVersion } from "../helpers.js";
+
 export const BADI_DEFAULT_API_VERSION = "1.x";
 
 /**
@@ -104,16 +106,9 @@ function makeRange(matcher, recognized) {
 	return fn;
 }
 
-export function parseVersion(version) {
-	if (!version || typeof version !== "string") return null;
-	const m = version.match(/^(\d+)\.(\d+)\.(\d+)/);
-	if (!m) return null;
-	return {
-		major: Number(m[1]),
-		minor: Number(m[2]),
-		patch: Number(m[3]),
-	};
-}
+// parseVersion now lives in lib/helpers.js (single source); re-exported here so
+// existing importers of this module's public surface keep working.
+export { parseVersion };
 
 /**
  * Manifest validate. Returns {valid, errors[], warnings[]}.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,6 +3,55 @@ import { cpSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { extname, join, relative } from "node:path";
 import { chalk } from "./cli.js";
 
+// ─── Semver ───
+// Single source for version parsing/bumping (was duplicated: parseVersion in
+// lib/data/plugin-manifest.js, identical bumpVersion in release.js + mobile.js,
+// ad-hoc split in update-check.js). Strict 3-part parse; trailing
+// prerelease/build metadata is tolerated and ignored.
+
+/**
+ * Parse a semver string into {major,minor,patch}, or null if unparseable.
+ * @param {string} version
+ * @returns {{major:number,minor:number,patch:number}|null}
+ */
+export function parseVersion(version) {
+	if (!version || typeof version !== "string") return null;
+	const m = version.match(/^(\d+)\.(\d+)\.(\d+)/);
+	if (!m) return null;
+	return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+}
+
+/**
+ * Bump a semver string by release type. Throws on an unparseable version
+ * (fail-fast: the old permissive `.split(".")` produced "1.2.NaN" silently).
+ * @param {string} version
+ * @param {"major"|"minor"|"patch"} [type="patch"]
+ * @returns {string} the bumped version
+ */
+export function bumpVersion(version, type = "patch") {
+	const v = parseVersion(version);
+	if (!v) throw new Error(`bumpVersion: unparseable version "${version}"`);
+	if (type === "major") return `${v.major + 1}.0.0`;
+	if (type === "minor") return `${v.major}.${v.minor + 1}.0`;
+	return `${v.major}.${v.minor}.${v.patch + 1}`;
+}
+
+/**
+ * True if version `a` is strictly greater than `b` (semver). Unparseable
+ * operands compare as not-greater (conservative).
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+export function semverGt(a, b) {
+	const pa = parseVersion(a);
+	const pb = parseVersion(b);
+	if (!pa || !pb) return false;
+	if (pa.major !== pb.major) return pa.major > pb.major;
+	if (pa.minor !== pb.minor) return pa.minor > pb.minor;
+	return pa.patch > pb.patch;
+}
+
 // ─── URL Security (SSRF) ───
 
 /**

--- a/lib/update-check.js
+++ b/lib/update-check.js
@@ -2,16 +2,11 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { chalk, VERSION } from "./cli.js";
+import { semverGt } from "./helpers.js";
 
-export function semverGt(a, b) {
-	const pa = a.split(".").map(Number);
-	const pb = b.split(".").map(Number);
-	for (let i = 0; i < 3; i++) {
-		if ((pa[i] || 0) > (pb[i] || 0)) return true;
-		if ((pa[i] || 0) < (pb[i] || 0)) return false;
-	}
-	return false;
-}
+// semverGt now lives in lib/helpers.js (single semver source); re-exported so
+// existing importers of this module keep working.
+export { semverGt };
 
 export async function checkForUpdate() {
 	if (process.env.BADI_NO_UPDATE_NOTIFIER === "1" || process.env.CI)

--- a/tests/semver.test.js
+++ b/tests/semver.test.js
@@ -1,0 +1,68 @@
+// Consolidated semver helpers (v1.35.0): parseVersion/bumpVersion/semverGt were
+// duplicated across plugin-manifest.js, release.js, mobile.js, update-check.js
+// and now live in lib/helpers.js. These guard the single source directly;
+// plugin-manifest.test.js and release-checks.test.js still exercise the
+// re-exported surfaces.
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { bumpVersion, parseVersion, semverGt } from "../lib/helpers.js";
+
+describe("helpers semver — parseVersion", () => {
+	it("parses a 3-part version", () => {
+		assert.deepEqual(parseVersion("1.34.2"), {
+			major: 1,
+			minor: 34,
+			patch: 2,
+		});
+	});
+
+	it("tolerates trailing prerelease/build metadata", () => {
+		assert.deepEqual(parseVersion("2.0.0-beta.3"), {
+			major: 2,
+			minor: 0,
+			patch: 0,
+		});
+	});
+
+	it("returns null for unparseable / non-3-part input", () => {
+		assert.equal(parseVersion("1.30"), null);
+		assert.equal(parseVersion("abc"), null);
+		assert.equal(parseVersion(""), null);
+		assert.equal(parseVersion(null), null);
+		assert.equal(parseVersion(undefined), null);
+	});
+});
+
+describe("helpers semver — bumpVersion", () => {
+	it("bumps patch/minor/major", () => {
+		assert.equal(bumpVersion("1.29.0", "patch"), "1.29.1");
+		assert.equal(bumpVersion("1.29.5", "minor"), "1.30.0");
+		assert.equal(bumpVersion("1.29.5", "major"), "2.0.0");
+	});
+
+	it("defaults to patch", () => {
+		assert.equal(bumpVersion("1.34.2"), "1.34.3");
+	});
+
+	it("throws on an unparseable version (no silent 1.2.NaN)", () => {
+		assert.throws(() => bumpVersion("1.2", "patch"), /unparseable version/);
+		assert.throws(() => bumpVersion("nope"), /unparseable version/);
+	});
+});
+
+describe("helpers semver — semverGt", () => {
+	it("compares across major/minor/patch", () => {
+		assert.equal(semverGt("1.10.0", "1.9.0"), true);
+		assert.equal(semverGt("2.0.0", "1.99.99"), true);
+		assert.equal(semverGt("1.0.1", "1.0.0"), true);
+		assert.equal(semverGt("1.0.0", "1.0.1"), false);
+		assert.equal(semverGt("1.0.0", "1.0.0"), false);
+	});
+
+	it("ignores prerelease tails and is conservative on bad input", () => {
+		assert.equal(semverGt("1.2.3-beta", "1.2.3"), false); // same core
+		assert.equal(semverGt("garbage", "1.0.0"), false);
+		assert.equal(semverGt("1.0.0", "garbage"), false);
+	});
+});


### PR DESCRIPTION
**v1.35.0 hardening, PR-B.** `parseVersion`/`bumpVersion`/`semverGt` were duplicated across 4 modules; now one strict 3-part source in `lib/helpers.js`, re-exported from the old locations so no importer breaks.

## Changes
- **`parseVersion`** moved from `lib/data/plugin-manifest.js` (re-exported there).
- **`bumpVersion`** — removed the byte-identical copies in `release.js` + `mobile.js`; both import from helpers. Now **throws** on an unparseable version instead of silently emitting `1.2.NaN` (callers only ever pass valid `package.json` versions; behaviour-identical for valid input).
- **`semverGt`** moved from `update-check.js` (re-exported); rebuilt on `parseVersion` so it tolerates prerelease tails and is conservative on bad input.
- New `tests/semver.test.js` (8 cases incl. throw-on-invalid). Existing `plugin-manifest.test.js` / `release-checks.test.js` still exercise the re-exported `parseVersion`/`bumpVersion` surfaces.

## Verification
- `npx biome check` clean · `release check` docs in sync (1293/226) ✓
- Tests **1285 → 1293** (isolated green; the 1 intermittent failure under load is the known `stats` flake — fixed in PR-D).

Pure refactor, no behavior change for valid inputs. Part of v1.35.0: PR-A ✓ → **PR-B (this)** → C branch-guard · D stats-flake → E/F splits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)