### PR TITLE
docs(readme): reposition around the agentic safety layer wedge

### DIFF
--- a/.claude/workspace/TaskBoard.md
+++ b/.claude/workspace/TaskBoard.md
@@ -5,11 +5,11 @@
 
 ## This Week
 
-- [ ] **DISTRIBUTION (CEO directive — not code). Plan + turnkey drafts in `.claude/workspace/launch/`** (2026-06-20 /market + 7-agent workflow). Order:
-  1. **awesome-claude-code #1955** — OPEN, bot-validated, not listed; maintainer README is a WIP stub + 300+ queue → **watch only** (AI comments BANNED, browser-UI only).
-  2. **Show HN (P1, THIS WEEK)** — owner posts (human-only, no upvote solicitation); draft ready `launch/show-hn.md`. Tue–Thu 9–12 ET.
-  3. **README conversion fixes** — single repo-side lever (docs-only = freeze-safe); APPLIED on branch `docs/readme-first-impression` (uncommitted, pending review). ⚠ audit's fabricated ROI table NOT used.
-  4. **r/ClaudeAI workflow writeup + dev.to/Hashnode tutorial (P2)** — human-written, value-first, compounding. Drafts `launch/social.md` + full post `launch/blog-post.md`.
+- [ ] **DISTRIBUTION (CEO directive — not code). Plan + turnkey drafts in `.claude/workspace/launch/`** (2026-06-20 /market + 7-agent workflow). **POSITIONING (owner-approved 06-21): agentic safety layer for Claude Code — canonical `launch/POSITIONING.md`.** Order:
+  1. **awesome-claude-code #1955** — OPEN, bot-validated, not listed; maintainer README is a WIP stub + 300+ queue → **watch only** (AI comments BANNED, browser-UI only). Submission framing → safety angle.
+  2. **Show HN (P1, THIS WEEK)** — owner posts (human-only, no upvote solicitation); draft ready `launch/show-hn.md` (retitled to the safety/hooks angle). Tue–Thu 9–12 ET.
+  3. **README pivot → safety wedge** — DONE: lede + Why-Badi rewritten around the verified deterministic hooks; grounded in real `.claude/hooks/` (no fabricated claims). PR after #301 (which merged the now-superseded JTBD lede).
+  4. **Flagship + content (P2)** — `launch/incident-post.md` (dev.to, real verified blocks) + r/ClaudeAI writeup + split-screen demo (wk 3). Drafts: `launch/incident-post.md` · `launch/social.md` · `launch/blog-post.md`.
   5. **awesome-ai-devtools #616** — OPEN/clean; ping ONLY after ~July 5 silence, one human line.
   6. **Product Hunt → DEFER (P3)** — premature (5 stars, no 400+ list); revisit at ~2k weekly downloads. (Corrects the earlier "PH prep" assumption.)
   - awesome-nodejs: still needs 100 stars (far off).

--- a/.claude/workspace/launch/PLAN.md
+++ b/.claude/workspace/launch/PLAN.md
@@ -3,7 +3,15 @@
 > Freeze-safe distribution work. CEO directive: grow organic signal, not features.
 > Source: 7-agent `/market` + `badi-distribution-launch-prep` workflow (read-only research).
 > Companion files in this dir: submission-status · credibility-audit · channels ·
