### PR TITLE
fix(test): v1.35.0 PR-D — deterministic stats tests (kill the load flake)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Fixed — deterministic stats tests (v1.35.0 hardening, PR-D)
+
+- **The `stats v1.29+` tests no longer flake (timeout) under load.** They ran the
+  real CLI against the machine's actual `~/.claude/projects`, which on a dev box
+  is large enough to exceed the 15s timeout when the box is busy. `transcriptsRoot`
+  gained a `BADI_TRANSCRIPTS_ROOT` env seam (precedence: override arg > env >
+  default); the test now points it at an empty fixture dir, so the scan is instant
+  and deterministic regardless of load. Run time dropped from ~15-30s to <0.5s.
+
 ### Fixed — branch-guard cwd/cd awareness (v1.35.0 hardening, PR-C)
 
 - **The `branch-guard` hook no longer false-positives on legitimate commits and

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,16 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+### Duzeltildi — deterministik stats testleri (v1.35.0 hardening, PR-D)
+
+- **`stats v1.29+` testleri artik yuk altinda flake (timeout) vermiyor.** Gercek
+  CLI'i makinenin gercek `~/.claude/projects`'ine karsi calistiriyorlardi; dev
+  makinesinde bu dizin, makine mesgulken 15s timeout'u asacak kadar buyuk.
+  `transcriptsRoot` bir `BADI_TRANSCRIPTS_ROOT` env seam'i kazandi (oncelik:
+  override arg > env > default); test artik onu bos bir fixture dizine
+  yonlendiriyor, boylece tarama yuk ne olursa olsun aninda ve deterministik.
+  Sure ~15-30s'den <0.5s'ye dustu.
+
 ### Duzeltildi — branch-guard cwd/cd farkindaligi (v1.35.0 hardening, PR-C)
 
 - **`branch-guard` hook'u artik mesru commit'lerde yanlis-pozitif vermiyor ve

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img src="https://img.shields.io/npm/dm/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm downloads per month" />
   <img src="https://img.shields.io/npm/dt/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm total downloads" />
   <img src="https://img.shields.io/npm/l/@fatihkan/badi?color=00d4ff&style=flat-square" alt="license" />
-  <img src="https://img.shields.io/badge/tests-1312%20passing-00d4ff?style=flat-square" alt="tests" />
+  <img src="https://img.shields.io/badge/tests-1315%20passing-00d4ff?style=flat-square" alt="tests" />
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
@@ -87,7 +87,7 @@ Claude is the canonical source. Cursor/Gemini/Windsurf/AGENTS.md adapters compil
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+, expanded v1.30+)** | Claude Code, Cursor, Gemini CLI, Windsurf, AGENTS.md — same `.claude/` source, 5 targets |
 | **Observability (v1.29+) + self-telemetry (v1.30+)** | Read Claude Code transcripts (`badi stats --session/--models/--cost`, `badi search`, `badi session`) + emit own command events (`badi events list/stats`, BADI_TELEMETRY=off to disable) |
-| **1312 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, design, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter, vault frontmatter, hook-path anchoring, scoop manifest sync, settings-derived doctor hooks, consolidated semver, branch-guard cwd-awareness |
+| **1315 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, design, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter, vault frontmatter, hook-path anchoring, scoop manifest sync, settings-derived doctor hooks, consolidated semver, branch-guard cwd-awareness, deterministic stats fixtures |
 | **Content engine (English)** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
 | **Modular architecture** | 36 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
@@ -655,7 +655,7 @@ No telemetry, no analytics. See `lib/update-check.js` and `lib/commands/*` for t
 
 ```bash
 npm install
-npm test           # 1312 tests across 232 suites
+npm test           # 1315 tests across 233 suites
 npm run lint       # Biome code-quality checks
 npm run format     # Biome formatting
 ```

--- a/lib/data/transcript-reader.js
+++ b/lib/data/transcript-reader.js
@@ -3,9 +3,16 @@ import { homedir } from "node:os";
 import { basename, join } from "node:path";
 
 // Canonical location of Claude Code transcript JSONLs.
-// can be overridden (for tests).
+// Precedence: explicit override arg > BADI_TRANSCRIPTS_ROOT env > default.
+// The env seam lets tests point the scanner at an empty/fixture dir so they
+// don't walk the machine's real (potentially huge) ~/.claude/projects — the
+// source of the flaky 15-30s stats-test timeouts under load.
 export function transcriptsRoot(override) {
-	return override || join(homedir(), ".claude", "projects");
+	return (
+		override ||
+		process.env.BADI_TRANSCRIPTS_ROOT ||
+		join(homedir(), ".claude", "projects")
+	);
 }
 
 // Per-1M-token approximate pricing (USD). Public Anthropic list.

