### PR TITLE
feat(ads): ground meta/ads-review in live-verified measurement mechanics

### DIFF
--- a/.claude/agents/ads-strategist.md
+++ b/.claude/agents/ads-strategist.md
@@ -21,10 +21,17 @@ The paid-advertising voice on the virtual team. Knows the project from the insid
 4. **Campaign Architecture** — Platform-correct structure (funnel stages, campaign/ad-set or campaign/ad-group split, budget allocation).
 5. **Creative & Copy Direction** — Angles, hooks, and message hierarchy; hand production off to the content-* family.
 6. **Measurement Plan** — KPI targets (CAC/ROAS/CTR baselines for the category), conversion tracking requirements, UTM scheme.
+   - **Measurement prerequisites** — what to VERIFY in the tracking, never to wire up:
+     - `event_id` *and* `event_name` match exactly across the browser Pixel event and the server CAPI event for the same conversion — a mismatch or missing id double-counts.
+     - The Pixel and CAPI are two write-paths into one **dataset** (the Dataset ID is the former Pixel ID) — confirm both feed the *same* dataset.
+     - `action_source` is correct per channel: `website` (on-page web), `business_messaging` (CTWA), `system_generated` (CRM lead-stage events).
+     - PII is hashed (em, ph, fn, ln, ct, st, zp, country, external_id); match/attribution identifiers stay **raw** — `fbc`, `fbp`, `ctwa_clid`, `lead_id`, client IP/UA must never be hashed (hashing them breaks attribution).
 7. **Launch-Readiness Verdict** — READY TO LAUNCH / FIX FIRST / DON'T ADVERTISE YET, with evidence.
 
 ## Platform Lenses
-- **Meta (FB/IG)** — cold/warm/hot funnel, CBO vs ABO, creative-first ranking, Advantage+ trade-offs, policy risk scan (restricted categories, claims).
+- **Meta (FB/IG)** — cold/warm/hot funnel, CBO vs ABO, creative-first ranking, Advantage+ trade-offs, policy risk scan (restricted categories, claims). Treat these as distinct objectives, not only funnel temperatures:
+  - **Click-to-message (CTWA)** — messaging-destination objective: the conversion is a *started conversation*, attributed server-side (`action_source=business_messaging` + `ctwa_clid`), not via an on-page pixel. The sales cycle lives in the thread, so its attribution window runs longer than form leads — verify the current window for this funnel against Meta's live docs, never hardcode it.
+  - **Lead Ads / Instant Forms** — on-ad form: the ad set carries `promoted_object={page_id}` + `destination_type=ON_AD`, and the form binds on the **ad creative** (`lead_gen_form_id`), not the ad set. Distinguish the lead-volume baseline (`optimization_goal=LEAD_GENERATION`) from the opt-in "conversion leads" upgrade (`QUALITY_LEAD`), which additionally needs CRM lead-stage events fed back via CAPI. Published forms are immutable — editing one means a new form_id + rebind, so flag it as a real launch blocker.
 - **Google Ads** — intent capture: keyword universe + match types + negatives, Search vs PMax, RSA asset coverage, Quality Score levers (landing page, ad relevance), conversion tracking prerequisites.
 
 ## Verdict Frame
@@ -44,6 +51,7 @@ Blockers    : what must exist before spending (landing page, pixel, policy)
 - Verifies platform policies via research, never from memory (policies change fast).
 - Does not produce final creatives — defines angles/briefs and delegates production to content-generate / content-visual-brief / content-video-script.
 - Honest verdicts: "DON'T ADVERTISE YET" when the funnel can't convert (no landing page, no tracking, unclear offer).
+- **Advise launching PAUSED** — recommend every campaign be created in PAUSED state as a no-spend safeguard; a best-practice default, not a Meta rule (Meta otherwise creates new campaigns ACTIVE). And verify tracking is *correct*, not merely present: a pixel that fires but double-counts or sets the wrong `action_source` is worse than no tracking at all.
 
 ## Output Format
 1. **Verdict** (one line + why)