-> product-hunt · show-hn · social · blog-outline · blog-post.
+> product-hunt · show-hn · social · blog-outline · blog-post · POSITIONING · incident-post.
+
+> **UPDATE 2026-06-21 — POSITIONING DECIDED (owner-approved full pivot).** Standout wedge =
+> **agentic safety layer for Claude Code** (deterministic, verified hooks). Canonical messaging:
+> **`POSITIONING.md`**. README lede + Why-Badi rewritten to the safety angle; flagship asset =
+> `incident-post.md` (grounded in badi's REAL blocks, NOT the unverified "PocketOS" story);
+> show-hn + social re-led on the hook-vs-prompt contrast. Source: `badi-standout-positioning`
+> workflow (2 of 3 wedges + judge converged). The README-fix items below are now superseded by
+> this pivot.
 
 ## TL;DR
 The binding constraint is **distribution + trust** (5 stars, ~329 weekly npm downloads),

--- a/.claude/workspace/launch/POSITIONING.md
+++ b/.claude/workspace/launch/POSITIONING.md
@@ -1,0 +1,61 @@
+# badi — Positioning (the standout wedge)
+
+> Decided 2026-06-21 via the `badi-standout-positioning` workflow (3 wedges judged → 1).
+> Two independent strategies + the product-strategist judge converged on the same wedge.
+> All proof points below were **verified against the live repo** before adoption.
+
+## The wedge
+**Agentic safety layer for Claude Code.** Deterministic hooks that run as real code on
+every tool call and block irreversible actions *before* they execute — not prompts the
+model can reason around.
+
+## Positioning statement
+> For developers running Claude Code autonomously, **badi is the agentic safety layer that
+> blocks irreversible actions at the tool-call level with real code** — not prompts the model
+> can reason around, not config flags, but deterministic hooks that physically intercept every
+> tool call before it executes.
+
+**Category to lead with:** *agentic safety layer for Claude Code*
+**Beachhead user:** solo devs / small teams running Claude Code in headless or near-autonomous
+mode who have felt (or read about) the moment the agent does something they can't undo.
+
+## Proof — verified, shipped today (no new features)
+- `guard-bash.mjs` HARD_BLOCKS (lines 36-50): `rm -rf /`, `rm -rf *`, `git push --force origin main|master`, `git reset --hard origin/`, `chmod 777`, `curl|wget … | bash/sh`, `> /etc/`, `mkfs.`, `dd of=/dev/`, `cat *.env|pem|key|secret … | curl|nc|wget`, `echo $…secret/token/key … | curl|nc|wget`. Plus SOFT_BLOCKS + LOG_WARNINGS tiers.
+- `branch-guard.mjs`: protected branches `main/master/production` (direct commit blocked); force-push blocked on `main/master/release/*`.
+- `completeness-gate.mjs`: scans file writes for live secrets (`sk_live_…`, etc.) and blocks before bytes hit disk.
+- `backup-before-write.mjs`: snapshots a file before it's overwritten.
+- Fail-safe: every hook catches `uncaughtException`/`unhandledRejection` and exits 0 — a crashing hook never wedges a session.
+
+## Stop saying (the "too general" traps)
+- "workflow management system" (sounds like Jira, no urgency)
+- leading with "30 agents, 86 commands, 63 skills" (breadth = the generic trap)
+- "structured operations management" (abstract, nobody searches it)
+- "multi-harness support" as a headline (a distribution fact, not a value prop)
+
+## Messaging by surface
+- **README lede:** "Claude Code does what you tell it — until it doesn't." → the hook guarantee, breadth as supporting evidence.
+- **awesome-claude-code submission:** name the problems, not the counts — "Pre-packaged, fail-safe hook layer: branch protection, secret blocking, bash guard, daily ritual, /team orchestrator. One npm install."
+- **Show HN:** lead with the deterministic-hooks angle (`show-hn.md`).
+- **Social:** the hook-vs-prompt contrast (`social.md`).
+
+## Signature assets (in order)
+1. **Incident post** (`incident-post.md`) — grounded in badi's **real** blocks (NOT the unverified
+   "PocketOS" story the research suggested). Shows the actual HARD_BLOCKS regex + the real block
+   message. 100% verifiable, copy-pasteable, useful even without installing badi.
+2. **Split-screen demo** (week 3) — left: a `CLAUDE.md` rule ignored mid-session; right: `branch-guard`
+   blocking the identical action with the incident-log entry appearing live.
+3. **README rewrite** (done in this pivot) — converts existing referral traffic with zero extra distribution.
+
+## Measure / kill
+- Leading (wk 1-4): incident post gets ≥3 non-author reactions or 1 real comment, OR any maintainer
+  response on awesome-cc #1955.
+- Lagging (day 90): GitHub stars cross 15, OR ≥1 external post/repo links badi *for its hook behavior*.
+- Kill: 90 days, zero external references / zero outside stars / awesome-cc still silent → the wedge
+  isn't pulling; reassess the audience/sub-community (Discord, a specific HN/subreddit), back to /ceo-review.
+- **Kill-watch:** Anthropic shipping a first-party "safe mode" hook bundle → moat narrows to the
+  daily-ritual + /team combination. Watch the Claude Code changelog.
+
+## Honesty guardrails (do NOT violate)
+- The blocking **hooks** enforce; the **pentest/security-scan** family is advisory-only — keep them distinct.
+- Do not build the flagship on the unverified "PocketOS" incident. Ground claims in badi's real, readable hooks.
+- Distinguish HARD_BLOCKS (always blocked) from SOFT_BLOCKS (blocked with warning) from LOG_WARNINGS (logged only).

