### PR TITLE
fix(models): refresh model catalog to Fable 5 / Opus 4.8 / Sonnet 5 + correct Opus pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 npx @fatihkan/badi init && badi doctor   # ~2 minutes
 ```
 
-Beyond the guardrails, badi is a full Claude Code workflow layer — a daily ritual, code review, a virtual eng team, content & SEO — as **30 subagents, 86 commands, and 63 opt-in skills** you enable only when you need them. Works with Cursor, Gemini CLI, and Windsurf too. Built for **Claude Opus 4.7 / Sonnet 4.6** · 1321 passing tests · MIT.
+Beyond the guardrails, badi is a full Claude Code workflow layer — a daily ritual, code review, a virtual eng team, content & SEO — as **30 subagents, 86 commands, and 63 opt-in skills** you enable only when you need them. Works with Cursor, Gemini CLI, and Windsurf too. Built for the latest Claude — **Opus 4.8 / Sonnet 5 / Fable 5** · 1321 passing tests · MIT.
 
 ## Demo
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/lib/commands/stats.js
+++ b/lib/commands/stats.js
@@ -192,6 +192,7 @@ function modelClassFor(models) {
 	const real = models.filter((m) => m && m !== "<synthetic>");
 	if (real.length === 0) return "synth";
 	const first = real[0];
+	if (first.includes("fable") || first.includes("mythos")) return "fable";
 	if (first.includes("opus")) return "opus";
 	if (first.includes("sonnet")) return "sonnet";
 	if (first.includes("haiku")) return "haiku";

--- a/lib/data/transcript-reader.js
+++ b/lib/data/transcript-reader.js
@@ -17,25 +17,15 @@ export function transcriptsRoot(override) {
 
 // Per-1M-token approximate pricing (USD). Public Anthropic list.
 // Note: this table is not fixed; if the model name changes, a fallback applies.
+// Current families: Fable 5 $10/$50, Opus 4.x $5/$25, Sonnet $3/$15, Haiku 4.5 $1/$5.
+// Cache write = 1.25x input, cache read = 0.1x input.
 export const MODEL_PRICING = {
-	"claude-opus-4-7": {
-		input: 15,
-		output: 75,
-		cacheWrite: 18.75,
-		cacheRead: 1.5,
-	},
-	"claude-opus-4-6": {
-		input: 15,
-		output: 75,
-		cacheWrite: 18.75,
-		cacheRead: 1.5,
-	},
-	"claude-opus-4-5": {
-		input: 15,
-		output: 75,
-		cacheWrite: 18.75,
-		cacheRead: 1.5,
-	},
+	"claude-fable-5": { input: 10, output: 50, cacheWrite: 12.5, cacheRead: 1 },
+	"claude-opus-4-8": { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 },
+	"claude-opus-4-7": { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 },
+	"claude-opus-4-6": { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 },
+	"claude-opus-4-5": { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 },
+	"claude-sonnet-5": { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 },
 	"claude-sonnet-4-6": {
 		input: 3,
 		output: 15,
@@ -59,6 +49,7 @@ export const MODEL_PRICING = {
 
 function classifyModel(model) {
 	if (!model) return "unknown";
+	if (model.includes("fable") || model.includes("mythos")) return "fable";
 	if (model.includes("opus")) return "opus";
 	if (model.includes("sonnet")) return "sonnet";
 	if (model.includes("haiku")) return "haiku";
@@ -68,8 +59,10 @@ function classifyModel(model) {
 function pricingFor(model) {
 	if (MODEL_PRICING[model]) return MODEL_PRICING[model];
 	const family = classifyModel(model);
+	if (family === "fable")
+		return { input: 10, output: 50, cacheWrite: 12.5, cacheRead: 1 };
 	if (family === "opus")
-		return { input: 15, output: 75, cacheWrite: 18.75, cacheRead: 1.5 };
+		return { input: 5, output: 25, cacheWrite: 6.25, cacheRead: 0.5 };
 	if (family === "sonnet")
 		return { input: 3, output: 15, cacheWrite: 3.75, cacheRead: 0.3 };
 	if (family === "haiku")

--- a/tests/transcript-reader.test.js
+++ b/tests/transcript-reader.test.js
@@ -167,9 +167,9 @@ describe("transcript-reader", () => {
 			input_tokens: 1_000_000,
 			output_tokens: 1_000_000,
 		};
-		const opus = costForUsage("claude-opus-4-7", usage);
-		const sonnet = costForUsage("claude-sonnet-4-6", usage);
-		assert.equal(opus, 15 + 75);
+		const opus = costForUsage("claude-opus-4-8", usage);
+		const sonnet = costForUsage("claude-sonnet-5", usage);
+		assert.equal(opus, 5 + 25);
 		assert.equal(sonnet, 3 + 15);
 		assert.ok(opus > sonnet);
 	});
@@ -178,7 +178,7 @@ describe("transcript-reader", () => {
 		const c = costForUsage("claude-opus-4-99", {
 			input_tokens: 1_000_000,
 		});
-		assert.equal(c, 15);
+		assert.equal(c, 5);
 	});
 
 	it("costForUsage returns 0 for a completely unknown model", () => {
@@ -187,8 +187,9 @@ describe("transcript-reader", () => {
 	});
 
 	it("MODEL_PRICING covers the main models", () => {
-		assert.ok(MODEL_PRICING["claude-opus-4-7"]);
-		assert.ok(MODEL_PRICING["claude-sonnet-4-6"]);
+		assert.ok(MODEL_PRICING["claude-fable-5"]);
+		assert.ok(MODEL_PRICING["claude-opus-4-8"]);
+		assert.ok(MODEL_PRICING["claude-sonnet-5"]);
 		assert.ok(MODEL_PRICING["claude-haiku-4-5"]);
 	});
 


### PR DESCRIPTION
The Claude 5 family (Fable 5, Sonnet 5) and Opus 4.8 shipped; this brings badi's model references current.

## The real bug
`badi stats` cost table priced **Opus at $15/$75** — that's the retired Opus-3 rate. Current Opus 4.x is **$5/$25** (1M context, no long-context premium), so every Opus session was being over-costed ~3×. Corrected the table, the fallback, and the two test assertions that pinned the old number.

## Updates
- **Added** `claude-fable-5` ($10/$50), `claude-opus-4-8` ($5/$25), `claude-sonnet-5` ($3/$15) to `MODEL_PRICING`.
- **Corrected** Opus 4.5/4.6/4.7 to $5/$25 (cache-write $6.25, cache-read $0.50).
- **Categorizers** (`classifyModel`, `modelClassFor`) learn the `fable` family (fable + mythos) so `badi stats` groups them correctly.
- **README** flagship line → Opus 4.8 / Sonnet 5 / Fable 5.
- **biome.json** `$schema` 2.5.0 → 2.5.1 (leftover from the biome bump in #321).

## Agents — no change needed
The 30 agents use `model: sonnet` (29) / `model: haiku` (1) — Claude Code **aliases that already auto-resolve** to Sonnet 5 / Haiku 4.5. Hardcoding versioned IDs or `fable` into frontmatter would fight badi's alias design and isn't a Claude Code alias. Promoting heavy-reasoning agents to `opus` is a separate cost/quality decision, left to the owner.

## Checks
- 1321 tests green (count unchanged) · doctor 53/0/0 · lint clean

## Freeze
Maintenance + accuracy bug fix, no new surface. Freeze stays active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)