### PR TITLE
deps: bump node-html-parser from 7.1.0 to 8.0.4 (supersedes #304)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "chalk": "^5.3.0",
         "figlet": "^1.11.0",
-        "node-html-parser": "^7.1.0"
+        "node-html-parser": "^8.0.3"
       },
       "bin": {
         "badi": "bin/badi.js"
@@ -2791,15 +2791,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
-      }
-    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -4096,13 +4087,25 @@
       }
     },
     "node_modules/node-html-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.1.0.tgz",
-      "integrity": "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-8.0.4.tgz",
+      "integrity": "sha512-w2YxujN/TqrSIWGVNW/fVgKKfAyQeHMXCvnKZI0owLnfP0tfjdLecUoy9zhOMZGoEFk6eP5qSDyvUarjPl3bwQ==",
       "license": "MIT",
       "dependencies": {
         "css-select": "^5.1.0",
-        "he": "1.2.0"
+        "entities": "^8.0.0"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/nopt": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "figlet": "^1.11.0",
-    "node-html-parser": "^7.1.0"
+    "node-html-parser": "^8.0.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",


### PR DESCRIPTION
Major bump (7→8) of a **production** dependency, verified locally (no PR CI in this repo).

## Verification
`node-html-parser` is used in exactly one place — `lib/commands/seo/_shared.js` `countWords()` (`parse` + `querySelectorAll` + `remove` + `structuredText`). Direct behavior check confirms **identical output on v8**: block-element newline insertion (`<p>One</p><p>Two</p>` → 2 words) and script/style stripping unchanged. The v8 change is internal — it swaps its `he` dependency for `entities` ^8.0.0.

- 1321 tests green · SEO suite 13/13 · doctor 53/0/0 · lint clean
- Minimal diff: package.json 1 line, package-lock.json 31 lines (node-html-parser + he→entities)

## Supersedes #304
Dependabot #304 pinned 8.0.3 off a stale base (before the biome/checkout merges); this lands **8.0.4** on top of current `main` with a clean lockfile. Close #304 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)