--- a/.claude/workspace/launch/incident-post.md
+++ b/.claude/workspace/launch/incident-post.md
@@ -1,0 +1,112 @@
+<!--
+DRAFT for MANUAL human posting (dev.to / Hashnode). Do NOT auto-publish.
+Do NOT paste into Reddit/HN/Discord or the awesome-claude-code repo (AI-authored promo is a strike).
+Rewrite in your own voice before publishing. Tags: #claudecode #claudecodehooks #guardrails
+EVERY claim below is grounded in the real .claude/hooks/guard-bash.mjs, branch-guard.mjs, and
+completeness-gate.mjs in this repo — open them and confirm the wording matches what you ship.
+This deliberately does NOT cite the unverified "PocketOS" incident; it uses badi's own verifiable behavior.
+-->
+
+# Your AI agent has a shell. Here are the commands it should never run — and the hooks that stop them.
+
+Claude Code is an autonomous agent with access to your terminal. Most of the time that's the point. But "most of the time" is doing a lot of work in that sentence — because the same agent that writes your migration can also run `git push --force origin main`, `rm -rf` the wrong directory, or pipe your `.env` straight into `curl`. You can *ask* it not to, in `CLAUDE.md`. But a rule in `CLAUDE.md` is advice the model can reason its way around. It is not a guarantee.
+
+The fix isn't a better prompt. It's a hook — code that runs deterministically on every tool call, before the call executes, and returns a hard "no" that the model cannot talk itself past. That's the idea behind badi's hook layer, and this post walks through three real blocks, with the actual matching rules and the real output. You can copy the patterns whether or not you ever install badi.
+
+## 1. The force-push to `main`
+
+The classic. The agent decides the cleanest way out of a messy rebase is to force the branch. `branch-guard` intercepts every Bash call and checks the git operation against a protected-branch list (`main`, `master`, `production` for commits; `main`/`master`/`release/*` for force-push):
+
+```js
+// .claude/hooks/branch-guard.mjs (paraphrased)
+if (/git\s+push.*(--force\b|\s-f\b)/.test(command)) {
+  if (base === "main" || base === "master" || /^release\//.test(base)) {
+    // → block decision
+    "'main' is a protected branch; force push is not allowed."
+  }
+}
+```
+
+The agent gets a block, not a force-push. It has to switch to a feature branch like everyone else.
+
+## 2. `rm -rf /`, `curl | bash`, and friends
+
+`guard-bash.mjs` runs on every Bash tool call and matches the command against a tier of patterns. The top tier is **HARD_BLOCKS** — never allowed, no warning, no override:
+
+```js
+// .claude/hooks/guard-bash.mjs — HARD_BLOCKS (verbatim)
+const HARD_BLOCKS = [
+  /rm\s+-rf\s+\//i,
+  /rm\s+-rf\s+\*/i,
+  /git\s+push\s+--force\s+origin\s+(main|master)/i,
+  /git\s+reset\s+--hard\s+origin\//i,
+  /chmod\s+777/i,
+  /curl.*\|\s*(bash|sh|zsh)/i,
+  /wget.*\|\s*(bash|sh|zsh)/i,
+  />\s*\/etc\//i,
+  /mkfs\./i,
+  /dd\s+if=.*of=\/dev\//i,
+  /cat\s+.*\.(env|pem|key|secret).*\|\s*(curl|nc|wget)/i,
+  /echo\s+.*\$(.*password|.*secret|.*token|.*key).*\|\s*(curl|nc|wget)/i,
+];
+```
+
+Match any of these and the call is blocked with a logged incident:
+
+```
+Dangerous command blocked. This operation could harm the system.
+```
+
+Note the last two patterns specifically: they target **credential exfiltration** — `cat .env | curl …`, `echo $SECRET | nc …`. That's not a hypothetical; piping secrets to a remote host is exactly the kind of thing a confused (or compromised) agent does, and it's blocked at the tool-call layer, not the prompt layer.
+
+Below HARD_BLOCKS there's a **SOFT_BLOCKS** tier (blocked, but with a "use a safer alternative" message — e.g. any `rm -rf`, any `git push --force`, `git reset --hard`, `sudo rm`) and a **LOG_WARNINGS** tier that records `rm`/`mv`/`chmod`/`npm publish` without blocking, so you have an audit trail.
+
+## 3. The secret that almost got committed
+
+`completeness-gate.mjs` runs before file writes and scans the content for live-secret patterns (`sk_live_…` and friends). If it finds one, the write is blocked before the bytes hit disk:
+
+```js
+// .claude/hooks/completeness-gate.mjs (paraphrased)
+const secretPatterns = [ /sk_live_[a-zA-Z0-9]+/, /* … */ ];
+// match → block decision, the file is never written
+```
+
+The agent helpfully pasting a real API key into a committed config file is a quiet, common failure. This turns it into a hard stop.
+
+## The one design detail that makes it usable
+
+A guardrail you have to disable isn't a guardrail. Every one of these hooks is **fail-safe**: it catches `uncaughtException` and `unhandledRejection` and exits `0`. If the hook itself ever breaks, your session keeps moving — safety never becomes the thing that wedges your work:
+
+```js
+const _failSafe = (e) => { /* optional debug log */ process.exit(0); };
+process.on("uncaughtException", _failSafe);
+process.on("unhandledRejection", _failSafe);
+```
+
+## Steal the pattern
+
+You don't need my CLI to get this. The whole idea is small:
+
+1. Register a `PreToolUse` hook on `Bash` (and `Write|Edit`).
+2. Read the command/content from stdin, test it against a list of regexes.
+3. Return a block decision for the dangerous ones. Catch errors and exit 0.
+
+That's the highest-leverage safety code you can write for an autonomous agent — a dozen lines that turn "please don't" into "can't."
+
+If you'd rather not maintain your own, badi ships 14 of these wired together, fail-safe, as one install:
+
+```bash
+npm install -g @fatihkan/badi
+badi init      # wires up .claude/ (agents, commands, hooks)
+badi doctor    # validates the install and reports what's active
+```
+
+It's open source (MIT), early-stage, and the hooks are all readable in `.claude/hooks/`. If you try it and a block is too aggressive or not aggressive enough, that's the most useful thing you can tell me.
+
+---
+
+### Notes for the human posting this (delete before publishing)
+- **Verify before publishing:** open `.claude/hooks/guard-bash.mjs` / `branch-guard.mjs` / `completeness-gate.mjs` and confirm the regexes + block messages match the version you ship. The HARD_BLOCKS block above is verbatim from the current repo.
+- **Do NOT** reference the "PocketOS" incident (or any specific company outage) unless you have independently verified it — the credibility of a safety post dies the moment one claim is wrong.
+- Keep HARD_BLOCKS vs SOFT_BLOCKS vs LOG_WARNINGS distinct; don't claim something is hard-blocked when it's a soft block.
+- Post manually, in your own voice. Never auto-post; never into awesome-claude-code.

