### PR TITLE
chore(release): v1.36.0 — 2026 advisory currency + badi stats cost fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
 			],
 			"category": "productivity",
 			"strict": true,
-			"lastUpdated": "2026-06-20T08:24:28+03:00"
+			"lastUpdated": "2026-07-05T09:34:15+03:00"
 		}
 	]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
 	"name": "badi",
-	"version": "1.35.0",
+	"version": "1.36.0",
 	"description": "Workflow management for Claude Code, Cursor, Gemini, Windsurf, AGENTS.md — 30 AI agents, 86 commands, 14 hooks, 63 opt-in skill categories. Built for Anthropic Claude Opus 4.7 and Sonnet 4.6.",
 	"author": {
 		"name": "Fatih Kan",
@@ -93,5 +93,5 @@
 			}
 		]
 	},
-	"lastUpdated": "2026-06-20T08:24:28+03:00"
+	"lastUpdated": "2026-07-05T09:34:15+03:00"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ _bootstrap/badi-skills/.git/
 /VULN-FINDINGS.md
 /TRIAGE.json
 /TRIAGE.md
+
+# Local-only competitor positioning analysis (never published)
+.claude/workspace/launch/ANALYSIS-addy-agent-skills.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,63 @@ This project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [1.36.0] - 2026-07-05
+
+> Minor release. A 2026 currency pass across the whole advisory surface — the ads,
+> market, SEO, ASO, and content commands/agents are re-grounded in live-verified
+> 2026 platform mechanics and algorithms — plus a real cost-reporting bug fix. No
+> new commands/agents/skills (surface unchanged: 30/86/63); the freeze held (all
+> maintenance/currency). Every claim was researched live against current provider
+> docs, folded in as verify-live checks with no baked numbers, then adversarially
+> re-verified (6 corrections applied — incl. dropping the "ad_storage sole gate"
+> overstatement and an unverifiable Meta webhook claim).
+
+### Changed — advisory currency (2026)
+
+- **`/meta-review`, `/ads-review`, `ads-strategist`** — grounded in live-verified
+  Meta/Google measurement mechanics (Pixel↔CAPI one-dataset dedup on
+  `event_id`+`event_name`, `action_source` per channel, PII hash scope, CTWA +
+  Lead Ads funnels) and 2026 delivery-algorithm reality (AI creative-reading
+  retrieval + unified ranking → creative-is-targeting, Advantage+ default,
+  cross-surface learning, incrementality over last-click). Platform changes: the
+  one-click-CAPI second-pipeline dedup trap, Google Consent Mode decoupling from
+  Google Signals, offline-import → Data Manager API, Enhanced Conversions unified
+  toggle, AI Max Final-URL 404 risk, Call Ads retired, PMax campaign-level
+  negatives.
+- **`/market`, `market-researcher`** — 2026 signal reliability: search volume is a
+  floor, not a market size (zero-click + AI-Mode query fan-out); a multi-signal
+  stack (TikTok trend velocity, community pain-points, marketplace SQP); AI answer
+  engines as a discovery surface; AI-citation presence ≠ SERP rank.
+- **`/seo`, `seo-strategist`** — aligned to Google's official 2026 AI-search
+  guidance: GEO = SEO (same index via RAG + query fan-out); `llms.txt` is ignored
+  (removed the prior recommendation); FAQ rich results deprecated; Preferred
+  Sources; the Search Console Gen-AI impression report; `Google-Extended` ≠ AI
+  Overviews.
+- **`/aso`** — 2026 App Store algorithm reality: Apple LLM semantic-relevance
+  ranking, Apple Search Ads' second in-organic slot, App Intents/Spotlight
+  discovery, indexed screenshot captions, Custom Product Pages, and Google Play
+  "Ask Play".
+- **`content-creator`, `visual-director`, `/content-generate`** — 2026 platform
+  reality: originality enforced (reposts/third-party watermarks de-recommended),
+  AI-assist is fine but mass-produced "slop" is penalized, realistic-AI-media
+  disclosure (C2PA/SynthID; EU AI Act Art. 50), engineer sends-per-reach +
+  watch-through, interest-graph through-lines for LinkedIn/X/Threads.
+
+### Fixed
+
+- **`badi stats` cost reporting** — the transcript pricing table charged Opus at
+  the retired Opus-3 rate (`$15/$75`); corrected to the current `$5/$25` (was
+  over-costing every Opus session ~3×). Added `claude-fable-5` ($10/$50),
+  `claude-opus-4-8` ($5/$25), and `claude-sonnet-5` ($3/$15), and taught the
+  model-family classifier the `fable` family (Fable 5 / Mythos 5).
+
+### Maintenance
+
+- Dependency bumps: `node-html-parser` 7 → 8.0.4 (behaviour-verified),
+  `actions/checkout` 6 → 7, `@biomejs/biome` 2.5.1 (+ `biome.json` schema).
+- README flagship line refreshed to Opus 4.8 / Sonnet 5 / Fable 5. Agent `model:`
+  aliases (`sonnet`/`haiku`) auto-track to Sonnet 5 / Haiku 4.5 — left unchanged.
+
 ## [1.35.0] - 2026-06-20
 
 > Minor release. Internal hardening (branch-guard, semver, doctor/release gates,

--- a/CHANGELOG.tr.md
+++ b/CHANGELOG.tr.md
@@ -6,6 +6,57 @@ Bu proje [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) formatini ve [
 
 ## [Unreleased]
 
+## [1.36.0] - 2026-07-05
+
+> Minor surum. Tum advisory yuzeyinde 2026 guncellik gecisi — ads, market, SEO,
+> ASO ve content komut/ajanlari canli-dogrulanmis 2026 platform mekanikleri ve
+> algoritmalarina yeniden temellendirildi — arti gercek bir maliyet-raporlama
+> bug fix'i. Yeni komut/ajan/skill YOK (yuzey ayni: 30/86/63); freeze korundu
+> (hepsi maintenance/currency). Her iddia guncel saglayici dokumanlarina karsi
+> canli arastirildi, baked-number olmadan verify-live kontrol olarak eklendi,
+> sonra adversarial olarak yeniden dogrulandi (6 duzeltme uygulandi).
+
+### Changed — advisory currency (2026)
+
+- **`/meta-review`, `/ads-review`, `ads-strategist`** — canli-dogrulanmis
+  Meta/Google olcum mekanikleri (Pixel↔CAPI tek-dataset dedup: `event_id` +
+  `event_name`, kanal bazli `action_source`, PII hash kapsami, CTWA + Lead Ads
+  huniler) + 2026 delivery-algoritma gerceigi (AI retrieval + unified ranking →
+  creative-is-targeting, Advantage+ default, cross-surface, incrementality).
+  Platform degisiklikleri: one-click-CAPI ikinci-pipeline dedup tuzagi, Consent
+  Mode'un Google Signals'tan ayrilmasi, offline-import → Data Manager API, EC tek
+  toggle, AI Max Final-URL 404, Call Ads kapandi, PMax campaign-level negatives.
+- **`/market`, `market-researcher`** — 2026 sinyal guvenilirligi: arama hacmi
+  taban, market boyutu degil (zero-click + AI-Mode query fan-out); coklu-sinyal
+  stack (TikTok trend velocity, community pain-point, marketplace SQP); AI answer
+  engine'ler kesif yuzeyi; AI-citation ≠ SERP rank.
+- **`/seo`, `seo-strategist`** — Google'in resmi 2026 AI-search rehberine
+  hizalandi: GEO = SEO (ayni index, RAG + query fan-out); `llms.txt` gormezden
+  geliniyor (eski oneri kaldirildi); FAQ rich-result deprecated; Preferred
+  Sources; Search Console Gen-AI impression raporu; `Google-Extended` ≠ AIO.
+- **`/aso`** — 2026 App Store algoritma gerceigi: Apple LLM semantic ranking,
+  Apple Search Ads 2. organik slot, App Intents/Spotlight, indexed screenshot
+  caption'lari, Custom Product Pages, Google Play "Ask Play".
+- **`content-creator`, `visual-director`, `/content-generate`** — 2026 platform
+  gerceigi: originallik zorunlu (repost/3rd-party watermark de-recommend),
+  AI-assist serbest ama mass-produced "slop" cezali, realistic-AI disclosure
+  (C2PA/SynthID; EU AI Act Art. 50), sends-per-reach + watch-through,
+  LinkedIn/X/Threads interest-graph.
+
+### Fixed
+
+- **`badi stats` maliyet raporlama** — transcript pricing tablosu Opus'u kaldirilan
+  Opus-3 fiyatiyla (`$15/$75`) hesapliyordu; guncel `$5/$25`'e duzeltildi (her Opus
+  oturumu ~3x fazla maliyetleniyordu). `claude-fable-5` ($10/$50), `claude-opus-4-8`
+  ($5/$25), `claude-sonnet-5` ($3/$15) eklendi + `fable` ailesi siniflandiricisi.
+
+### Maintenance
+
+- Bagimlilik bump: `node-html-parser` 7 → 8.0.4 (davranis-dogrulandi),
+  `actions/checkout` 6 → 7, `@biomejs/biome` 2.5.1 (+ `biome.json` schema).
+- README flagship satiri Opus 4.8 / Sonnet 5 / Fable 5'e tazelendi. Agent `model:`
+  alias'lari (`sonnet`/`haiku`) Sonnet 5 / Haiku 4.5'e OTO-track eder — degismedi.
+
 ## [1.35.0] - 2026-06-20
 
 > Minor surum. Ic sertlestirme (branch-guard, semver, doctor/release kapilari,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Support |
 |---------|---------|
-| 1.35.x | Active |
-| < 1.35 | Unsupported |
+| 1.36.x | Active |
+| < 1.36 | Unsupported |
 
 ## Security Features
 

--- a/dist/scoop/badi.json
+++ b/dist/scoop/badi.json
@@ -1,12 +1,12 @@
 {
 	"_comment_": "Scoop bucket manifest. fatihkan/scoop-bucket repo'sunda bucket/badi.json olarak yer alir.",
 	"_install_": "scoop bucket add badi https://github.com/fatihkan/scoop-bucket && scoop install badi",
-	"version": "1.35.0",
+	"version": "1.36.0",
 	"description": "Workflow management for Claude Code (30 AI agents, 86 commands, 63 opt-in skill categories). Supports Cursor, Gemini, Windsurf, AGENTS.md.",
 	"homepage": "https://github.com/fatihkan/badi",
 	"license": "MIT",
 	"depends": "nodejs-lts",
-	"url": "https://registry.npmjs.org/@fatihkan/badi/-/badi-1.35.0.tgz",
+	"url": "https://registry.npmjs.org/@fatihkan/badi/-/badi-1.36.0.tgz",
 	"hash": "REPLACE_AT_RELEASE_TIME",
 	"extract_dir": "package",
 	"installer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fatihkan/badi",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "Workflow management CLI for Claude Code, Cursor, and Gemini CLI — 30 AI agents (incl. a virtual eng team, ads strategist, market/SEO/data analysts), 86 commands, OWASP security scans. Built for Anthropic Claude Opus and Sonnet.",
   "type": "module",
   "main": "bin/badi.js",


### PR DESCRIPTION
Minor release cutting this session's merged work (#307–#326) to a version.

## What ships
- **2026 advisory currency** across `/meta-review`, `/ads-review`, `ads-strategist`, `/market`, `market-researcher`, `/seo`, `seo-strategist`, `/aso`, `content-creator`, `visual-director`, `/content-generate` — re-grounded in live-verified 2026 platform mechanics + algorithms, adversarially re-verified.
- **Fix:** `badi stats` cost table corrected — Opus was priced at the retired $15/$75 (over-costing ~3×) → $5/$25; added Fable 5 / Opus 4.8 / Sonnet 5.
- **Maintenance:** node-html-parser 8.0.4, checkout v7, biome 2.5.1; README flagship line.

No new commands/agents/skills (surface unchanged: **30/86/63**). Freeze held (all maintenance/currency).

## Release gate
`badi release check --version 1.36.0` → **10 OK / 0 FAIL** (2 warns: the branch warn clears on merge; npm-pack check quirk — tarball verified building). Version synced across package.json + plugin/marketplace/scoop manifests + CHANGELOG (EN + TR) + SECURITY.md.

## Publish
npm is **not** authenticated in the working env — the final `npm publish` is the maintainer's action (per policy). After merge + tag, run `npm login && npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)