### PR TITLE
chore(deps): sync biome.json schema to 2.5.2 (follows #328)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fatihkan/badi",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fatihkan/badi",
-      "version": "1.35.0",
+      "version": "1.36.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",


### PR DESCRIPTION
Follow-up to Dependabot #328 (biome 2.5.1 → 2.5.2). Bumps the `biome.json` `$schema` URL to 2.5.2 so the schema-version mismatch info stays quiet. Lint clean · 1321 tests green · doctor 53/0/0 on biome 2.5.2. Dev-tooling only; does not affect the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)