--- a/.claude/workspace/launch/show-hn.md
+++ b/.claude/workspace/launch/show-hn.md
@@ -12,11 +12,11 @@ Here is the deliverable.
 
 ## 1. Three "Show HN:" title options
 
-1. **Show HN: badi – a workflow layer for Claude Code (hooks, release gates, agent orchestration)**
+1. **Show HN: badi – deterministic safety hooks for Claude Code (blocks force-push to main, rm -rf, .env exfiltration)**
 2. **Show HN: badi – I wrapped my Claude Code setup in a CLI with git hooks and a release gate**
-3. **Show HN: badi – structured agents, hooks and slash commands for Claude Code**
+3. **Show HN: badi – a workflow layer for Claude Code (hooks, release gates, agent orchestration)**
 
-*(Title 1 is the recommended primary — it names the concrete technical surface without adjectives. Title 2 is a stronger fit if you want the honest "this started as my own config" framing, which HN tends to reward. Avoid exclamation points, "powerful," "ultimate," etc.)*
+*(Repositioned to lead with the safety wedge — Title 1 foregrounds the concrete, verifiable guardrails, which is the most differentiated and HN-credible angle since the claims map to readable code. Title 2 keeps the honest "started as my own config" origin story HN tends to reward. Title 3 is the older breadth framing — use only if the safety angle feels too narrow. Avoid exclamation points, "powerful," "ultimate," etc. The body below already leads with the enforcing hooks, which fits this title.)*
 
 ---
 