--- a/tests/cli.observability.test.js
+++ b/tests/cli.observability.test.js
@@ -1,11 +1,25 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
-import { describe, it } from "node:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { after, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 const CLI = resolve(__dirname, "..", "bin", "badi.js");
+
+// Point the transcript scanner at an EMPTY fixture dir via the BADI_TRANSCRIPTS_ROOT
+// seam — otherwise `stats --session/--models/--cost` walk the machine's real
+// ~/.claude/projects, which on a dev box is huge and times out under load (the
+// long-standing flaky 15-30s stats-test failures). These tests assert
+// banners/titles/empty-state invariants, so empty data is the correct fixture.
+const EMPTY_TRANSCRIPTS = mkdtempSync(join(tmpdir(), "badi-no-transcripts-"));
+after(() => {
+	try {
+		rmSync(EMPTY_TRANSCRIPTS, { recursive: true, force: true });
+	} catch {}
+});
 
 function run(args = []) {
 	try {
@@ -13,6 +27,7 @@ function run(args = []) {
 			stdout: execFileSync("node", [CLI, ...args], {
 				encoding: "utf-8",
 				timeout: 15000,
+				env: { ...process.env, BADI_TRANSCRIPTS_ROOT: EMPTY_TRANSCRIPTS },
 			}),
 			code: 0,
 		};

--- a/tests/transcript-reader.test.js
+++ b/tests/transcript-reader.test.js
@@ -13,7 +13,42 @@ import {
 	parseSession,
 	parseSessionWithEvents,
 	shortSessionId,
+	transcriptsRoot,
 } from "../lib/data/transcript-reader.js";
+
+describe("transcriptsRoot precedence (override > env > default)", () => {
+	it("explicit override wins over env and default", () => {
+		const prev = process.env.BADI_TRANSCRIPTS_ROOT;
+		process.env.BADI_TRANSCRIPTS_ROOT = "/env/path";
+		try {
+			assert.equal(transcriptsRoot("/explicit"), "/explicit");
+		} finally {
+			if (prev === undefined) delete process.env.BADI_TRANSCRIPTS_ROOT;
+			else process.env.BADI_TRANSCRIPTS_ROOT = prev;
+		}
+	});
+
+	it("BADI_TRANSCRIPTS_ROOT env is used when no override is given", () => {
+		const prev = process.env.BADI_TRANSCRIPTS_ROOT;
+		process.env.BADI_TRANSCRIPTS_ROOT = "/env/path";
+		try {
+			assert.equal(transcriptsRoot(), "/env/path");
+		} finally {
+			if (prev === undefined) delete process.env.BADI_TRANSCRIPTS_ROOT;
+			else process.env.BADI_TRANSCRIPTS_ROOT = prev;
+		}
+	});
+
+	it("falls back to ~/.claude/projects when neither is set", () => {
+		const prev = process.env.BADI_TRANSCRIPTS_ROOT;
+		delete process.env.BADI_TRANSCRIPTS_ROOT;
+		try {
+			assert.match(transcriptsRoot(), /[/\\]\.claude[/\\]projects$/);
+		} finally {
+			if (prev !== undefined) process.env.BADI_TRANSCRIPTS_ROOT = prev;
+		}
+	});
+});
 
 function jsonl(arr) {
 	return arr.map((o) => JSON.stringify(o)).join("\n");


### PR DESCRIPTION
**v1.35.0 hardening, PR-D.** Kills the long-standing flaky `stats` test timeouts that intermittently reddened the release gate.

## Root cause
The `stats v1.29+` tests ran the real CLI against the machine's actual `~/.claude/projects`. On a dev box that directory is large enough that `stats --session/--models/--cost` exceeds the 15s timeout when the box is under load (concurrent agents) — clean in isolation, red under load.

## Fix
- `transcriptsRoot` gained a **`BADI_TRANSCRIPTS_ROOT` env seam** (precedence: explicit override arg > env > default — additive, override still wins).
- The observability test points it at an **empty fixture dir**, so the scan is instant and deterministic regardless of load. Run time **~15-30s → <0.5s**.
- The tests assert banner/title/empty-state invariants, so empty data is the correct fixture.

## Verification
- `npx biome check` clean · observability suite 11/11 in 0.49s · transcriptsRoot precedence unit tests
- Tests **1312 → 1315**; **two consecutive full runs green** (the flake is structurally gone).

Part of v1.35.0: A ✓ · B ✓ · C ✓ · **D (this)** → E mobile-split · F seo-split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)