### PR TITLE
feat(market): /market command + market-research skill (CEO-approved wiring exception)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
 		{
 			"name": "badi",
 			"source": "./",
-			"description": "Workflow management for Claude Code — 30 AI agents, 84 commands, 62 skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
+			"description": "Workflow management for Claude Code — 30 AI agents, 85 commands, 63 skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
 			"author": {
 				"name": "Fatih Kan",
 				"url": "https://github.com/fatihkan"
@@ -35,7 +35,7 @@
 			],
 			"category": "productivity",
 			"strict": true,
-			"lastUpdated": "2026-06-14T14:20:18+03:00"
+			"lastUpdated": "2026-06-20T08:24:28+03:00"
 		}
 	]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
 	"name": "badi",
 	"version": "1.34.2",
-	"description": "Workflow management for Claude Code, Cursor, Gemini, Windsurf, AGENTS.md — 30 AI agents, 84 commands, 14 hooks, 62 opt-in skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
+	"description": "Workflow management for Claude Code, Cursor, Gemini, Windsurf, AGENTS.md — 30 AI agents, 85 commands, 14 hooks, 63 opt-in skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
 	"author": {
 		"name": "Fatih Kan",
 		"url": "https://github.com/fatihkan"
@@ -93,5 +93,5 @@
 			}
 		]
 	},
-	"lastUpdated": "2026-06-14T14:20:18+03:00"
+	"lastUpdated": "2026-06-20T08:24:28+03:00"
 }

--- a/.claude/command-index.md
+++ b/.claude/command-index.md
@@ -1,6 +1,6 @@
 # Badi Command Index
 
-> 84 commands | 4 profiles (core / dev / content / pentest) — filter with `badi commands profile <name>`. The pentest profile is reserved (0 commands today); pentest capabilities ship as opt-in skills (`badi skills`).
+> 85 commands | 4 profiles (core / dev / content / pentest) — filter with `badi commands profile <name>`. The pentest profile is reserved (0 commands today); pentest capabilities ship as opt-in skills (`badi skills`).
 
 ## Core — always active (session, audit, measurement) (21)
 
@@ -28,7 +28,7 @@
 | `/unstick` | Unblocking command. Finds a fast solution with a structured approach when you're stuck. |
 | `/wrap-up` | End-of-day ritual command. Prepares the day for closure and sets the stage for tomorrow. |
 
-## Dev — code / infra / devops (44)
+## Dev — code / infra / devops (45)
 
 | Command | Description |
 |---------|-------------|
@@ -56,6 +56,7 @@
 | `/env-check` | .env file validation. Detects missing, extra, empty, and placeholder values + .gitignore check. |
 | `/hotfix` | Emergency fix workflow. Manages a fast, safe patching process for production errors. |
 | `/lighthouse` | Lighthouse audit command. Performance, Accessibility, Best Practices, SEO scores and Core Web Vitals via the Google PageSpeed Insights API. |
+| `/market` | Market & demand research command. Niche discovery, opportunity sizing, competitor/gap analysis via the market-researcher agent (+ `badi market` for App Store data). |
 | `/mobile` | Mobile project management command. React Native/Flutter/Expo/Swift/Kotlin scaffolding, version sync, build and release guides. |
 | `/perf-check` | Performance profiling. Detects hot paths, bottlenecks, and optimization opportunities. |
 | `/playbook` | Workflow-to-command command. Converts repetitive manual workflows into reusable Badi commands. |