--- a/.claude/commands-vault/ads-review.md
+++ b/.claude/commands-vault/ads-review.md
@@ -22,7 +22,11 @@ Launch the **ads-strategist** agent with the project context. Ask for:
 - Campaign architecture: Search vs Performance Max trade-off for this product; ad-group theming.
 - RSA asset coverage: headlines/descriptions angles derived from real features (hand production to content-*).
 - Quality Score levers: landing page ↔ ad relevance gaps found in the repo's actual pages.
-- Conversion tracking prerequisites (what counts as a conversion for this product; GA4/gtag plan).
+- Conversion tracking prerequisites (what counts as a conversion for this product; GA4/gtag plan), plus the privacy-durable layer to verify before launch:
+  - Enhanced Conversions: supplement the gtag/GA4 tag with SHA-256-hashed first-party data (email required) matched to signed-in Google accounts.
+  - Offline Conversion Import: capture GCLID at click (or its iOS BRAID fallbacks) and upload the CRM close with a conversion timestamp — verify the current upload path.
+  - Dedup: one unique transaction_id / order_id shared EXACTLY by the client tag and the upload, or conversions double-count.
+  - Consent Mode v2 (ad_storage, analytics_storage, ad_user_data, ad_personalization), required for EEA/UK — verify current semantics + enforcement live (governance actively changing).
 - Starting budget + bid strategy progression (manual/maximize → tCPA when data allows) + kill threshold.
 
 ### Step 3: Readiness Gate

--- a/.claude/commands-vault/meta-review.md
+++ b/.claude/commands-vault/meta-review.md
@@ -25,10 +25,24 @@ Launch the **ads-strategist** agent with the project context. Ask for:
 - Starting budget + scaling rule + kill threshold.
 - Policy risk scan (restricted categories, claim rules) — verified by research, not memory.
 
+#### Funnel destination — fork before staging (each first-class, not an afterthought to cold/warm/hot)
+Pick the conversion destination first, then layer cold → warm → hot inside it:
+- **Web conversion** — traffic to a landing page; Pixel + CAPI both feeding one dataset (`action_source=website`). Standard cold→warm→hot retargeting.
+- **Click-to-WhatsApp (CTWA)** — messaging-destination funnel; the conversation *is* the funnel. Server signal `action_source=business_messaging` + `ctwa_clid` (+ `messaging_channel`), not an on-page pixel. The sales cycle runs longer than a web lead, so re-engagement timing and the kill clock should reflect that (verify the current attribution window for this funnel type live).
+- **Lead Ads / Instant Forms** — on-ad form, no landing page. Ad set carries `promoted_object={page_id}` + `destination_type=ON_AD`, baseline `optimization_goal=LEAD_GENERATION`; the `lead_gen_form_id` binds on the AD CREATIVE, not the ad set. `QUALITY_LEAD` is an opt-in "conversion leads" upgrade that ALSO requires CRM lead-stage events returned via CAPI (`action_source=system_generated` + `lead_id`) — do not present it as the default.
+
+#### Measurement prerequisites (verify live)
+Before any READY verdict, the strategist must confirm the tracking the chosen funnel depends on:
+- **One dataset, two write-paths** — the browser Pixel (client tag) and the CAPI server endpoint feed ONE shared dataset (the Dataset ID; in the common case the former Pixel ID). Confirm both paths target the same dataset — "pixel" = the browser tag, "dataset" = the container both feed.
+- **Deterministic `event_id` dedup** — for a single conversion the Pixel event and the CAPI event must carry an IDENTICAL `event_id` AND the same `event_name`, derived from a stable source (e.g. `order_id` for purchases, the form-submit/lead UUID for leads). A mismatch or missing id double-counts. Dedup is also bounded by a rolling time window — verify the current window live and keep the two timestamps close.
+- **`action_source` matches the channel** — required on every server event: `website` (web/Pixel conversions), `business_messaging` (CTWA + messaging, paired with `ctwa_clid`), `system_generated` (CRM lead-stage events, paired with `lead_id`). A wrong value yields unattributed / mis-optimized conversions.
+- **PII hash scope** — SHA-256 *after normalization* the identifiers: `em, ph, fn, ln, ct, st, zp, country, external_id` (plus `db/ge` if sent). Keep RAW, never hash: `fbc, fbp, client_ip_address, client_user_agent, ctwa_clid, lead_id, subscription_id, order_id` — hashing these breaks matching/attribution.
+
 ### Step 3: Readiness Gate
 Require an explicit verdict:
 - **READY TO LAUNCH** — funnel complete (landing page, pixel/CAPI plan, offer clear).
 - **FIX FIRST** — launchable after named blockers (e.g., no conversion tracking).