--- a/.claude/workspace/launch/social.md
+++ b/.claude/workspace/launch/social.md
@@ -1,104 +1,86 @@
-I have everything I need from the diagnosis brief. This is a content-only task with no need to touch the repo or any external site. Here is the launch copy, grounded in the brief and honest about traction.
+# Social launch copy — SAFETY WEDGE (agentic safety layer for Claude Code)
 
----
+> Repositioned 2026-06-21 to lead with the verified safety hooks (see POSITIONING.md).
+> All claims grounded in badi's real hooks. **Human-only posting** — rewrite in your own
+> voice; never auto-post; never into the awesome-claude-code repo.
 
 # 1. X/Twitter Launch Thread (5 tweets)
 
 **Tweet 1 — Hook**
-> Every new Claude Code project, I'd rebuild the same .claude/ setup from scratch: agents, slash commands, hooks. Copy-paste, tweak, forget what I changed last time.
+> Claude Code can run `git push --force origin main`, `rm -rf` the wrong folder, or pipe your `.env` into curl.
 >
-> So I packaged mine into a CLI. It's called badi. v1.35 is on npm.
+> You can tell it not to in CLAUDE.md. But that's advice — and a model can reason its way around advice.
 
-*(238 chars)*
-
-**Tweet 2 — The problem**
-> The real cost isn't the first setup. It's drift.
+**Tweet 2 — The shift**
+> A prompt is a suggestion. A hook is enforcement.
 >
-> Six projects in, every .claude/ is slightly different. No two have the same review command, the same security pass, the same daily ritual. You stop trusting your own config.
+> badi is the agentic safety layer for Claude Code: 14 deterministic hooks that run as real code on every tool call and block the irreversible actions before they execute.
 
-*(244 chars)*
-
-**Tweet 3 — What badi does**
-> badi pre-wires .claude/ from one source:
-> - 30 agents (code review, security, market/SEO research)
-> - 86 commands across dev, content, mobile, infra
-> - 14 hooks (branch guard, backups, session briefing)
+**Tweet 3 — The proof**
+> The bash guard hard-blocks `rm -rf /`, `curl | bash`, and `.env` exfiltration. branch-guard blocks commits + force-push to main. A completeness gate blocks writes containing live secrets.
 >
-> One install, same setup everywhere.
-
-*(255 chars)*
+> All fail-safe: a crashing hook never wedges your session.
 
 **Tweet 4 — Before / after**
-> Before: new repo, hand-roll a /review command, wire a backup hook, hope I matched last project.
+> Before: "don't commit to main" in CLAUDE.md → ignored mid-session.
+> After: the commit hits the hook and stops, with an incident-log entry.
 >
-> After:
-> npx @fatihkan/badi init
-> badi doctor
->
-> /review, /security-scan, /start all there. Security stays advisory-only — findings get triaged, never auto-run.
-
-*(279 chars)*
+> npx @fatihkan/badi init && badi doctor
 
 **Tweet 5 — CTA (honest)**
-> Early days, low traction, and I'd rather have 10 users who file real issues than a vanity number.
+> Early days (~5 stars). I'd rather have 10 users who file real issues than a vanity number.
 >