--- a/.claude/commands-vault/market.md
+++ b/.claude/commands-vault/market.md
@@ -1,0 +1,44 @@
+Market & demand research command. Discovers niches, sizes opportunity, and reads competitor/demand signals BEFORE you build — via the market-researcher agent, with the `badi market` CLI for App Store data.
+
+# Required Tools
+- Read (context, memory, prior research)
+- Grep / Glob (find related notes and prior decisions)
+- Bash (`badi market` for App Store discover/reviews/difficulty)
+- Agent (delegate to market-researcher)
+
+# When to Use
+Before committing to a product, feature, or niche — when the question is "is there demand, who is it for, and is the space winnable?". Pairs with `/ceo-review` (should we build it) and `/aso` + `/seo` (once you're in-market). For pure App Store metrics, `badi market` alone is enough; use `/market` when you want a synthesized opportunity read.
+
+# Procedure
+
+### Step 1: Frame the Question
+- State the niche/keyword/category and the decision it informs in one sentence.
+- Read `memory.md` / prior research notes for what's already known.
+
+### Step 2: Pull Hard Data (optional, App Store)
+- Run `badi market discover <keyword>`, `badi market reviews <appId>`, and/or `badi market difficulty <keyword>` for concrete App Store signals (ratings, review themes, ranking difficulty, wishlist/gaps).
+- Capture the raw numbers so the agent reasons from data, not vibes.
+
+### Step 3: Delegate to Market Researcher
+Launch the **market-researcher** agent (read-only; WebSearch/WebFetch + the data from Step 2). Ask it to:
+- Size the opportunity (demand signals, search/category volume, trend direction).
+- Identify the target user and the job-to-be-done.
+- Map competitors and find the gap (under-served segment, weak incumbents, unmet need).
+- Surface the risks and what would tell us to walk away.
+
+### Step 4: Synthesize the Read
+Produce a decision-grade brief:
+- **Opportunity** — demand + size + trend.
+- **Who** — target user and their job.
+- **Gap** — the under-served angle to win on.
+- **Verdict** — pursue / shrink / pass, with the signal that would change it.
+
+### Step 5: Record
+- Add the read + verdict to the daily note / `memory.md` so it informs `/ceo-review`.
+
+# Output Format
+- **Opportunity** (demand, size, trend)
+- **Target user + job-to-be-done**
+- **Competitive gap**
+- **Verdict** + the kill/go signal
+- (If App Store) the `badi market` data the read is grounded in

--- a/.claude/commands/market.md
+++ b/.claude/commands/market.md
@@ -1,0 +1,44 @@
+Market & demand research command. Discovers niches, sizes opportunity, and reads competitor/demand signals BEFORE you build — via the market-researcher agent, with the `badi market` CLI for App Store data.
+
+# Required Tools
+- Read (context, memory, prior research)
+- Grep / Glob (find related notes and prior decisions)
+- Bash (`badi market` for App Store discover/reviews/difficulty)
+- Agent (delegate to market-researcher)
+
+# When to Use
+Before committing to a product, feature, or niche — when the question is "is there demand, who is it for, and is the space winnable?". Pairs with `/ceo-review` (should we build it) and `/aso` + `/seo` (once you're in-market). For pure App Store metrics, `badi market` alone is enough; use `/market` when you want a synthesized opportunity read.
+
+# Procedure
+
+### Step 1: Frame the Question
+- State the niche/keyword/category and the decision it informs in one sentence.
+- Read `memory.md` / prior research notes for what's already known.
+
+### Step 2: Pull Hard Data (optional, App Store)
+- Run `badi market discover <keyword>`, `badi market reviews <appId>`, and/or `badi market difficulty <keyword>` for concrete App Store signals (ratings, review themes, ranking difficulty, wishlist/gaps).
+- Capture the raw numbers so the agent reasons from data, not vibes.
+
+### Step 3: Delegate to Market Researcher
+Launch the **market-researcher** agent (read-only; WebSearch/WebFetch + the data from Step 2). Ask it to:
+- Size the opportunity (demand signals, search/category volume, trend direction).
+- Identify the target user and the job-to-be-done.
+- Map competitors and find the gap (under-served segment, weak incumbents, unmet need).
+- Surface the risks and what would tell us to walk away.
+
+### Step 4: Synthesize the Read
+Produce a decision-grade brief:
+- **Opportunity** — demand + size + trend.
+- **Who** — target user and their job.
+- **Gap** — the under-served angle to win on.
+- **Verdict** — pursue / shrink / pass, with the signal that would change it.
+
+### Step 5: Record
+- Add the read + verdict to the daily note / `memory.md` so it informs `/ceo-review`.
+
+# Output Format
+- **Opportunity** (demand, size, trend)
+- **Target user + job-to-be-done**
+- **Competitive gap**
+- **Verdict** + the kill/go signal
+- (If App Store) the `badi market` data the read is grounded in

--- a/.claude/skills-vault/INDEX.md
+++ b/.claude/skills-vault/INDEX.md
@@ -1,10 +1,10 @@
 # Badi Skill Library
 
-> 62 opt-in categories — 25 general + 25 pentest-* (advisory/defensive, v1.25+) + 12 expo-* (mobile dev lifecycle, v1.27+)
+> 63 opt-in categories — 26 general + 25 pentest-* (advisory/defensive, v1.25+) + 12 expo-* (mobile dev lifecycle, v1.27+)
 
 Skills are not prompt templates but structured operating procedures. Claude activates them automatically when it detects a relevant task. Activate categories with: badi skills add <name>
 
-## General (25)
+## General (26)
 
 | # | Category | Description |
 |---|----------|-------------|
@@ -21,18 +21,19 @@ Skills are not prompt templates but structured operating procedures. Claude acti
 | 11 | [email](email/) | Email marketing and automation skills |
 | 12 | [finance](finance/) | Budget planning, cash flow management, financial modeling, reporting, tax strategy, investment analysis,… |
 | 13 | [frontend-taste](frontend-taste/) | Premium frontend design skills that override LLM defaults |
-| 14 | [marketing](marketing/) | Digital marketing, brand strategy, ad management, content marketing, conversion optimization, and… |
-| 15 | [mobile](mobile/) | Mobile app design, development, testing, deployment, and optimization |
-| 16 | [product](product/) | Product management, strategy, user experience, development planning, and product analytics skills |
-| 17 | [productivity](productivity/) | Personal productivity, time management, project management, team productivity, automation, and process… |
-| 18 | [sales](sales/) | Sales strategy, customer relationships, pipeline management, sales techniques, CRM, and sales analytics |
-| 19 | [security](security/) | Cybersecurity, compliance, access control, application security, and threat management skills |
-| 20 | [security-check](security-check/) | Comprehensive AI-powered security scanning suite with 48 skills covering OWASP Top 10, 7 language-specific… |
-| 21 | [seo](seo/) | Technical SEO, content SEO, link building, local SEO, e-commerce SEO, analytics, and AI SEO/AEO skills |
-| 22 | [seo-crawl-budget](seo-crawl-budget/) | A 6-24 hour indexing methodology for low-competition long-tail keywords |
-| 23 | [social-media](social-media/) | Platform strategy, content production, community management, ads, and social analytics |
-| 24 | [startup](startup/) | Idea validation, MVP development, team building, fundraising preparation, and growth strategy skills for… |
-| 25 | [testing](testing/) | Software test strategy, test automation, performance testing, security testing, and quality assurance skills |
+| 14 | [market-research](market-research/) | Market and demand research — niche discovery, demand sizing, competitor/gap analysis, positioning/pricing signals before you build |
+| 15 | [marketing](marketing/) | Digital marketing, brand strategy, ad management, content marketing, conversion optimization, and… |
+| 16 | [mobile](mobile/) | Mobile app design, development, testing, deployment, and optimization |
+| 17 | [product](product/) | Product management, strategy, user experience, development planning, and product analytics skills |
+| 18 | [productivity](productivity/) | Personal productivity, time management, project management, team productivity, automation, and process… |
+| 19 | [sales](sales/) | Sales strategy, customer relationships, pipeline management, sales techniques, CRM, and sales analytics |
+| 20 | [security](security/) | Cybersecurity, compliance, access control, application security, and threat management skills |
+| 21 | [security-check](security-check/) | Comprehensive AI-powered security scanning suite with 48 skills covering OWASP Top 10, 7 language-specific… |
+| 22 | [seo](seo/) | Technical SEO, content SEO, link building, local SEO, e-commerce SEO, analytics, and AI SEO/AEO skills |
+| 23 | [seo-crawl-budget](seo-crawl-budget/) | A 6-24 hour indexing methodology for low-competition long-tail keywords |
+| 24 | [social-media](social-media/) | Platform strategy, content production, community management, ads, and social analytics |
+| 25 | [startup](startup/) | Idea validation, MVP development, team building, fundraising preparation, and growth strategy skills for… |
+| 26 | [testing](testing/) | Software test strategy, test automation, performance testing, security testing, and quality assurance skills |
 
 ## Pentest Family (25, advisory-only)
 

--- a/.claude/skills-vault/market-research/SKILL.md
+++ b/.claude/skills-vault/market-research/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: market-research
+description: Market and demand research procedures. Niche discovery, demand sizing, competitor/gap analysis, opportunity scoring, and pricing/positioning signals BEFORE building. Triggers on: market research, demand, niche, opportunity sizing, competitor analysis, TAM, positioning, pricing, go-to-market, validate idea, is there demand.
+license: MIT
+compatibility: Works with Claude Code, Cursor, or any compatible AI coding agent.
+allowed-tools: Read Write Edit Bash Grep WebSearch WebFetch
+metadata:
+  author: fatihkan
+  homepage: https://github.com/fatihkan/badi-skills/tree/main/skills/market-research
+  badi-version: ">=1.35.0"
+  category: market-research
+---
+# Market Research Skills
+
+> Structured procedures for validating demand and sizing an opportunity before you build. Pairs with the `market-researcher` agent and the `/market` command; for App Store metrics use `badi market`.
+
+## Skill List
+
+### 1. Demand validation
+Confirm a real, expressed need exists before committing build time.
+- Search the language users actually use (forums, reviews, search suggest, social).
+- Distinguish vitamin (nice-to-have) from painkiller (urgent, paid-for) demand.
+- Look for existing spend: are people already paying for a worse alternative?
+- Output: a demand verdict (strong / weak / none) with the evidence quoted.
+
+### 2. Niche discovery
+Find an under-served, winnable segment instead of a crowded horizontal.
+- Decompose a broad market into segments by user, use-case, and platform.
+- Score each on demand × competition × your unfair advantage.
+- Prefer a narrow segment you can dominate over a wide one you can't.
+
+### 3. Opportunity sizing
+Put a credible number on the prize.
+- Top-down (category size × reachable share) sanity-checked bottom-up
+  (reachable users × conversion × price).
+- State assumptions explicitly; size a range, not a false-precise point.
+- Flag when the honest answer is "too small to matter".
+
+### 4. Competitor + gap analysis
+Map who's already here and where the opening is.
+- List incumbents; for each: positioning, pricing, strengths, weak reviews.
+- Mine 1-2★ reviews of incumbents for the unmet need to build around.
+- Name the specific gap (segment, feature, price point, channel) to win on.
+
+### 5. Positioning + pricing signal
+Decide how to enter, not just whether.
+- Anchor pricing to the value/alternative, not cost; find the willingness-to-pay band.
+- Draft a one-line positioning: for [who] who [need], [product] is [category] that [benefit].
+- Identify the wedge channel where the target user already congregates.
+
+### 6. Go / shrink / pass decision
+Convert research into a decision.
+- Synthesize demand + size + gap into a verdict with a confidence level.
+- Define the single kill-signal that would reverse a "go".
+- Record the read so `/ceo-review` can challenge it.
+
+## How to use
+Run `/market` for an agent-driven synthesis, or `badi market discover|reviews|difficulty` for App Store data. This skill provides the methodology the agent and command follow; activate it with `badi skills add market-research`.

--- a/.claude/workspace/freeze-exceptions.md
+++ b/.claude/workspace/freeze-exceptions.md
@@ -1,0 +1,18 @@
+# Feature-Freeze Exceptions Log
+
+> Freeze (CEO directive): no new features until the FIRST ORGANIC EXTERNAL SIGNAL
+> (star/fork/issue from outside). Current: 5 stars / 0 forks / 0 external issues —
+> signal NOT arrived. Owner-requested work during the freeze is logged here per the
+> product-strategist freeze-exception framework (classify: wiring | hardening |
+> feature; only wiring/hardening qualify). 3+ exceptions without the signal → prompt
+> the owner to lift/tighten the freeze or change the threshold.
+
+| # | Date | Item | Classification | Verdict | Rationale |
+|---|------|------|----------------|---------|-----------|
+| 1 | 2026-06-20 | `/market` slash command + market-research vault skill | **wiring** | SHRINK & BUILD | The capability already ships — `badi market` CLI (v1.15) + `market-researcher` agent (v1.34). Only the slash-command wrapper + vault-skill packaging are missing. Completing existing infra, no new logic. |
+| 2 | 2026-06-20 | "Fix PR #281" (biome 2.4.16→2.5.0) | n/a | KILL | Already resolved by #283 (merged today); #281 closed/superseded. Non-item. |
+| 3 | 2026-06-20 | spec-kit-derived dependency-aware task sequencing → Workflow | **hardening** (engine) | SHRINK & BUILD (engine only) | The one badi-native, non-overlapping idea from spec-kit: a dependency-aware tasks.md whose `[P]` markers feed badi's existing Workflow `parallel()`. The rest of spec-kit (constitution agent, /clarify, /specify, /plan) KILLED — heavy overlap with existing `/architect`, `/brief`, `/proposal`, `/spec-check`, `/team`, `/eng-review`. |
+
+## Count
+- Exceptions logged without organic signal: **2 build items** (#1 wiring, #3 engine). #2 is a non-item.
+- At 3+, prompt the owner to explicitly lift/tighten the freeze (per framework).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Added — `/market` command + `market-research` skill (freeze exception: wiring)
+
+- **New `/market` slash command** — niche discovery, opportunity sizing, and
+  competitor/gap analysis via the existing `market-researcher` agent, with
+  `badi market` for App Store data. Wraps capability that already shipped (the
+  agent v1.34, the CLI v1.15); commands 84 → 85.
+- **New `market-research` vault skill** (general family) — the methodology the
+  command/agent follow (demand validation, niche discovery, opportunity sizing,
+  competitor/gap, positioning/pricing, go/shrink/pass). Skill categories 62 → 63
+  (general 25 → 26).
+- Approved through `/ceo-review` as a **wiring exception** to the feature freeze
+  (completes existing market infra, no new capability); logged in
+  `.claude/workspace/freeze-exceptions.md`.
+
 ### Changed — seo command split (v1.35.0 hardening, PR-F)
 
 - **`lib/commands/seo.js` (1060 lines) split into a `seo/` directory-module** —

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,20 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+### Eklendi — `/market` komutu + `market-research` skill (freeze istisnasi: wiring)
+
+- **Yeni `/market` slash komutu** — nis kesfi, firsat boyutlama, rakip/bosluk
+  analizi; mevcut `market-researcher` ajani uzerinden, App Store verisi icin
+  `badi market`. Zaten var olan yetenegi sariyor (ajan v1.34, CLI v1.15);
+  komutlar 84 → 85.
+- **Yeni `market-research` vault skill** (general aile) — komut/ajanin izledigi
+  metodoloji (talep dogrulama, nis kesfi, firsat boyutlama, rakip/bosluk,
+  konumlandirma/fiyatlama, go/shrink/pass). Skill kategorileri 62 → 63
+  (general 25 → 26).
+- `/ceo-review` ile feature-freeze'e **wiring istisnasi** olarak onaylandi
+  (mevcut market altyapisini tamamlar, yeni yetenek degil);
+  `.claude/workspace/freeze-exceptions.md`'ye loglandi.
+
 ### Degisti — seo komut split (v1.35.0 hardening, PR-F)
 
 - **`lib/commands/seo.js` (1060 satir) `seo/` dizin-modulune bolundu** —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Badi - Workflow Management System
 
-> Structured operations management for Claude Code. 30 agents, 84 commands, 14 hooks, 62 opt-in skill categories. v1.20+ prompt-aware skill router; v1.25+ pentest-* family (25 categories, advisory/defensive); v1.26+ profile-based command management (core/dev/content/pentest) + command routing; v1.27+ expo-* family (12 categories, Expo + React Native mobile dev lifecycle); v1.32+ virtual eng team (product-strategist, engineering-manager, release-manager, qa-lead + /ceo-review, /eng-review, /qa, /ship) + the /team orchestrator; v1.33+ ads review (ads-strategist agent + /meta-review + /ads-review, advisory-only). v1.34+ research/SEO/data advisory agents (market-researcher, seo-strategist, data-analyst).
+> Structured operations management for Claude Code. 30 agents, 85 commands, 14 hooks, 63 opt-in skill categories. v1.20+ prompt-aware skill router; v1.25+ pentest-* family (25 categories, advisory/defensive); v1.26+ profile-based command management (core/dev/content/pentest) + command routing; v1.27+ expo-* family (12 categories, Expo + React Native mobile dev lifecycle); v1.32+ virtual eng team (product-strategist, engineering-manager, release-manager, qa-lead + /ceo-review, /eng-review, /qa, /ship) + the /team orchestrator; v1.33+ ads review (ads-strategist agent + /meta-review + /ads-review, advisory-only). v1.34+ research/SEO/data advisory agents (market-researcher, seo-strategist, data-analyst).
 
 ## Memory Rules
 
@@ -9,9 +9,9 @@
 | Session | `.claude/memory.md` | 100 lines; `/clear` when exceeded |
 | Knowledge Base | `.claude/knowledge-base.md` | 200 lines, with Auditor approval |
 | Task Board | `.claude/workspace/TaskBoard.md` | No limit |
-| Skills Vault | `.claude/skills-vault/` | 62 categories (25 general + 25 pentest-* + 12 expo-*), not loaded (opt-in) |
+| Skills Vault | `.claude/skills-vault/` | 63 categories (26 general + 25 pentest-* + 12 expo-*), not loaded (opt-in) |
 | Active Skills | `.claude/skills/` | User selection (`badi skills`) |
-| Commands Vault | `.claude/commands-vault/` | 84 commands canonical (v1.26+), not loaded |
+| Commands Vault | `.claude/commands-vault/` | 85 commands canonical (v1.26+), not loaded |
 | Active Commands | `.claude/commands/` | Filtered by profile (`badi commands profile`) |
 
 - TBD/TODO/FIXME are **FORBIDDEN** inside `knowledge-base.md`

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
   <img src="https://img.shields.io/npm/dm/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm downloads per month" />
   <img src="https://img.shields.io/npm/dt/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm total downloads" />
   <img src="https://img.shields.io/npm/l/@fatihkan/badi?color=00d4ff&style=flat-square" alt="license" />
-  <img src="https://img.shields.io/badge/tests-1317%20passing-00d4ff?style=flat-square" alt="tests" />
+  <img src="https://img.shields.io/badge/tests-1318%20passing-00d4ff?style=flat-square" alt="tests" />
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **30 AI subagents** (incl. a virtual eng team, ads strategist, and market/SEO/data analysts), **84 slash commands** (profile-based core/dev/content/pentest management since v1.26), **14 automation hooks**, and **62 opt-in skill categories** (25 general + 25 pentest-* advisory/defensive since v1.25 + 12 expo-* mobile dev lifecycle since v1.27) with **prompt-aware auto-routing** for both skills and commands (v1.20+ / v1.26+). OWASP Top 10 scans, code review, content production, mobile/web SEO, App Store market research with `wishlist` + `gaps` analysis. Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
+**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **30 AI subagents** (incl. a virtual eng team, ads strategist, and market/SEO/data analysts), **85 slash commands** (profile-based core/dev/content/pentest management since v1.26), **14 automation hooks**, and **63 opt-in skill categories** (26 general + 25 pentest-* advisory/defensive since v1.25 + 12 expo-* mobile dev lifecycle since v1.27) with **prompt-aware auto-routing** for both skills and commands (v1.20+ / v1.26+). OWASP Top 10 scans, code review, content production, mobile/web SEO, App Store market research with `wishlist` + `gaps` analysis. Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
 
 ## Demo
 
@@ -43,7 +43,7 @@ Source of truth: npm. Other channels mirror the same `@fatihkan/badi-<version>.t
 /plugin install badi@badi-marketplace
 ```
 
-**As an npm CLI (full feature set: 30 agents · 84 commands with profile management (v1.26+) · 14 hooks · 62 opt-in skill categories with auto-router)**:
+**As an npm CLI (full feature set: 30 agents · 85 commands with profile management (v1.26+) · 14 hooks · 63 opt-in skill categories with auto-router)**:
 
 ```bash
 npx @fatihkan/badi init                    # interactive harness picker
@@ -70,8 +70,8 @@ For Turkish/UTF-8 output in cmd, run `chcp 65001` once or use Windows Terminal /
 
 | Harness | Rules | Commands | MCP | Subagents | Hooks | Skills |
 |---------|:-----:|:--------:|:---:|:---------:|:-----:|:------:|
-| Claude Code | `CLAUDE.md` | 84 | `.mcp.json` | 30 | 14 | 62 |
-| Cursor | `.cursor/rules/badi-main.mdc` | 84 | `.cursor/mcp.json` | — | — | — |
+| Claude Code | `CLAUDE.md` | 85 | `.mcp.json` | 30 | 14 | 63 |
+| Cursor | `.cursor/rules/badi-main.mdc` | 85 | `.cursor/mcp.json` | — | — | — |
 | Gemini CLI | `GEMINI.md` (merged) | inline | `.gemini/settings.json` | — | — | — |
 | Windsurf (v1.30+) | `.windsurfrules` (merged) | inline | — | — | — | — |
 | AGENTS.md (v1.30+) | `AGENTS.md` (merged) | inline | — | — | — | — |
@@ -82,12 +82,12 @@ Claude is the canonical source. Cursor/Gemini/Windsurf/AGENTS.md adapters compil
 
 | Feature | Details |
 |---------|---------|
-| **30 expert agents + 84 commands** | Full toolkit from security scanner to performance profiler, plus a virtual eng team (CEO / eng manager / release manager / QA lead) wired together by `/team`, and an ads strategist (`/meta-review`, `/ads-review`) — profile-based filtering (core/dev/content/pentest) since v1.26 |
-| **14 automation hooks + 62 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants. Skills load zero tokens by default since v1.17; auto-router (v1.20+) injects matching skills per prompt; pentest-* family (v1.25+ advisory/defensive); expo-* family (v1.27+ mobile dev lifecycle); command routing (v1.26+); plan-injection hook (v1.30+) |
+| **30 expert agents + 85 commands** | Full toolkit from security scanner to performance profiler, plus a virtual eng team (CEO / eng manager / release manager / QA lead) wired together by `/team`, and an ads strategist (`/meta-review`, `/ads-review`) — profile-based filtering (core/dev/content/pentest) since v1.26 |
+| **14 automation hooks + 63 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants. Skills load zero tokens by default since v1.17; auto-router (v1.20+) injects matching skills per prompt; pentest-* family (v1.25+ advisory/defensive); expo-* family (v1.27+ mobile dev lifecycle); command routing (v1.26+); plan-injection hook (v1.30+) |
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+, expanded v1.30+)** | Claude Code, Cursor, Gemini CLI, Windsurf, AGENTS.md — same `.claude/` source, 5 targets |
 | **Observability (v1.29+) + self-telemetry (v1.30+)** | Read Claude Code transcripts (`badi stats --session/--models/--cost`, `badi search`, `badi session`) + emit own command events (`badi events list/stats`, BADI_TELEMETRY=off to disable) |
-| **1317 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, design, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter, vault frontmatter, hook-path anchoring, scoop manifest sync, settings-derived doctor hooks, consolidated semver, branch-guard cwd-awareness, deterministic stats fixtures, directory-module help-doctor |
+| **1318 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, design, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter, vault frontmatter, hook-path anchoring, scoop manifest sync, settings-derived doctor hooks, consolidated semver, branch-guard cwd-awareness, deterministic stats fixtures, directory-module help-doctor |
 | **Content engine (English)** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
 | **Modular architecture** | 36 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
@@ -171,7 +171,7 @@ When the skill is active, Claude Code loads the SKILL.md body on `/start` or in 
 
 ### Profile-Based Commands + Command Router (v1.26+)
 
-Same opt-in philosophy applied to the 84 slash commands. Pick a profile (`core`, `dev`, `content`, `pentest`, `all`) to physically filter `.claude/commands/`; the canonical store lives in `.claude/commands-vault/`. The router additionally scores prompts against command descriptions and surfaces top matches as a lightweight hint blob — your skills router hook calls both routers automatically.
+Same opt-in philosophy applied to the 85 slash commands. Pick a profile (`core`, `dev`, `content`, `pentest`, `all`) to physically filter `.claude/commands/`; the canonical store lives in `.claude/commands-vault/`. The router additionally scores prompts against command descriptions and surfaces top matches as a lightweight hint blob — your skills router hook calls both routers automatically.
 
 ```bash
 # Profile management
@@ -552,9 +552,9 @@ lib/                   13 top-level ESM modules
 .claude/
   agents/              30 expert agents
   commands/            84 workflow commands (profile-filtered active set)
-  commands-vault/      84 commands canonical store
+  commands-vault/      85 commands canonical store
   hooks/               14 automation hooks
-  skills-vault/        62 skill categories (25 general + 25 pentest + 12 expo)
+  skills-vault/        63 skill categories (26 general + 25 pentest + 12 expo)
                        (incl. mobile/app-store-screenshots)
   references/          8 project guides
   workspace/           Content files, task board
@@ -655,7 +655,7 @@ No telemetry, no analytics. See `lib/update-check.js` and `lib/commands/*` for t
 
 ```bash
 npm install
-npm test           # 1317 tests across 234 suites
+npm test           # 1318 tests across 234 suites
 npm run lint       # Biome code-quality checks
 npm run format     # Biome formatting
 ```

--- a/lib/command-profiles.js
+++ b/lib/command-profiles.js
@@ -1,6 +1,6 @@
 // Command profile definitions.
 //
-// The 84 .claude/commands/ files split into 4 profiles:
+// The 85 .claude/commands/ files split into 4 profiles:
 //   core    — always active (session management, measurement)
 //   dev     — code/infrastructure/devops focused
 //   content — social media/marketing focused
@@ -86,6 +86,7 @@ export const COMMAND_PROFILES = {
 	aso: "dev",
 	wp: "dev",
 	mobile: "dev",
+	market: "dev",
 
 	// content (19) — content production/marketing + ads review
 	"meta-review": "content",

--- a/tests/command-profiles.test.js
+++ b/tests/command-profiles.test.js
@@ -122,7 +122,7 @@ describe("command-profiles: isInProfile", () => {
 });
 
 describe("command-profiles: profileCounts", () => {
-	it("total defined command count should be 84", () => {
+	it("total defined command count should be 85", () => {
 		const counts = profileCounts();
 		const total = counts.core + counts.dev + counts.content + counts.pentest;
 		assert.equal(total, Object.keys(COMMAND_PROFILES).length);


### PR DESCRIPTION
Approved via `/ceo-review` as a **wiring exception** to the feature freeze — completes existing market infra (no new capability), logged in `.claude/workspace/freeze-exceptions.md`.

## What
- **`/market` slash command** — niche discovery, opportunity sizing, competitor/gap analysis via the *existing* `market-researcher` agent (v1.34) + `badi market` CLI (v1.15) for App Store data. The capability already shipped; this is the slash wrapper that was missing.
- **`market-research` vault skill** (general family) — the methodology the command/agent follow (demand validation → niche → sizing → gap → positioning → go/shrink/pass).

## Counts synced (84→85 commands, 62→63 skills, general 25→26)
`command-profiles.js`, `command-index.md`, `INDEX.md` (guard-enforced), `CLAUDE.md`, `README` (incl. harness table), plugin/marketplace manifest (sync-manifest). Corrected a stale `dev (45)` comment (was off-by-one; real count 45 after market).

## Verification
- `npx biome check` clean · `doctor` 53/0/0 · `release check`: docs in sync (1318), plugin.json up to date
- Tests **1317 → 1318** (+1 per-category vault validation for the new skill)

Part of the CEO-review bundle: **#1 (this)** · #2 was already done (#283) · #3 `/tasks` spec-kit engine next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)