+  - *Lead-form immutability* — a published/active Instant Lead Form cannot be edited (API or UI); changing its questions/fields means a NEW `form_id` + rebinding the ad (a new/duplicated creative). FIX FIRST: lock the form's fields before publish — it is editable only while in DRAFT, and duplicate-then-edit is the supported path.
 - **DON'T ADVERTISE YET** — spending now would burn budget; say what to build first.
 
 ### Step 4: Handoffs
@@ -39,6 +53,7 @@ Require an explicit verdict:
 # Rules
 - **Advisory only** — never call ad-platform APIs, never handle credentials; the user executes spend.
 - Policies are researched live, never recalled from training.
+- **Safe default: any proposed campaign starts PAUSED** — badi's no-spend posture, not a Meta rule (Meta otherwise creates new campaigns ACTIVE); verify tracking end-to-end before recommending activation.
 - An honest DON'T ADVERTISE YET beats a polite launch plan.
 
 # Output Format

--- a/.claude/commands/ads-review.md
+++ b/.claude/commands/ads-review.md
@@ -22,7 +22,11 @@ Launch the **ads-strategist** agent with the project context. Ask for:
 - Campaign architecture: Search vs Performance Max trade-off for this product; ad-group theming.
 - RSA asset coverage: headlines/descriptions angles derived from real features (hand production to content-*).
 - Quality Score levers: landing page ↔ ad relevance gaps found in the repo's actual pages.
-- Conversion tracking prerequisites (what counts as a conversion for this product; GA4/gtag plan).
+- Conversion tracking prerequisites (what counts as a conversion for this product; GA4/gtag plan), plus the privacy-durable layer to verify before launch:
+  - Enhanced Conversions: supplement the gtag/GA4 tag with SHA-256-hashed first-party data (email required) matched to signed-in Google accounts.
+  - Offline Conversion Import: capture GCLID at click (or its iOS BRAID fallbacks) and upload the CRM close with a conversion timestamp — verify the current upload path.
+  - Dedup: one unique transaction_id / order_id shared EXACTLY by the client tag and the upload, or conversions double-count.
+  - Consent Mode v2 (ad_storage, analytics_storage, ad_user_data, ad_personalization), required for EEA/UK — verify current semantics + enforcement live (governance actively changing).
 - Starting budget + bid strategy progression (manual/maximize → tCPA when data allows) + kill threshold.
 
 ### Step 3: Readiness Gate

--- a/.claude/commands/meta-review.md
+++ b/.claude/commands/meta-review.md
@@ -25,10 +25,24 @@ Launch the **ads-strategist** agent with the project context. Ask for:
 - Starting budget + scaling rule + kill threshold.
 - Policy risk scan (restricted categories, claim rules) — verified by research, not memory.
 
