### PR TITLE
fix(review): post-review hardening — branch-guard bugs + lint gate + drift

### DIFF
--- a/.claude/hooks/_util.mjs
+++ b/.claude/hooks/_util.mjs
@@ -126,10 +126,13 @@ export function stripHeredocs(command) {
 			if (line.trim() === tag) tag = null; // body terminator — drop it too
 			continue;
 		}
-		const m = line.match(/<<-?\s*['"]?([A-Za-z_]\w*)['"]?/);
+		// `<<TAG` heredoc opener — but NOT the `<<<` here-string operator
+		// (matching inside `<<<` would swallow the rest of the command and let a
+		// later `git commit` slip past the guard). Lookbehind/ahead reject a 3rd `<`.
+		const m = line.match(/(?<!<)<<-?(?!<)\s*['"]?([A-Za-z_]\w*)['"]?/);
 		if (m) {
 			tag = m[1];
-			out.push(line.slice(0, line.indexOf("<<")));
+			out.push(line.slice(0, m.index));
 			continue;
 		}
 		out.push(line);
@@ -202,10 +205,13 @@ export function effectiveBranchForCommit(command, baseBranch) {
 	let tracked = baseBranch;
 	for (const seg of segs) {
 		if (isGitCommit(seg)) break; // evaluate as of the commit
+		// Track switch/checkout to a branch before the commit. Handles create
+		// flags (-c/-C/-b/-B/--create), and quoted branch names that contain
+		// spaces ("feat space") which an unquoted [^\s] capture would truncate.
 		const m = seg.match(
-			/\bgit\s+(?:switch|checkout)\s+(?:-c\s+|-b\s+|--create\s+)?(?!-)(['"]?)([^\s'"]+)\1/,
+			/\bgit\s+(?:switch|checkout)\s+(?:-[cCbB]\s+|--create\s+)?(?!-)(?:"([^"]+)"|'([^']+)'|(\S+))/,
 		);
-		if (m) tracked = m[2];
+		if (m) tracked = m[1] || m[2] || m[3];
 	}
 	return tracked;
 }

--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -86,12 +86,10 @@
   vault frontmatter 37/62 fail (CI gezmez), README.tr tablo drift'i, dist/scoop bayat (1.30.1),
   INDEX.md 25-vs-21.
 - 2026-06-05: v1.33.0/.1/.2 (#248-#267) — English-only VERIFIED CLEAN + 3 advisory ajan
-  (27→30) + evaluate-repository 7.5/10 onarimlari. **AKTIF KISIT**: awesome-claude-code
-  #1955'e AI yorumu YASAK (maintainer kuyrugu, cooldown riski; tum etkilesim kullanicidan).
-  Detay: memory-archive.md. Yan bulgu (acik P4): branch-guard hook cwd-farkindaligi yok.
-- 2026-06-03/04: v1.32.0 (#221-#230) — sanal eng ekibi + CLI grammar/content- oneki
-  (BREAKING ama MINOR, kullanici karari). Detay: memory-archive.md. Test 1130->1155.
-- 2026-05-22..29: v1.31.0 + bakim turu. Detay: memory-archive.md. Test 1074->1130.
+  (27→30). **AKTIF KISIT**: awesome-claude-code #1955'e AI yorumu YASAK (maintainer kuyrugu,
+  cooldown riski; tum etkilesim kullanicidan). Detay: memory-archive.md.
+- 2026-05-22..06-04: v1.31.0 + v1.32.0 (sanal eng ekibi + CLI grammar BREAKING/MINOR).
+  Detay: memory-archive.md. Test 1074->1155.
 
 ## Yan Repo
 - **badi-skills** v1.0.0 — CI `lib/skills/schema.js`'i ana repo'dan curl ile cekiyor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Fixed — post-review hardening (multi-lens review of the v1.35.0 diff)
+
+A 6-lens review (code/security/eng/ceo/audit) with adversarial verification of
+`v1.34.1..HEAD` caught real defects — most in this cycle's own new code:
+
+- **branch-guard `<<<` here-string bypass (HIGH).** `stripHeredocs` matched the
+  bash here-string `<<<` as a heredoc opener and swallowed the rest of the
+  command, so `cat <<< x && git commit` on a protected branch was NOT blocked.
+  The heredoc regex now rejects a 3rd `<` (lookbehind/ahead).
+- **branch-guard quoted branch names (MEDIUM).** `git switch -c "feat space"`
+  was not tracked (the capture stopped at the space), wrongly blocking a
+  legitimate commit. The switch/checkout matcher now handles quoted names and
+  the capital force-create forms `-C`/`-B`.
+- **`npm run lint` was red** — `biome check .` flagged 3 cycle-authored test
+  files that `biome check` (no path) skipped. Formatted; the gate is green.
+- **`checkScoopManifest`** now matches the version as a delimited tarball token
+  (`badi-${v}.tgz`) instead of a bare substring (avoids `badi-11.3.2` ≅ `1.3.2`).
+- **Stale runtime/doc counts** corrected: `badi skills` help (62→63), README
+  "command modules" (36→38) + "workflow commands" (84→86), scoop description
+  (84/62→86/63), `badi mobile` unknown-command usage (now lists all 8 subs),
+  `command-profiles.js` `core` comment (20→21), `.claude/memory.md` trimmed back
+  under 100 lines (cleared the doctor warning).
+- New regression tests: `<<<` non-heredoc, quoted/space + `-C`/`-B` branch names.
+
 ### Fixed — `badi --help` subcommand lists were stale
 
 - Audited every CLI command, slash command, and skill against its registry: all

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,28 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+### Duzeltildi — review sonrasi sertlestirme (v1.35.0 diff'inin cok-mercek incelemesi)
+
+6-mercekli (code/security/eng/ceo/audit) + adversarial dogrulamali `v1.34.1..HEAD`
+incelemesi gercek kusurlar yakaladi — cogu bu turun kendi yeni kodunda:
+
+- **branch-guard `<<<` here-string bypass'i (HIGH).** `stripHeredocs`, bash
+  here-string `<<<`'i heredoc acici sanip komutun gerisini yutuyordu; korumali
+  branch'te `cat <<< x && git commit` BLOKLANMIYORDU. Heredoc regex'i artik 3.
+  `<`'i reddediyor (lookbehind/ahead).
+- **branch-guard tirnak-icinde branch adi (MEDIUM).** `git switch -c "feat space"`
+  izlenmiyordu (capture boslukta duruyordu), mesru commit'i yanlislikla blokluyordu.
+  switch/checkout matcher'i artik tirnakli adlari + capital `-C`/`-B` formlarini isliyor.
+- **`npm run lint` kirmiziydi** — `biome check .` bu turda yazilan 3 test dosyasini
+  isaretliyordu (`biome check` path'siz atliyordu). Formatlandi; gate yesil.
+- **`checkScoopManifest`** version'i artik delimited tarball token (`badi-${v}.tgz`)
+  olarak eslestiriyor (bare substring degil; `badi-11.3.2` ≅ `1.3.2` onlenir).
+- **Bayat runtime/doc sayilari** duzeltildi: `badi skills` help (62→63), README
+  "command modules" (36→38) + "workflow commands" (84→86), scoop description
+  (84/62→86/63), `badi mobile` bilinmeyen-komut usage (artik 8 sub), command-profiles
+  `core` yorumu (20→21), `.claude/memory.md` 100 satir altina cekildi (doctor warning gitti).
+- Yeni regresyon testleri: `<<<` non-heredoc, tirnakli/bosluklu + `-C`/`-B` branch adlari.
+
 ### Duzeltildi — `badi --help` subcommand listeleri bayatti
 
 - Her CLI komutu, slash komutu ve skill registry'sine karsi denetlendi: 86 komut

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img src="https://img.shields.io/npm/dm/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm downloads per month" />
   <img src="https://img.shields.io/npm/dt/@fatihkan/badi?color=00d4ff&style=flat-square" alt="npm total downloads" />
   <img src="https://img.shields.io/npm/l/@fatihkan/badi?color=00d4ff&style=flat-square" alt="license" />
-  <img src="https://img.shields.io/badge/tests-1318%20passing-00d4ff?style=flat-square" alt="tests" />
+  <img src="https://img.shields.io/badge/tests-1321%20passing-00d4ff?style=flat-square" alt="tests" />
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
@@ -87,10 +87,10 @@ Claude is the canonical source. Cursor/Gemini/Windsurf/AGENTS.md adapters compil
 | **App Store market research** | `badi market discover/reviews/difficulty/wishlist/gaps` — competitor maps, demand×supply matrix (Reddit + App Store), opportunity gap cross-analysis |
 | **Multi-harness support (v1.12+, expanded v1.30+)** | Claude Code, Cursor, Gemini CLI, Windsurf, AGENTS.md — same `.claude/` source, 5 targets |
 | **Observability (v1.29+) + self-telemetry (v1.30+)** | Read Claude Code transcripts (`badi stats --session/--models/--cost`, `badi search`, `badi session`) + emit own command events (`badi events list/stats`, BADI_TELEMETRY=off to disable) |
-| **1318 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, design, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter, vault frontmatter, hook-path anchoring, scoop manifest sync, settings-derived doctor hooks, consolidated semver, branch-guard cwd-awareness, deterministic stats fixtures, directory-module help-doctor |
+| **1321 passing tests** | CLI integration, harness adapters, schema/bundler/publish, watcher/scheduler, market, design, profile management, hook fail-safe resilience, secret-scan hardening, plugin manifest schema, transcript-reader, event emitter, vault frontmatter, hook-path anchoring, scoop manifest sync, settings-derived doctor hooks, consolidated semver, branch-guard cwd-awareness, deterministic stats fixtures, directory-module help-doctor |
 | **Content engine (English)** | Template inheritance, auto-generated posts, threads, newsletters, podcasts, case studies |
 | **WordPress + SEO + ASO + Mobile modules** | WP-CLI/REST, 20+ SEO checks, App Store + Play Store, crash/deeplink/OTA scaffolding |
-| **Modular architecture** | 36 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
+| **Modular architecture** | 38 command modules, `lib/harnesses/` adapter layer, ~6MB `.claude/` tree |
 | **Open source (MIT)** | Community-first, transparent licensing |
 
 > CLI language: all output, command grammar, and slash commands are English as of v1.32 (English-only migration complete).
@@ -544,14 +544,14 @@ badi dev [deps|bundle|docker-lint|env-check|api-test]             # v1.8+
 bin/badi.js            Entry point (thin dispatcher)
 lib/                   13 top-level ESM modules
   cli.js               Shared utilities (chalk, figlet, VERSION)
-  commands/            36 command modules (init, update, doctor, list,
+  commands/            38 command modules (init, update, doctor, list,
                        plugin, stats, completion, schedule, wp, seo,
                        security, release, …) + icerik/ and plugin/ splits
   harnesses/           Multi-harness adapters (Claude, Cursor, Gemini, …)
   icerik-helpers.js    Search, similarity, frontmatter
 .claude/
   agents/              30 expert agents
-  commands/            84 workflow commands (profile-filtered active set)
+  commands/            86 workflow commands (profile-filtered active set)
   commands-vault/      86 commands canonical store
   hooks/               14 automation hooks
   skills-vault/        63 skill categories (26 general + 25 pentest + 12 expo)
@@ -655,7 +655,7 @@ No telemetry, no analytics. See `lib/update-check.js` and `lib/commands/*` for t
 
 ```bash
 npm install
-npm test           # 1318 tests across 234 suites
+npm test           # 1321 tests across 234 suites
 npm run lint       # Biome code-quality checks
 npm run format     # Biome formatting
 ```

--- a/dist/scoop/badi.json
+++ b/dist/scoop/badi.json
@@ -2,7 +2,7 @@
 	"_comment_": "Scoop bucket manifest. fatihkan/scoop-bucket repo'sunda bucket/badi.json olarak yer alir.",
 	"_install_": "scoop bucket add badi https://github.com/fatihkan/scoop-bucket && scoop install badi",
 	"version": "1.34.2",
-	"description": "Workflow management for Claude Code (30 AI agents, 84 commands, 62 opt-in skill categories). Supports Cursor, Gemini, Windsurf, AGENTS.md.",
+	"description": "Workflow management for Claude Code (30 AI agents, 86 commands, 63 opt-in skill categories). Supports Cursor, Gemini, Windsurf, AGENTS.md.",
 	"homepage": "https://github.com/fatihkan/badi",
 	"license": "MIT",
 	"depends": "nodejs-lts",

--- a/lib/command-profiles.js
+++ b/lib/command-profiles.js
@@ -18,7 +18,7 @@ export const PROFILES = ["core", "dev", "content", "pentest", "all"];
  * profile-changing commands.
  */
 export const COMMAND_PROFILES = {
-	// core (20) — always active
+	// core (21) — always active
 	start: "core",
 	sync: "core",
 	"wrap-up": "core",

--- a/lib/commands/mobile/index.js
+++ b/lib/commands/mobile/index.js
@@ -52,7 +52,9 @@ export async function runMobile(args) {
 			break;
 		default:
 			console.error(chalk.red(`Unknown mobile command: ${sub}`));
-			console.log("Usage: badi mobile [init|version|build|release|assets]");
+			console.log(
+				"Usage: badi mobile [init|version|build|release|assets|crash-setup|deeplink|ota]",
+			);
 			process.exit(1);
 	}
 }

--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -335,7 +335,12 @@ export function checkScoopManifest(ctx = {}) {
 	if (scoop.version !== version) {
 		problems.push(`version ${scoop.version} != ${version}`);
 	}
-	if (typeof scoop.url === "string" && !scoop.url.includes(version)) {
+	// Match the version as a delimited tarball token, not a bare substring —
+	// `badi-11.3.2.tgz` must not satisfy version `1.3.2` (prefix collision).
+	if (
+		typeof scoop.url === "string" &&
+		!scoop.url.includes(`badi-${version}.tgz`)
+	) {
 		problems.push(`url does not reference ${version} (${scoop.url})`);
 	}
 	if (problems.length) {

--- a/lib/commands/skills.js
+++ b/lib/commands/skills.js
@@ -357,7 +357,7 @@ function showHelp() {
 	console.log(chalk.bold("Categories (v1.27):"));
 	console.log(
 		chalk.dim(
-			"  25 general + 25 pentest-* + 12 expo-* = 62 categories (opt-in vault).",
+			"  26 general + 25 pentest-* + 12 expo-* = 63 categories (opt-in vault).",
 		),
 	);
 	console.log(

--- a/tests/branch-guard-helpers.test.js
+++ b/tests/branch-guard-helpers.test.js
@@ -43,6 +43,15 @@ describe("branch-guard: stripHeredocs", () => {
 	it("is a no-op without a heredoc", () => {
 		assert.equal(stripHeredocs("git commit -m x"), "git commit -m x");
 	});
+
+	it("does NOT treat the `<<<` here-string as a heredoc (guard-bypass regression)", () => {
+		// `<<<` must not be parsed as a heredoc opener — otherwise everything
+		// after it (incl. a real `git commit`) would be swallowed and the guard
+		// bypassed. The command must survive stripHeredocs intact.
+		const cmd = "cat <<< notes && git commit -m x";
+		assert.equal(stripHeredocs(cmd), cmd);
+		assert.ok(stripHeredocs(cmd).includes("git commit"));
+	});
 });
 
 describe("branch-guard: splitSegments", () => {
@@ -65,11 +74,17 @@ describe("branch-guard: effectiveBranchForCommit", () => {
 
 	it("a `git switch -c` before the commit takes effect (the false-positive bug)", () => {
 		assert.equal(
-			effectiveBranchForCommit("git switch -c feature/x && git commit -m x", "main"),
+			effectiveBranchForCommit(
+				"git switch -c feature/x && git commit -m x",
+				"main",
+			),
 			"feature/x",
 		);
 		assert.equal(
-			effectiveBranchForCommit("git checkout -b feat 2>&1 | tail\ngit commit", "main"),
+			effectiveBranchForCommit(
+				"git checkout -b feat 2>&1 | tail\ngit commit",
+				"main",
+			),
 			"feat",
 		);
 	});
@@ -95,6 +110,31 @@ describe("branch-guard: effectiveBranchForCommit", () => {
 				"main",
 			),
 			"main",
+		);
+	});
+
+	it("tracks a quoted new-branch name with spaces (false-positive regression)", () => {
+		assert.equal(
+			effectiveBranchForCommit(
+				'git switch -c "feat space" && git commit',
+				"main",
+			),
+			"feat space",
+		);
+		assert.equal(
+			effectiveBranchForCommit("git switch -c 'q space' && git commit", "main"),
+			"q space",
+		);
+	});
+
+	it("tracks the capital force-create forms (-C / -B)", () => {
+		assert.equal(
+			effectiveBranchForCommit("git switch -C feat && git commit", "main"),
+			"feat",
+		);
+		assert.equal(
+			effectiveBranchForCommit("git checkout -B feat && git commit", "main"),
+			"feat",
 		);
 	});
 });

--- a/tests/cli.hooks-node.test.js
+++ b/tests/cli.hooks-node.test.js
@@ -187,7 +187,11 @@ describe("hooks-node: branch-guard (cwd/cd awareness, PR-C)", () => {
 			{ cwd: d },
 		);
 		assert.equal(r.status, 0);
-		assert.equal(r.stdout.trim(), "", "switch precedes commit -> must not block");
+		assert.equal(
+			r.stdout.trim(),
+			"",
+			"switch precedes commit -> must not block",
+		);
 	});
 
 	it("ignores a `git commit` mention inside a heredoc body", () => {

--- a/tests/help-doctor.test.js
+++ b/tests/help-doctor.test.js
@@ -211,7 +211,10 @@ describe("help-doctor: directory-module coverage (v1.35.0)", () => {
 				'switch (sub) { case "alpha": break; case "beta": break; }',
 			);
 			// help.js documents alpha but not beta -> beta should drift
-			writeFileSync(join(dir, "help.js"), 'console.log("badi demo alpha ...");');
+			writeFileSync(
+				join(dir, "help.js"),
+				'console.log("badi demo alpha ...");',
+			);
 			const drift = auditFiles([dir]);
 			assert.equal(drift.length, 1);
 			assert.equal(drift[0].file, "demo");


### PR DESCRIPTION
A **6-lens review** (code / security / eng / ceo / audit) of \`v1.34.1..HEAD\` with adversarial verification (23 agents) — caught **8 confirmed defects, refuted 9**. Most were in this cycle's own new code.

## Fixed (verified findings)
| sev | fix |
|---|---|
| **HIGH** | branch-guard `<<<` here-string bypass — `stripHeredocs` parsed the bash here-string as a heredoc opener and swallowed the rest, so `cat <<< x && git commit` on a protected branch was **not blocked**. Regex now rejects a 3rd `<`. |
| **MED** | branch-guard quoted branch names — `git switch -c "feat space"` wasn't tracked (false-positive block). Matcher now handles quoted/space names + capital `-C`/`-B`. |
| **BLOCKER** | `npm run lint` (= `biome check .`) was red on files that `biome check` (no path) skipped — formatted; gate green. |
| nit | `checkScoopManifest` matches `badi-${v}.tgz` (delimited) not bare substring. |
| drift | stale counts: `badi skills` help 62→63, README modules 36→38 / commands 84→86, scoop desc 84/62→86/63, `badi mobile` usage (all 8 subs), `command-profiles` core comment, `memory.md` trimmed <100 (doctor warning cleared). |

Plus regression tests (`<<<` non-heredoc, quoted + `-C`/`-B` branch names).

## Strategic verdicts (eng/ceo — for the owner, not code)
- **eng:** the v1.35.0 accumulation is coherent and root-cause (not band-aid); was NOT green-to-cut only due to the lint gate — **now fixed**.
- **ceo:** CONDITIONAL GO — publish the pending release and then spend a session on **distribution** (the 5⭐/0-fork needle hasn't moved); hold new features (don't trigger the 3rd freeze exception).

## Verification
Tests **1318 → 1321** · `release check` green (Lint OK, Test 1321, Docs in sync, scoop in sync) · doctor 53/0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)