### PR TITLE
fix(cli): revise stale badi --help subcommand lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Fixed — `badi --help` subcommand lists were stale
+
+- Audited every CLI command, slash command, and skill against its registry: all
+  86 commands (COMMAND_PROFILES / command-index / vault) and 63 skills (INDEX vs
+  disk) are consistent — nothing orphaned. The drift was only in the `badi --help`
+  subcommand summaries, now corrected: `market` (+ `gaps`/`wishlist`), `mobile`
+  (+ `version`/`assets`), `aso` (+ `metadata`/`compete`/`search`), `wp`
+  (`plugin`/`theme` → `plugins`/`themes`, + `update`).
+
 ### Added — `/tasks` dependency-aware sequencing command (freeze exception: engine)
 
 - **New `/tasks` slash command** — turns a plan/spec into an ordered, parallel-

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,15 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+### Duzeltildi — `badi --help` subcommand listeleri bayatti
+
+- Her CLI komutu, slash komutu ve skill registry'sine karsi denetlendi: 86 komut
+  (COMMAND_PROFILES / command-index / vault) ve 63 skill (INDEX vs disk) tutarli —
+  hicbiri orphan degil. Drift yalnizca `badi --help` subcommand ozetlerindeydi,
+  duzeltildi: `market` (+ `gaps`/`wishlist`), `mobile` (+ `version`/`assets`),
+  `aso` (+ `metadata`/`compete`/`search`), `wp` (`plugin`/`theme` →
+  `plugins`/`themes`, + `update`).
+
 ### Eklendi — `/tasks` dependency-aware siralama komutu (freeze istisnasi: engine)
 
 - **Yeni `/tasks` slash komutu** — bir plan/spec'i sirali, paralel-calistirilabilir

--- a/bin/badi.js
+++ b/bin/badi.js
@@ -43,22 +43,22 @@ function showHelp() {
 		`  ${chalk.cyan("mcp")}       Model Context Protocol server (serve/tools/config) — v1.23+`,
 	);
 	console.log(
-		`  ${chalk.cyan("wp")}        WordPress site management (status/plugin/theme/security)`,
+		`  ${chalk.cyan("wp")}        WordPress site management (status/plugins/themes/security/update)`,
 	);
 	console.log(
 		`  ${chalk.cyan("seo")}       SEO audit (audit/meta/sitemap/speed/backlinks/rank/compare)`,
 	);
 	console.log(
-		`  ${chalk.cyan("aso")}       App Store Optimization (audit/playstore/keywords/reviews/screenshots)`,
+		`  ${chalk.cyan("aso")}       App Store Optimization (audit/keywords/metadata/compete/search/playstore/reviews/screenshots)`,
 	);
 	console.log(
-		`  ${chalk.cyan("market")}    App Store market research (discover/reviews/difficulty + full report) — v1.15+`,
+		`  ${chalk.cyan("market")}    App Store market research (discover/reviews/difficulty/gaps/wishlist + full) — v1.15+`,
 	);
 	console.log(
 		`  ${chalk.cyan("design")}    Visual identity command (init/lint/export/show — DESIGN.md) — v1.16+`,
 	);
 	console.log(
-		`  ${chalk.cyan("mobile")}    Mobile development (init/build/release/crash-setup/deeplink/ota)`,
+		`  ${chalk.cyan("mobile")}    Mobile development (init/version/build/release/assets/crash-setup/deeplink/ota)`,
 	);
 	console.log(
 		`  ${chalk.cyan("taste")}     Premium frontend skills (9 variants: default/minimalist/brutalist/soft...)`,


### PR DESCRIPTION
Audited every CLI command / slash command / skill against its registry — **all 86 commands and 63 skills are consistent, nothing orphaned**. The only drift was in the `badi --help` subcommand summaries:

| command | fix |
|---|---|
| `market` | + `gaps`, `wishlist` |
| `mobile` | + `version`, `assets` |
| `aso` | + `metadata`, `compete`, `search` |
| `wp` | `plugin`/`theme` → `plugins`/`themes`, + `update` |

Help text only, no logic. Tests 1318, biome clean, help/cli tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)