+#### Funnel destination — fork before staging (each first-class, not an afterthought to cold/warm/hot)
+Pick the conversion destination first, then layer cold → warm → hot inside it:
+- **Web conversion** — traffic to a landing page; Pixel + CAPI both feeding one dataset (`action_source=website`). Standard cold→warm→hot retargeting.
+- **Click-to-WhatsApp (CTWA)** — messaging-destination funnel; the conversation *is* the funnel. Server signal `action_source=business_messaging` + `ctwa_clid` (+ `messaging_channel`), not an on-page pixel. The sales cycle runs longer than a web lead, so re-engagement timing and the kill clock should reflect that (verify the current attribution window for this funnel type live).
+- **Lead Ads / Instant Forms** — on-ad form, no landing page. Ad set carries `promoted_object={page_id}` + `destination_type=ON_AD`, baseline `optimization_goal=LEAD_GENERATION`; the `lead_gen_form_id` binds on the AD CREATIVE, not the ad set. `QUALITY_LEAD` is an opt-in "conversion leads" upgrade that ALSO requires CRM lead-stage events returned via CAPI (`action_source=system_generated` + `lead_id`) — do not present it as the default.
+
+#### Measurement prerequisites (verify live)
+Before any READY verdict, the strategist must confirm the tracking the chosen funnel depends on:
+- **One dataset, two write-paths** — the browser Pixel (client tag) and the CAPI server endpoint feed ONE shared dataset (the Dataset ID; in the common case the former Pixel ID). Confirm both paths target the same dataset — "pixel" = the browser tag, "dataset" = the container both feed.
+- **Deterministic `event_id` dedup** — for a single conversion the Pixel event and the CAPI event must carry an IDENTICAL `event_id` AND the same `event_name`, derived from a stable source (e.g. `order_id` for purchases, the form-submit/lead UUID for leads). A mismatch or missing id double-counts. Dedup is also bounded by a rolling time window — verify the current window live and keep the two timestamps close.
+- **`action_source` matches the channel** — required on every server event: `website` (web/Pixel conversions), `business_messaging` (CTWA + messaging, paired with `ctwa_clid`), `system_generated` (CRM lead-stage events, paired with `lead_id`). A wrong value yields unattributed / mis-optimized conversions.
+- **PII hash scope** — SHA-256 *after normalization* the identifiers: `em, ph, fn, ln, ct, st, zp, country, external_id` (plus `db/ge` if sent). Keep RAW, never hash: `fbc, fbp, client_ip_address, client_user_agent, ctwa_clid, lead_id, subscription_id, order_id` — hashing these breaks matching/attribution.
+
 ### Step 3: Readiness Gate
 Require an explicit verdict:
 - **READY TO LAUNCH** — funnel complete (landing page, pixel/CAPI plan, offer clear).
 - **FIX FIRST** — launchable after named blockers (e.g., no conversion tracking).
+  - *Lead-form immutability* — a published/active Instant Lead Form cannot be edited (API or UI); changing its questions/fields means a NEW `form_id` + rebinding the ad (a new/duplicated creative). FIX FIRST: lock the form's fields before publish — it is editable only while in DRAFT, and duplicate-then-edit is the supported path.
 - **DON'T ADVERTISE YET** — spending now would burn budget; say what to build first.
 
 ### Step 4: Handoffs
@@ -39,6 +53,7 @@ Require an explicit verdict:
 # Rules
 - **Advisory only** — never call ad-platform APIs, never handle credentials; the user executes spend.
 - Policies are researched live, never recalled from training.
+- **Safe default: any proposed campaign starts PAUSED** — badi's no-spend posture, not a Meta rule (Meta otherwise creates new campaigns ACTIVE); verify tracking end-to-end before recommending activation.
 - An honest DON'T ADVERTISE YET beats a polite launch plan.
 
 # Output Format

