### PR TITLE
feat(tasks): /tasks dependency-aware sequencing command (spec-kit distillate, CEO-approved)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
 		{
 			"name": "badi",
 			"source": "./",
-			"description": "Workflow management for Claude Code — 30 AI agents, 85 commands, 63 skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
+			"description": "Workflow management for Claude Code — 30 AI agents, 86 commands, 63 skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
 			"author": {
 				"name": "Fatih Kan",
 				"url": "https://github.com/fatihkan"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
 	"name": "badi",
 	"version": "1.34.2",
-	"description": "Workflow management for Claude Code, Cursor, Gemini, Windsurf, AGENTS.md — 30 AI agents, 85 commands, 14 hooks, 63 opt-in skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
+	"description": "Workflow management for Claude Code, Cursor, Gemini, Windsurf, AGENTS.md — 30 AI agents, 86 commands, 14 hooks, 63 opt-in skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
 	"author": {
 		"name": "Fatih Kan",
 		"url": "https://github.com/fatihkan"

--- a/.claude/command-index.md
+++ b/.claude/command-index.md
@@ -1,6 +1,6 @@
 # Badi Command Index
 
-> 85 commands | 4 profiles (core / dev / content / pentest) — filter with `badi commands profile <name>`. The pentest profile is reserved (0 commands today); pentest capabilities ship as opt-in skills (`badi skills`).
+> 86 commands | 4 profiles (core / dev / content / pentest) — filter with `badi commands profile <name>`. The pentest profile is reserved (0 commands today); pentest capabilities ship as opt-in skills (`badi skills`).
 
 ## Core — always active (session, audit, measurement) (21)
 
@@ -28,7 +28,7 @@
 | `/unstick` | Unblocking command. Finds a fast solution with a structured approach when you're stuck. |
 | `/wrap-up` | End-of-day ritual command. Prepares the day for closure and sets the stage for tomorrow. |
 
-## Dev — code / infra / devops (45)
+## Dev — code / infra / devops (46)
 
 | Command | Description |
 |---------|-------------|
@@ -74,6 +74,7 @@
 | `/ship` | Ship command. Runs the pre-flight gate, decides the version bump, assembles the changelog, and opens the PR via the release-manager agent. Nothing ships unless the gate is green. |
 | `/spec-check` | Specification conformance command. Audits the current code against SPECIFICATION.md, detecting feature gaps and scope drift. |
 | `/ssl-check` | SSL certificate analysis command. Checks certificate validity, TLS version, and cipher strength for a domain. |
+| `/tasks` | Dependency-aware task sequencing command. Turns a plan/spec into an ordered, parallel-executable tasks.md (`[P]` markers → Workflow `parallel()`) and runs it — the execution layer between `/eng-review` and the work. |
 | `/team` | Virtual eng team orchestrator. Runs a goal end-to-end through the whole team — strategy → plan → build → QA → ship — conducted by the engineering-manager, delegating to every specialist. One entry point that connects /ceo-review, /eng-review, /qa, and /ship. |
 | `/whois` | Domain WHOIS command. Checks registration date, expiry, registrar, and transfer lock status. |
 | `/wp` | WordPress site management command. Site status, plugin/theme management, security scan, and bulk updates. |

--- a/.claude/commands-vault/tasks.md
+++ b/.claude/commands-vault/tasks.md
@@ -1,0 +1,63 @@
+Dependency-aware task sequencing command. Turns a plan or spec into an ordered, parallel-executable `tasks.md` — then runs it, fanning out independent (`[P]`) tasks concurrently and respecting dependencies. The execution layer between `/eng-review` (the plan) and the actual work.
+
+# Required Tools
+- Read (the plan/spec, affected files)
+- Grep / Glob (map files each task touches, to decide what is parallel-safe)
+- Write (the tasks.md artifact)
+- Workflow / Agent (execute `[P]` tasks concurrently; sequential ones in order)
+
+# When to Use
+After a plan exists (`/eng-review`, a spec, or a clear goal) and the work splits into many concrete steps. Use `/tasks` to make the dependency structure explicit and to actually parallelize the independent parts instead of doing everything sequentially. Not for a single-step change — that's just doing it.
+
+# Task Format (the artifact)
+Write `tasks.md` (or `.claude/workspace/tasks-<feature>.md`) with one line per task:
+
+```
+- [ ] T001 [P] Create the data model in src/models/user.js
+- [ ] T002 [P] Add the config schema in src/config/schema.js
+- [ ] T003 Wire the service in src/services/user.js   (depends on T001)
+```
+
+Rules:
+- **`T001`, `T002`, …** — sequential ids in execution order.
+- **`[P]`** — parallel-safe: touches *different files* and has *no dependency on an
+  incomplete task*. Tasks WITHOUT `[P]` run sequentially (they share a file or
+  depend on an earlier task).
+- **Explicit file path** in every task — it's how you decide what is parallel-safe
+  (two `[P]` tasks must not write the same file).
+- **Phases** when useful: Setup → Foundational (blocking) → per-feature → Polish.
+
+# Procedure
+
+### Step 1: Derive the task list
+- Read the plan/spec. Break it into the smallest independently-verifiable tasks.
+- For each task, name the exact file(s) it creates/edits and its dependencies.
+
+### Step 2: Mark parallelism
+- Tag a task `[P]` only if it touches files no other in-flight task touches AND all
+  its dependencies are already complete. When unsure, leave `[P]` off (sequential is
+  the safe default).
+
+### Step 3: Write tasks.md
+- Emit the artifact in the format above so the structure is reviewable before any
+  code is written.
+
+### Step 4: Execute
+- Run `[P]` tasks of the same phase concurrently (Workflow `parallel()` / parallel
+  subagents); run non-`[P]` tasks sequentially in id order.
+- A task that depends on an incomplete one waits; a failed task drops its dependents
+  (report them, don't silently skip).
+- Tick each task `[x]` as it completes.
+
+### Step 5: Report
+- Summarize: completed / skipped (with the blocking failure) / remaining, and the
+  wall-clock saved by the parallel fan-out.
+
+# Output Format
+- The `tasks.md` artifact (numbered, `[P]`-marked, file-pathed)
+- Execution summary: done / blocked / remaining + what ran in parallel
+
+# Notes
+- This is badi-native: the `[P]` markers map directly onto the Workflow engine's
+  `parallel()` — independent tasks fan out, dependent tasks pipeline.
+- Pairs with `/eng-review` (produces the plan) and `/qa` (verifies the result).

--- a/.claude/commands/tasks.md
+++ b/.claude/commands/tasks.md
@@ -1,0 +1,63 @@
+Dependency-aware task sequencing command. Turns a plan or spec into an ordered, parallel-executable `tasks.md` — then runs it, fanning out independent (`[P]`) tasks concurrently and respecting dependencies. The execution layer between `/eng-review` (the plan) and the actual work.
+
+# Required Tools
+- Read (the plan/spec, affected files)
+- Grep / Glob (map files each task touches, to decide what is parallel-safe)
+- Write (the tasks.md artifact)
+- Workflow / Agent (execute `[P]` tasks concurrently; sequential ones in order)
+
+# When to Use
+After a plan exists (`/eng-review`, a spec, or a clear goal) and the work splits into many concrete steps. Use `/tasks` to make the dependency structure explicit and to actually parallelize the independent parts instead of doing everything sequentially. Not for a single-step change — that's just doing it.
+
+# Task Format (the artifact)
+Write `tasks.md` (or `.claude/workspace/tasks-<feature>.md`) with one line per task:
+
+```
+- [ ] T001 [P] Create the data model in src/models/user.js
+- [ ] T002 [P] Add the config schema in src/config/schema.js
+- [ ] T003 Wire the service in src/services/user.js   (depends on T001)
+```
+
+Rules:
+- **`T001`, `T002`, …** — sequential ids in execution order.
+- **`[P]`** — parallel-safe: touches *different files* and has *no dependency on an
+  incomplete task*. Tasks WITHOUT `[P]` run sequentially (they share a file or
+  depend on an earlier task).
+- **Explicit file path** in every task — it's how you decide what is parallel-safe
+  (two `[P]` tasks must not write the same file).
+- **Phases** when useful: Setup → Foundational (blocking) → per-feature → Polish.
+
+# Procedure
+
+### Step 1: Derive the task list
+- Read the plan/spec. Break it into the smallest independently-verifiable tasks.
+- For each task, name the exact file(s) it creates/edits and its dependencies.
+
+### Step 2: Mark parallelism
+- Tag a task `[P]` only if it touches files no other in-flight task touches AND all
+  its dependencies are already complete. When unsure, leave `[P]` off (sequential is
+  the safe default).
+
+### Step 3: Write tasks.md
+- Emit the artifact in the format above so the structure is reviewable before any
+  code is written.
+
+### Step 4: Execute
+- Run `[P]` tasks of the same phase concurrently (Workflow `parallel()` / parallel
+  subagents); run non-`[P]` tasks sequentially in id order.
+- A task that depends on an incomplete one waits; a failed task drops its dependents
+  (report them, don't silently skip).
+- Tick each task `[x]` as it completes.
+
+### Step 5: Report
+- Summarize: completed / skipped (with the blocking failure) / remaining, and the
+  wall-clock saved by the parallel fan-out.
+
+# Output Format
+- The `tasks.md` artifact (numbered, `[P]`-marked, file-pathed)
+- Execution summary: done / blocked / remaining + what ran in parallel
+
+# Notes
+- This is badi-native: the `[P]` markers map directly onto the Workflow engine's
+  `parallel()` — independent tasks fan out, dependent tasks pipeline.
+- Pairs with `/eng-review` (produces the plan) and `/qa` (verifies the result).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Added — `/tasks` dependency-aware sequencing command (freeze exception: engine)
+
+- **New `/tasks` slash command** — turns a plan/spec into an ordered, parallel-
+  executable `tasks.md` (numbered `T001…`, `[P]` parallel-safe markers, explicit
+  file paths, phases) and runs it: `[P]` tasks fan out concurrently (mapping onto
+  the Workflow engine's `parallel()`), dependent tasks pipeline. The execution
+  layer between `/eng-review` (the plan) and the work. Commands 85 → 86.
+- This is the single piece distilled from github/spec-kit after a `/ceo-review`
+  pass — the rest (constitution agent, `/clarify`, `/specify`, `/plan`) was KILLED
+  as overlapping `/architect` / `/brief` / `/spec-check` / `/team`. Approved as an
+  **engine exception** to the freeze; logged in `.claude/workspace/freeze-exceptions.md`.
+
 ### Added — `/market` command + `market-research` skill (freeze exception: wiring)
 
 - **New `/market` slash command** — niche discovery, opportunity sizing, and

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,18 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+### Eklendi — `/tasks` dependency-aware siralama komutu (freeze istisnasi: engine)
+
+- **Yeni `/tasks` slash komutu** — bir plan/spec'i sirali, paralel-calistirilabilir
+  `tasks.md`'ye cevirir (numarali `T001…`, `[P]` paralel-guvenli marker'lar, acik
+  dosya yollari, fazlar) ve calistirir: `[P]` gorevler es-zamanli fan-out
+  (Workflow `parallel()`'a eslenir), bagimli gorevler pipeline. `/eng-review` (plan)
+  ile is arasindaki yurutme katmani. Komutlar 85 → 86.
+- github/spec-kit'ten `/ceo-review` sonrasi damitilan TEK parca — gerisi
+  (constitution ajani, `/clarify`, `/specify`, `/plan`) `/architect` / `/brief` /
+  `/spec-check` / `/team` ile ortustugu icin KILL edildi. Freeze'e **engine
+  istisnasi** olarak onaylandi; `.claude/workspace/freeze-exceptions.md`'ye loglandi.
+
 ### Eklendi — `/market` komutu + `market-research` skill (freeze istisnasi: wiring)
 
 - **Yeni `/market` slash komutu** — nis kesfi, firsat boyutlama, rakip/bosluk

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Badi - Workflow Management System
 
-> Structured operations management for Claude Code. 30 agents, 85 commands, 14 hooks, 63 opt-in skill categories. v1.20+ prompt-aware skill router; v1.25+ pentest-* family (25 categories, advisory/defensive); v1.26+ profile-based command management (core/dev/content/pentest) + command routing; v1.27+ expo-* family (12 categories, Expo + React Native mobile dev lifecycle); v1.32+ virtual eng team (product-strategist, engineering-manager, release-manager, qa-lead + /ceo-review, /eng-review, /qa, /ship) + the /team orchestrator; v1.33+ ads review (ads-strategist agent + /meta-review + /ads-review, advisory-only). v1.34+ research/SEO/data advisory agents (market-researcher, seo-strategist, data-analyst).
+> Structured operations management for Claude Code. 30 agents, 86 commands, 14 hooks, 63 opt-in skill categories. v1.20+ prompt-aware skill router; v1.25+ pentest-* family (25 categories, advisory/defensive); v1.26+ profile-based command management (core/dev/content/pentest) + command routing; v1.27+ expo-* family (12 categories, Expo + React Native mobile dev lifecycle); v1.32+ virtual eng team (product-strategist, engineering-manager, release-manager, qa-lead + /ceo-review, /eng-review, /qa, /ship) + the /team orchestrator; v1.33+ ads review (ads-strategist agent + /meta-review + /ads-review, advisory-only). v1.34+ research/SEO/data advisory agents (market-researcher, seo-strategist, data-analyst).
 
 ## Memory Rules
 
@@ -11,7 +11,7 @@
 | Task Board | `.claude/workspace/TaskBoard.md` | No limit |
 | Skills Vault | `.claude/skills-vault/` | 63 categories (26 general + 25 pentest-* + 12 expo-*), not loaded (opt-in) |
 | Active Skills | `.claude/skills/` | User selection (`badi skills`) |
-| Commands Vault | `.claude/commands-vault/` | 85 commands canonical (v1.26+), not loaded |
+| Commands Vault | `.claude/commands-vault/` | 86 commands canonical (v1.26+), not loaded |
 | Active Commands | `.claude/commands/` | Filtered by profile (`badi commands profile`) |
 
 - TBD/TODO/FIXME are **FORBIDDEN** inside `knowledge-base.md`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **30 AI subagents** (incl. a virtual eng team, ads strategist, and market/SEO/data analysts), **85 slash commands** (profile-based core/dev/content/pentest management since v1.26), **14 automation hooks**, and **63 opt-in skill categories** (26 general + 25 pentest-* advisory/defensive since v1.25 + 12 expo-* mobile dev lifecycle since v1.27) with **prompt-aware auto-routing** for both skills and commands (v1.20+ / v1.26+). OWASP Top 10 scans, code review, content production, mobile/web SEO, App Store market research with `wishlist` + `gaps` analysis. Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
+**Workflow management CLI for Anthropic Claude Code, Cursor, and Gemini CLI** — built for **Claude Opus 4.7** and **Sonnet 4.6**. Ships **30 AI subagents** (incl. a virtual eng team, ads strategist, and market/SEO/data analysts), **86 slash commands** (profile-based core/dev/content/pentest management since v1.26), **14 automation hooks**, and **63 opt-in skill categories** (26 general + 25 pentest-* advisory/defensive since v1.25 + 12 expo-* mobile dev lifecycle since v1.27) with **prompt-aware auto-routing** for both skills and commands (v1.20+ / v1.26+). OWASP Top 10 scans, code review, content production, mobile/web SEO, App Store market research with `wishlist` + `gaps` analysis. Cuts token consumption ~96% on repetitive workflows. **v1.12+** adds multi-harness support — the same `.claude/` tree compiles into Cursor and Gemini CLI assets. **v1.16+** hardens CodeQL surface (TLS strict-first, DOM-based HTML parsing, URL hostname validation).
 
 ## Demo
 
@@ -43,7 +43,7 @@ Source of truth: npm. Other channels mirror the same `@fatihkan/badi-<version>.t
 /plugin install badi@badi-marketplace
 ```
 
-**As an npm CLI (full feature set: 30 agents · 85 commands with profile management (v1.26+) · 14 hooks · 63 opt-in skill categories with auto-router)**:
+**As an npm CLI (full feature set: 30 agents · 86 commands with profile management (v1.26+) · 14 hooks · 63 opt-in skill categories with auto-router)**:
 
 ```bash
 npx @fatihkan/badi init                    # interactive harness picker
@@ -70,8 +70,8 @@ For Turkish/UTF-8 output in cmd, run `chcp 65001` once or use Windows Terminal /
 
 | Harness | Rules | Commands | MCP | Subagents | Hooks | Skills |
 |---------|:-----:|:--------:|:---:|:---------:|:-----:|:------:|
-| Claude Code | `CLAUDE.md` | 85 | `.mcp.json` | 30 | 14 | 63 |
-| Cursor | `.cursor/rules/badi-main.mdc` | 85 | `.cursor/mcp.json` | — | — | — |
+| Claude Code | `CLAUDE.md` | 86 | `.mcp.json` | 30 | 14 | 63 |
+| Cursor | `.cursor/rules/badi-main.mdc` | 86 | `.cursor/mcp.json` | — | — | — |
 | Gemini CLI | `GEMINI.md` (merged) | inline | `.gemini/settings.json` | — | — | — |
 | Windsurf (v1.30+) | `.windsurfrules` (merged) | inline | — | — | — | — |
 | AGENTS.md (v1.30+) | `AGENTS.md` (merged) | inline | — | — | — | — |
@@ -82,7 +82,7 @@ Claude is the canonical source. Cursor/Gemini/Windsurf/AGENTS.md adapters compil
 
 | Feature | Details |
 |---------|---------|
-| **30 expert agents + 85 commands** | Full toolkit from security scanner to performance profiler, plus a virtual eng team (CEO / eng manager / release manager / QA lead) wired together by `/team`, and an ads strategist (`/meta-review`, `/ads-review`) — profile-based filtering (core/dev/content/pentest) since v1.26 |
+| **30 expert agents + 86 commands** | Full toolkit from security scanner to performance profiler, plus a virtual eng team (CEO / eng manager / release manager / QA lead) wired together by `/team`, and an ads strategist (`/meta-review`, `/ads-review`) — profile-based filtering (core/dev/content/pentest) since v1.26 |
 | **14 automation hooks + 63 opt-in skill categories** | Branch protection, backups, OWASP Top 10 scanning, 9 Frontend Taste variants. Skills load zero tokens by default since v1.17; auto-router (v1.20+) injects matching skills per prompt; pentest-* family (v1.25+ advisory/defensive); expo-* family (v1.27+ mobile dev lifecycle); command routing (v1.26+); plan-injection hook (v1.30+) |
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+, expanded v1.30+)** | Claude Code, Cursor, Gemini CLI, Windsurf, AGENTS.md — same `.claude/` source, 5 targets |
@@ -171,7 +171,7 @@ When the skill is active, Claude Code loads the SKILL.md body on `/start` or in 
 
 ### Profile-Based Commands + Command Router (v1.26+)
 
-Same opt-in philosophy applied to the 85 slash commands. Pick a profile (`core`, `dev`, `content`, `pentest`, `all`) to physically filter `.claude/commands/`; the canonical store lives in `.claude/commands-vault/`. The router additionally scores prompts against command descriptions and surfaces top matches as a lightweight hint blob — your skills router hook calls both routers automatically.
+Same opt-in philosophy applied to the 86 slash commands. Pick a profile (`core`, `dev`, `content`, `pentest`, `all`) to physically filter `.claude/commands/`; the canonical store lives in `.claude/commands-vault/`. The router additionally scores prompts against command descriptions and surfaces top matches as a lightweight hint blob — your skills router hook calls both routers automatically.
 
 ```bash
 # Profile management
@@ -552,7 +552,7 @@ lib/                   13 top-level ESM modules
 .claude/
   agents/              30 expert agents
   commands/            84 workflow commands (profile-filtered active set)
-  commands-vault/      85 commands canonical store
+  commands-vault/      86 commands canonical store
   hooks/               14 automation hooks
   skills-vault/        63 skill categories (26 general + 25 pentest + 12 expo)
                        (incl. mobile/app-store-screenshots)

--- a/lib/command-profiles.js
+++ b/lib/command-profiles.js
@@ -1,6 +1,6 @@
 // Command profile definitions.
 //
-// The 85 .claude/commands/ files split into 4 profiles:
+// The 86 .claude/commands/ files split into 4 profiles:
 //   core    — always active (session management, measurement)
 //   dev     — code/infrastructure/devops focused
 //   content — social media/marketing focused
@@ -41,7 +41,7 @@ export const COMMAND_PROFILES = {
 	standup: "core",
 	onboard: "core",
 
-	// dev (45) — development/devops/audit + virtual eng team
+	// dev (46) — development/devops/audit + virtual eng team
 	adr: "dev",
 	"ceo-review": "dev",
 	"eng-review": "dev",
@@ -87,6 +87,7 @@ export const COMMAND_PROFILES = {
 	wp: "dev",
 	mobile: "dev",
 	market: "dev",
+	tasks: "dev",
 
 	// content (19) — content production/marketing + ads review
 	"meta-review": "content",

--- a/tests/command-profiles.test.js
+++ b/tests/command-profiles.test.js
@@ -122,7 +122,7 @@ describe("command-profiles: isInProfile", () => {
 });
 
 describe("command-profiles: profileCounts", () => {
-	it("total defined command count should be 85", () => {
+	it("total defined command count should be 86", () => {
 		const counts = profileCounts();
 		const total = counts.core + counts.dev + counts.content + counts.pentest;
 		assert.equal(total, Object.keys(COMMAND_PROFILES).length);


### PR DESCRIPTION
The single piece distilled from **github/spec-kit** after a `/ceo-review` pass. The rest of spec-kit (constitution agent, `/clarify`, `/specify`, `/plan`) was **KILLED** as overlapping badi's existing `/architect`, `/brief`, `/spec-check`, `/team`. Approved as an **engine exception** to the feature freeze; logged in `.claude/workspace/freeze-exceptions.md`.

## What
**`/tasks`** turns a plan/spec into an ordered, parallel-executable `tasks.md`:
- numbered `T001…`, `[P]` parallel-safe markers (different files + deps complete), explicit file paths, phases.
- then runs it: `[P]` tasks fan out concurrently (mapping directly onto the Workflow engine's `parallel()`), dependent tasks pipeline.
- the execution layer between `/eng-review` (the plan) and the actual work; pairs with `/qa`.

This is the badi-native idea — spec-kit's `[P]` markers → badi's real parallel-execution engine — rather than importing overlapping agents/skills.

## Verification
- `npx biome check` clean · `doctor` 53/0/0 · `release check`: docs in sync (1318), plugin.json up to date
- Tests **1318 unchanged** (commands have no per-item test); counts synced 85→86 across command-profiles, command-index, CLAUDE.md, README, manifest.

Completes the `/ceo-review` build bundle: #1 `/market` (wiring) ✅ · #2 already done (#283) · **#3 `/tasks` (this)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)