-> Try it, break it, tell me what's missing:
-> npm i -g @fatihkan/badi
-> github.com/fatihkan/badi
+> Every hook is readable in .claude/hooks/. Try it, break it, tell me what's too aggressive:
+> npm i -g @fatihkan/badi · github.com/fatihkan/badi
 >
-> Works with Claude Code; Cursor/Gemini export too.
-
-*(263 chars)*
+> (It's a full workflow layer too — 30 agents, a daily ritual, /team — but the hooks are why I'd install it.)
 
 ---
 
 # 2. LinkedIn Post
 
-> I kept rebuilding the same Claude Code setup for every project, and I kept getting it slightly wrong.
+> Claude Code is an autonomous agent with access to your terminal. Most of the time that's the point — until it force-pushes to main, removes the wrong directory, or pastes a live API key into a committed file.
 >
-> The pattern was always the same: a fresh repo, then an hour wiring up the .claude/ directory — a code-review command here, a backup hook there, a security pass I'd written for the last project but couldn't quite remember. Multiply that across half a dozen repos and you get configuration drift: six setups that are all almost the same, and none you fully trust.
+> You can write "don't do that" in a CLAUDE.md file. But that's a suggestion, and a model can reason its way past a suggestion. The only thing that reliably stops an irreversible action is code that runs *before* the action executes.
 >
-> So I turned my own setup into a CLI: **badi** (v1.35, on npm).
+> So I built **badi** (v1.35, on npm) around that idea: the agentic safety layer for Claude Code.
 >
-> One install wires .claude/ from a single source:
-> - 30 agents — code review, security scanning, plus advisory research roles (market, SEO, data)
-> - 86 slash commands spanning dev, content, mobile, and infrastructure work
-> - 14 automation hooks — a branch guard, file backups, a session-start briefing
-> - Profile-based filtering so a content project doesn't carry pentest commands it'll never use
+> It ships 14 deterministic hooks that fire on every tool call:
+> - a bash guard that hard-blocks destructive commands (rm -rf /, curl | bash, .env exfiltration),
+> - a branch guard that blocks direct commits and force-pushes to protected branches,
+> - a completeness gate that blocks file writes containing live secrets.
 >
-> Two design choices I'd call out honestly:
+> Two things I'd call out honestly:
 >