--- a/.claude/workspace/ANALYSIS-meta-ads-mechanics.md
+++ b/.claude/workspace/ANALYSIS-meta-ads-mechanics.md
@@ -1,0 +1,94 @@
+# Analysis: Meta-platform ads mechanics → sharpening badi's `/meta-review` + `/ads-review` (2026-06-26)
+
+> Source: deep read-only of a real, in-production Meta Ads + CAPI + WhatsApp SaaS (the owner's own
+> `e-meta` project). Goal: harvest the **concrete Meta-platform mechanics** that badi's two advisory
+> ad commands currently describe only abstractly. Freeze active → these are `/ceo-review` HARDENING
+> candidates, not an immediate build. The source project is **never named** in any shipped badi file;
+> only the generic Meta-platform facts (CAPI, CTWA, event_id dedup) — which are public-API truths — travel.
+
+## The gap (one sentence)
+badi's `/meta-review`, `/ads-review`, and `ads-strategist.md` are **strategically complete but mechanically thin**:
+they say "pixel/CAPI plan", "conversion tracking", "policy risk", "hash PII" as checkboxes — the source
+project proves those checkboxes hide 8 load-bearing mechanics that decide whether a Meta campaign actually
+measures conversions or silently burns budget. Adding them makes the advisory verdicts *operationally true*,
+not just plausible.
+
+## Ground truth (what the source implements)
+A full Meta Ads API surface: campaigns (6 `OUTCOME_*` objectives, default **PAUSED**), adsets
+(`QUALITY_LEAD` for lead ads), creatives, custom audiences (SHA-256 PII upload), pixels/datasets,
+insights, targeting search, **Lead Ads + Instant Forms**, **CTWA (Click-to-WhatsApp Ads)**, and a
+shared **`sendCapiEvents()`** core with a `CapiEvent` idempotency ledger. This is exactly the
+"send-traffic-TO + measure-it" layer badi's commands gate on.
+
+## ADOPT — ranked HARDENING candidates (sharpen existing specs; no new command/agent/skill surface)
+
+| # | Mechanic (generic Meta fact) | Why it matters | Lands in |
+|---|------------------------------|----------------|----------|
+| 1 | **Deterministic `event_id` dedup** — pixel and CAPI must fire the *same* `event_id` per conversion (e.g. `lead:<id>:<stage>`) or Meta double-counts. | The single most common silent measurement bug. badi's specs say "dedup" without saying *how*. | `meta-review.md` Measurement; `ads-strategist.md` Measurement Plan |
+| 2 | **Pixel ≠ Dataset** — same object, two roles: browser pixel (client) vs CAPI dataset (server-side `/events` edge). | badi conflates them ("pixel/CAPI plan"). Naming the split is the prerequisite to #1. | `meta-review.md` Step 2 / Measurement |
+| 3 | **`action_source` per channel** — `website` (pixel) vs `business_messaging` (CTWA) vs `system_generated` (Lead Ads). Wrong value = unattributed. | badi treats all Meta conversions uniformly; the funnel destination dictates the setup. | `meta-review.md` Campaign Architecture |
+| 4 | **PII hashing scope** — hash em/ph/fn/ln/zip/country (SHA-256, normalized); keep `ctwa_clid`/`lead_id`/`fbc`/`fbp`/IP **raw** (hashing identifiers breaks attribution). | badi says "hash PII" generically — hashing the wrong field silently kills the match. Real policy nuance. | `ads-strategist.md` Boundaries; `meta-review.md` Rules |
+| 5 | **Attribution window varies by funnel** — CTWA ~90-day click window vs Lead Ads ~28-day. Drives re-engagement timing + the kill-threshold clock. | badi's kill/scale thresholds assume one window. | `meta-review.md` Budget (start/scale/kill) |
+| 6 | **CTWA / Lead Ads as first-class Meta funnels** — click-to-WhatsApp and Instant Lead Forms are objectives (`OUTCOME_LEADS` + `QUALITY_LEAD` + `lead_gen_form_id`, `destination_type=ON_AD`), not afterthoughts. | badi's Meta lens only names cold/warm/hot + Advantage+; messaging/lead funnels are a whole branch it omits. | `meta-review.md` Step 2 (add a funnel-type fork); `ads-strategist.md` Platform Lenses |
+| 7 | **Default-PAUSED + two-source token pattern** — never auto-activate; env system-user token (permanent) → user token (60-day refresh) fallback. | Reinforces badi's *advisory-only / no-spend* boundary with a concrete safe-default. | `ads-strategist.md` Boundaries; both command Rules |
+| 8 | **Lead-form immutability** — Meta lead forms can't be updated via API; editing = new `form_id` + rebind ads. | A real launch-readiness blocker badi's readiness gate doesn't flag. | `meta-review.md` Readiness Gate (FIX FIRST list) |
+
+**Best single edit:** fold #1–#4 into a tight **"Measurement prerequisites"** block in `meta-review.md` +
+the matching 3 lines in `ads-strategist.md`'s Measurement Plan. ~25-30 lines total, turns the readiness
+gate from "do you have tracking?" into "is your tracking *correct*?" — the difference between a verdict
+that sounds right and one that is.
+
+## `/ads-review` (Google) — lighter touch
+The source is Meta-only, so the direct transfer is the **principle**, not the mechanics: Google's analogue
+to #1/#2 is **enhanced conversions + offline conversion import (GCLID)** and **dedup on the conversion
+`order_id`**. Worth one sentence in `ads-review.md`'s Measurement Plan; no deep adoption — don't fabricate
+Google specifics from a Meta codebase.
+
+## DON'T
+- **Don't add an ads *execution* surface.** badi's commands are advisory by hard rule (no API calls, no
+  credentials, user executes spend). These mechanics enter as **what to verify**, never as code that calls Meta.
+- **Don't name the source project** (or any repo) in shipped `meta-review.md` / `ads-review.md` /
+  `ads-strategist.md` / README. The mechanics are public Meta-API facts; they need no attribution and
+  carry none. This internal doc may reference it; shipped files may not.
+- **Don't build a new agent or skill.** Everything here sharpens 3 existing files. New surface = the
+  exact anti-pattern the freeze guards against.
+- **Don't import TRY currency / WhatsApp-specifics as defaults** — they're the source's locale, not badi's.
+  Keep adopted text channel-agnostic.
+
+## Freeze + posture
+- **Classification:** HARDENING (internal quality of existing advisory specs; zero new user-visible surface).
+  Still a freeze-touch → route through `/ceo-review` before editing, per the exception framework.
+- **Freeze-exception count:** this would be the **3rd** standing exception (gate at 3 → product-strategist
+  prompts the owner to hold / change-threshold / lift). So adoption is explicitly an **owner decision**, not
+  a build decision.
+- **Posture:** this is tooling-quality, not promotion — fully consistent with "don't over-advertise badi."
+
+## Bottom line
+Real, shippable sharpening: the source project is a working proof of the exact layer badi's two commands
+advise on, and it exposes 8 concrete mechanics that make the difference between a measurement plan that
+*reads* correct and one that *is*. Adopting #1–#4 (Measurement prerequisites block) is the high-leverage,
+low-risk move. It's freeze-gated and owner-decided — not something to ship unprompted.
+
+---
+
+## APPLIED (2026-06-26) — owner-directed, live-verified, shipped
+Owner green-lit the build ("use the improvements to make the skill better"). A 3-phase workflow
+(verify-facts-live → draft → adversarial-review, 8 agents) verified every mechanic against **current**
+Meta/Google docs before any edit. Net: 6 of 8 are stable structural facts, 1 verify-live, 1 needed
+correction. The harvested mechanics were corrected against ground truth — what shipped reflects the
+corrections, not the original harvest:
+- **#6 corrected** — `lead_gen_form_id` binds on the **ad creative** (`object_story_spec→link_data→call_to_action`),
+  **not** the ad set. The ad set carries `promoted_object={page_id}` + `destination_type=ON_AD`. The instant-form
+  **baseline** is `optimization_goal=LEAD_GENERATION`; `QUALITY_LEAD` is the **opt-in** "conversion leads"
+  upgrade that *additionally* needs CRM lead-stage events via CAPI. (Original harvest conflated these.)
+- **#4 expanded** — must-hash list adds `ct, st, external_id` (+ `db/ge`); never-hash list adds `subscription_id`.
+  Real Meta param key is `zp` (not `zip`).
+- **#2 terminology** — current Meta naming is **dataset** (Dataset ID ≈ former Pixel ID); "pixel" = the browser tag.
+- **#5 kept verify-live** — no day-count baked; windows differ by funnel, pulled live.
+- **#7 reframed** — default-PAUSED is **badi's advisory best practice**, not a Meta rule, and is phrased as
+  *advice to the user* (badi never creates campaigns / calls the API).
+
+**Shipped:** `meta-review.md` (+vault), `ads-strategist.md`, `ads-review.md` (+vault) — HARDENING only, no new
+surface. Vault/active copies in parity; line-1 descriptions untouched. 1321 tests green, doctor 53/0/0, lint clean.
+The full live-verified fact sheet (8 Meta + 4 Google, with evidence/citations) is in the workflow result
+journal for this session.

