### PR TITLE
fix(hooks): v1.35.0 PR-C — branch-guard cwd/cd awareness

### DIFF
--- a/.claude/hooks/_util.mjs
+++ b/.claude/hooks/_util.mjs
@@ -19,7 +19,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 /**
  * Read JSON from stdin — Claude Code hook input.
@@ -80,17 +80,134 @@ export function projectRoot() {
 }
 
 /**
- * Current git branch (HEAD). Empty string if none.
+ * Git branch (HEAD) of a specific directory. Empty string if none/not a repo.
+ * @param {string} [dir] working directory; defaults to the process cwd.
  */
-export function currentBranch() {
+export function branchOf(dir) {
 	try {
 		return execFileSync("git", ["branch", "--show-current"], {
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "ignore"],
+			...(dir ? { cwd: dir } : {}),
 		}).trim();
 	} catch {
 		return "";
 	}
+}
+
+/**
+ * Current git branch (HEAD) of the process cwd. Empty string if none.
+ */
+export function currentBranch() {
+	return branchOf();
+}
+
+// ─── Shell command analysis (branch-guard cwd/cd awareness) ───
+// Pure, exported for testing. branch-guard used to flat-regex the raw command
+// against the PROCESS branch evaluated once — so it (a) blocked legit commits
+// where a `git switch -c` precedes the commit in the same compound command,
+// (b) tripped on `git commit` text inside a heredoc body, and (c) checked the
+// wrong repo when the command targets another dir via `cd`/`git -C`.
+
+/**
+ * Remove heredoc bodies from a command so text inside a commit-message heredoc
+ * (e.g. a literal "git commit" line) is not mistaken for an operation. The
+ * command text BEFORE the `<<` on the opening line is kept (so a real
+ * `git commit -F - <<'EOF'` is still detected).
+ * @param {string} command
+ * @returns {string}
+ */
+export function stripHeredocs(command) {
+	const lines = String(command || "").split("\n");
+	const out = [];
+	let tag = null;
+	for (const line of lines) {
+		if (tag) {
+			if (line.trim() === tag) tag = null; // body terminator — drop it too
+			continue;
+		}
+		const m = line.match(/<<-?\s*['"]?([A-Za-z_]\w*)['"]?/);
+		if (m) {
+			tag = m[1];
+			out.push(line.slice(0, line.indexOf("<<")));
+			continue;
+		}
+		out.push(line);
+	}
+	return out.join("\n");
+}
+
+/**
+ * Split a command into top-level segments on &&, ||, ;, |, and newlines.
+ * `||` is matched before `|` so it is not split twice. Best-effort (does not
+ * parse quotes/subshells); callers fall back to conservative behavior.
+ * @param {string} command
+ * @returns {string[]}
+ */
+export function splitSegments(command) {
+	return String(command || "")
+		.split(/&&|\|\||;|\n|\|/)
+		.map((s) => s.trim())
+		.filter(Boolean);
+}
+
+/**
+ * Resolve the directory a git command actually targets: `git -C <path>`, else a
+ * leading `cd`/`pushd <path>`, else baseDir. A path that doesn't exist falls
+ * back to baseDir (fail-closed: evaluate the base repo rather than guess).
+ * @param {string} command
+ * @param {string} baseDir
+ * @returns {string}
+ */
+export function resolveTargetDir(command, baseDir) {
+	const base = baseDir || process.cwd();
+	const stripped = stripHeredocs(command);
+	const gc = stripped.match(/\bgit\s+-C\s+(['"]?)([^\s'"]+)\1/);
+	if (gc) {
+		const p = resolve(base, gc[2]);
+		return existsSync(p) ? p : base;
+	}
+	const cd = stripped.match(/^\s*(?:cd|pushd)\s+(['"]?)([^\s'"&|;]+)\1/);
+	if (cd) {
+		const p = resolve(base, cd[2]);
+		return existsSync(p) ? p : base;
+	}
+	return base;
+}
+
+/**
+ * True if `text` invokes `git commit`, tolerating git global options between
+ * `git` and the subcommand (e.g. `git -C <path> commit`, `git -c k=v commit`,
+ * `git --no-pager commit`). A plain substring/`git\s+commit` test misses the
+ * `-C <path>` form used to target another repo.
+ * @param {string} text
+ * @returns {boolean}
+ */
+export function isGitCommit(text) {
+	return /\bgit\s+(?:-C\s+\S+\s+|-c\s+\S+\s+|--[\w-]+(?:=\S+)?\s+)*commit\b/.test(
+		String(text || ""),
+	);
+}
+
+/**
+ * The branch a `git commit` in this command would land on: start from
+ * baseBranch and apply any `git switch`/`checkout` (incl. `-c`/`-b` creation)
+ * that appears BEFORE the commit segment. Heredoc bodies are stripped first.
+ * @param {string} command
+ * @param {string} baseBranch  branch of the target dir at invocation time
+ * @returns {string}
+ */
+export function effectiveBranchForCommit(command, baseBranch) {
+	const segs = splitSegments(stripHeredocs(command));
+	let tracked = baseBranch;
+	for (const seg of segs) {
+		if (isGitCommit(seg)) break; // evaluate as of the commit
+		const m = seg.match(
+			/\bgit\s+(?:switch|checkout)\s+(?:-c\s+|-b\s+|--create\s+)?(?!-)(['"]?)([^\s'"]+)\1/,
+		);
+		if (m) tracked = m[2];
+	}
+	return tracked;
 }
 
 /**

--- a/.claude/hooks/branch-guard.mjs
+++ b/.claude/hooks/branch-guard.mjs
@@ -17,10 +17,14 @@ process.on("unhandledRejection", _badiFailSafe);
 
 import {
 	appendLog,
-	currentBranch,
+	branchOf,
+	effectiveBranchForCommit,
 	incidentLine,
+	isGitCommit,
 	logPath,
 	readStdinJson,
+	resolveTargetDir,
+	stripHeredocs,
 	writeDecision,
 } from "./_util.mjs";
 
@@ -28,34 +32,47 @@ const input = await readStdinJson();
 const command = input.tool_input?.command || "";
 if (!command) process.exit(0);
 
-const branch = currentBranch();
+// Evaluate the repo the command actually targets (cd/git -C), not just the
+// hook's own cwd — and ignore heredoc bodies when scanning for operations.
+const baseDir = input.cwd || process.cwd();
+const targetDir = resolveTargetDir(command, baseDir);
+const baseBranch = branchOf(targetDir);
+const scan = stripHeredocs(command);
 
 // Force push: block on main/master/release/* branches
 // --force | --force-with-lease | -f flag (finding #8).
-if (/git\s+push.*(--force\b|\s-f\b)/.test(command)) {
-	if (branch === "main" || branch === "master" || /^release\//.test(branch)) {
+if (/git\s+push.*(--force\b|\s-f\b)/.test(scan)) {
+	if (
+		baseBranch === "main" ||
+		baseBranch === "master" ||
+		/^release\//.test(baseBranch)
+	) {
 		appendLog(
 			logPath("incident-log.md"),
 			incidentLine(
 				"BRANCH-GUARD",
 				"BLOCK",
-				`force push to '${branch}' blocked`,
+				`force push to '${baseBranch}' blocked`,
 			),
 		);
 		writeDecision(
 			"block",
-			`'${branch}' is a protected branch; force push is not allowed.`,
+			`'${baseBranch}' is a protected branch; force push is not allowed.`,
 		);
 		process.exit(0);
 	}
 }
 
-// Only block the git commit command on protected branches
-if (!/git\s+commit\b/.test(command)) process.exit(0);
+// Only block the git commit command on protected branches (heredoc bodies
+// stripped; tolerates git global options like `-C <path>` before `commit`).
+if (!isGitCommit(scan)) process.exit(0);
 
 // Do not block merge commits — git merge already creates a commit automatically
-if (/git\s+merge\b/.test(command)) process.exit(0);
+if (/git\s+merge\b/.test(scan)) process.exit(0);
 
+// The branch the commit would actually land on: a `git switch -c`/`checkout -b`
+// earlier in the same compound command takes effect before the commit.
+const branch = effectiveBranchForCommit(command, baseBranch);
 if (!branch) process.exit(0);
 
 const protectedBranches = ["main", "master", "production"];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Fixed — branch-guard cwd/cd awareness (v1.35.0 hardening, PR-C)
+
+- **The `branch-guard` hook no longer false-positives on legitimate commits and
+  no longer checks the wrong repo.** It used to (a) flat-regex the raw command
+  against the process branch evaluated once — so a compound command that does
+  `git switch -c feature/x && git commit` was blocked because the branch was
+  still `main` at evaluation time; (b) trip on a `git commit` string inside a
+  heredoc body; and (c) check the hook's own repo even when the command targets
+  another via `cd`/`git -C`. Now it resolves the target directory, reads that
+  repo's branch, strips heredoc bodies, and walks command segments so a
+  `switch`/`checkout -b` before the commit takes effect. New exported pure
+  helpers in `_util.mjs`: `branchOf`, `stripHeredocs`, `splitSegments`,
+  `resolveTargetDir`, `effectiveBranchForCommit`, `isGitCommit`. Fail-closed on
+  parse/path ambiguity (evaluates the base branch).
+
 ### Changed — internal refactor (v1.35.0 hardening, PR-B)
 
 - **Consolidated semver helpers into `lib/helpers.js`.** `parseVersion` (was in

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,21 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+### Duzeltildi — branch-guard cwd/cd farkindaligi (v1.35.0 hardening, PR-C)
+
+- **`branch-guard` hook'u artik mesru commit'lerde yanlis-pozitif vermiyor ve
+  yanlis repo'yu kontrol etmiyor.** Eskiden (a) ham komutu, bir kez degerlendirilen
+  process branch'ine karsi duz-regex'liyordu — `git switch -c feature/x && git
+  commit` bilesik komutu, degerlendirme aninda branch hala `main` oldugu icin
+  blokleniyordu; (b) heredoc govdesindeki `git commit` metnine takiliyordu; (c)
+  komut `cd`/`git -C` ile baska repo'yu hedeflese bile kendi repo'sunu kontrol
+  ediyordu. Artik hedef dizini cozuyor, o repo'nun branch'ini okuyor, heredoc
+  govdelerini cikariyor ve komut segmentlerini yuruyerek commit'ten onceki bir
+  `switch`/`checkout -b`'yi etkili sayiyor. `_util.mjs`'te yeni export pure
+  helper'lar: `branchOf`, `stripHeredocs`, `splitSegments`, `resolveTargetDir`,
+  `effectiveBranchForCommit`, `isGitCommit`. Parse/path belirsizliginde
+  fail-closed (base branch'i degerlendirir).
+
 ### Degisti — ic refactor (v1.35.0 hardening, PR-B)
 
 - **Semver helper'lari `lib/helpers.js`'te birlestirildi.** `parseVersion`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img src="https://img.shields.io/npm/dm/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm downloads per month" />
   <img src="https://img.shields.io/npm/dt/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm total downloads" />
   <img src="https://img.shields.io/npm/l/@fatihkan/badi?color=00d4ff&style=flat-square" alt="license" />
-  <img src="https://img.shields.io/badge/tests-1293%20passing-00d4ff?style=flat-square" alt="tests" />
+  <img src="https://img.shields.io/badge/tests-1312%20passing-00d4ff?style=flat-square" alt="tests" />
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
@@ -87,7 +87,7 @@ Claude is the canonical source. Cursor/Gemini/Windsurf/AGENTS.md adapters compil
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+, expanded v1.30+)** | Claude Code, Cursor, Gemini CLI, Windsurf, AGENTS.md — same `.claude/` source, 5 targets |
 | **Observability (v1.29+) + self-telemetry (v1.30+)** | Read Claude Code transcripts (`badi stats --session/--models/--cost`, `badi search`, `badi session`) + emit own command events (`badi events list/stats`, BADI_TELEMETRY=off to disable) |
-| **1293 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, design, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter, vault frontmatter, hook-path anchoring, scoop manifest sync, settings-derived doctor hooks, consolidated semver |
+| **1312 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, design, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter, vault frontmatter, hook-path anchoring, scoop manifest sync, settings-derived doctor hooks, consolidated semver, branch-guard cwd-awareness |
 | **Content engine (English)** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
 | **Modular architecture** | 36 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
@@ -655,7 +655,7 @@ No telemetry, no analytics. See `lib/update-check.js` and `lib/commands/*` for t
 
 ```bash
 npm install
-npm test           # 1293 tests across 226 suites
+npm test           # 1312 tests across 232 suites
 npm run lint       # Biome code-quality checks
 npm run format     # Biome formatting
 ```

--- a/tests/branch-guard-helpers.test.js
+++ b/tests/branch-guard-helpers.test.js
@@ -1,0 +1,134 @@
+// Pure unit tests for the branch-guard cwd/cd-awareness helpers (v1.35.0 PR-C).
+// These live in .claude/hooks/_util.mjs (no top-level execution, safe to import).
+// End-to-end hook behavior is covered in cli.hooks-node.test.js.
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import {
+	effectiveBranchForCommit,
+	isGitCommit,
+	resolveTargetDir,
+	splitSegments,
+	stripHeredocs,
+} from "../.claude/hooks/_util.mjs";
+
+describe("branch-guard: isGitCommit", () => {
+	it("matches git commit incl. global options before the subcommand", () => {
+		assert.equal(isGitCommit("git commit -m x"), true);
+		assert.equal(isGitCommit("git -C /repo commit -m x"), true);
+		assert.equal(isGitCommit("git -c user.name=x commit"), true);
+		assert.equal(isGitCommit("git --no-pager commit"), true);
+	});
+
+	it("does not match non-commit git commands", () => {
+		assert.equal(isGitCommit("git push"), false);
+		assert.equal(isGitCommit("git merge main"), false);
+		assert.equal(isGitCommit("ls -la"), false);
+	});
+});
+
+describe("branch-guard: stripHeredocs", () => {
+	it("drops the heredoc body and terminator, keeps text before <<", () => {
+		const cmd = "git commit -F - <<'EOF'\ngit switch -c sneaky\nbody\nEOF\nls";
+		const out = stripHeredocs(cmd);
+		assert.match(out, /git commit -F -/);
+		assert.doesNotMatch(out, /switch -c sneaky/);
+		assert.doesNotMatch(out, /\bbody\b/);
+		assert.match(out, /\bls\b/);
+	});
+
+	it("is a no-op without a heredoc", () => {
+		assert.equal(stripHeredocs("git commit -m x"), "git commit -m x");
+	});
+});
+
+describe("branch-guard: splitSegments", () => {
+	it("splits on && || ; | and newlines, || before |", () => {
+		assert.deepEqual(splitSegments("a && b || c ; d | e\nf"), [
+			"a",
+			"b",
+			"c",
+			"d",
+			"e",
+			"f",
+		]);
+	});
+});
+
+describe("branch-guard: effectiveBranchForCommit", () => {
+	it("plain commit stays on the base branch", () => {
+		assert.equal(effectiveBranchForCommit("git commit -m x", "main"), "main");
+	});
+
+	it("a `git switch -c` before the commit takes effect (the false-positive bug)", () => {
+		assert.equal(
+			effectiveBranchForCommit("git switch -c feature/x && git commit -m x", "main"),
+			"feature/x",
+		);
+		assert.equal(
+			effectiveBranchForCommit("git checkout -b feat 2>&1 | tail\ngit commit", "main"),
+			"feat",
+		);
+	});
+
+	it("a plain switch to an existing branch also takes effect", () => {
+		assert.equal(
+			effectiveBranchForCommit("git switch feature/y; git commit", "main"),
+			"feature/y",
+		);
+	});
+
+	it("a switch AFTER the commit does NOT count (commit still on base)", () => {
+		assert.equal(
+			effectiveBranchForCommit("git commit && git switch -c x", "main"),
+			"main",
+		);
+	});
+
+	it("a switch buried in a heredoc body is ignored", () => {
+		assert.equal(
+			effectiveBranchForCommit(
+				"git commit -F - <<'EOF'\ngit switch -c sneaky\nEOF",
+				"main",
+			),
+			"main",
+		);
+	});
+});
+
+describe("branch-guard: resolveTargetDir", () => {
+	it("returns baseDir when no cd / git -C is present", () => {
+		assert.equal(resolveTargetDir("git commit -m x", "/base"), "/base");
+	});
+
+	it("falls back to baseDir when the cd target does not exist (fail-closed)", () => {
+		assert.equal(
+			resolveTargetDir("cd /nope-xyz-123 && git commit", "/base"),
+			"/base",
+		);
+	});
+
+	it("resolves an existing cd target", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-bg-"));
+		try {
+			assert.equal(resolveTargetDir(`cd ${tmp} && git commit`, tmpdir()), tmp);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves an existing `git -C <path>` target", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "badi-bg-c-"));
+		try {
+			assert.equal(
+				resolveTargetDir(`git -C ${tmp} commit -m x`, tmpdir()),
+				tmp,
+			);
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/cli.hooks-node.test.js
+++ b/tests/cli.hooks-node.test.js
@@ -153,6 +153,83 @@ describe("hooks-node: branch-guard", () => {
 	});
 });
 
+describe("hooks-node: branch-guard (cwd/cd awareness, PR-C)", () => {
+	const dirs = [];
+	// A sandbox repo forced onto a known branch (no commit needed:
+	// `git branch --show-current` reports the unborn branch).
+	function mkRepo(branch) {
+		mkdirSync(SANDBOX_BASE, { recursive: true });
+		const d = mkdtempSync(join(SANDBOX_BASE, "badi-bg-"));
+		spawnSync("git", ["init", "-q", "-b", branch], { cwd: d });
+		dirs.push(d);
+		return d;
+	}
+	afterEach(() => {
+		while (dirs.length) rmSync(dirs.pop(), { recursive: true, force: true });
+	});
+
+	it("BLOCKS a plain commit on a protected branch (main)", () => {
+		const d = mkRepo("main");
+		const r = runHook(
+			"branch-guard",
+			{ tool_input: { command: "git commit -m x" } },
+			{ cwd: d },
+		);
+		assert.equal(r.status, 0);
+		assert.equal(JSON.parse(r.stdout.trim()).decision, "block");
+	});
+
+	it("PASSES when a `git switch -c` precedes the commit (the false-positive bug)", () => {
+		const d = mkRepo("main");
+		const r = runHook(
+			"branch-guard",
+			{ tool_input: { command: "git switch -c feature/x && git commit -m x" } },
+			{ cwd: d },
+		);
+		assert.equal(r.status, 0);
+		assert.equal(r.stdout.trim(), "", "switch precedes commit -> must not block");
+	});
+
+	it("ignores a `git commit` mention inside a heredoc body", () => {
+		const d = mkRepo("main");
+		const r = runHook(
+			"branch-guard",
+			{
+				tool_input: {
+					command: "cat <<'EOF' > note.txt\ngit commit -m junk\nEOF",
+				},
+			},
+			{ cwd: d },
+		);
+		assert.equal(r.status, 0);
+		assert.equal(r.stdout.trim(), "", "heredoc body is not a real commit");
+	});
+
+	it("BLOCKS a commit targeting another repo on main via `cd`", () => {
+		const feature = mkRepo("feature/here");
+		const mainRepo = mkRepo("main");
+		const r = runHook(
+			"branch-guard",
+			{ tool_input: { command: `cd ${mainRepo} && git commit -m x` } },
+			{ cwd: feature },
+		);
+		assert.equal(r.status, 0);
+		assert.equal(JSON.parse(r.stdout.trim()).decision, "block");
+	});
+
+	it("BLOCKS a commit targeting another repo on main via `git -C`", () => {
+		const feature = mkRepo("feature/here");
+		const mainRepo = mkRepo("main");
+		const r = runHook(
+			"branch-guard",
+			{ tool_input: { command: `git -C ${mainRepo} commit -m x` } },
+			{ cwd: feature },
+		);
+		assert.equal(r.status, 0);
+		assert.equal(JSON.parse(r.stdout.trim()).decision, "block");
+	});
+});
+
 describe("hooks-node: guard-bash", () => {
 	it("rm -rf / is blocked (HARD_BLOCK)", () => {
 		const r = runHook("guard-bash", {


### PR DESCRIPTION
**v1.35.0 hardening, PR-C.** Fixes three branch-guard misbehaviors — two false-positives that bit this project repeatedly, plus a wrong-repo check.

## The bugs
- **(a) Pre-switch false-positive** — it flat-regexed the raw command against the process branch evaluated *once*, so `git switch -c feature/x && git commit` was blocked because the branch was still `main` at eval time. (Hit twice this week, incl. the wrap-up commit.)
- **(b) Heredoc false-positive** — a `git commit` string inside a heredoc *body* was treated as a real commit.
- **(c) Wrong repo** — it checked the hook's own repo even when the command targeted another via `cd`/`git -C` (the original /tmp-clone report).

## The fix
- `resolveTargetDir(command, baseDir)` — finds the repo the commit targets (`git -C` / leading `cd`, else `input.cwd || cwd`).
- `branchOf(dir)` — reads **that** repo's branch (the old `currentBranch()` ran git with no cwd; kept, delegating).
- `stripHeredocs()` — drops heredoc bodies before scanning.
- `effectiveBranchForCommit()` — walks command segments so a `switch`/`checkout -b` before the commit takes effect.
- `isGitCommit()` — tolerates git global options (`-C <path>`, `-c k=v`, `--opt`) before `commit`.
- **Fail-closed** on parse/path ambiguity (evaluates the base branch). Behavior unchanged when no `cd`/`-C`/`switch` is present.

All helpers are exported pure functions in `_util.mjs` (unit-tested) on top of the e2e hook tests.

## Verification
- `npx biome check` clean · branch-guard unit + 5 new e2e cases (block-on-main, post-switch pass, heredoc ignore, cd-target block, `git -C`-target block) + isolation/failsafe green
- Tests **1293 → 1312**. This very PR's commit passed through the new hook on a feature branch.

Part of v1.35.0: A ✓ · B ✓ · **C (this)** → D stats-flake → E/F splits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)