-> **Security is advisory, not autonomous.** Scans produce findings that go through a triage step (true positive / false positive / can't verify). Nothing executes a payload on its own. If you've ever inherited a scanner that dumped 200 low-confidence "criticals" on you, that distinction matters.
+> **Enforcement, not advice.** These are hooks, not prompts — the model cannot talk its way past a block. And they're fail-safe: if a hook ever errors, it exits cleanly so it can never wedge your session.
 >
-> **It's early.** Around 1,600 monthly npm downloads and a handful of GitHub stars. I'm not going to dress that up. What I can say is it's shipped consistently through 35 releases with a real test suite behind it, and it does the one job I built it for: I stop re-deriving my setup.
+> **It's early.** A handful of GitHub stars, low download numbers. I'm not dressing that up. But the hooks are real, readable, and tested (1321 passing tests on the deterministic parts), and badi is also a full workflow layer — daily ritual, code review, a virtual eng team — once you're past the guardrails.
 >
-> If you work in Claude Code daily and you're tired of copy-pasting your config, I'd genuinely value your feedback — especially the "this is missing X" kind.
+> If you run Claude Code anywhere near autonomously, I'd genuinely value your feedback on whether the hooks are the right primitive.
 >
-> Repo and install instructions: github.com/fatihkan/badi
+> Repo + install: github.com/fatihkan/badi
 
 ---
 
 # 3. r/ClaudeAI Note
 
-> **HUMAN-ONLY: post manually. Follow r/ClaudeAI's self-promo rules — disclose "I built this," lead with the workflow not the product, and don't auto-post. Reddit flags AI-written promo aggressively; rewrite this in your own voice before posting. Do NOT have any bot or automation submit it.**
+> **HUMAN-ONLY: post manually. Follow r/ClaudeAI's self-promo rules — disclose "I built this," lead with the workflow/problem not the product, and don't auto-post. Reddit flags AI-written promo aggressively; rewrite this in your own voice before posting. Do NOT have any bot or automation submit it.**
 
 **Suggested title:**
-How I stopped my Claude Code `.claude/` configs from drifting across projects
+I made Claude Code physically unable to force-push to main (and a few other things) — here's the hook pattern
 
 **Suggested body (rewrite in your own words):**
 
-> Disclosure up front: I built the tool I'm about to mention, so take this as a workflow writeup with a bias, not a neutral review.
+> Disclosure up front: I built the tool I'll mention, so treat this as a workflow writeup with a bias.
 >
-> The problem I kept hitting: every new project meant rebuilding my .claude/ directory — review commands, hooks, the daily-start ritual. After a few repos they'd all drifted apart and I couldn't remember which one had the config I actually liked.
+> The thing that finally bugged me enough to fix: a CLAUDE.md rule is just advice the model can ignore. "Don't commit to main," "don't run destructive commands" — useful until the agent decides otherwise mid-session.
 >
-> What worked for me was treating the whole setup as one installable source instead of per-project copy-paste. I ended up packaging it as a CLI (badi) so `init` lays down the same agents, commands, and hooks everywhere, and a profile filter keeps each project from carrying commands it doesn't need.
+> What actually worked was Claude Code's hook system. A PreToolUse hook runs code before a tool call executes, reads the command from stdin, and can return a hard block. I wired up a branch guard (blocks commits/force-push to protected branches), a bash guard (hard-blocks rm -rf /, curl | bash, .env exfiltration), and a completeness gate (blocks writes with live secrets). All fail-safe — a broken hook exits 0 so it never wedges the session.
 >
-> Two things I'd flag honestly if you try it:
-> - The security agents are advisory-only — findings go through a triage step rather than auto-running anything. I went that route after getting burned by noisy scanners.
-> - It's low-traction and early, so expect rough edges. I'm mostly looking for "this is broken / this is missing" feedback.
+> I packaged mine as a CLI (badi) so `init` lays them all down at once, but honestly the pattern is the valuable part — a dozen lines of regex + a block decision turns "please don't" into "can't." Happy to share the exact hook source.
 >
-> More interested in how others here handle config reuse across Claude Code projects — do you template it, script it, or just re-do it each time? Happy to share the specific hook/command setup if it's useful.
+> How does everyone else here handle guardrails for near-autonomous Claude Code sessions — hooks, sandboxing, manual approval, or just trust?
 
 ---
 
-**Notes on constraints honored:** All copy is read-only — nothing was posted, commented, or filed anywhere, and no repo files were changed. The awesome-claude-code listing is deliberately not referenced as a posting target; the Reddit note is flagged human-only at the top per the AI/bot ban risk. No competitor projects are named in the badi-facing copy. Traction is stated plainly (early, low downloads/stars) rather than hyped, since credibility is the priority for a tool at this stage.
+**Notes on constraints honored:** All copy is read-only — nothing posted/commented/filed; no repo files changed by writing this. Reddit note flagged human-only per the AI/bot ban risk. No competitor projects named. Traction stated plainly (early, low stars) — for a tool at this stage, candor is the credibility lever. Claims grounded in the real `.claude/hooks/` (guard-bash, branch-guard, completeness-gate); verify wording before posting.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
   <img src="https://img.shields.io/badge/node-%3E%3D20.11-00d4ff?style=flat-square" alt="node" />
 </p>
 
-**Stop re-wiring `.claude/` for every project.** Badi installs a vetted, tested operations layer for **Anthropic Claude Code** (and Cursor, Gemini CLI, Windsurf) — so you start working instead of configuring. One command gives you **30 expert subagents**, **86 slash commands**, **63 opt-in skill categories**, and **14 automation hooks**, all prompt-aware and profile-managed.
+**Claude Code does what you tell it — until it doesn't.** badi is the **agentic safety layer for Claude Code**: 14 deterministic hooks that run as real code on every tool call and block the irreversible actions — a force-push to `main`, an `rm -rf /`, a `.env` piped to `curl` — *before* they execute. Not a prompt the model can reason around — code that intercepts the call. And it's fail-safe: if a hook ever errors it exits cleanly, so safety never wedges your session.
 
 ```bash
-npx @fatihkan/badi init && badi doctor   # ~2 minutes, interactive harness picker
+npx @fatihkan/badi init && badi doctor   # ~2 minutes
 ```
 
-Advisory-only security (OWASP Top 10), code review, a virtual engineering team, content, mobile/SEO, and App Store demand research — opt into only what you need. Built for **Claude Opus 4.7 / Sonnet 4.6** · 1321 passing tests · MIT.
+Beyond the guardrails, badi is a full Claude Code workflow layer — a daily ritual, code review, a virtual eng team, content & SEO — as **30 subagents, 86 commands, and 63 opt-in skills** you enable only when you need them. Works with Cursor, Gemini CLI, and Windsurf too. Built for **Claude Opus 4.7 / Sonnet 4.6** · 1321 passing tests · MIT.
 
 ## Demo
 
@@ -30,12 +30,13 @@ Advisory-only security (OWASP Top 10), code review, a virtual engineering team, 
 
 ## Why Badi?
 
-You could hand-roll your own slash commands and agents — many people do. Badi is the maintained, tested alternative:
+You could hand-roll your own slash commands and agents — many people do. Badi is the maintained, tested alternative, and it starts with guarantees, not suggestions:
 
-- **Curated, not assembled** — 30 subagents and 86 commands that already work together (a virtual eng team, security/review, content, mobile/SEO), instead of writing and maintaining each one yourself.
+- **Enforced, not suggested** — guardrails run as code on every tool call: `branch-guard` blocks direct commits and force-pushes to protected branches, a bash guard hard-blocks destructive commands (`rm -rf /`, `curl | bash`, `.env` exfiltration), and a completeness gate blocks file writes that contain live secrets. A `CLAUDE.md` rule is advice; a hook is enforcement.
+- **Fail-safe by design** — if a hook ever errors it exits cleanly and never wedges your session, so safety doesn't become friction.
+- **Curated, not assembled** — 30 subagents and 86 commands that already work together (a virtual eng team, code review, content, mobile/SEO), instead of writing and maintaining each one yourself.
 - **One source, five harnesses** — author once in `.claude/`; compile to Claude Code, Cursor, Gemini CLI, Windsurf, and AGENTS.md.
-- **Opt-in by default** — skills load zero tokens until a prompt needs them, and profiles hide the commands you don't use, so the surface stays small.
-- **Safe by default** — branch protection, backups, and advisory-only security scans (no autonomous execution).
+- **Opt-in by default** — skills load zero tokens until a prompt needs them, and profiles hide the commands you don't use.
 - **Tested** — 1321 passing tests, with releases gated on a docs/security sync check.
 
 ## Install Options (v1.30.1+)


### PR DESCRIPTION
## What
Owner-approved positioning pivot so badi **stands out**. The wedge: **agentic safety layer for Claude Code** — deterministic hooks that run as code on every tool call and block irreversible actions (destructive shell commands, a force-push to a protected branch, credential exfiltration) before they execute.

- **README**: lede + Why-Badi rewritten around the verified safety hooks (replaces the JTBD lede from #301). Every claim grounded in the repo's real hooks (guard-bash / branch-guard / completeness-gate). Counts unchanged (30/86/63/14/1321); markdown lint clean.
- **launch/POSITIONING.md**: canonical messaging (wedge, statement, verified proof, stop-saying, per-surface copy, kill-watch).
- **launch/incident-post.md**: flagship dev.to post grounded in badi's REAL verified blocks (NOT an unverified third-party incident).
- **show-hn.md / social.md**: re-led on the hook-vs-prompt contrast.
- **PLAN.md / TaskBoard**: record the pivot.

## Why
Both independent positioning strategies + the product-strategist judge converged on the safety wedge: it's defensible, credible TODAY (proof is shipped + readable), searchable demand, and passes the 5-second test — escaping the 'too general' trap.

## Notes
- Docs/workspace only; no code, no version bump, not a freeze exception.
- All claims verified against the live hooks before adoption. External posting stays a human action.
- Fun fact: the first commit attempt was blocked by badi's own guard-bash hook (the message contained a destructive-command literal) — a live demo of the wedge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)