--- a/.claude/workspace/freeze-exceptions.md
+++ b/.claude/workspace/freeze-exceptions.md
@@ -12,7 +12,8 @@
 | 1 | 2026-06-20 | `/market` slash command + market-research vault skill | **wiring** | SHRINK & BUILD | The capability already ships — `badi market` CLI (v1.15) + `market-researcher` agent (v1.34). Only the slash-command wrapper + vault-skill packaging are missing. Completing existing infra, no new logic. |
 | 2 | 2026-06-20 | "Fix PR #281" (biome 2.4.16→2.5.0) | n/a | KILL | Already resolved by #283 (merged today); #281 closed/superseded. Non-item. |
 | 3 | 2026-06-20 | spec-kit-derived dependency-aware task sequencing → Workflow | **hardening** (engine) | SHRINK & BUILD (engine only) | The one badi-native, non-overlapping idea from spec-kit: a dependency-aware tasks.md whose `[P]` markers feed badi's existing Workflow `parallel()`. The rest of spec-kit (constitution agent, /clarify, /specify, /plan) KILLED — heavy overlap with existing `/architect`, `/brief`, `/proposal`, `/spec-check`, `/team`, `/eng-review`. |
+| 4 | 2026-06-26 | Ground `/meta-review` + `/ads-review` + `ads-strategist` in live-verified Meta/Google measurement mechanics (commit `1037613`, branch `feat/ads-review-mechanics`) | **hardening** (existing advisory specs) | BUILD (owner-directed) | Sharpens 3 existing advisory files — no new command/agent/skill surface. 8 Meta + 4 Google mechanics, each live-verified against current docs before edit; mechanics enter as *what to verify*, never as API code. Honors advisory-only + research-live rules; no baked numbers, no source-project naming. Tests 1321 green, doctor 53/0/0. |
 
 ## Count
-- Exceptions logged without organic signal: **2 build items** (#1 wiring, #3 engine). #2 is a non-item.
-- At 3+, prompt the owner to explicitly lift/tighten the freeze (per framework).
+- Exceptions logged without organic signal: **3 build items** (#1 wiring, #3 engine, #4 hardening). #2 is a non-item.
+- **GATE FIRED (2026-06-27):** 3rd build exception reached. Owner prompted to lift / tighten / change-threshold → **decision: keep the freeze ACTIVE, threshold unchanged** (target still the first organic external signal). Exceptions remain owner-directed only.


### PR DESCRIPTION
## What

Grounds badi's two advisory ad commands and the `ads-strategist` agent in **live-verified** Meta and Google measurement mechanics. Pure **HARDENING** — sharpens 3 existing files, **no new command/agent/skill surface**.

- `/meta-review` (+vault): funnel-destination fork (Web / CTWA / Lead Ads) + a "Measurement prerequisites (verify live)" block + lead-form-immutability blocker + PAUSED safe-default.
- `/ads-review` (+vault): privacy-durable layer — Enhanced Conversions, Offline Conversion Import (GCLID/iOS BRAIDs), transaction_id/order_id dedup, Consent Mode v2 (verify-live).
- `ads-strategist`: CTWA + Lead Ads platform lenses, measurement-prerequisite verification list, "advise launching PAUSED" boundary.

## How it was verified

Every mechanic was checked against **current** Meta/Google docs before any edit (3-phase verify→draft→adversarial-review). Mechanics enter strictly as **what to verify**, never as code that calls an ad API — preserving the advisory-only and research-live rules. No baked numbers (windows/prices pulled live), no third-party source named.

## Checks

- 1321 tests green · doctor 53/0/0 · frontmatter suites 186/0 · lint clean
- Vault/active command copies in byte parity; line-1 descriptions untouched

## Freeze

Logged as exception **#3** in `freeze-exceptions.md` (owner-directed HARDENING). Gate fired at the 3rd build exception; owner decision: **keep the freeze active**, threshold unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
